### PR TITLE
fix1997: Making "dependences" transient in ClientTaskState.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,8 @@ configure(javaSubprojects) {
         testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'
 
         testCompile 'org.mockito:mockito-core:1.10.19'
+        testCompile 'org.powermock:powermock-api-mockito:1.6.3'
+        testCompile 'org.powermock:powermock-module-junit4:1.6.3'
         testCompile 'com.jayway.awaitility:awaitility:1.6.0'
     }
 

--- a/scheduler/scheduler-client/build.gradle
+++ b/scheduler/scheduler-client/build.gradle
@@ -3,7 +3,12 @@ dependencies {
 
     compile project(':scheduler:scheduler-api')
     compile project(':common-client')
+
+    testCompile files("${System.properties['java.home']}/../lib/tools.jar")
 }
+
+task('functionalTest', type: Test).configure schedulingFunctionalTestConfiguration
+functionalTest.dependsOn rootProject.dist
 
 task stub(type: StubTask) {
     classes = [
@@ -12,4 +17,3 @@ task stub(type: StubTask) {
     ]
 }
 serialver.dependsOn stub
-

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobSerializationHelper.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobSerializationHelper.java
@@ -1,0 +1,20 @@
+package org.ow2.proactive.scheduler.job;
+
+import org.ow2.proactive.scheduler.common.task.TaskId;
+import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.task.ClientTaskState;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+
+
+public class ClientJobSerializationHelper implements Serializable {
+    public void serializeTasks(Map<TaskId, TaskState> tasks) throws IOException, ClassNotFoundException {
+        for(TaskState task : tasks.values()) {
+            if (task instanceof ClientTaskState) {
+                ((ClientTaskState)task).restoreDependences(tasks);
+            }
+        }
+    }
+}

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -1,21 +1,19 @@
 package org.ow2.proactive.scheduler.job;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
 import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.job.JobType;
-import org.ow2.proactive.scheduler.common.task.RestartMode;
-import org.ow2.proactive.scheduler.common.task.TaskId;
-import org.ow2.proactive.scheduler.common.task.TaskInfo;
-import org.ow2.proactive.scheduler.common.task.TaskState;
-import org.ow2.proactive.scheduler.common.task.TaskStatus;
+import org.ow2.proactive.scheduler.common.task.*;
 import org.ow2.proactive.scheduler.task.ClientTaskState;
 import org.ow2.proactive.scheduler.task.TaskInfoImpl;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -169,6 +167,15 @@ public final class ClientJobState extends JobState {
     public RestartMode getRestartTaskOnError() {
         throw new RuntimeException(
             "Not implemented: the restart task on error property is not available on client side.");
+    }
+
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        ois.defaultReadObject();
+        for(TaskState task : this.getTasks()) {
+            if (task instanceof ClientTaskState) {
+                ((ClientTaskState)task).restoreDependences(this.tasks);
+            }
+        }
     }
 
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -29,14 +29,13 @@ import java.util.Map;
  */
 public final class ClientJobState extends JobState {
 
+    private final ClientJobSerializationHelper clientJobSerializationHelper;
     private JobInfoImpl jobInfo;
     private String owner;
     private JobType type;
     private Map<TaskId, TaskState> tasks = new HashMap<>();
-
     private boolean cancelJobOnError;
     private int maxNumberOfExecution;
-
     private HashMap<String, String> genericInformations;
 
     public ClientJobState(JobState jobState) {
@@ -56,6 +55,8 @@ public final class ClientJobState extends JobState {
         this.maxNumberOfExecution = jobState.getMaxNumberOfExecution();
 
         this.genericInformations = new HashMap<>(jobState.getGenericInformations());
+
+        this.clientJobSerializationHelper = new ClientJobSerializationHelper();
 
         List<ClientTaskState> taskStates = new ArrayList<>();
         for (TaskState ts : jobState.getTasks()) {
@@ -169,13 +170,10 @@ public final class ClientJobState extends JobState {
             "Not implemented: the restart task on error property is not available on client side.");
     }
 
+
     private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
         ois.defaultReadObject();
-        for(TaskState task : this.getTasks()) {
-            if (task instanceof ClientTaskState) {
-                ((ClientTaskState)task).restoreDependences(this.tasks);
-            }
-        }
+        this.clientJobSerializationHelper.serializeTasks(this.tasks);
     }
 
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/ClientTaskState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/ClientTaskState.java
@@ -1,9 +1,5 @@
 package org.ow2.proactive.scheduler.task;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.task.RestartMode;
 import org.ow2.proactive.scheduler.common.task.TaskId;
@@ -14,6 +10,12 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.OutputSelector;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.scripting.SelectionScript;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -190,5 +192,10 @@ public final class ClientTaskState extends TaskState {
     public RestartMode getRestartTaskOnError() {
         throw new RuntimeException(
             "Not implemented: the restart task on error property is not available on client side.");
+    }
+
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        ois.defaultReadObject();
+        this.dependences = new ArrayList<>();
     }
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/ClientTaskState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/ClientTaskState.java
@@ -34,7 +34,7 @@ public final class ClientTaskState extends TaskState {
     private TaskInfo taskInfo;
     private int maxNumberOfExecutionOnFailure;
     private List<TaskId> dependenceIds = new ArrayList<>();
-    private List<TaskState> dependences = new ArrayList<>();
+    transient private List<TaskState> dependences = new ArrayList<>();
 
     private boolean cancelJobOnError;
     private int maxNumberOfExecution;

--- a/scheduler/scheduler-client/src/test/java/functionaltests/job/serialization/ClientJobStateSerializationTest.java
+++ b/scheduler/scheduler-client/src/test/java/functionaltests/job/serialization/ClientJobStateSerializationTest.java
@@ -1,0 +1,164 @@
+package functionaltests.job.serialization;
+
+
+import org.junit.Test;
+import org.ow2.proactive.scheduler.common.job.JobInfo;
+import org.ow2.proactive.scheduler.common.job.JobState;
+import org.ow2.proactive.scheduler.common.job.JobType;
+import org.ow2.proactive.scheduler.common.task.TaskId;
+import org.ow2.proactive.scheduler.common.task.TaskInfo;
+import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.job.ClientJobState;
+import org.ow2.proactive.scheduler.job.JobIdImpl;
+import org.ow2.proactive.scheduler.job.JobInfoImpl;
+import org.ow2.proactive.scheduler.task.ClientTaskState;
+import org.ow2.proactive.scheduler.task.TaskIdImpl;
+import org.ow2.proactive.scheduler.task.TaskInfoImpl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ClientJobStateSerializationTest {
+
+    @Test
+    public void JobStateSerializationRestoresAllDependenciesFromClientTaskSates() {
+        // Task1 depends on task2
+        ClientTaskState clientTaskState1 = new ClientTaskState(new TestTaskState(1L));
+        ClientTaskState clientTaskState2 = new ClientTaskState(new TestTaskState(2L));
+        clientTaskState2.getDependences().add(clientTaskState1);
+
+        // Create JClientJobState which contains task1 and task2
+        TestJobState testJobState = new TestJobState(1);
+        testJobState.getHMTasks().put(clientTaskState1.getId(), clientTaskState1);
+        testJobState.getHMTasks().put(clientTaskState2.getId(), clientTaskState2);
+        ClientJobState clientJobState = new ClientJobState(testJobState);
+
+        //Serialize and de-serialize the ClientJobState instance
+        ClientJobState deserializedClientJobState = null;
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            new ObjectOutputStream(output).writeObject(clientJobState);
+            deserializedClientJobState = (ClientJobState) new ObjectInputStream(new ByteArrayInputStream(output.toByteArray())).readObject();
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Serialization must not fail with exception. " + e.getMessage());
+        }
+
+        List<TaskState> listWithOneElement = deserializedClientJobState
+                .getHMTasks().get(clientTaskState2.getId()).getDependences();
+
+        assertThat(listWithOneElement.size(), is(1));
+    }
+
+
+    //********** HELPER TEST CLASSES ****************//
+
+
+    public class TestJobState extends JobState {
+
+        JobInfoImpl jobInfo;
+        Map<TaskId, TaskState> taskMap = new HashMap<>();
+
+        public TestJobState(long number) {
+            this.jobInfo = new JobInfoImpl();
+            this.jobInfo.setJobId(new JobIdImpl(number, Long.toString(number)));
+        }
+
+        @Override
+        public void update(TaskInfo info) {
+
+        }
+
+        @Override
+        public void update(JobInfo jobInfo) {
+
+        }
+
+        @Override
+        public JobInfo getJobInfo() {
+            return this.jobInfo;
+        }
+
+        @Override
+        public ArrayList<TaskState> getTasks() {
+            return new ArrayList<>(this.taskMap.values());
+        }
+
+        @Override
+        public Map<TaskId, TaskState> getHMTasks() {
+            return this.taskMap;
+        }
+
+        @Override
+        public String getOwner() {
+            return null;
+        }
+
+        @Override
+        public JobType getType() {
+            return null;
+        }
+    }
+
+    public class TestTaskState extends TaskState {
+
+        List<TaskState> dependencies = new ArrayList<>();
+        TaskInfoImpl taskInfo;
+
+        public TestTaskState(long number) {
+            this.taskInfo = new TaskInfoImpl();
+            taskInfo.setJobId(new JobIdImpl(number, Long.toString(number)));
+            this.taskInfo.setTaskId(TaskIdImpl.createTaskId(taskInfo.getJobId(), Long.toString(number), number));
+        }
+
+        @Override
+        public void update(TaskInfo taskInfo) {
+
+        }
+
+        @Override
+        public List<TaskState> getDependences() {
+            return this.dependencies;
+        }
+
+        @Override
+        public TaskInfo getTaskInfo() {
+            return this.taskInfo;
+        }
+
+        @Override
+        public int getMaxNumberOfExecutionOnFailure() {
+            return 0;
+        }
+
+        @Override
+        public TaskState replicate() throws Exception {
+            return null;
+        }
+
+        @Override
+        public int getIterationIndex() {
+            return 0;
+        }
+
+        @Override
+        public int getReplicationIndex() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            return "Task"+this.taskInfo.getJobId().value();
+        }
+    }
+}

--- a/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobSerializationHelperTest.java
+++ b/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobSerializationHelperTest.java
@@ -1,0 +1,124 @@
+package org.ow2.proactive.scheduler.job;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.ow2.proactive.scheduler.common.task.TaskId;
+import org.ow2.proactive.scheduler.common.task.TaskInfo;
+import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.task.ClientTaskState;
+import org.ow2.proactive.scheduler.task.TaskIdImpl;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ClientTaskState.class)
+public class ClientJobSerializationHelperTest {
+
+
+    private ClientJobSerializationHelper clientJobSerializationHelper;
+
+    @Before
+    public void init() {
+        clientJobSerializationHelper = new ClientJobSerializationHelper();
+    }
+
+    @Test
+    public void serializeTasksTest() throws IOException, ClassNotFoundException {
+        Map<TaskId, TaskState> taskStateMap = new HashMap<>();
+        ClientTaskState taskStateMock = PowerMockito.mock(ClientTaskState.class);
+
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(1L, "First"),"", 1L), taskStateMock);
+
+        this.clientJobSerializationHelper.serializeTasks(taskStateMap);
+        Mockito.verify(taskStateMock).restoreDependences(taskStateMap);
+    }
+
+    @Test
+    public void serializeTasksWithFiveTasksTest() throws IOException, ClassNotFoundException {
+        Map<TaskId, TaskState> taskStateMap = new HashMap<>();
+        ClientTaskState taskStateMock = PowerMockito.mock(ClientTaskState.class);
+
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(1L, "First"),"", 1L), taskStateMock);
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(2L, "Second"),"", 2L), taskStateMock);
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(3L, "Third"),"", 3L), taskStateMock);
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(4L, "Fourth"),"", 4L), taskStateMock);
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(5L, "Fifth"),"", 5L), taskStateMock);
+
+        this.clientJobSerializationHelper.serializeTasks(taskStateMap);
+        Mockito.verify(taskStateMock,Mockito.times(5)).restoreDependences(taskStateMap);
+    }
+
+    @Test
+    public void serializeTasksWithZeroTasksTest() throws IOException, ClassNotFoundException {
+        Map<TaskId, TaskState> taskStateMap = new HashMap<>();
+        ClientTaskState taskStateMock = PowerMockito.mock(ClientTaskState.class);
+
+
+        this.clientJobSerializationHelper.serializeTasks(taskStateMap);
+        Mockito.verify(taskStateMock,Mockito.times(0)).restoreDependences(taskStateMap);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void serializeTasksThrowsNullPointerExceptionWhenNullTest() throws IOException, ClassNotFoundException {
+        this.clientJobSerializationHelper.serializeTasks(null);
+    }
+
+    @Test
+    public void serializeTasksNotInstanceOfClientTaskStateTest() throws IOException, ClassNotFoundException {
+        Map<TaskId, TaskState> taskStateMap = new HashMap<>();
+        ClientTaskState taskStateMock = PowerMockito.mock(ClientTaskState.class);
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(1L, "First"),"", 1L), new TestTaskState());
+        taskStateMap.put(TaskIdImpl.createTaskId(new JobIdImpl(2L, "Second"),"", 2L), new TestTaskState());
+
+        this.clientJobSerializationHelper.serializeTasks(taskStateMap);
+        Mockito.verify(taskStateMock,Mockito.times(0)).restoreDependences(taskStateMap);
+    }
+
+    public class TestTaskState extends TaskState {
+
+        @Override
+        public void update(TaskInfo taskInfo) {
+
+        }
+
+        @Override
+        public List<TaskState> getDependences() {
+            return null;
+        }
+
+        @Override
+        public TaskInfo getTaskInfo() {
+            return null;
+        }
+
+        @Override
+        public int getMaxNumberOfExecutionOnFailure() {
+            return 0;
+        }
+
+        @Override
+        public TaskState replicate() throws Exception {
+            return null;
+        }
+
+        @Override
+        public int getIterationIndex() {
+            return 0;
+        }
+
+        @Override
+        public int getReplicationIndex() {
+            return 0;
+        }
+    }
+
+}

--- a/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobStateTest.java
+++ b/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobStateTest.java
@@ -1,30 +1,77 @@
 package org.ow2.proactive.scheduler.job;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
 import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.job.JobType;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.task.ClientTaskState;
 import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.TaskInfoImpl;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.varia.NullAppender;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.*;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ClientTaskState.class)
 public class ClientJobStateTest {
 
     @BeforeClass
     public static void configureLogger() throws Exception {
         BasicConfigurator.configure(new NullAppender());
+    }
+
+    @Test
+    public void restoreDependenciesSerializationCallsDefaultReadObjectAndSerializationHelperTest() throws NoSuchFieldException, IllegalAccessException, IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
+        // Create a ClientJobState
+        ClientJobState jobState = new ClientJobState(new TestJobState());
+
+        ClientJobSerializationHelper helperMock = Mockito.mock(ClientJobSerializationHelper.class);
+        this.setPrivateField(ClientJobState.class.getDeclaredField("clientJobSerializationHelper")
+                , jobState
+                , helperMock);
+
+
+        Method method = jobState.getClass().getDeclaredMethod("readObject", ObjectInputStream.class);
+        method.setAccessible(true);
+        ObjectInputStream mockedObjectInputStream = Mockito.mock(ObjectInputStream.class);
+        method.invoke(jobState, mockedObjectInputStream);
+
+        Mockito.verify(mockedObjectInputStream).defaultReadObject();
+        Mockito.verify(helperMock).serializeTasks(Mockito.any(Map.class));
+
+    }
+
+
+    /**
+     * Sets a private field.
+     *
+     * @param privateField The private field to set.
+     * @param target       Instance of class, in which to set the field.
+     * @param value        Value to set the field to.
+     */
+    private void setPrivateField(Field privateField, Object target, Object value) throws IllegalAccessException {
+        privateField.setAccessible(true);
+        privateField.set(target, value);
+        privateField.setAccessible(false);
     }
 
     @Test
@@ -136,5 +183,45 @@ public class ClientJobStateTest {
                 return null;
             }
         };
+    }
+
+    class TestJobState extends JobState {
+
+        final ArrayList<TaskState> listOfTasks = new ArrayList<>();
+
+        @Override
+        public void update(TaskInfo info) {
+
+        }
+
+        @Override
+        public void update(JobInfo jobInfo) {
+
+        }
+
+        @Override
+        public JobInfo getJobInfo() {
+            return new JobInfoImpl();
+        }
+
+        @Override
+        public ArrayList<TaskState> getTasks() {
+            return this.listOfTasks;
+        }
+
+        @Override
+        public Map<TaskId, TaskState> getHMTasks() {
+            return new HashMap<>();
+        }
+
+        @Override
+        public String getOwner() {
+            return "testOwnder";
+        }
+
+        @Override
+        public JobType getType() {
+            return JobType.TASKSFLOW;
+        }
     }
 }

--- a/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/task/ClientTaskStateTest.java
+++ b/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/task/ClientTaskStateTest.java
@@ -1,0 +1,95 @@
+package org.ow2.proactive.scheduler.task;
+
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.ow2.proactive.scheduler.common.task.TaskInfo;
+import org.ow2.proactive.scheduler.common.task.TaskState;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ClientTaskStateTest {
+
+    @Test
+    public void restoreDependenciesSerializationCallsDefaultReadObjectTest() throws NoSuchFieldException, IllegalAccessException, IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
+        ClientTaskState clientTaskState = new ClientTaskState(new TestTaskState());
+
+        Method method = clientTaskState.getClass().getDeclaredMethod("readObject", ObjectInputStream.class);
+        method.setAccessible(true);
+        ObjectInputStream mockedObjectInputStream = Mockito.mock(ObjectInputStream.class);
+        Object r = method.invoke(clientTaskState, mockedObjectInputStream);
+
+        Mockito.verify(mockedObjectInputStream).defaultReadObject();
+
+    }
+
+    @Test
+    public void restoreDependenciesSerializationCreatesEmptyArrayListTest() throws NoSuchFieldException, IllegalAccessException, IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
+        TestTaskState testTaskState = new TestTaskState();
+        ClientTaskState clientTaskState = new ClientTaskState(testTaskState);
+
+        // Fill the dependencies ArrayList
+        clientTaskState.getDependences().add(testTaskState);
+
+        // Check that there is one task in the dependencies list
+        assertThat(clientTaskState.getDependences().size(), is(1));
+
+        // Call then eadObject method
+        Method method = clientTaskState.getClass().getDeclaredMethod("readObject", ObjectInputStream.class);
+        method.setAccessible(true);
+        ObjectInputStream mockedObjectInputStream = Mockito.mock(ObjectInputStream.class);
+        Object r = method.invoke(clientTaskState, mockedObjectInputStream);
+
+        // Check that the ArrayList is now an empty list
+        assertThat(clientTaskState.getDependences().size(), is(0));
+
+    }
+
+    public class TestTaskState extends TaskState {
+
+        List<TaskState> dependencies = new ArrayList<>();
+
+        @Override
+        public void update(TaskInfo taskInfo) {
+
+        }
+
+        @Override
+        public List<TaskState> getDependences() {
+            return this.dependencies;
+        }
+
+        @Override
+        public TaskInfo getTaskInfo() {
+            return new TaskInfoImpl();
+        }
+
+        @Override
+        public int getMaxNumberOfExecutionOnFailure() {
+            return 0;
+        }
+
+        @Override
+        public TaskState replicate() throws Exception {
+            return this;
+        }
+
+        @Override
+        public int getIterationIndex() {
+            return 0;
+        }
+
+        @Override
+        public int getReplicationIndex() {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
This will have a big and unforeseeable effect on the execution of the scheduler server. I submitted this pull request to check if all test run and to collect comments about what can be affected by this change.


So what I have found is that the ClientTaskState is serialized inside the ProActive scheduler:
- ClientTaskState has an ```ArrayList<TaskState>``` -> Custom arbitrary tree
- Java serializes custom arbitrary trees recursively. 
- Around 600 recursive method calls will throw a ```StackOverflowError``` exception

What are the solutions?
- Write own serialization code
- Make it versatile 
- Change internal data-structures Task, TaskState, .....


*Write own serialization code*
I investigated how to manually serialize an arbitrary tree.
- It is possible by flattening the class through custom code -> That has a huge disadvantage because the track of objects gets lost.
That means that an ArrayList, which references two nodes in the tree, it will not reference the same objects after serialization. Because objects will be deeply copied and not re-used, even if the initial references were to the same object.

-> So if a ClientJobState object is serialized (it holds a list of all tasks), the amount deserialized objects (with n tasks) will be n(n+1)/2. That means we will have n*n/2 more traffic/memory utilization. – I think that is too much increase


*Make it versatile*
Just changing the serialization behavior in an environment where nearly everything depends on serialization does not seem very safe?!


*Change internal data-structure* 
We can change the data structure but it is a lot of work.



