### PR TITLE
Allow execution of server side workflows

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -603,6 +603,29 @@ public interface SchedulerRestInterface {
             NotConnectedRestException, PermissionRestException, SubmissionClosedRestException, IOException;
 
     /**
+     * Submits a workflow to the scheduler from a workflow URL,
+     * creating hence a new job resource.
+     *
+     * @param sessionId a valid session id
+     * @param url url to the workflow content
+     * @param pathSegment variables of the workflow
+     * @return the <code>jobid</code> of the newly created job
+     * @throws NotConnectedRestException
+     * @throws IOException
+     * @throws JobCreationRestException
+     * @throws PermissionRestException
+     * @throws SubmissionClosedRestException
+     */
+    @POST
+    @Path("jobs")
+    @Produces("application/json")
+    public JobIdData submitFromUrl(@HeaderParam("sessionid")
+    String sessionId, @HeaderParam("link")
+    String url, @PathParam("path")
+    PathSegment pathSegment) throws JobCreationRestException, NotConnectedRestException,
+    PermissionRestException, SubmissionClosedRestException, IOException;
+
+    /**
      * Pushes a file from the local file system into the given DataSpace
      * @param sessionId a valid session id
      * @param spaceName the name of the DataSpace

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
@@ -104,6 +104,18 @@ public interface StudioInterface {
     Workflow createWorkflow(@HeaderParam("sessionid")
     String sessionId, Workflow workflow) throws NotConnectedRestException, IOException;
 
+    @GET
+    @Path("workflows/{id}")
+    @Produces(APPLICATION_JSON)
+    Workflow getWorkflow(@HeaderParam("sessionid")
+    String sessionId, @PathParam("id") String workflowId) throws NotConnectedRestException, IOException;
+
+    @GET
+    @Path("workflows/{id}/content")
+    @Produces(APPLICATION_JSON)
+    String getWorkflowContent(@HeaderParam("sessionid")
+    String sessionId, @PathParam("id") String workflowId) throws NotConnectedRestException, IOException;
+
     @PUT
     @Path("workflows/{id}")
     @Consumes(APPLICATION_JSON)
@@ -127,6 +139,18 @@ public interface StudioInterface {
     @Consumes(APPLICATION_JSON)
     Workflow createTemplate(@HeaderParam("sessionid")
     String sessionId, Workflow template) throws NotConnectedRestException, IOException;
+
+    @GET
+    @Path("templates/{id}")
+    @Produces(APPLICATION_JSON)
+    Workflow getTemplate(@HeaderParam("sessionid")
+    String sessionId, @PathParam("id") String templateId) throws NotConnectedRestException, IOException;
+
+    @GET
+    @Path("templates/{id}/content")
+    @Produces(APPLICATION_JSON)
+    String getTemplateContent(@HeaderParam("sessionid")
+    String sessionId, @PathParam("id") String templateId) throws NotConnectedRestException, IOException;
 
     @PUT
     @Path("templates/{id}")

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
@@ -51,7 +51,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.PathSegment;
 import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
@@ -66,6 +65,7 @@ import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 
 
 @Path("/studio")
@@ -111,9 +111,9 @@ public interface StudioInterface {
     String sessionId, @PathParam("id") String workflowId) throws NotConnectedRestException, IOException;
 
     @GET
-    @Path("workflows/{id}/content")
-    @Produces(APPLICATION_JSON)
-    String getWorkflowContent(@HeaderParam("sessionid")
+    @Path("workflows/{id}/xml")
+    @Produces(APPLICATION_XML)
+    String getWorkflowXmlContent(@HeaderParam("sessionid")
     String sessionId, @PathParam("id") String workflowId) throws NotConnectedRestException, IOException;
 
     @PUT
@@ -147,9 +147,9 @@ public interface StudioInterface {
     String sessionId, @PathParam("id") String templateId) throws NotConnectedRestException, IOException;
 
     @GET
-    @Path("templates/{id}/content")
-    @Produces(APPLICATION_JSON)
-    String getTemplateContent(@HeaderParam("sessionid")
+    @Path("templates/{id}/xml")
+    @Produces(APPLICATION_XML)
+    String getTemplateXmlContent(@HeaderParam("sessionid")
     String sessionId, @PathParam("id") String templateId) throws NotConnectedRestException, IOException;
 
     @PUT

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/HttpResourceDownloader.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/HttpResourceDownloader.java
@@ -48,7 +48,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 
-public class WorkflowDownloader {
+public class HttpResourceDownloader {
 
     private static final Integer CONNECTION_POOL_SIZE = 5;
 
@@ -68,7 +68,8 @@ public class WorkflowDownloader {
             ResteasyWebTarget target = client.target(url);
             response = target.request().header("sessionid", sessionId).get();
             if (responseIsNotHttpOk(response)) {
-                throw new IOException(String.format("Cannot access resource %s: code %d", url, response.getStatus()));
+                throw new IOException(String.format(
+                        "Cannot access resource %s: code %d", url, response.getStatus()));
             }
             return (T) response.readEntity(clazz);
         } finally {

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -69,7 +69,6 @@ import org.ow2.proactive.scheduler.common.*;
 import org.ow2.proactive.scheduler.common.exception.*;
 import org.ow2.proactive.scheduler.common.job.*;
 import org.ow2.proactive.scheduler.common.job.factories.FlatJobFactory;
-import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
@@ -1479,6 +1478,52 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     /**
+     * Submits a workflow to the scheduler from a workflow URL,
+     * creating hence a new job resource.
+     *
+     * @param sessionId a valid session id
+     * @param url url to the workflow content
+     * @param pathSegment variables of the workflow
+     * @return the <code>jobid</code> of the newly created job
+     * @throws NotConnectedRestException
+     * @throws IOException
+     * @throws JobCreationRestException
+     * @throws PermissionRestException
+     * @throws SubmissionClosedRestException
+     */
+    @Override
+    @POST
+    @Path("jobs")
+    @Produces("application/json")
+    public JobIdData submitFromUrl(
+            @HeaderParam("sessionid") String sessionId,
+            @HeaderParam("link") String url,
+            @PathParam("path") PathSegment pathSegment
+    ) throws JobCreationRestException, NotConnectedRestException, PermissionRestException, SubmissionClosedRestException, IOException {
+        Scheduler s = checkAccess(sessionId, "jobs");
+
+        File tmpWorkflowFile = null;
+        try {
+            String jobXml = downloadWorkflowContent(sessionId, url);
+            tmpWorkflowFile = File.createTempFile("job", "d");
+            IOUtils.write(jobXml, new FileOutputStream(tmpWorkflowFile));
+
+            WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(s);
+            JobId jobId = workflowSubmitter.submit(
+                    tmpWorkflowFile,
+                    getWorkflowVariablesFromPathSegment(pathSegment));
+
+            return mapper.map(jobId, JobIdData.class);
+        } catch (IOException e) {
+            throw new IOException("I/O Error: " + e.getMessage(), e);
+        } finally {
+            if (tmpWorkflowFile != null) {
+                tmpWorkflowFile.delete();
+            }
+        }
+    }
+
+    /**
      * Submits a job to the scheduler
      *
      * @param sessionId
@@ -1502,74 +1547,33 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Map<String, List<InputPart>> formDataMap = multipart.getFormDataMap();
 
             String name = formDataMap.keySet().iterator().next();
-            File tmp = null;
+            File tmpJobFile = null;
             try {
 
                 InputPart part1 = multipart.getFormDataMap().get(name).get(0); // "file"
                 // is the name of the browser's input field
-                InputStream is = part1.getBody(new GenericType<InputStream>() {
-                });
-                tmp = File.createTempFile("job", "d");
+                InputStream is = part1.getBody(new GenericType<InputStream>() {});
+                tmpJobFile = File.createTempFile("job", "d");
 
-                IOUtils.copy(is, new FileOutputStream(tmp));
+                IOUtils.copy(is, new FileOutputStream(tmpJobFile));
 
-                Map<String, String> variables = null;
-                MultivaluedMap<String, String> matrixParams = pathSegment.getMatrixParameters();
-                if (matrixParams != null && !matrixParams.isEmpty()) {
-                    variables = Maps.newHashMap();
-                    for (String key : matrixParams.keySet()) {
-                        variables.put(key, matrixParams.getFirst(key));
-                    }
-                }
+                Map<String, String> jobVariables = getWorkflowVariablesFromPathSegment(pathSegment);
+                Boolean isXml = isXmlWorkflow(part1);
 
-                Job j;
-                boolean isAnArchive = false;
-                if (part1.getMediaType().toString().toLowerCase()
-                        .contains(MediaType.APPLICATION_XML.toLowerCase())) {
-                    // the job sent is the xml file
-                    j = JobFactory.getFactory().createJob(tmp.getAbsolutePath(), variables);
-                } else {
-                    // it is a job archive
-                    j = JobFactory.getFactory().createJobFromArchive(tmp.getAbsolutePath(), variables);
-                    isAnArchive = true;
-                }
+                WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(s);
 
-                JobId jobid = s.submit(j);
+                JobId jobId = workflowSubmitter.submit(tmpJobFile, isXml, jobVariables);
 
-                File archiveToStore = new File(PortalConfiguration.jobIdToPath(jobid.value()));
-                if (isAnArchive) {
-                    logger.debug("saving archive to " + archiveToStore.getAbsolutePath());
-                    tmp.renameTo(archiveToStore);
-                } else {
-                    // the job is not an archive, however an archive file can
-                    // exist for this new job (due to an old submission)
-                    // In that case, we remove the existing file preventing erronous
-                    // access
-                    // to this previously submitted archive.
-
-                    if (archiveToStore.exists()) {
-                        archiveToStore.delete();
-                    }
-                }
-
-                return mapper.map(jobid, JobIdData.class);
+                return mapper.map(jobId, JobIdData.class);
 
             } finally {
-                if (tmp != null) {
+                if (tmpJobFile != null) {
                     // clean the temporary file
-                    tmp.delete();
+                    tmpJobFile.delete();
                 }
             }
         } catch (IOException e) {
             throw new IOException("I/O Error: " + e.getMessage(), e);
-        } catch (JobCreationException e) {
-            throw new JobCreationRestException(e);
-        } catch (NotConnectedException e) {
-            throw new NotConnectedRestException(e);
-        } catch (SubmissionClosedException e) {
-            throw new SubmissionClosedRestException(e);
-        } catch (PermissionException e) {
-            throw new PermissionRestException(e);
         }
     }
 
@@ -2561,4 +2565,31 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     public Response index() throws URISyntaxException {
         return Response.seeOther(new URI("doc/jaxrsdocs/scheduler/index.html")).build();
     }
+
+    private String downloadWorkflowContent(
+            String sessionId,
+            String workflowUrl
+    ) throws JobCreationRestException, IOException {
+        WorkflowDownloader workflowDownloader = new WorkflowDownloader();
+        if (workflowUrl == null || workflowUrl.isEmpty())
+            throw new JobCreationRestException("Cannot create workflow without workflowUrl");
+        return workflowDownloader.getResource(sessionId, workflowUrl, String.class);
+    }
+
+    private Map<String, String> getWorkflowVariablesFromPathSegment(PathSegment pathSegment) {
+        Map<String, String> variables = null;
+        MultivaluedMap<String, String> matrixParams = pathSegment.getMatrixParameters();
+        if (matrixParams != null && !matrixParams.isEmpty()) {
+            variables = Maps.newHashMap();
+            for (String key : matrixParams.keySet()) {
+                variables.put(key, matrixParams.getFirst(key));
+            }
+        }
+        return variables;
+    }
+
+    private boolean isXmlWorkflow(InputPart part1) {
+        return part1.getMediaType().toString().toLowerCase().contains(MediaType.APPLICATION_XML.toLowerCase());
+    }
+
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowDownloader.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowDownloader.java
@@ -1,0 +1,85 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2011 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ActiveEon Team
+ *                        http://www.activeeon.com/
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$ACTIVEEON_INITIAL_DEV$$
+ */
+
+package org.ow2.proactive_grid_cloud_portal.scheduler;
+
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+public class WorkflowDownloader {
+
+    private static final Integer CONNECTION_POOL_SIZE = 5;
+
+    private static ResteasyClient client;
+
+    static {
+        PoolingClientConnectionManager cm = new PoolingClientConnectionManager();
+        cm.setMaxTotal(CONNECTION_POOL_SIZE);
+        cm.setDefaultMaxPerRoute(CONNECTION_POOL_SIZE);
+        ApacheHttpClient4Engine engine = new ApacheHttpClient4Engine(new DefaultHttpClient(cm));
+        client = new ResteasyClientBuilder().httpEngine(engine).build();
+    }
+
+    public <T> T getResource(String sessionId, String url, Class<T> clazz) throws IOException {
+        Response response = null;
+        try {
+            ResteasyWebTarget target = client.target(url);
+            response = target.request().header("sessionid", sessionId).get();
+            if (responseIsNotHttpOk(response)) {
+                throw new IOException(String.format("Cannot access resource %s: code %d", url, response.getStatus()));
+            }
+            return (T) response.readEntity(clazz);
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    private boolean responseIsNotHttpOk(Response response) {
+        return response.getStatus() != HttpURLConnection.HTTP_OK;
+    }
+
+}

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
@@ -1,0 +1,155 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2011 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ActiveEon Team
+ *                        http://www.activeeon.com/
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$ACTIVEEON_INITIAL_DEV$$
+ */
+
+package org.ow2.proactive_grid_cloud_portal.scheduler;
+
+import org.apache.log4j.Logger;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.exception.JobCreationException;
+import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
+import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
+import org.ow2.proactive.scheduler.common.job.Job;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SubmissionClosedRestException;
+import org.ow2.proactive_grid_cloud_portal.webapp.PortalConfiguration;
+
+import java.io.File;
+import java.util.Map;
+
+public class WorkflowSubmitter {
+
+    private static final Logger logger = ProActiveLogger.getLogger(WorkflowSubmitter.class);
+
+    private Scheduler scheduler;
+
+    public WorkflowSubmitter(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Submits an XML workflow to the scheduler.
+     *
+     * @param workflowFile a workflow file (xml or archive)
+     * @param variables    variables to be replaced in the job before submission
+     * @return
+     * @throws JobCreationException
+     * @throws NotConnectedException
+     * @throws PermissionException
+     * @throws SubmissionClosedException
+     */
+    public JobId submit(
+            File workflowFile,
+            Map<String, String> variables
+    ) throws PermissionRestException, JobCreationRestException, SubmissionClosedRestException, NotConnectedRestException {
+        return submit(workflowFile, true, variables);
+    }
+
+    /**
+     * Submits a workflow to the scheduler (XML or archive).
+     *
+     * @param workflowFile a workflow file (XML or archive)
+     * @param isXml        flag indicating if XML workflow or archive
+     * @param variables    variables to be replaced on submission
+     * @return
+     * @throws JobCreationException
+     * @throws NotConnectedException
+     * @throws PermissionException
+     * @throws SubmissionClosedException
+     */
+    public JobId submit(
+            File workflowFile,
+            Boolean isXml,
+            Map<String, String> variables
+    ) throws NotConnectedRestException, PermissionRestException, SubmissionClosedRestException, JobCreationRestException {
+
+        JobId jobId;
+        try {
+            jobId = scheduler.submit(createJobObject(workflowFile, isXml, variables));
+        } catch (NotConnectedException e) {
+            throw new NotConnectedRestException(e);
+        } catch (PermissionException e) {
+            throw new PermissionRestException(e);
+        } catch (SubmissionClosedException e) {
+            throw new SubmissionClosedRestException(e);
+        } catch (JobCreationException e) {
+            throw new JobCreationRestException(e);
+        }
+
+        storeWorkflowFile(workflowFile, !isXml, jobId);
+
+        return jobId;
+    }
+
+    private Job createJobObject(
+            File jobFile,
+            Boolean isApplicationXmlJob,
+            Map<String, String> jobVariables
+    ) throws JobCreationException {
+        Job jobObject;
+        if (isApplicationXmlJob) {
+            jobObject = JobFactory.getFactory().createJob(jobFile.getAbsolutePath(), jobVariables);
+        } else {
+            jobObject = JobFactory.getFactory().createJobFromArchive(jobFile.getAbsolutePath(), jobVariables);
+        }
+        return jobObject;
+    }
+
+    private void storeWorkflowFile(File workflowFile, boolean isAnArchive, JobId jobid) {
+        File archiveToStore = new File(PortalConfiguration.jobIdToPath(jobid.value()));
+        if (isAnArchive) {
+            logger.debug("saving archive to " + archiveToStore.getAbsolutePath());
+            workflowFile.renameTo(archiveToStore);
+        } else {
+            // the job is not an archive, however an archive file can
+            // exist for this new job (due to an old submission)
+            // In that case, we remove the existing file preventing erronous
+            // access
+            // to this previously submitted archive.
+
+            if (archiveToStore.exists()) {
+                archiveToStore.delete();
+            }
+        }
+    }
+
+}

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -52,10 +52,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.PathSegment;
 
 import org.apache.commons.io.FileUtils;
-import org.objectweb.proactive.ActiveObjectCreationException;
-import org.objectweb.proactive.core.node.NodeException;
-import org.ow2.proactive.resourcemanager.exception.RMException;
-import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
 import org.ow2.proactive_grid_cloud_portal.common.Session;
 import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
@@ -153,6 +149,20 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
+    public Workflow getWorkflow(@HeaderParam("sessionid") String sessionId,
+    @PathParam("id") String workflowId) throws NotConnectedRestException, IOException {
+        String userName = getUserName(sessionId);
+        return getFileStorageSupport().getWorkflowStorage(userName).read(workflowId);
+    }
+
+    @Override
+    public String getWorkflowContent(@HeaderParam("sessionid") String sessionId,
+    @PathParam("id") String workflowId) throws NotConnectedRestException, IOException {
+        String userName = getUserName(sessionId);
+        return getFileStorageSupport().getWorkflowStorage(userName).read(workflowId).getXml();
+    }
+
+    @Override
     public Workflow updateWorkflow(@HeaderParam("sessionid")
     String sessionId, @PathParam("id")
     String workflowId, Workflow workflow) throws NotConnectedRestException, IOException {
@@ -180,6 +190,18 @@ public class StudioRest implements StudioInterface {
     public Workflow createTemplate(@HeaderParam("sessionid")
     String sessionId, Workflow template) throws NotConnectedRestException, IOException {
         return getFileStorageSupport().getTemplateStorage().store(template);
+    }
+
+    @Override
+    public Workflow getTemplate(@HeaderParam("sessionid") String sessionId,
+    @PathParam("id") String templateId) throws NotConnectedRestException, IOException {
+        return getFileStorageSupport().getTemplateStorage().read(templateId);
+    }
+
+    @Override
+    public String getTemplateContent(@HeaderParam("sessionid") String sessionId,
+    @PathParam("id") String templateId) throws NotConnectedRestException, IOException {
+        return getFileStorageSupport().getTemplateStorage().read(templateId).getXml();
     }
 
     @Override

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -156,7 +156,7 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public String getWorkflowContent(@HeaderParam("sessionid") String sessionId,
+    public String getWorkflowXmlContent(@HeaderParam("sessionid") String sessionId,
     @PathParam("id") String workflowId) throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         return getFileStorageSupport().getWorkflowStorage(userName).read(workflowId).getXml();
@@ -199,7 +199,7 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public String getTemplateContent(@HeaderParam("sessionid") String sessionId,
+    public String getTemplateXmlContent(@HeaderParam("sessionid") String sessionId,
     @PathParam("id") String templateId) throws NotConnectedRestException, IOException {
         return getFileStorageSupport().getTemplateStorage().read(templateId).getXml();
     }

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
@@ -167,48 +167,28 @@ public class SchedulerRestWorkflowFromCatalogExecutionTest extends RestTestServe
     }
 
 
-    @Test
+    @Test(expected = JobCreationRestException.class)
     public void testWhenSubmittingACorruptWorkflowThenThrowException() throws Exception {
         String workflowUrl = getBaseUriTestWorkflowsServer() + "/corrupt";
-        try {
-            schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
-            fail();
-        } catch (JobCreationRestException e) {
-            // Expected
-        }
+        schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
     }
 
-    @Test
+    @Test(expected = IOException.class)
     public void testWhenSubmittingUsingAnInvalidWorkflowUrlThenThrowException() throws Exception {
         String workflowUrl = getBaseUriTestWorkflowsServer() + "/nonexistent";
-        try {
-            schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
-            fail();
-        } catch (IOException e) {
-            // Expected
-        }
+        schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
     }
 
-    @Test
+    @Test(expected = JobCreationRestException.class)
     public void testWhenSubmittingUsingANullWorkflowUrlThenThrowException() throws Exception {
         String workflowUrl = null;
-        try {
-            schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
-            fail();
-        } catch (JobCreationRestException e) {
-            // Expected
-        }
+        schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
     }
 
-    @Test
+    @Test(expected = NotConnectedRestException.class)
     public void testWhenExceptionSubmittingATemplateWithoutValidSessionIdThenThrowException() throws Exception {
         String sessionId = "invalidSessionId";
-        try {
-            schedulerRest.submitFromUrl(sessionId, null, getEmptyPathSegment());
-            fail();
-        } catch (NotConnectedRestException e) {
-            // Expected
-        }
+        schedulerRest.submitFromUrl(sessionId, null, getEmptyPathSegment());
     }
 
     private String getBaseUriTestWorkflowsServer() {

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
@@ -1,0 +1,232 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2011 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ActiveEon Team
+ *                        http://www.activeeon.com/
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$ACTIVEEON_INITIAL_DEV$$
+ */
+
+package org.ow2.proactive_grid_cloud_portal.scheduler;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+import org.ow2.proactive.scheduler.common.job.Job;
+import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
+import org.ow2.proactive.scheduler.job.JobIdImpl;
+import org.ow2.proactive_grid_cloud_portal.RestTestServer;
+import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStoreTestUtils;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobIdData;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+public class SchedulerRestWorkflowFromCatalogExecutionTest extends RestTestServer {
+
+    private SchedulerStateRest schedulerRest;
+    private SchedulerProxyUserInterface scheduler;
+    private String sessionId;
+
+    @BeforeClass
+    public static void setUpWorkflowsServer() throws Exception {
+        // This resource will expose workflow contents so that they can
+        // be downloaded and used for the tests.
+        addResource(new WorkflowServerHelper());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        schedulerRest = new SchedulerStateRest();
+        scheduler = mock(SchedulerProxyUserInterface.class);
+        sessionId = SharedSessionStoreTestUtils.createValidSession(scheduler);
+    }
+
+    @Test
+    public void testWhenSubmittingUsingAValidWfContentUrlThenAJobIdMustBeRetrieved() throws Exception {
+        when(scheduler.submit(Matchers.<Job>any())).thenReturn(new JobIdImpl(77L, "job"));
+
+        String workflowUrl = getBaseUriTestWorkflowsServer() + "/workflow";
+        JobIdData jobId = schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
+
+        Assert.assertNotNull(jobId);
+        Assert.assertEquals(77L, jobId.getId());
+        Assert.assertEquals("job", jobId.getReadableName());
+    }
+
+    @Test
+    public void testWhenSubmittingConcurrentlyUsingAValidWfContentUrlAllValidJobIdsMustBeRetrieved() throws Exception {
+        Integer NRO_THREADS = 100;
+        when(scheduler.submit(Matchers.<Job>any())).thenReturn(new JobIdImpl(55L, "job"));
+
+        final AtomicInteger successfullyFinished = new AtomicInteger(0);
+        Runnable runnable = new Runnable() {
+            public void run() {
+                try {
+                    String workflowUrl = getBaseUriTestWorkflowsServer() + "/workflow";
+                    JobIdData jobId = schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
+                    if (jobId.getId() == 55L) {
+                        successfullyFinished.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    fail(e.getMessage());
+                }
+            }
+        };
+        List<Thread> threads = new ArrayList<>(NRO_THREADS);
+        for (int i = 0; i < NRO_THREADS; i++) {
+            Thread t = new Thread(runnable, "submitter-" + i);
+            t.start();
+            threads.add(t);
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        Assert.assertEquals(NRO_THREADS, (Integer) successfullyFinished.get());
+    }
+
+    @Test
+    public void testWhenSubmittingAValidTemplateWithoutVariablesThenTheDefaultJobVariableIsUsed() throws Exception {
+        when(scheduler.submit(Matchers.<Job>any())).thenReturn(new JobIdImpl(88L, "job"));
+        ArgumentCaptor<Job> argumentCaptor = ArgumentCaptor.forClass(Job.class);
+
+        String workflowUrl = getBaseUriTestWorkflowsServer() + "/workflow";
+
+        JobIdData response = schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
+
+        verify(scheduler).submit(argumentCaptor.capture());
+        Job interceptedJob = argumentCaptor.getValue();
+        Assert.assertEquals(1, interceptedJob.getVariables().size());
+        Assert.assertEquals("defaultvalue", interceptedJob.getVariables().get("var1"));
+
+        Assert.assertEquals(88L, response.getId());
+        Assert.assertEquals("job", response.getReadableName());
+    }
+
+    @Test
+    public void testWhenSubmittingAValidTemplateWithVariablesThenTheProvidedJobVariableIsUsed() throws Exception {
+        when(scheduler.submit(Matchers.<Job>any())).thenReturn(new JobIdImpl(99L, "job"));
+        ArgumentCaptor<Job> argumentCaptor = ArgumentCaptor.forClass(Job.class);
+
+        String workflowUrl = getBaseUriTestWorkflowsServer() + "/workflow";
+
+        JobIdData response = schedulerRest.submitFromUrl(
+                sessionId, workflowUrl, getOneVariablePathSegment("var1", "value1"));
+
+        verify(scheduler).submit(argumentCaptor.capture());
+        Job interceptedJob = argumentCaptor.getValue();
+
+        Assert.assertEquals(1, interceptedJob.getVariables().size());
+        Assert.assertEquals("value1", interceptedJob.getVariables().get("var1"));
+
+        Assert.assertEquals(99L, response.getId());
+        Assert.assertEquals("job", response.getReadableName());
+    }
+
+
+    @Test
+    public void testWhenSubmittingACorruptWorkflowThenThrowException() throws Exception {
+        String workflowUrl = getBaseUriTestWorkflowsServer() + "/corrupt";
+        try {
+            schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
+            fail();
+        } catch (JobCreationRestException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testWhenSubmittingUsingAnInvalidWorkflowUrlThenThrowException() throws Exception {
+        String workflowUrl = getBaseUriTestWorkflowsServer() + "/nonexistent";
+        try {
+            schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
+            fail();
+        } catch (IOException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testWhenSubmittingUsingANullWorkflowUrlThenThrowException() throws Exception {
+        String workflowUrl = null;
+        try {
+            schedulerRest.submitFromUrl(sessionId, workflowUrl, getEmptyPathSegment());
+            fail();
+        } catch (JobCreationRestException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testWhenExceptionSubmittingATemplateWithoutValidSessionIdThenThrowException() throws Exception {
+        String sessionId = "invalidSessionId";
+        try {
+            schedulerRest.submitFromUrl(sessionId, null, getEmptyPathSegment());
+            fail();
+        } catch (NotConnectedRestException e) {
+            // Expected
+        }
+    }
+
+    private String getBaseUriTestWorkflowsServer() {
+        return "http://localhost:" + port + "/wsh";
+    }
+
+    private PathSegment getEmptyPathSegment() {
+        return getOneVariablePathSegment(null, null);
+    }
+
+    private PathSegment getOneVariablePathSegment(String key, String value) {
+        PathSegment pathSegment = mock(PathSegment.class);
+        MultivaluedMap<String, String> matrix = new MultivaluedHashMap<>();
+        if (key != null) {
+            matrix.put(key, Arrays.asList(value));
+        }
+        when(pathSegment.getMatrixParameters()).thenReturn(matrix);
+        return pathSegment;
+    }
+
+}

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowServerHelper.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowServerHelper.java
@@ -1,0 +1,76 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2011 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$PROACTIVE_INITIAL_DEV$$
+ */
+package org.ow2.proactive_grid_cloud_portal.scheduler;
+
+import functionaltests.AbstractRestFuncTestCase;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import java.io.File;
+import java.io.IOException;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+
+@Path("/wsh")
+@Produces(APPLICATION_JSON)
+public class WorkflowServerHelper {
+
+    private final static String DEFAULT_JOB_XML = AbstractRestFuncTestCase.class.getResource("config/test-job-with-variables.xml").getFile();
+
+    @GET
+    @Path("/workflow")
+    public String validWorkflow() throws IOException {
+        return readFile(new File(DEFAULT_JOB_XML));
+    }
+
+    @GET
+    @Path("/corrupt")
+    public String corruptWorkflow() throws IOException {
+        return "<<corruptxml";
+    }
+
+    private String readFile(File file) throws IOException {
+        if (file.exists()) {
+            return FileUtils.readFileToString(file);
+        }
+        throw new IOException(String.format("Could not read file %s", file.getAbsolutePath()));
+    }
+
+}

--- a/rest/rest-server/src/test/resources/functionaltests/config/test-job-with-variables.xml
+++ b/rest/rest-server/src/test/resources/functionaltests/config/test-job-with-variables.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:proactive:jobdescriptor:3.2"
+    xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
+    name="Jobby" priority="normal" cancelJobOnError="false">
+    <variables>
+        <variable name="var1" value="defaultvalue"/>
+    </variables>
+    <taskFlow>
+        <task name="Task">
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+println variables
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+            <controlFlow block="none"></controlFlow>
+        </task>
+    </taskFlow>
+</job>


### PR DESCRIPTION
This commit enable the Scheduler REST API to be able to create jobs
using workflows that are retrieved from HTTP servers.
Also makes the Studio REST API expose workflow and template contents
(provided valid credentials).
Consequently, now it is possible to create a workflow (or template)
using the Studio, get its URL, and create with it (and additional
variables if needed) a new job resource on the Scheduler REST API. It
will automatically perform authentication and downloading of the
workflow, and then submission.