### PR TITLE
Change handling of URIs in TaskProActiveDataspaces #2300

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -36,17 +36,8 @@
  */
 package org.ow2.proactive.scheduler.task;
 
-import java.io.File;
-import java.io.Serializable;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
-import java.security.SecureRandom;
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.base.Stopwatch;
+import org.apache.log4j.Logger;
 import org.objectweb.proactive.Body;
 import org.objectweb.proactive.InitActive;
 import org.objectweb.proactive.annotation.ImmediateService;
@@ -71,8 +62,13 @@ import org.ow2.proactive.scheduler.task.executors.TaskExecutor;
 import org.ow2.proactive.scheduler.task.utils.Decrypter;
 import org.ow2.proactive.scheduler.task.utils.TaskKiller;
 import org.ow2.proactive.scheduler.task.utils.WallTimer;
-import com.google.common.base.Stopwatch;
-import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.Serializable;
+import java.security.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -128,7 +124,7 @@ public class TaskLauncher implements InitActive {
     }
 
     public void doTask(ExecutableContainer executableContainer, TaskResult[] previousTasksResults,
-            TaskTerminateNotification terminateNotification) {
+                       TaskTerminateNotification terminateNotification) {
         logger.info("Task started");
 
         WallTimer wallTimer = new WallTimer(initializer.getWalltime(), taskKiller);
@@ -148,11 +144,17 @@ public class TaskLauncher implements InitActive {
             progressFileReader.start(dataspaces.getScratchFolder(), taskId);
 
             TaskContext context = new TaskContext(executableContainer, initializer, previousTasksResults,
-                dataspaces.getScratchURI(), dataspaces.getInputURI(), dataspaces.getOutputURI(),
-                dataspaces.getUserURI(), dataspaces.getGlobalURI(), progressFileReader.getProgressFile()
-                        .toString(), getHostname());
+                    dataspaces.getScratchURI(), dataspaces.getInputURI(), dataspaces.getOutputURI(),
+                    dataspaces.getUserURI(), dataspaces.getGlobalURI(), progressFileReader.getProgressFile()
+                    .toString(), getHostname());
 
             File workingDir = getTaskWorkingDir(context, dataspaces);
+
+            logger.info("Task working dir : " + workingDir);
+            logger.info("Input space : " + context.getInputURI());
+            logger.info("Output space : " + context.getOutputURI());
+            logger.info("User space : " + context.getUserURI());
+            logger.info("Global space : " + context.getGlobalURI());
 
             wallTimer.start();
 
@@ -204,7 +206,7 @@ public class TaskLauncher implements InitActive {
                     logger.info("Failed to execute task", taskFailure);
                     taskFailure.printStackTrace(taskLogger.getErrorSink());
                     taskResult = new TaskResultImpl(taskId, taskFailure, taskLogger.getLogs(),
-                        taskStopwatchForFailures.elapsed(TimeUnit.MILLISECONDS));
+                            taskStopwatchForFailures.elapsed(TimeUnit.MILLISECONDS));
                     sendResultToScheduler(terminateNotification, taskResult);
 
             }
@@ -239,7 +241,7 @@ public class TaskLauncher implements InitActive {
 
     private TaskResultImpl getWalltimedTaskResult(Stopwatch taskStopwatchForFailures) {
         String message = "Walltime of " + initializer.getWalltime() + " ms reached on task " +
-            taskId.getReadableName();
+                taskId.getReadableName();
 
         return getTaskResult(taskStopwatchForFailures, new WalltimeExceededException(message));
     }
@@ -248,7 +250,7 @@ public class TaskLauncher implements InitActive {
         taskLogger.getErrorSink().println(exception.getMessage());
 
         return new TaskResultImpl(taskId, exception, taskLogger.getLogs(),
-            taskStopwatchForFailures.elapsed(TimeUnit.MILLISECONDS));
+                taskStopwatchForFailures.elapsed(TimeUnit.MILLISECONDS));
     }
 
     private Map<String, Serializable> fileSelectorsFilters(TaskContext taskContext, TaskResult taskResult)
@@ -264,7 +266,7 @@ public class TaskLauncher implements InitActive {
         if (initializer.isPreciousLogs()) {
             try {
                 dataspaces.copyScratchDataToOutput(Collections.singletonList(new OutputSelector(
-                  new FileSelector(taskLogFile.getName()), OutputAccessMode.TransferToUserSpace)));
+                        new FileSelector(taskLogFile.getName()), OutputAccessMode.TransferToUserSpace)));
             } catch (FileSystemException e) {
                 logger.warn("Cannot copy logs of task to user data spaces", e);
             }
@@ -285,7 +287,7 @@ public class TaskLauncher implements InitActive {
     }
 
     private void sendResultToScheduler(TaskTerminateNotification terminateNotification,
-            TaskResultImpl taskResult) {
+                                       TaskResultImpl taskResult) {
         if (isNodeShuttingDown()) {
             return;
         }
@@ -299,7 +301,7 @@ public class TaskLauncher implements InitActive {
                 return;
             } catch (Throwable th) {
                 logger.warn("Cannot notify task termination " + taskId + ", will try again in " +
-                  pingPeriodMs + " ms", th);
+                        pingPeriodMs + " ms", th);
                 try {
                     Thread.sleep(pingPeriodMs);
                 } catch (InterruptedException e) {
@@ -308,7 +310,7 @@ public class TaskLauncher implements InitActive {
             }
         }
         logger.error("Cannot notify task termination " + taskId + " after " + pingAttempts +
-            " attempts, terminating task launcher now");
+                " attempts, terminating task launcher now");
     }
 
     private boolean isNodeShuttingDown() {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
@@ -35,17 +35,7 @@
 package org.ow2.proactive.scheduler.task.data;
 
 import org.apache.commons.io.FileUtils;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
+import org.apache.log4j.Logger;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.extensions.dataspaces.Utils;
 import org.objectweb.proactive.extensions.dataspaces.api.DataSpacesFileObject;
@@ -61,7 +51,15 @@ import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputSelector;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputSelector;
 import org.ow2.proactive.utils.Formatter;
-import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
 
 
 public class TaskProActiveDataspaces implements TaskDataspaces {
@@ -102,14 +100,14 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
                 // assign it to the space
                 space = tidOutput;
                 logger.info(SchedulerConstants.TASKID_DIR_DEFAULT_NAME + " pattern found, changed " +
-                  spaceName + " space to : " + space.getRealURI());
+                        spaceName + " space to : " + space.getRealURI());
             }
         }
         return space;
     }
 
     private DataSpacesFileObject resolveToExisting(DataSpacesFileObject space, String spaceName,
-      boolean input) {
+                                                   boolean input) {
         if (space == null) {
             logger.info(spaceName + " space is disabled");
             return null;
@@ -128,7 +126,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         } else {
             logger.debug(spaceName + " space is " + space.getRealURI());
             logger.debug("(other available urls for " + spaceName + " space are " + space.getAllRealURIs() +
-              " )");
+                    " )");
         }
         return space;
     }
@@ -143,13 +141,13 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
                     .getStubOnThis()), id, namingService);
 
             SCRATCH = PADataSpaces.resolveScratchForAO();
-            logger.debug("SCRATCH space is " + SCRATCH.getRealURI());
+            logger.info("SCRATCH space is " + SCRATCH.getRealURI());
 
         } catch (FileSystemException fse) {
             logger.error("There was a problem while initializing dataSpaces, they are not activated", fse);
             this.logDataspacesStatus(
-              "There was a problem while initializing dataSpaces, they are not activated",
-              DataspacesStatusLevel.ERROR);
+                    "There was a problem while initializing dataSpaces, they are not activated",
+                    DataspacesStatusLevel.ERROR);
             this.logDataspacesStatus(Formatter.stackTraceToString(fse), DataspacesStatusLevel.ERROR);
         }
 
@@ -198,12 +196,34 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         return null;
     }
 
+    public static String convertDataSpaceURIToFileIfPossible(String dataspaceURI, boolean errorIfNotFile) {
+        URI foUri = null;
+        try {
+            foUri = new URI(dataspaceURI);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+        String answer;
+        if (foUri.getScheme() == null || foUri.getScheme().equals("file")) {
+            answer = (new File(foUri)).getAbsolutePath();
+        } else {
+            if (errorIfNotFile) {
+                throw new IllegalStateException("Space " + dataspaceURI +
+                        " is not accessible via the file system.");
+            }
+            answer = foUri.toString();
+        }
+        return answer;
+    }
+
+
     @Override
     public File getScratchFolder() {
         if (SCRATCH == null) {
             return new File(".");
         }
-        return new File(SCRATCH.getPath());
+
+        return new File(convertDataSpaceURIToFileIfPossible(SCRATCH.getRealURI(), true));
     }
 
     @Override
@@ -211,39 +231,39 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         if (SCRATCH == null) {
             return new File(".").getAbsolutePath();
         }
-        return SCRATCH.getPath();
+        return convertDataSpaceURIToFileIfPossible(SCRATCH.getRealURI(), true);
     }
 
     @Override
     public String getInputURI() {
-        if(INPUT == null){
+        if (INPUT == null) {
             return "";
         }
-        return INPUT.getVirtualURI();
+        return convertDataSpaceURIToFileIfPossible(INPUT.getRealURI(), false);
     }
 
     @Override
     public String getOutputURI() {
-        if(OUTPUT == null){
+        if (OUTPUT == null) {
             return "";
         }
-        return OUTPUT.getVirtualURI();
+        return convertDataSpaceURIToFileIfPossible(OUTPUT.getRealURI(), false);
     }
 
     @Override
     public String getUserURI() {
-        if(USER == null){
+        if (USER == null) {
             return "";
         }
-        return USER.getVirtualURI();
+        return convertDataSpaceURIToFileIfPossible(USER.getRealURI(), false);
     }
 
     @Override
     public String getGlobalURI() {
-        if(GLOBAL == null){
+        if (GLOBAL == null) {
             return "";
         }
-        return GLOBAL.getVirtualURI();
+        return convertDataSpaceURIToFileIfPossible(GLOBAL.getRealURI(), false);
     }
 
     protected enum DataspacesStatusLevel {
@@ -267,11 +287,11 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
     private boolean checkInputSpaceConfigured(DataSpacesFileObject space, String spaceName, InputSelector is) {
         if (space == null) {
             logger.error("Job " + spaceName +
-              " space is not defined or not properly configured while input files are specified : ");
+                    " space is not defined or not properly configured while input files are specified : ");
 
             this.logDataspacesStatus("Job " + spaceName +
-                " space is not defined or not properly configured while input files are specified : ",
-              DataspacesStatusLevel.ERROR);
+                            " space is not defined or not properly configured while input files are specified : ",
+                    DataspacesStatusLevel.ERROR);
 
             logger.error("--> " + is);
             this.logDataspacesStatus("--> " + is, DataspacesStatusLevel.ERROR);
@@ -455,15 +475,15 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
     }
 
     protected ExecutorService executorTransfer = Executors.newFixedThreadPool(5,
-      new NamedThreadFactory("FileTransferThreadPool"));
+            new NamedThreadFactory("FileTransferThreadPool"));
 
     private boolean checkOuputSpaceConfigured(DataSpacesFileObject space, String spaceName, OutputSelector os) {
         if (space == null) {
             logger.debug("Job " + spaceName +
-              " space is not defined or not properly configured, while output files are specified :");
+                    " space is not defined or not properly configured, while output files are specified :");
             this.logDataspacesStatus("Job " + spaceName +
-                " space is not defined or not properly configured, while output files are specified :",
-              DataspacesStatusLevel.ERROR);
+                            " space is not defined or not properly configured, while output files are specified :",
+                    DataspacesStatusLevel.ERROR);
             this.logDataspacesStatus("--> " + os, DataspacesStatusLevel.ERROR);
             return false;
         }
@@ -603,6 +623,10 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
 
                         finalout.resolveFile(finalRelativePath).copyFrom(finaldsfo,
                                 FileSelector.SELECT_SELF);
+                        if (!finalout.resolveFile(finalRelativePath).exists()) {
+                            logger.error("There was a problem during the copy of " + finaldsfo.getRealURI() + " to " + finalout.getRealURI() +
+                                    "/" + finalRelativePath +" ");
+                        }
                         return true;
                     }
                 }));
@@ -614,7 +638,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         for (Future f : transferFutures) {
             try {
                 f.get();
-            } catch (InterruptedException | ExecutionException  e) {
+            } catch (InterruptedException | ExecutionException e) {
                 logger.error("", e);
                 exceptionMsg.append(StackTraceUtil.getStackTrace(e)).append(nl);
             }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/TestScheduler.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/TestScheduler.java
@@ -64,7 +64,7 @@ public class TestScheduler {
     public static final int PNP_PORT = TestRM.PA_PNP_PORT;
 
     private static String schedulerUrl = "pnp://" + ProActiveInet.getInstance().getHostname() + ":" +
-        PNP_PORT + "/";
+            PNP_PORT + "/";
     private static Process schedulerProcess;
 
     private SchedulerAuthenticationInterface schedulerAuth;
@@ -80,7 +80,7 @@ public class TestScheduler {
         startedConfiguration = configuration;
 
         List<String> commandLine = new ArrayList<>();
-        commandLine.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+        commandLine.add("java");
         commandLine.add("-Djava.security.manager");
         //commandLine.add("-agentlib:jdwp=transport=dt_socket,server=y,address=9009,suspend=y");
         String proactiveHome = CentralPAPropertyRepository.PA_HOME.getValue();
@@ -98,7 +98,7 @@ public class TestScheduler {
         String securityPolicy = CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getValue();
         if (!CentralPAPropertyRepository.JAVA_SECURITY_POLICY.isSet()) {
             securityPolicy = PASchedulerProperties.SCHEDULER_HOME.getValueAsString() +
-                "/config/security.java.policy-server";
+                    "/config/security.java.policy-server";
         }
         commandLine.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() + securityPolicy);
 
@@ -109,12 +109,12 @@ public class TestScheduler {
         commandLine.add(CentralPAPropertyRepository.LOG4J.getCmdLine() + log4jConfiguration);
 
         commandLine.add(PASchedulerProperties.SCHEDULER_HOME.getCmdLine() +
-            PASchedulerProperties.SCHEDULER_HOME.getValueAsString());
+                PASchedulerProperties.SCHEDULER_HOME.getValueAsString());
         commandLine.add(PAResourceManagerProperties.RM_HOME.getCmdLine() +
-            PAResourceManagerProperties.RM_HOME.getValueAsString());
+                PAResourceManagerProperties.RM_HOME.getValueAsString());
         if (System.getProperty("pas.launcher.forkas.method") != null) {
             commandLine.add("-Dpas.launcher.forkas.method=" +
-                System.getProperty("pas.launcher.forkas.method"));
+                    System.getProperty("pas.launcher.forkas.method"));
         }
         if (System.getProperty("proactive.test.runAsMe") != null) {
             commandLine.add("-Dproactive.test.runAsMe=true");
@@ -141,13 +141,14 @@ public class TestScheduler {
         System.out.println("Starting Scheduler process: " + commandLine);
 
         ProcessBuilder processBuilder = new ProcessBuilder(commandLine);
+        processBuilder.directory(new File(System.getProperty("java.home") + File.separator + "bin"));
         processBuilder.redirectErrorStream(true);
         processTreeKiller = CookieBasedProcessTreeKiller.createProcessChildrenKiller("TEST_SCHED",
                 processBuilder.environment());
         schedulerProcess = processBuilder.start();
 
         InputStreamReaderThread outputReader = new InputStreamReaderThread(schedulerProcess.getInputStream(),
-            "[Scheduler output]: ");
+                "[Scheduler output]: ");
         outputReader.start();
 
         System.out.println("Waiting for the Scheduler using URL: " + schedulerUrl);
@@ -160,7 +161,7 @@ public class TestScheduler {
     }
 
     private void startLocalNodes(
-      SchedulerTestConfiguration configuration) throws KeyException, LoginException, InterruptedException {
+            SchedulerTestConfiguration configuration) throws KeyException, LoginException, InterruptedException {
         if (configuration.hasLocalNodes()) {
             // Waiting while all the nodes will be registered in the RM.
             // Without waiting test can finish earlier than nodes are added.

--- a/scheduler/smartproxy/src/test/java/functionaltests/SimpleJavaExecutable.java
+++ b/scheduler/smartproxy/src/test/java/functionaltests/SimpleJavaExecutable.java
@@ -7,6 +7,7 @@ import org.ow2.proactive.scheduler.common.task.executable.JavaExecutable;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.Serializable;
+import java.util.Arrays;
 
 
 /**
@@ -19,8 +20,8 @@ public class SimpleJavaExecutable extends JavaExecutable {
     @Override
     public Serializable execute(TaskResult... results) throws Throwable {
         File localSpaceFolder = new File(".");
-        System.out.println("Using localspace folder " + localSpaceFolder.getAbsolutePath());
-        System.out.println(localSpaceFolder.listFiles());
+        System.out.println("Using current space folder " + localSpaceFolder.getAbsolutePath());
+        System.out.println(Arrays.toString(localSpaceFolder.listFiles()));
         File[] inputFiles = localSpaceFolder.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {

--- a/scheduler/smartproxy/src/test/java/functionaltests/TestSmartProxy.java
+++ b/scheduler/smartproxy/src/test/java/functionaltests/TestSmartProxy.java
@@ -1,10 +1,9 @@
 package functionaltests;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-
+import functionaltests.monitor.EventMonitor;
+import functionaltests.utils.SchedulerFunctionalTest;
+import functionaltests.utils.SchedulerTHelper;
+import functionaltests.utils.TestUsers;
 import org.apache.log4j.Level;
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,10 +22,10 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
 import org.ow2.proactive.scheduler.smartproxy.SmartProxyImpl;
 
-import functionaltests.monitor.EventMonitor;
-import functionaltests.utils.SchedulerFunctionalTest;
-import functionaltests.utils.SchedulerTHelper;
-import functionaltests.utils.TestUsers;
+import java.io.File;
+import java.io.FileWriter;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 
 
 /**
@@ -36,20 +35,19 @@ public class TestSmartProxy extends SchedulerFunctionalTest {
 	
 	private static String OS = System.getProperty("os.name").toLowerCase();
 
-
     /**
      * Local folder on client side where the input data is located and where the
      * output data is to be downloaded
      */
     public static final String workFolderPath = System.getProperty("java.io.tmpdir") + File.separator +
-        "testDS_LocalFolder";
+            "testDS_LocalFolder";
 
     /**
      * Intermediary folder accessible (via file transfer protocol supported by
      * VFS) both from client side and from computing node side
      */
     public static final String dataServerFolderPath = System.getProperty("java.io.tmpdir") + File.separator +
-        "testDS_remoteFolder";
+            "testDS_remoteFolder";
 
     public static long TIMEOUT = 120000;
 
@@ -69,7 +67,7 @@ public class TestSmartProxy extends SchedulerFunctionalTest {
     protected static final String TASK_NAME = "TestJavaTask";
 
     public final static String inputFileBaseName = "input";
-    public final static String inputFileExt = ".txt";
+    public final static String inputFileExt = ".in";
     public final static String outputFileBaseName = "output";
     public final static String outputFileExt = ".out";
 
@@ -177,11 +175,11 @@ public class TestSmartProxy extends SchedulerFunctionalTest {
         } catch (URISyntaxException e1) {
             functionaltests.utils.SchedulerTHelper
                     .log(
-                      "Preview of the partial results will not be possible as some resources could not be " +
-                        "found by the system. \nThis will not alterate your results in any way. ");
+                            "Preview of the partial results will not be possible as some resources could not be " +
+                                    "found by the system. \nThis will not alterate your results in any way. ");
             functionaltests.utils.SchedulerTHelper
                     .log(
-                      "JobCreator: The bin folder of the project is null. It is needed to set the job environment. ");
+                            "JobCreator: The bin folder of the project is null. It is needed to set the job environment. ");
             functionaltests.utils.SchedulerTHelper.log(e1);
         }
         return appClassPath;
@@ -218,54 +216,54 @@ public class TestSmartProxy extends SchedulerFunctionalTest {
     	
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "********************** Testing isolateTaskOutputs = false automaticTransfer = false " +
-                    "***************");
+                        "********************** Testing isolateTaskOutputs = false automaticTransfer = false " +
+                                "***************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         submitJobWithDataAndWaitToFinish(inputLocalFolder.getAbsolutePath(), outputLocalFolder
                 .getAbsolutePath(), false, false);
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "********************** Testing isolateTaskOutputs = true automaticTransfer = false ****************");
+                        "********************** Testing isolateTaskOutputs = true automaticTransfer = false ****************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         submitJobWithDataAndWaitToFinish(inputLocalFolder.getAbsolutePath(), outputLocalFolder
                 .getAbsolutePath(), true, false);
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "********************** Testing isolateTaskOutputs = false automaticTransfer = true ****************");
+                        "********************** Testing isolateTaskOutputs = false automaticTransfer = true ****************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         submitJobWithDataAndWaitToFinish(inputLocalFolder.getAbsolutePath(), outputLocalFolder
                 .getAbsolutePath(), false, true);
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "********************** Testing isolateTaskOutputs = true automaticTransfer = true *****************");
+                        "********************** Testing isolateTaskOutputs = true automaticTransfer = true *****************");
         functionaltests.utils.SchedulerTHelper
                 .log(
-                  "***************************************************************************************************");
+                        "***************************************************************************************************");
         submitJobWithDataAndWaitToFinish(inputLocalFolder.getAbsolutePath(), outputLocalFolder
                 .getAbsolutePath(), true, true);
 
     }
 
     protected void submitJobWithDataAndWaitToFinish(String localInputFolderPath,
-            String localOutputFolderPath, boolean isolateTaskOutputs, boolean automaticTransfer)
+                                                    String localOutputFolderPath, boolean isolateTaskOutputs, boolean automaticTransfer)
             throws Exception {
 
         TaskFlowJob job = createTestJob(isolateTaskOutputs);
@@ -305,8 +303,11 @@ public class TestSmartProxy extends SchedulerFunctionalTest {
             }
         }
 
+
         // check the presence of output files
         for (int i = 0; i < NB_TASKS; i++) {
+            functionaltests.utils.SchedulerTHelper
+                    .log(schedProxy.getTaskResult(id.toString(), TASK_NAME + i).getOutput().getAllLogs(true));
             String outputFileName = outputFileBaseName + "_" + i + outputFileExt;
             File outputFile = new File(outputLocalFolder, outputFileName);
             SchedulerTHelper.log("Checking file exists : " + outputFile);


### PR DESCRIPTION
fix TestSmartProxy on jenkins Windows #2299

fix #2299 Changed the way the java command was started to avoid command path which contains dots.

fix #2300 switched to the use of RealURIs and added a method which converts them to file if possible.