### PR TITLE
Fix revisionjobsinfo functional test

### DIFF
--- a/rest/rest-server/src/test/java/functionaltests/RestSchedulerJobPaginationTest.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestSchedulerJobPaginationTest.java
@@ -112,7 +112,8 @@ public class RestSchedulerJobPaginationTest extends AbstractRestFuncTestCase {
         jobs = (JSONArray) page.get("list");
         checkJob((JSONObject) jobs.get(2), JobStatus.RUNNING, 1, 0);
 
-        JSONObject map = getRequestJSONObject(getResourceUrl("revisionjobsinfo"));
+        page = getRequestJSONObject(getResourceUrl("revisionjobsinfo"));
+        JSONObject map = (JSONObject) page.get("map");
         Assert.assertEquals(1, map.keySet().size());
         jobs = (JSONArray) map.get(map.keySet().iterator().next());
         checkJob((JSONObject) jobs.get(2), JobStatus.RUNNING, 1, 0);
@@ -140,7 +141,8 @@ public class RestSchedulerJobPaginationTest extends AbstractRestFuncTestCase {
         jobs = (JSONArray) page.get("list");
         checkJob(findJob("1", jobs), JobStatus.KILLED, 0, 0);
 
-        map = getRequestJSONObject(getResourceUrl("revisionjobsinfo"));
+        page = getRequestJSONObject(getResourceUrl("revisionjobsinfo"));
+        map = (JSONObject) page.get("map");
         Assert.assertEquals(1, map.keySet().size());
         jobs = (JSONArray) map.get(map.keySet().iterator().next());
         checkJob(findJob("1", jobs), JobStatus.KILLED, 0, 0);
@@ -316,7 +318,8 @@ public class RestSchedulerJobPaginationTest extends AbstractRestFuncTestCase {
         Set<String> expected = new HashSet<>(Arrays.asList(expectedIds));
         Set<String> actual = new HashSet<>();
 
-        JSONObject map = getRequestJSONObject(url);
+        JSONObject page = getRequestJSONObject(url);
+        JSONObject map = (JSONObject) page.get("map");
         Assert.assertEquals(1, map.keySet().size());
         JSONArray jobs = (JSONArray) map.get(map.keySet().iterator().next());
         for (int i = 0; i < jobs.size(); i++) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/TaskFilterCriteria.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/TaskFilterCriteria.java
@@ -1,0 +1,215 @@
+package org.ow2.proactive.scheduler.common;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.ow2.proactive.db.SortParameter;
+
+/**
+ * Default values for the embedded criterias are the following:
+ * <li>
+ *     <ul>no tag filtering</ul>
+ *     <ul>no dates filtering</ul>
+ *     <ul>no pagination</ul>
+ *     <ul>all status are selected</ul>
+ *     <ul>no sort parameter</ul>
+ * </li>
+ */
+public class TaskFilterCriteria implements Serializable {
+
+    private String tag = null;
+    private long from = 0;
+    private long to = 0;
+    private int offset = 0;
+    private int limit = 0;
+    private String user = null;
+    private boolean running = true;
+    private boolean pending = true;
+    private boolean finished = true;
+    private ArrayList<SortParameter<TaskSortParameter>> sortParameters = null;
+    
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public long getFrom() {
+        return from;
+    }
+
+    public void setFrom(long from) {
+        this.from = from;
+    }
+
+    public long getTo() {
+        return to;
+    }
+
+    public void setTo(long to) {
+        this.to = to;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public void setRunning(boolean running) {
+        this.running = running;
+    }
+
+    public boolean isPending() {
+        return pending;
+    }
+
+    public void setPending(boolean pending) {
+        this.pending = pending;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public void setFinished(boolean finished) {
+        this.finished = finished;
+    }
+    
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public List<SortParameter<TaskSortParameter>> getSortParameters() {
+        if (sortParameters != null)
+            return Collections.unmodifiableList(sortParameters);
+        else
+            return null;
+    }
+
+    public void setSortParameters(List<SortParameter<TaskSortParameter>> sortParameters) {
+        if (sortParameters != null)
+            this.sortParameters = new ArrayList<SortParameter<TaskSortParameter>>(sortParameters);
+    }
+
+    public static class TFCBuilder {
+        
+        private TaskFilterCriteria criterias = null;
+        
+        private TFCBuilder() {
+            criterias = new TaskFilterCriteria();
+        }
+        
+        public static TFCBuilder newInstance() {
+            return new TFCBuilder();
+        }
+        
+        /**
+         * Default value is <code>null</code> (no task tag filtering)
+         */
+        public TFCBuilder tag(String tag) {
+            criterias.setTag(tag);
+            return this;
+        }
+        
+        /**
+         * Default value is <code>0L</code> (no date filtering)
+         */
+        public TFCBuilder from(long from) {
+            criterias.setFrom(from);
+            return this;
+        }
+        
+        /**
+         * Default value is <code>0L</code> (no date filtering)
+         */
+        public TFCBuilder to(long to) {
+            criterias.setTo(to);
+            return this;
+        }
+        
+        /**
+         * Default value is <code>0</code> (no pagination)
+         */
+        public TFCBuilder offset(int offset) {
+            criterias.setOffset(offset);
+            return this;
+        }
+        
+        /**
+         * Default value is <code>0</code> (no pagination)
+         */
+        public TFCBuilder limit(int limit) {
+            criterias.setLimit(limit);
+            return this;
+        }
+
+        /**
+         * Default value is <code>true</code> (fetch all tasks)
+         */
+        public TFCBuilder running(boolean running) {
+            criterias.setRunning(running);
+            return this;
+        }
+
+        /**
+         * Default value is <code>true</code> (fetch all tasks)
+         */
+        public TFCBuilder pending(boolean pending) {
+            criterias.setPending(pending);
+            return this;
+        }
+
+        /**
+         * Default value is <code>true</code> (fetch all tasks)
+         */
+        public TFCBuilder finished(boolean finished) {
+            criterias.setFinished(finished);
+            return this;
+        }
+
+        /**
+         * Default value is <code>null</code> (no user specific filtering)
+         */
+        public TFCBuilder user(String user) {
+            criterias.setUser(user);
+            return this;
+        }
+
+        /**
+         * Default value is <code>null</code> (no sort parameters)
+         */
+        public TFCBuilder sortParameters(List<SortParameter<TaskSortParameter>> sortParameters) {
+            criterias.setSortParameters(sortParameters);
+            return this;
+        }
+
+        public TaskFilterCriteria criterias() {
+            return criterias;
+        }
+        
+    }
+    
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/TaskSortParameter.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/TaskSortParameter.java
@@ -36,6 +36,8 @@
  */
 package org.ow2.proactive.scheduler.common;
 
-public enum TaskSortParameter {
+import java.io.Serializable;
+
+public enum TaskSortParameter implements Serializable {
     ID, NAME
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBTaskDataParameters.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBTaskDataParameters.java
@@ -42,9 +42,12 @@ public class DBTaskDataParameters {
         
         Set<TaskStatus> newStatus = new HashSet<TaskStatus>();
 
-        if (pending) newStatus.addAll(SchedulerDBManager.PENDING_TASKS);
-        if (running) newStatus.addAll(SchedulerDBManager.RUNNING_TASKS);
-        if (finished) newStatus.addAll(SchedulerDBManager.PENDING_TASKS);
+        if (pending)
+            newStatus.addAll(SchedulerDBManager.PENDING_TASKS);
+        if (running)
+            newStatus.addAll(SchedulerDBManager.RUNNING_TASKS);
+        if (finished)
+            newStatus.addAll(SchedulerDBManager.FINISHED_TASKS);
         
         this.status = Collections.unmodifiableSet(newStatus);
         
@@ -72,6 +75,18 @@ public class DBTaskDataParameters {
 
     public String getUser() {
         return user;
+    }
+    
+    public boolean isRunning() {
+        return running;
+    }
+
+    public boolean isPending() {
+        return pending;
+    }
+
+    public boolean isFinished() {
+        return finished;
     }
 
     public List<SortParameter<TaskSortParameter>> getSortParameters() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -35,6 +35,7 @@ import org.ow2.proactive.authentication.crypto.HybridEncryptionUtil.HybridEncryp
 import org.ow2.proactive.db.DatabaseManagerException;
 import org.ow2.proactive.db.FilteredExceptionCallback;
 import org.ow2.proactive.db.SortParameter;
+import org.ow2.proactive.scheduler.common.JobFilterCriteria;
 import org.ow2.proactive.scheduler.common.JobSortParameter;
 import org.ow2.proactive.scheduler.common.Page;
 import org.ow2.proactive.scheduler.common.TaskSortParameter;
@@ -200,6 +201,8 @@ public class SchedulerDBManager {
         if (!pending && !running && !finished) {
             return new Page<JobInfo>(new ArrayList<JobInfo>(), 0);
         }
+        
+        JobFilterCriteria jfc = new JobFilterCriteria(false, true, true, true);
 
         DBJobDataParameters params = new DBJobDataParameters(offset, limit, user, pending, running, finished, sortParameters);
         int totalNbJobs = getTotalNumberOfJobs(params);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskDBUtils.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskDBUtils.java
@@ -25,7 +25,11 @@ public class TaskDBUtils {
             @SuppressWarnings("unchecked")
             public List<TaskState> executeWork(Session session) {
                 Criteria criteria = session.createCriteria(TaskData.class);
-
+                List<TaskState> result = null;
+                
+                if (params.getStatuses().isEmpty())
+                    return new ArrayList<TaskState>();
+                
                 if (params.getLimit() > 0)
                     criteria.setMaxResults(params.getLimit());
                 if (params.getOffset() >= 0)
@@ -67,7 +71,7 @@ public class TaskDBUtils {
                 }
 
                 List<TaskData> tasksList = criteria.list();
-                List<TaskState> result = new ArrayList<TaskState>(tasksList.size());
+                result = new ArrayList<TaskState>(tasksList.size());
                 for (TaskData taskData : tasksList) {
                     result.add(taskData.toTaskState());
                 }


### PR DESCRIPTION
The `revisionjobsinfo` functional test have been updated to use the new returned format.