### PR TITLE
Increase timeout five minutes.

### DIFF
--- a/scheduler/scheduler-server/src/test/java/functionaltests/rm/TestOperationsWhenUnlinked.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/rm/TestOperationsWhenUnlinked.java
@@ -78,13 +78,11 @@ public class TestOperationsWhenUnlinked extends SchedulerFunctionalTest {
 
     static final String TASK_NAME = "Test task";
 
-    static final long EVENT_TIMEOUT = 60000;
-
-    private File config;
-    private RMTHelper rmHelper;
-
+    static final long EVENT_TIMEOUT = 5*60000;
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
+    private File config;
+    private RMTHelper rmHelper;
 
     @Before
     public void createConfig() throws Exception {


### PR DESCRIPTION
Increase timeout to give tests more slack with jenkins.