### PR TITLE
Add a runtime dependency to the jsr223 docker compose scriptengine. That will include the scriptengine into the dist/lib folder and as a matter of fact the script engine will be part of the next releases.

### DIFF
--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -24,4 +24,5 @@ dependencies {
 
     runtime 'org.codehaus.groovy:groovy-all:2.4.5'
     runtime 'jsr223:jsr223-nativeshell:0.3'
+    runtime 'jsr223:jsr223-docker-compose:0.0.1'
 }


### PR DESCRIPTION
Add a runtime dependency to the jsr223 docker compose scriptengine. That will include the scriptengine into the dist/lib folder and as a matter of fact the script engine will be part of the next releases.