### PR TITLE
Fix an issue with precious logs option which is no longer enabled by …

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -907,7 +907,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                         logger.warn("Retrieving truncated logs for task '" + taskState.getId() + "'");
                     }
                 } catch (Exception e) {
-                    logger.error(
+                    logger.info(
                             "Could not retrieve logs for task " + taskState.getId()
                                     + " (could be a non finished or killed task)", e);
                 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskState.java
@@ -75,10 +75,11 @@ public abstract class TaskState extends Task implements Comparable<TaskState> {
     public static final int DESC_ORDER = 2;
     protected static int currentSort = SORT_BY_ID;
     protected static int currentOrder = ASC_ORDER;
+
     public static final Comparator<TaskState> COMPARE_BY_FINISHED_TIME_ASC = new Comparator<TaskState>() {
         @Override
         public int compare(TaskState task1, TaskState task2) {
-            return Long.valueOf(task1.getFinishedTime()).compareTo(task2.getFinishedTime());
+            return Long.compare(task1.getFinishedTime(), task2.getFinishedTime());
         }
     };
 


### PR DESCRIPTION
…default

Precious logs option is no longer enabled by default on tasks. Consequently,
when a user tries to retrieve full logs for a task, an exception was occuring.
This is because the file containing logs is not found.

The workaround consists of retrieving truncated logs from the database if a task
was not executed using precious logs.