### PR TITLE
Add configuration for scriptengines. Add a log4j configuration file for scriptengines. Add docker-compose.properties to configure the docker-compose (docker task) script engine.

### DIFF
--- a/config/log/scriptengines.properties
+++ b/config/log/scriptengines.properties
@@ -1,0 +1,15 @@
+# Console appender
+log4j.logger.jsr223.docker.compose.utils.DockerComposePropertyLoader=INFO, CONSOLE
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+
+# File appender - add logs to Node logs because nodes execute the scriptengine
+log4j.appender.SCRIPTENGINES=org.apache.log4j.RollingFileAppender
+log4j.appender.SCRIPTENGINES.File=${proactive.home}/logs/Node-${node.name}.log
+log4j.appender.SCRIPTENGINES.MaxFileSize=10MB
+log4j.appender.SCRIPTENGINES.MaxBackupIndex=10
+log4j.appender.SCRIPTENGINES.layout=org.apache.log4j.PatternLayout
+log4j.appender.SCRIPTENGINES.layout.ConversionPattern=[%d{ISO8601} %-5p] [%X{job.id}t%X{task.id}] [NODE.%C{1}.%M] %m%n
+
+# CONSOLE appender
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout

--- a/config/scriptengines/docker-compose.properties
+++ b/config/scriptengines/docker-compose.properties
@@ -1,0 +1,5 @@
+# General configuration
+docker.compose.command=/usr/local/bin/docker-compose
+docker.compose.sudo.command=/usr/bin/sudo
+docker.compose.use.sudo=false
+docker.host=


### PR DESCRIPTION
Add configuration for scriptengines. Add a log4j configuration file for scriptengines. Add docker-compose.properties to configure the docker-compose (docker task) script engine.