### PR TITLE
SCHEDULING-2279 Node events are slow to process in Resource Manager

### DIFF
--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMInitialState.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMInitialState.java
@@ -38,6 +38,7 @@ package org.ow2.proactive.resourcemanager.common.event;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -79,7 +80,7 @@ public class RMInitialState implements Serializable {
 
     /**
      * Creates an InitialState object.
-     * 
+     *
      * @param nodesEventList RM's node events.
      * @param nodeSourcesList RM's node sources list.
      */
@@ -102,5 +103,30 @@ public class RMInitialState implements Serializable {
      */
     public ArrayList<RMNodeSourceEvent> getNodeSource() {
         return this.nodeSources;
+    }
+
+    public void nodeStateChanged(RMNodeEvent stateChangedEvent) {
+        int size = nodesList.size();
+        for (int i = 0; i < size; i++) {
+            if (stateChangedEvent.getNodeUrl().equals(nodesList.get(i).getNodeUrl())) {
+                nodesList.set(i, stateChangedEvent);
+                break;
+            }
+        }
+    }
+
+    public void nodeRemoved(RMNodeEvent removedEvent) {
+        Iterator<RMNodeEvent> events = nodesList.iterator();
+        while (events.hasNext()) {
+            RMNodeEvent nodeEvent = events.next();
+            if (removedEvent.getNodeUrl().equals(nodeEvent.getNodeUrl())) {
+                events.remove();
+                break;
+            }
+        }
+    }
+
+    public void nodeAdded(RMNodeEvent event) {
+        nodesList.add(event);
     }
 }

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMListenerProxy.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMListenerProxy.java
@@ -48,7 +48,6 @@ import javax.management.AttributeList;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.MBeanException;
-import javax.management.MBeanInfo;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
@@ -186,23 +185,13 @@ public class RMListenerProxy extends RMGroupEventListener {
     public void nodeEvent(RMNodeEvent event) {
         switch (event.getEventType()) {
             case NODE_REMOVED:
-                for (int i = 0; i < rmInitialState.getNodesEvents().size(); i++) {
-                    if (event.getNodeUrl().equals(rmInitialState.getNodesEvents().get(i).getNodeUrl())) {
-                        rmInitialState.getNodesEvents().remove(i);
-                        break;
-                    }
-                }
+                rmInitialState.nodeRemoved(event);
                 break;
             case NODE_ADDED:
-                rmInitialState.getNodesEvents().add(event);
+                rmInitialState.nodeAdded(event);
                 break;
             case NODE_STATE_CHANGED:
-                for (int i = 0; i < rmInitialState.getNodesEvents().size(); i++) {
-                    if (event.getNodeUrl().equals(rmInitialState.getNodesEvents().get(i).getNodeUrl())) {
-                        rmInitialState.getNodesEvents().set(i, event);
-                        break;
-                    }
-                }
+                rmInitialState.nodeStateChanged(event);
                 break;
 
         }


### PR DESCRIPTION
The looping over nodes in RMListenerProxy resulted in many ProActive calls/use
of futures slowing down the dispatch of events.
Now only one call is performed and the lookup of nodes is done on RMInitialState
side.