### PR TITLE
User session is extended for SchedulerStateRest#getSchedulerStatus only

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -36,134 +36,11 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.io.SequenceInputStream;
-import java.io.Serializable;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.security.KeyException;
-import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-
-import javax.security.auth.login.LoginException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.PathSegment;
-import javax.ws.rs.core.Response;
-
-import org.objectweb.proactive.ActiveObjectCreationException;
-import org.objectweb.proactive.api.PAActiveObject;
-import org.objectweb.proactive.api.PAFuture;
-import org.objectweb.proactive.core.node.NodeException;
-import org.objectweb.proactive.core.util.log.ProActiveLogger;
-import org.objectweb.proactive.extensions.dataspaces.vfs.VFSFactory;
-import org.objectweb.proactive.utils.StackTraceUtil;
-import org.ow2.proactive.authentication.crypto.CredData;
-import org.ow2.proactive.authentication.crypto.Credentials;
-import org.ow2.proactive.db.SortOrder;
-import org.ow2.proactive.db.SortParameter;
-import org.ow2.proactive.scheduler.common.JobFilterCriteria;
-import org.ow2.proactive.scheduler.common.JobSortParameter;
-import org.ow2.proactive.scheduler.common.Scheduler;
-import org.ow2.proactive.scheduler.common.SchedulerAuthenticationInterface;
-import org.ow2.proactive.scheduler.common.SchedulerConnection;
-import org.ow2.proactive.scheduler.common.SchedulerConstants;
-import org.ow2.proactive.scheduler.common.exception.ConnectionException;
-import org.ow2.proactive.scheduler.common.exception.InternalSchedulerException;
-import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
-import org.ow2.proactive.scheduler.common.exception.JobCreationException;
-import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
-import org.ow2.proactive.scheduler.common.exception.PermissionException;
-import org.ow2.proactive.scheduler.common.exception.SchedulerException;
-import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
-import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
-import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
-import org.ow2.proactive.scheduler.common.job.Job;
-import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.job.JobPriority;
-import org.ow2.proactive.scheduler.common.job.JobResult;
-import org.ow2.proactive.scheduler.common.job.JobState;
-import org.ow2.proactive.scheduler.common.job.factories.FlatJobFactory;
-import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
-import org.ow2.proactive.scheduler.common.task.TaskResult;
-import org.ow2.proactive.scheduler.common.task.TaskState;
-import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
-import org.ow2.proactive.scheduler.common.util.logforwarder.LogForwardingException;
-import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
-import org.ow2.proactive_grid_cloud_portal.common.Session;
-import org.ow2.proactive_grid_cloud_portal.common.SessionStore;
-import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
-import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobIdData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobInfoData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobResultData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobStateData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobUsageData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobValidationData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerStatusData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerUserData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskIdData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskResultData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskStateData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.UserJobData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventNotification;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventSubscription;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobAlreadyFinishedRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.LogForwardingRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SchedulerRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SubmissionClosedRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownJobRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownTaskRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.util.EventUtil;
-import org.ow2.proactive_grid_cloud_portal.webapp.DateFormatter;
-import org.ow2.proactive_grid_cloud_portal.webapp.PortalConfiguration;
+import com.google.common.collect.Maps;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileSystemManager;
-import org.apache.commons.vfs2.FileType;
-import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.*;
 import org.apache.log4j.Logger;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResourceFactory;
@@ -177,8 +54,54 @@ import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.jboss.resteasy.util.GenericType;
+import org.objectweb.proactive.ActiveObjectCreationException;
+import org.objectweb.proactive.api.PAActiveObject;
+import org.objectweb.proactive.api.PAFuture;
+import org.objectweb.proactive.core.node.NodeException;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.extensions.dataspaces.vfs.VFSFactory;
+import org.objectweb.proactive.utils.StackTraceUtil;
+import org.ow2.proactive.authentication.crypto.CredData;
+import org.ow2.proactive.authentication.crypto.Credentials;
+import org.ow2.proactive.db.SortOrder;
+import org.ow2.proactive.db.SortParameter;
+import org.ow2.proactive.scheduler.common.*;
+import org.ow2.proactive.scheduler.common.exception.*;
+import org.ow2.proactive.scheduler.common.job.*;
+import org.ow2.proactive.scheduler.common.job.factories.FlatJobFactory;
+import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
+import org.ow2.proactive.scheduler.common.util.logforwarder.LogForwardingException;
+import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
+import org.ow2.proactive_grid_cloud_portal.common.Session;
+import org.ow2.proactive_grid_cloud_portal.common.SessionStore;
+import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
+import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.*;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventNotification;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventSubscription;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.*;
+import org.ow2.proactive_grid_cloud_portal.scheduler.util.EventUtil;
+import org.ow2.proactive_grid_cloud_portal.webapp.DateFormatter;
+import org.ow2.proactive_grid_cloud_portal.webapp.PortalConfiguration;
 
-import com.google.common.collect.Maps;
+import javax.security.auth.login.LoginException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.KeyException;
+import java.security.PublicKey;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML_TYPE;
@@ -265,12 +188,12 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     /**
-     * call a method on the scheduler's frontend in order to renew the lease the
+     * Call a method on the scheduler's frontend in order to renew the lease the
      * user has on this frontend. see PORTAL-70
      *
      * @throws NotConnectedRestException
      */
-    private void renewLeaseForClient(Scheduler scheduler) throws NotConnectedRestException {
+    protected void renewLeaseForClient(Scheduler scheduler) throws NotConnectedRestException {
         try {
             scheduler.renewSession();
         } catch (NotConnectedException e) {
@@ -400,8 +323,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     @Produces( { "application/json", "application/xml" })
     public long schedulerStateRevision(@HeaderParam("sessionid")
     String sessionId) throws NotConnectedRestException {
-        Scheduler s = checkAccess(sessionId, "/scheduler/revision");
-        renewLeaseForClient(s);
+        checkAccess(sessionId, "/scheduler/revision");
         return SchedulerStateListener.getInstance().getSchedulerStateRevision();
     }
 
@@ -1407,19 +1329,23 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      */
     private SchedulerProxyUserInterface checkAccess(String sessionId, String path)
             throws NotConnectedRestException {
-        Session ss = sessionStore.get(sessionId);
-        if (ss == null) {
+        Session session = sessionStore.get(sessionId);
+
+        if (session == null) {
             throw new NotConnectedRestException(
-                "you are not connected to the scheduler, you should log on first");
+                "You are not connected to the scheduler, you should log on first");
         }
 
-        SchedulerProxyUserInterface s = ss.getScheduler();
+        SchedulerProxyUserInterface schedulerProxy = session.getScheduler();
 
-        if (s == null) {
+        if (schedulerProxy == null) {
             throw new NotConnectedRestException(
-                "you are not connected to the scheduler, you should log on first");
+                "You are not connected to the scheduler, you should log on first");
         }
-        return s;
+
+        renewLeaseForClient(schedulerProxy);
+
+        return schedulerProxy;
     }
 
     private SchedulerProxyUserInterface checkAccess(String sessionId) throws NotConnectedRestException {
@@ -2086,9 +2012,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     final String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "status");
-            renewLeaseForClient(s);
-            return SchedulerStatusData.valueOf(SchedulerStateListener.getInstance().getSchedulerStatus(s)
-                    .name());
+            return SchedulerStatusData.valueOf(
+                    SchedulerStateListener.getInstance().getSchedulerStatus(s).name());
         } catch (PermissionException e) {
             throw new PermissionRestException(e);
         } catch (NotConnectedException e) {

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestRenewLeaseForClientTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestRenewLeaseForClientTest.java
@@ -1,0 +1,169 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ActiveEon Team
+ *                        http://www.activeeon.com/
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package org.ow2.proactive_grid_cloud_portal.scheduler;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.text.WordUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.MockitoAnnotations;
+
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
+import org.ow2.proactive_grid_cloud_portal.RestTestServer;
+import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
+import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStoreTestUtils;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The purpose of the test is to check that each method from {@link
+ * SchedulerRestInterface} invokes {@link SchedulerStateRest#renewLeaseForClient(Scheduler)}
+ * if it tries to perform an action once logged.
+ * <p/>
+ * To this aim, the scheduler is mocked and the {@link SchedulerStateRest}
+ * instance is spied thanks to Mockito. One test is generated per method to test
+ * in {@link SchedulerRestInterface} by using Junit parameterized tests.
+ */
+@RunWith(Parameterized.class)
+public class SchedulerStateRestRenewLeaseForClientTest extends RestTestServer {
+
+    private static final String METHOD_NAME_THAT_MUST_BE_INVOKED = "renewLeaseForClient";
+
+    private final Map<Class<?>, Object> defaultParameterValues;
+
+    private SchedulerStateRest schedulerStateRest;
+
+    private SchedulerProxyUserInterface scheduler;
+
+    private String sessionId;
+
+    private Method methodToTest;
+
+    public SchedulerStateRestRenewLeaseForClientTest(String testName, Method methodToTest) {
+        this.defaultParameterValues = new HashMap<>();
+        this.methodToTest = methodToTest;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<Object[]> data() throws NoSuchMethodException, IllegalAccessException {
+        Set<String> methodsToIgnore =
+                ImmutableSet.of("validate", "login", "loginWithCredential", "getCreateCredential");
+
+        Method[] methodsToTest = SchedulerRestInterface.class.getMethods();
+        Object[][] data = new Object[methodsToTest.length][2];
+
+        int nbMethodsToIgnore = 0;
+
+        for (int i = 0; i < methodsToTest.length; i++) {
+            Method methodToTest = methodsToTest[i];
+
+            if (methodsToIgnore.contains(methodToTest.getName())) {
+                nbMethodsToIgnore++;
+                continue;
+            }
+
+            data[i - nbMethodsToIgnore][0] = "test" + WordUtils.capitalize(methodToTest.getName());
+            data[i - nbMethodsToIgnore][1] = methodToTest;
+        }
+
+        if (nbMethodsToIgnore > 0) {
+            data = Arrays.copyOfRange(data, 0, data.length - nbMethodsToIgnore);
+        }
+
+        return Arrays.asList(data);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        schedulerStateRest = spy(new SchedulerStateRest());
+        scheduler = mock(SchedulerProxyUserInterface.class);
+        sessionId = SharedSessionStoreTestUtils.createValidSession(scheduler);
+
+        defaultParameterValues.put(Character.class, '\0');
+        defaultParameterValues.put(Integer.class, 0);
+        defaultParameterValues.put(Long.class, 0L);
+        defaultParameterValues.put(String.class, sessionId);
+        defaultParameterValues.put(boolean.class, false);
+        defaultParameterValues.put(char.class, '\0');
+        defaultParameterValues.put(int.class, 0);
+        defaultParameterValues.put(long.class, 0L);
+        defaultParameterValues.put(scheduler.getClass(), scheduler);
+    }
+
+    @Test
+    public void test() throws Throwable {
+        Method methodThatMustBeInvoked =
+                SchedulerStateRest.class.getDeclaredMethod(
+                        METHOD_NAME_THAT_MUST_BE_INVOKED, Scheduler.class);
+
+        try {
+            methodToTest.invoke(schedulerStateRest, createMethodParameters(methodToTest));
+        } catch (InvocationTargetException e) {
+            // Ignore exceptions since the scheduler is mocked and dummy
+            // parameters are passed to methods which are invoked.
+            // However, renewLeaseForClient should have been invoked.
+        }
+
+        methodThatMustBeInvoked.invoke(verify(schedulerStateRest, times(1)), scheduler);
+    }
+
+    private Object[] createMethodParameters(Method method) throws IllegalAccessException {
+        Object[] params = new Object[method.getParameterTypes().length];
+        Class<?>[] parameterTypes = method.getParameterTypes();
+
+        for (int i = 0; i < method.getParameterTypes().length; i++) {
+            params[i] = defaultParameterValues.get(parameterTypes[i]);
+        }
+
+        return params;
+    }
+
+}

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestRenewLeaseForClientTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestRenewLeaseForClientTest.java
@@ -81,8 +81,6 @@ public class SchedulerStateRestRenewLeaseForClientTest extends RestTestServer {
 
     private SchedulerProxyUserInterface scheduler;
 
-    private String sessionId;
-
     private Method methodToTest;
 
     public SchedulerStateRestRenewLeaseForClientTest(String testName, Method methodToTest) {
@@ -121,11 +119,10 @@ public class SchedulerStateRestRenewLeaseForClientTest extends RestTestServer {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
-
         schedulerStateRest = spy(new SchedulerStateRest());
         scheduler = mock(SchedulerProxyUserInterface.class);
-        sessionId = SharedSessionStoreTestUtils.createValidSession(scheduler);
+
+        String sessionId = SharedSessionStoreTestUtils.createValidSession(scheduler);
 
         defaultParameterValues.put(Character.class, '\0');
         defaultParameterValues.put(Integer.class, 0);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -102,7 +102,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
     private static final JobLogger jlogger = JobLogger.getInstance();
 
     /** A repeated warning message */
-    private static final String ACCESS_DENIED = "Access denied ! You are not connected or your session has expired !";
+    private static final String ACCESS_DENIED = "Access denied! You are not connected or your session has expired!";
 
     /** Maximum duration of a session for a useless client */
     private static final long USER_SESSION_DURATION = PASchedulerProperties.SCHEDULER_USER_SESSION_TIME


### PR DESCRIPTION
The idea is to call renewLeaseForClient in all methods exposed in the REST API.
It seems that this call can be performed in the existing checkAccess method that
is already invoked in public methods.