### PR TITLE
Disable topology distance computation by default (#2373)

### DIFF
--- a/config/rm/settings.ini
+++ b/config/rm/settings.ini
@@ -157,6 +157,9 @@ pa.rm.db.hibernate.dropdb.nodesources=false
 #-------------------------------------------------------
 pa.rm.topology.enabled=true
 
+# By default, the computation of distances between nodes is disabled,
+# as it implies a very slow node acquisition time. Activate it only if mandatory
+pa.rm.topology.distance.enabled=false
 # Pings hosts using standard InetAddress.isReachable() method.
 pa.rm.topology.pinger.class=org.ow2.proactive.resourcemanager.frontend.topology.pinging.HostsPinger
 # Pings ProActive nodes using Node.getNumberOfActiveObjects().

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
@@ -36,13 +36,13 @@
  */
 package org.ow2.proactive.resourcemanager.core.properties;
 
+import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.utils.PAPropertiesLazyLoader;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
-
-import org.objectweb.proactive.annotation.PublicAPI;
-import org.ow2.proactive.utils.PAPropertiesLazyLoader;
 
 
 /**
@@ -199,6 +199,11 @@ public enum PAResourceManagerProperties {
     /** Topology feature enable option */
     RM_TOPOLOGY_ENABLED("pa.rm.topology.enabled", PropertyType.BOOLEAN),
 
+    /**
+     * If this is true, the topology mechanism will compute distances between hosts using ping
+     **/
+    RM_TOPOLOGY_DISTANCE_ENABLED("pa.rm.topology.distance.enabled", PropertyType.BOOLEAN),
+
     RM_TOPOLOGY_PINGER("pa.rm.topology.pinger.class", PropertyType.STRING),
 
     /** Resource Manager selection process logs*/
@@ -234,24 +239,6 @@ public enum PAResourceManagerProperties {
     }
 
     /**
-     * Get the key.
-     *
-     * @return the key.
-     */
-    public String getKey() {
-        return key;
-    }
-
-    /**
-     * Set the value of this property to the given one.
-     *
-     * @param value the new value to set.
-     */
-    public void updateProperty(String value) {
-        propertiesLoader.getProperties().setProperty(key, value);
-    }
-
-    /**
      * Load the properties from the given file.
      * This method will clean every loaded properties before.
      *
@@ -259,7 +246,7 @@ public enum PAResourceManagerProperties {
      */
     protected static void loadProperties(String filename) {
         propertiesLoader = new PAPropertiesLazyLoader(RM_HOME.key, PA_RM_PROPERTIES_FILEPATH,
-            PA_RM_PROPERTIES_RELATIVE_FILEPATH, filename);
+                PA_RM_PROPERTIES_RELATIVE_FILEPATH, filename);
     }
 
     /**
@@ -285,6 +272,40 @@ public enum PAResourceManagerProperties {
     }
 
     /**
+     * Get the absolute path of the given path.<br/>
+     * It the path is absolute, then it is returned. If the path is relative, then the RM_home directory is
+     * concatenated in front of the given string.
+     *
+     * @param userPath the path to check transform.
+     * @return the absolute path of the given path.
+     */
+    public static String getAbsolutePath(String userPath) {
+        if (new File(userPath).isAbsolute()) {
+            return userPath;
+        } else {
+            return PAResourceManagerProperties.RM_HOME.getValueAsString() + File.separator + userPath;
+        }
+    }
+
+    /**
+     * Get the key.
+     *
+     * @return the key.
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Set the value of this property to the given one.
+     *
+     * @param value the new value to set.
+     */
+    public void updateProperty(String value) {
+        propertiesLoader.getProperties().setProperty(key, value);
+    }
+
+    /**
      * Return true if this property is set, false otherwise.
      *
      * @return true if this property is set, false otherwise.
@@ -307,7 +328,7 @@ public enum PAResourceManagerProperties {
     /**
      * Returns the value of this property as an integer.
      * If value is not an integer, an exception will be thrown.
-     * 
+     *
      * @return the value of this property.
      */
     public int getValueAsInt() {
@@ -317,7 +338,7 @@ public enum PAResourceManagerProperties {
                 return Integer.parseInt(valueS);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException(key +
-                    " is not an integer property. getValueAsInt cannot be called on this property");
+                        " is not an integer property. getValueAsInt cannot be called on this property");
             }
         } else {
             return 0;
@@ -326,7 +347,7 @@ public enum PAResourceManagerProperties {
 
     /**
      * Returns the value of this property as a string.
-     * 
+     *
      * @return the value of this property.
      */
     public String getValueAsString() {
@@ -360,8 +381,8 @@ public enum PAResourceManagerProperties {
     /**
      * Returns the value of this property as a boolean.
      * If value is not a boolean, an exception will be thrown.<br>
-     * The behavior of this method is the same as the {@link java.lang.Boolean#parseBoolean(String s)}. 
-     * 
+     * The behavior of this method is the same as the {@link java.lang.Boolean#parseBoolean(String s)}.
+     *
      * @return the value of this property.
      */
     public boolean getValueAsBoolean() {
@@ -388,22 +409,6 @@ public enum PAResourceManagerProperties {
     @Override
     public String toString() {
         return getValueAsString();
-    }
-
-    /**
-     * Get the absolute path of the given path.<br/>
-     * It the path is absolute, then it is returned. If the path is relative, then the RM_home directory is 
-     * concatenated in front of the given string.
-     *
-     * @param userPath the path to check transform.
-     * @return the absolute path of the given path.
-     */
-    public static String getAbsolutePath(String userPath) {
-        if (new File(userPath).isAbsolute()) {
-            return userPath;
-        } else {
-            return PAResourceManagerProperties.RM_HOME.getValueAsString() + File.separator + userPath;
-        }
     }
 
     /**

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/topology/TopologyImpl.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/topology/TopologyImpl.java
@@ -73,6 +73,9 @@ public class TopologyImpl implements Topology, Cloneable {
      */
     private HashMap<String, InetAddress> hosts = new HashMap<>();
 
+    private Long long0 = new Long(0);
+    private Long longMax = new Long(Long.MAX_VALUE);
+
     /**
      * {@inheritDoc}
      */
@@ -87,13 +90,19 @@ public class TopologyImpl implements Topology, Cloneable {
      */
     public Long getDistance(InetAddress host, InetAddress host2) {
         if (host.equals(host2)) {
-            return new Long(0);
-        } else if (distances.get(host) != null && distances.get(host).get(host2) != null) {
-            return distances.get(host).get(host2);
-        } else if (distances.get(host2) != null && distances.get(host2).get(host) != null) {
-            return distances.get(host2).get(host);
+            return long0;
+        } else {
+            HashMap<InetAddress, Long> dhost = distances.get(host);
+            HashMap<InetAddress, Long> dhost2 = distances.get(host2);
+            Long dHostToHost2;
+            Long dHost2ToHost;
+            if (dhost != null && (dHostToHost2 = dhost.get(host2)) != null) {
+                return dHostToHost2;
+            } else if (dhost2 != null && (dHost2ToHost = dhost2.get(host)) != null) {
+                return dHost2ToHost;
+            }
         }
-        return new Long(Long.MAX_VALUE);
+        return longMax;
     }
 
     /**

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/topology/TopologyImpl.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/topology/TopologyImpl.java
@@ -36,20 +36,19 @@
  */
 package org.ow2.proactive.resourcemanager.frontend.topology;
 
+import org.objectweb.proactive.core.node.Node;
+import org.ow2.proactive.resourcemanager.frontend.topology.clustering.Cluster;
+import org.ow2.proactive.resourcemanager.frontend.topology.clustering.HAC;
+import org.ow2.proactive.topology.descriptor.DistanceFunction;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-
-import org.objectweb.proactive.core.node.Node;
-import org.ow2.proactive.resourcemanager.frontend.topology.clustering.Cluster;
-import org.ow2.proactive.resourcemanager.frontend.topology.clustering.HAC;
-import org.ow2.proactive.topology.descriptor.DistanceFunction;
 
 
 /**
@@ -94,7 +93,7 @@ public class TopologyImpl implements Topology, Cloneable {
         } else if (distances.get(host2) != null && distances.get(host2).get(host) != null) {
             return distances.get(host2).get(host);
         }
-        return null;
+        return new Long(Long.MAX_VALUE);
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
@@ -1,13 +1,5 @@
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
-import java.io.IOException;
-import java.security.KeyException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.util.ProActiveCounter;
@@ -20,16 +12,27 @@ import org.ow2.proactive.resourcemanager.utils.CommandLineBuilder;
 import org.ow2.proactive.resourcemanager.utils.OperatingSystem;
 import org.ow2.proactive.utils.Tools;
 
+import java.io.IOException;
+import java.security.KeyException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 
 public class LocalInfrastructure extends InfrastructureManager {
+
+    public static final int DEFAULT_NODE_NUMBER = 4;
+    public static final int DEFAULT_TIMEOUT = 30000;
 
     @Configurable(description = "Absolute path to credentials file\nused to add the node to the Resource Manager", credential = true)
     private Credentials credentials;
     @Configurable(description = "Maximum number of nodes to\nbe deployed on Resource Manager machine")
-    private int maxNodes = 4;
+    private int maxNodes = DEFAULT_NODE_NUMBER;
     private AtomicInteger atomicMaxNodes;
     @Configurable(description = "in ms. After this timeout expired\nthe node is considered to be lost")
-    private int nodeTimeout = 10000;
+    private int nodeTimeout = DEFAULT_TIMEOUT;
     @Configurable(description = "Additional ProActive properties")
     private String paProperties = "";
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
@@ -23,13 +23,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class LocalInfrastructure extends InfrastructureManager {
 
-    public static final int DEFAULT_NODE_NUMBER = 4;
+    public static final int DEFAULT_NODE_NUMBER = Math.max(2, Runtime.getRuntime().availableProcessors() - 1);
     public static final int DEFAULT_TIMEOUT = 30000;
 
     @Configurable(description = "Absolute path to credentials file\nused to add the node to the Resource Manager", credential = true)
     private Credentials credentials;
     @Configurable(description = "Maximum number of nodes to\nbe deployed on Resource Manager machine")
     private int maxNodes = DEFAULT_NODE_NUMBER;
+    // number of nodes which can still be acquired
     private AtomicInteger atomicMaxNodes;
     @Configurable(description = "in ms. After this timeout expired\nthe node is considered to be lost")
     private int nodeTimeout = DEFAULT_TIMEOUT;

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/topology/TopologyManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/topology/TopologyManager.java
@@ -103,7 +103,7 @@ public class TopologyManager {
             throw new TopologyDisabledException("Topology is disabled");
         }
         if (topologyDescriptor instanceof BestProximityDescriptor || topologyDescriptor instanceof ThresholdProximityDescriptor) {
-            if (!PAResourceManagerProperties.RM_TOPOLOGY_DISTANCE_ENABLED.isSet() || !PAResourceManagerProperties.RM_TOPOLOGY_DISTANCE_ENABLED.getValueAsBoolean()) {
+            if (!PAResourceManagerProperties.RM_TOPOLOGY_DISTANCE_ENABLED.getValueAsBoolean()) {
                 throw new TopologyDisabledException("Topology distance is disabled, cannot use distance-based descriptors");
             }
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/topology/TopologyManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/topology/TopologyManager.java
@@ -36,15 +36,6 @@
  */
 package org.ow2.proactive.resourcemanager.selection.topology;
 
-import java.net.InetAddress;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
-
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.ActiveObjectCreationException;
 import org.objectweb.proactive.api.PAActiveObject;
@@ -58,15 +49,11 @@ import org.ow2.proactive.resourcemanager.frontend.topology.TopologyException;
 import org.ow2.proactive.resourcemanager.frontend.topology.TopologyImpl;
 import org.ow2.proactive.resourcemanager.frontend.topology.clustering.HAC;
 import org.ow2.proactive.resourcemanager.frontend.topology.pinging.Pinger;
-import org.ow2.proactive.topology.descriptor.ArbitraryTopologyDescriptor;
-import org.ow2.proactive.topology.descriptor.BestProximityDescriptor;
-import org.ow2.proactive.topology.descriptor.DifferentHostsExclusiveDescriptor;
-import org.ow2.proactive.topology.descriptor.MultipleHostsExclusiveDescriptor;
-import org.ow2.proactive.topology.descriptor.SingleHostDescriptor;
-import org.ow2.proactive.topology.descriptor.SingleHostExclusiveDescriptor;
-import org.ow2.proactive.topology.descriptor.ThresholdProximityDescriptor;
-import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
+import org.ow2.proactive.topology.descriptor.*;
 import org.ow2.proactive.utils.NodeSet;
+
+import java.net.InetAddress;
+import java.util.*;
 
 
 /**
@@ -78,14 +65,12 @@ public class TopologyManager {
 
     // logger
     private final static Logger logger = Logger.getLogger(TopologyManager.class);
-
+    // list of handlers corresponded to topology descriptors
+    private final HashMap<Class<? extends TopologyDescriptor>, TopologyHandler> handlers = new HashMap<>();
     // hosts distances
     private TopologyImpl topology = new TopologyImpl();
     // this hash map allows to quickly find nodes on a single host (much faster than from the topology).
     private HashMap<InetAddress, List<Node>> nodesOnHost = new HashMap<>();
-    // list of handlers corresponded to topology descriptors
-    private final HashMap<Class<? extends TopologyDescriptor>, TopologyHandler> handlers = new HashMap<>();
-
     // class using for pinging
     private Class<? extends Pinger> pingerClass;
 
@@ -117,10 +102,16 @@ public class TopologyManager {
             !PAResourceManagerProperties.RM_TOPOLOGY_ENABLED.getValueAsBoolean()) {
             throw new TopologyDisabledException("Topology is disabled");
         }
+        if (topologyDescriptor instanceof BestProximityDescriptor || topologyDescriptor instanceof ThresholdProximityDescriptor) {
+            if (!PAResourceManagerProperties.RM_TOPOLOGY_DISTANCE_ENABLED.isSet() || !PAResourceManagerProperties.RM_TOPOLOGY_DISTANCE_ENABLED.getValueAsBoolean()) {
+                throw new TopologyDisabledException("Topology distance is disabled, cannot use distance-based descriptors");
+            }
+        }
         TopologyHandler handler = handlers.get(topologyDescriptor.getClass());
         if (handler == null) {
             throw new IllegalArgumentException("Unknown descriptor type " + topologyDescriptor.getClass());
         }
+
         handler.setDescriptor(topologyDescriptor);
         return handler;
     }
@@ -157,15 +148,16 @@ public class TopologyManager {
                     toPing.add(nodesOnHost.get(h).iterator().next());
                 }
             }
+            HashMap<InetAddress, Long> hostsTopology = null;
 
-            HashMap<InetAddress, Long> hostsTopology = pingNode(node, toPing);
+            if (PAResourceManagerProperties.RM_TOPOLOGY_DISTANCE_ENABLED.getValueAsBoolean()) {
+                hostsTopology = pingNode(node, toPing);
+            }
             synchronized (topology) {
-                if (hostsTopology != null) {
-                    topology.addHostTopology(node.getVMInformation().getHostName(), host, hostsTopology);
-                    List<Node> nodesList = new LinkedList<>();
-                    nodesList.add(node);
-                    nodesOnHost.put(node.getVMInformation().getInetAddress(), nodesList);
-                }
+                topology.addHostTopology(node.getVMInformation().getHostName(), host, hostsTopology);
+                List<Node> nodesList = new LinkedList<>();
+                nodesList.add(node);
+                nodesOnHost.put(node.getVMInformation().getInetAddress(), nodesList);
             }
         }
     }
@@ -432,45 +424,6 @@ public class TopologyManager {
      */
     private class MultipleHostsExclusiveHandler extends TopologyHandler {
 
-        private class Host implements Comparable<Host> {
-            private InetAddress address;
-            private int nodesNumber;
-
-            public Host(InetAddress address, int nodesNumber) {
-                this.address = address;
-                this.nodesNumber = nodesNumber;
-            }
-
-            public boolean equals(Object obj) {
-                if (obj instanceof Host) {
-                    Host host = (Host) obj;
-                    if (address == null && host.address == null) {
-                        return true;
-                    } else if (address != null && host.address != null) {
-                        return address.equals(host.address);
-                    }
-                }
-                return false;
-            }
-
-            public int compareTo(Host host) {
-                boolean equal = equals(host);
-                if (equal) {
-                    return 0;
-                } else {
-                    // must not return 0 in order to comply with equals()
-                    int nodesDiff = nodesNumber - host.nodesNumber;
-                    if (nodesDiff == 0) {
-                        // the same node number, use addresses to define what is bigger
-                        String thisAdd = address == null ? "" : address.toString();
-                        String hostAdd = host.address == null ? "" : host.address.toString();
-                        return thisAdd.compareTo(hostAdd);
-                    }
-                    return nodesDiff;
-                }
-            }
-        }
-
         @Override
         public NodeSet select(int number, List<Node> matchedNodes) {
             if (number <= 0 || matchedNodes.size() == 0) {
@@ -544,6 +497,45 @@ public class TopologyManager {
             }
             freeHosts.remove(host);
             return host.address;
+        }
+
+        private class Host implements Comparable<Host> {
+            private InetAddress address;
+            private int nodesNumber;
+
+            public Host(InetAddress address, int nodesNumber) {
+                this.address = address;
+                this.nodesNumber = nodesNumber;
+            }
+
+            public boolean equals(Object obj) {
+                if (obj instanceof Host) {
+                    Host host = (Host) obj;
+                    if (address == null && host.address == null) {
+                        return true;
+                    } else if (address != null && host.address != null) {
+                        return address.equals(host.address);
+                    }
+                }
+                return false;
+            }
+
+            public int compareTo(Host host) {
+                boolean equal = equals(host);
+                if (equal) {
+                    return 0;
+                } else {
+                    // must not return 0 in order to comply with equals()
+                    int nodesDiff = nodesNumber - host.nodesNumber;
+                    if (nodesDiff == 0) {
+                        // the same node number, use addresses to define what is bigger
+                        String thisAdd = address == null ? "" : address.toString();
+                        String hostAdd = host.address == null ? "" : host.address.toString();
+                        return thisAdd.compareTo(hostAdd);
+                    }
+                    return nodesDiff;
+                }
+            }
         }
     }
 

--- a/rm/rm-server/src/test/java/functionaltests/topology/LocalSelectionTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/topology/LocalSelectionTest.java
@@ -1,0 +1,140 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s): ActiveEon Team - http://www.activeeon.com
+ *
+ * ################################################################
+ * $$ACTIVEEON_CONTRIBUTOR$$
+ */
+package functionaltests.topology;
+
+import functionaltests.utils.RMFunctionalTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.objectweb.proactive.core.node.Node;
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
+import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
+import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
+import org.ow2.proactive.utils.NodeSet;
+
+import java.util.Collection;
+
+/**
+ * Local version of SelectionTest which tests only a few scenarios and verify
+ * that they work when topology distance is disabled
+ **/
+public class LocalSelectionTest extends RMFunctionalTest {
+
+    private ResourceManager resourceManager = null;
+
+    private static final int NODE_NUMBER = 4;
+
+    private void getNodesAndReleaseThem(int number, TopologyDescriptor descriptor, int expectedReceived, int expectedExtraNodesSize) {
+        NodeSet ns = resourceManager.getAtMostNodes(number, descriptor, null, null);
+        Assert.assertEquals(expectedReceived, ns.size());
+        Collection<Node> extra = ns.getExtraNodes();
+        if (expectedExtraNodesSize == 0) {
+            Assert.assertNull(extra);
+        } else {
+            Assert.assertEquals(expectedExtraNodesSize, extra.size());
+        }
+        resourceManager.releaseNodes(ns).getBooleanValue();
+    }
+
+    @Before
+    public void getRM() throws Exception {
+        //rmHelper.startRM(null, TestRM.PA_PNP_PORT, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007");
+        resourceManager = rmHelper.getResourceManager();
+
+    }
+
+    @After
+    public void removeNS() throws Exception {
+        if (resourceManager != null) {
+            try {
+                resourceManager.removeNodeSource(this.getClass().getSimpleName(), true);
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    @Test
+    public void action() throws Exception {
+        Assert.assertTrue("Topology must be enabled", PAResourceManagerProperties.RM_TOPOLOGY_ENABLED.getValueAsBoolean());
+        Assert.assertFalse("Topology distance must be disabled", PAResourceManagerProperties.RM_TOPOLOGY_DISTANCE_ENABLED.getValueAsBoolean());
+        Assert.assertTrue("Ressource manager must be deployed without nodes", resourceManager.getState().getFreeNodesNumber() == 0);
+
+        rmHelper.createNodeSource(this.getClass().getSimpleName(), NODE_NUMBER);
+
+        int counter = 0;
+        while (resourceManager.getState().getFreeNodesNumber() < NODE_NUMBER) {
+            Thread.sleep(1000);
+            counter++;
+            Assert.assertTrue("Node source must be deployed", counter < 30);
+        }
+
+        getNodesAndReleaseThem(1, TopologyDescriptor.ARBITRARY, 1, 0);
+        getNodesAndReleaseThem(NODE_NUMBER, TopologyDescriptor.ARBITRARY, NODE_NUMBER, 0);
+        getNodesAndReleaseThem(100, TopologyDescriptor.ARBITRARY, NODE_NUMBER, 0);
+
+        getNodesAndReleaseThem(1, TopologyDescriptor.SINGLE_HOST, 1, 0);
+        getNodesAndReleaseThem(NODE_NUMBER, TopologyDescriptor.SINGLE_HOST, NODE_NUMBER, 0);
+        getNodesAndReleaseThem(100, TopologyDescriptor.SINGLE_HOST, NODE_NUMBER, 0);
+
+        getNodesAndReleaseThem(1, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, 1, NODE_NUMBER - 1);
+        getNodesAndReleaseThem(NODE_NUMBER - 1, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, NODE_NUMBER - 1, 1);
+        getNodesAndReleaseThem(NODE_NUMBER, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, NODE_NUMBER, 0);
+        getNodesAndReleaseThem(100, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, NODE_NUMBER, 0);
+
+        getNodesAndReleaseThem(1, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, 1, NODE_NUMBER - 1);
+        getNodesAndReleaseThem(NODE_NUMBER - 1, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, NODE_NUMBER - 1, 1);
+        getNodesAndReleaseThem(NODE_NUMBER, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, NODE_NUMBER, 0);
+        getNodesAndReleaseThem(100, TopologyDescriptor.SINGLE_HOST_EXCLUSIVE, NODE_NUMBER, 0);
+
+        getNodesAndReleaseThem(1, TopologyDescriptor.MULTIPLE_HOSTS_EXCLUSIVE, 1, NODE_NUMBER - 1);
+        getNodesAndReleaseThem(NODE_NUMBER - 1, TopologyDescriptor.MULTIPLE_HOSTS_EXCLUSIVE, NODE_NUMBER - 1, 1);
+        getNodesAndReleaseThem(NODE_NUMBER, TopologyDescriptor.MULTIPLE_HOSTS_EXCLUSIVE, NODE_NUMBER, 0);
+        getNodesAndReleaseThem(100, TopologyDescriptor.MULTIPLE_HOSTS_EXCLUSIVE, NODE_NUMBER, 0);
+
+        getNodesAndReleaseThem(1, TopologyDescriptor.DIFFERENT_HOSTS_EXCLUSIVE, 1, NODE_NUMBER - 1);
+        getNodesAndReleaseThem(2, TopologyDescriptor.DIFFERENT_HOSTS_EXCLUSIVE, 1, NODE_NUMBER - 1);
+        getNodesAndReleaseThem(100, TopologyDescriptor.DIFFERENT_HOSTS_EXCLUSIVE, 1, NODE_NUMBER - 1);
+
+        try {
+            getNodesAndReleaseThem(1, TopologyDescriptor.BEST_PROXIMITY, 0, 0);
+            Assert.fail("An exception should be thrown when proximity is used");
+        } catch (Exception e) {
+
+        }
+    }
+}

--- a/rm/rm-server/src/test/java/functionaltests/topology/LocalSelectionTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/topology/LocalSelectionTest.java
@@ -45,6 +45,7 @@ import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
 import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
+import org.ow2.proactive.utils.Criteria;
 import org.ow2.proactive.utils.NodeSet;
 
 import java.util.Collection;
@@ -60,7 +61,9 @@ public class LocalSelectionTest extends RMFunctionalTest {
     private static final int NODE_NUMBER = 4;
 
     private void getNodesAndReleaseThem(int number, TopologyDescriptor descriptor, int expectedReceived, int expectedExtraNodesSize) {
-        NodeSet ns = resourceManager.getAtMostNodes(number, descriptor, null, null);
+        Criteria c = new Criteria(number);
+        c.setTopology(descriptor);
+        NodeSet ns = resourceManager.getNodes(c);
         Assert.assertEquals(expectedReceived, ns.size());
         Collection<Node> extra = ns.getExtraNodes();
         if (expectedExtraNodesSize == 0) {

--- a/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
@@ -91,7 +91,7 @@ public class RMTHelper {
     /**
      * Number of nodes deployed with default deployment descriptor
      */
-    private static final int DEFAULT_NODES_NUMBER = 2;
+    public static final int DEFAULT_NODES_NUMBER = 2;
 
     private final static ProActiveSetup setup = new ProActiveSetup();
 
@@ -177,6 +177,7 @@ public class RMTHelper {
     }
 
     /** Wait for the node source to be created and the nodes to be connected */
+    @Deprecated
     public void waitForNodeSourceCreation(String name, int nodeNumber) {
         waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, name);
         for (int i = 0; i < nodeNumber; i++) {

--- a/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-long-selection-script-timeout.ini
+++ b/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-long-selection-script-timeout.ini
@@ -19,4 +19,5 @@ pa.rm.select.node.dynamicity=10000
 
 pa.rm.client.ping.frequency=10000
 pa.rm.select.script.timeout=60000
-pa.rm.topology.enabled=false
+pa.rm.topology.enabled=true
+pa.rm.topology.distance.enabled=false

--- a/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties.ini
+++ b/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties.ini
@@ -19,4 +19,5 @@ pa.rm.select.node.dynamicity=10000
 
 pa.rm.client.ping.frequency=10000
 pa.rm.select.script.timeout=10000
-pa.rm.topology.enabled=false
+pa.rm.topology.enabled=true
+pa.rm.topology.distance.enabled=false


### PR DESCRIPTION
- Added new property `pa.rm.topology.distance.enabled`, disabled by default, which determines wether the topology mechanism computes distances when nodes are added.
- Created a test to verify that other topology scenario works properly when this is disabled
- Augmented default timeout in LocalInfrastructure