### PR TITLE
Fix dates parameters in task-centric REST resources

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/task/TaskIdImpl.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/task/TaskIdImpl.java
@@ -37,12 +37,12 @@
 package org.ow2.proactive.scheduler.task;
 
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.task.TaskId;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
 
 
 /**
@@ -85,6 +85,21 @@ public final class TaskIdImpl implements TaskId {
      */
     public static TaskId createTaskId(JobId jobId, String readableName, long taskId) {
         return new TaskIdImpl(jobId, readableName, taskId);
+    }
+    
+    /**
+     * Create task id, and set task name + tag.
+     *
+     * @param jobId        the id of the enclosing job.
+     * @param readableName the human readable name of the task.
+     * @param taskId       the task identifier value.
+     * @param tag          the tag of the task.
+     * @return new TaskId instance.
+     */
+    public static TaskId createTaskId(JobId jobId, String readableName, long taskId, String tag) {
+        TaskIdImpl t = new TaskIdImpl(jobId, readableName, taskId);
+        t.setTag(tag);
+        return t;
     }
 
     /**

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskDBUtils.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskDBUtils.java
@@ -57,8 +57,10 @@ public class TaskDBUtils {
                             .add(Restrictions.eq("job.owner", params.getUser()));
                 }
 
-                if (params.getFrom() != 0 && params.getTo() != 0) {
+                if (params.getFrom() > 0) {
                     criteria.add(Restrictions.ge("startTime", params.getFrom()));
+                }
+                if (params.getTo() > 0) {
                     criteria.add(Restrictions.le("finishedTime", params.getTo()));
                 }
 
@@ -120,8 +122,10 @@ public class TaskDBUtils {
                             .add(Restrictions.eq("job.owner", params.getUser()));
                 }
 
-                if (params.getFrom() != 0 && params.getTo() != 0) {
+                if (params.getFrom() > 0) {
                     criteria.add(Restrictions.ge("startTime", params.getFrom()));
+                }
+                if (params.getTo() > 0) {
                     criteria.add(Restrictions.le("finishedTime", params.getTo()));
                 }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -984,7 +984,7 @@ public class TaskData {
     
 
     TaskInfoImpl createTaskInfo(JobIdImpl jobId) {
-        TaskId taskId = TaskIdImpl.createTaskId(jobId, getTaskName(), getId().getTaskId());
+        TaskId taskId = TaskIdImpl.createTaskId(jobId, getTaskName(), getId().getTaskId(), getTag());
         TaskInfoImpl taskInfo = new TaskInfoImpl();
         taskInfo.setTaskId(taskId);
         taskInfo.setStatus(getTaskStatus());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
@@ -1,21 +1,27 @@
 package functionaltests.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.ow2.proactive.scheduler.common.Page;
 import org.ow2.proactive.scheduler.common.TaskFilterCriteria;
+import org.ow2.proactive.scheduler.common.job.JobInfo;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
+import org.ow2.proactive.scheduler.common.task.flow.FlowAction;
+import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
+import org.ow2.proactive.scheduler.job.ChangedTasksInfo;
 import org.ow2.proactive.scheduler.job.InternalJob;
+import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 
 /**
@@ -24,109 +30,281 @@ import org.ow2.proactive.scheduler.task.internal.InternalTask;
  */
 public class SchedulerDBManagerTest extends BaseServiceTest {
     
-
+    private static final int nbJobs = 10;
+    private static final int nbTasksPerJob = 20;
+    private static final int totalNbTasks = nbJobs * nbTasksPerJob;
+    private TaskFilterCriteria crit = null;
+    private Page<TaskInfo> actualPageInfo = null;
+    private Page<TaskState> actualPageState = null;
+    private List<InternalJob> actualInternalJobs = null;
+    private Page<JobInfo> actualJobPage = null;
+    private List<Task> lAllTasks = null;
     
     @Test
     public void testGetTasks() throws Throwable {
+        
+        initExpectedResults("testGetTasks-Job", "TEST-TAG");
+        
+        // no given statuses, no pagination, nothing should come up
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().running(false).pending(false).finished(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // all statuses, no pagination, everything should come up
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
 
-        int nbJobs = 10;
-        int nbTasksPerJob = 20; // we need  nbTasksPerJob > page size
-        int totalNbTasks = nbJobs * nbTasksPerJob;
-        Page<TaskInfo> actualPage = null;
-        TaskFilterCriteria crit = null;
-        List<InternalJob> lJobs = createTestJobs("TestGetJobs-Job", "TEST-TAG", nbJobs, nbTasksPerJob);
+        // all statuses, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // pending tasks only, no pagination
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().running(false).finished(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // running tasks only, no pagination
+        startJob(0);
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).finished(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // running tasks only, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).finished(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // finished tasks only, no pagination
+        terminateJob(1,100L);
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // finished tasks only, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // finished tasks only, dates [0,100], no pagination
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().from(0).to(100L).pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // finished tasks only, dates [0,100], pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().from(0).to(100L)
+                .offset(0).limit(5)
+                .pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // default parameters, with tag "TEST-TAG"
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().tag("TEST-TAG").criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+        // default parameters, with tag "NON-EXISTENT-TAG"
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().tag("NON-EXISTENT-TAG").criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskInfoPage(actualPageInfo, crit);
+        
+    }
+    
+    @Test
+    public void testGetTaskStates() throws Throwable {
+        
+        initExpectedResults("testGetTaskStates-Job", "TEST-TAG");
 
-        List<Task> lAllTasks = new ArrayList<Task>(totalNbTasks);
-        for (InternalJob j : lJobs) {
-            service.submitJob(j);
-            lAllTasks.addAll(j.getTasks());
-        }
+        // no given statuses, no pagination, nothing should come up
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().running(false).pending(false).finished(false).criterias();
+        actualPageState = getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // all statuses, no pagination, everything should come up
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+
+        // all statuses, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // pending tasks only, no pagination
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().running(false).finished(false).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // running tasks only, no pagination
+        startJob(0);
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).finished(false).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // running tasks only, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).finished(false).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // finished tasks only, no pagination
+        terminateJob(1, 100L);
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).running(false).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // finished tasks only, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).running(false).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // finished tasks only, dates [0,100], no pagination
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().from(0).to(100L).pending(false).running(false).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // finished tasks only, dates [0,100], pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().from(0).to(100L)
+                .offset(0).limit(5)
+                .pending(false).running(false).criterias();
+        actualPageState =getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // default parameters, with tag "TEST-TAG"
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().tag("TEST-TAG").criterias();
+        actualPageState = getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+        
+        // default parameters, with tag "NON-EXISTENT-TAG"
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().tag("NON-EXISTENT-TAG").criterias();
+        actualPageState = getTaskStates(crit);
+        assertTaskStatePage(actualPageState, crit);
+    }
+    
+    @Test
+    public void testgetTotalJobsCount() throws Throwable {
+        initExpectedResults("testgetTotalJobsCount-Job", "TEST-TAG");
+        
+        // default parameters
+        actualJobPage = dbManager.getJobs(0, 0, null, true, true, true, null);
+        assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
+        
+        // no pagination, no user, no pending, no running, no finished
+        actualJobPage = dbManager.getJobs(0, 0, null, false, false, false, null);
+        assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
+        
+        // no pagination, user = "admin", pending, running, finished
+        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, null);
+        assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
+        
+        // no pagination, user = "invalid_user", pending, no running, finished
+        actualJobPage = dbManager.getJobs(0, 0, "invalid_user", true, true, true, null);
+        assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
+        
+        // pagination [0,5[, user = "admin", pending, running, finished
+        actualJobPage = dbManager.getJobs(0, 5, "admin", true, true, true, null);
+        assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
+    }
+
+    @Test
+    public void testGetTotalTasksCount() throws Throwable {
+        initExpectedResults("testGetTotalTasksCount-Job", "TEST-TAG");
         assertEquals("Total number of tasks is incorrect", totalNbTasks, lAllTasks.size());
         
         // no given statuses, no pagination, nothing should come up
         crit = TaskFilterCriteria.TFCBuilder.newInstance().running(false).pending(false).finished(false).criterias();
-        actualPage = getTasks(crit);
-        assertSizes(actualPage, 0, 0);
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, 0, 0);
         
         // all statuses, no pagination, everything should come up
         crit = TaskFilterCriteria.TFCBuilder.newInstance().criterias();
-        actualPage = getTasks(crit);
-        assertSizes(actualPage, totalNbTasks, totalNbTasks);
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, totalNbTasks, totalNbTasks);
 
         // all statuses, pagination [0,5[
         crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).criterias();
-        actualPage = getTasks(crit);
-        assertSizes(actualPage, 5, totalNbTasks);
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, 5, totalNbTasks);
         
         // pending tasks only, no pagination
         crit = TaskFilterCriteria.TFCBuilder.newInstance().running(false).finished(false).criterias();
-        actualPage = getTasks(crit);
-        assertSizes(actualPage, totalNbTasks, totalNbTasks);
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, totalNbTasks, totalNbTasks);
         
         // running tasks only, no pagination
-        InternalJob startedJob = lJobs.get(0);
+        startJob(0);
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).finished(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, nbTasksPerJob, nbTasksPerJob);
+        
+        // running tasks only, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).finished(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, 5, nbTasksPerJob);
+        
+        // finished tasks only, no pagination
+        terminateJob(1, 100L);
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, nbTasksPerJob, nbTasksPerJob);
+        
+        // finished tasks only, pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, 5, nbTasksPerJob);
+        
+        // finished tasks only, dates [0,100], no pagination
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().from(0).to(100L).pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, nbTasksPerJob, nbTasksPerJob);
+        
+        // finished tasks only, dates [0,100], pagination [0,5[
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().from(0).to(100L)
+                .offset(0).limit(5)
+                .pending(false).running(false).criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, 5, nbTasksPerJob);
+        
+        // default parameters, with tag "TEST-TAG"
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().tag("TEST-TAG").criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, totalNbTasks, totalNbTasks);
+        
+        // default parameters, with tag "NON-EXISTENT-TAG"
+        crit = TaskFilterCriteria.TFCBuilder.newInstance().tag("NON-EXISTENT-TAG").criterias();
+        actualPageInfo = getTasks(crit);
+        assertTaskPageSizes(actualPageInfo, 0, 0);
+    }
+    
+    private void initExpectedResults(String jobName, String tag) throws Throwable {
+        actualInternalJobs = createTestJobs(jobName, tag, nbJobs, nbTasksPerJob);
+        lAllTasks = new ArrayList<Task>(totalNbTasks);
+        for (InternalJob j : actualInternalJobs) {
+            service.submitJob(j);
+            lAllTasks.addAll(j.getTasks());
+        }
+    }
+    
+    private void startJob(int jobIndex) throws Throwable {
+        InternalJob startedJob = actualInternalJobs.get(jobIndex);
         startedJob.start();
         for (InternalTask task : startedJob.getITasks()) {
             task.setStatus(TaskStatus.RUNNING);
         }
         dbManager.updateJobAndTasksState(startedJob);
-        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).finished(false).criterias();
-        actualPage = getTasks(crit);
-        assertSizes(actualPage, nbTasksPerJob, nbTasksPerJob);
-        
-        // running tasks only, pagination [0,5[
-        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).finished(false).criterias();
-        actualPage = getTasks(crit);
-        assertSizes(actualPage, 5, nbTasksPerJob);
-        
-        // finished tasks only, no pagination
-        InternalJob finishedJob = lJobs.get(1);
+    }
+   
+    private void terminateJob(int jobIndex, long finishedTime) throws Throwable {
+        InternalJob finishedJob = actualInternalJobs.get(jobIndex);
         finishedJob.start();
+        finishedJob.terminate();
         for (InternalTask task : finishedJob.getITasks()) {
-            task.setStatus(TaskStatus.FINISHED);
+            TaskResultImpl result = new TaskResultImpl(task.getId(), "ok", null, 0);
+            FlowAction action = new FlowAction(FlowActionType.CONTINUE);
+            ChangedTasksInfo changesInfo = finishedJob.terminateTask(false, task.getId(), null, action, result);
+            task.setFinishedTime(finishedTime);
+            dbManager.updateAfterWorkflowTaskFinished(finishedJob, changesInfo, result);
         }
-        dbManager.updateJobAndTasksState(finishedJob);
-        crit = TaskFilterCriteria.TFCBuilder.newInstance().pending(false).running(false).criterias();
-        actualPage = getTasks(crit);
-        //actualPage = dbManager.getTasks(0, 0, null, 0, 0, null, false, true, false, null);
-        assertSizes(actualPage, nbTasksPerJob, nbTasksPerJob);
-        
-        // finished tasks only, pagination [0,5[
-        crit = TaskFilterCriteria.TFCBuilder.newInstance().limit(5).pending(false).running(false).criterias();
-        actualPage = getTasks(crit);
-        assertSizes(actualPage, 5, nbTasksPerJob);
-        
-    }
-    
-    @Test
-    @Ignore
-    public void testGetTaskStates() throws Throwable {
-        // default criteria
-        
-        // all statuses, no pagination, everything should come up
-        
-        // only pending 
-        
-        // 
-        
-        // 
-        
-        
-        
-    }
-
-    
-    
-    @Test
-    @Ignore
-    public void testgetTotalJobsCount() throws Throwable {
-        // TODO 
-    }
-
-    @Test
-    @Ignore
-    public void testGetTotalTasksCount() throws Throwable {
-        // TODO 
     }
     
     private List<InternalJob> createTestJobs(String jobName, String taskTag, int nbJobs, int nbTasks)
@@ -135,7 +313,7 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
         List<InternalJob> lJobs = new ArrayList<InternalJob>(nbJobs);
 
         for (int i = 1; i <= nbJobs; i++) {
-            lJobs.add(createTestJob(jobName + "-" + i, taskTag + "-" + i, nbTasks));
+            lJobs.add(createTestJob(jobName + "-" + i, taskTag, nbTasks));
         }
 
         return lJobs;
@@ -157,33 +335,148 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
         return createJob(job);
     }
 
-    private Page<TaskInfo> getTasks(TaskFilterCriteria tfc) {
-        return dbManager.getTasks(tfc.getFrom(), tfc.getTo(), tfc.getTag(),
-                tfc.getOffset(), tfc.getLimit(), tfc.getUser(), tfc.isPending(),
-                tfc.isRunning(), tfc.isFinished(), tfc.getSortParameters());
+    private Page<TaskInfo> getTasks(TaskFilterCriteria criterias) {
+        return dbManager.getTasks(criterias.getFrom(), criterias.getTo(), criterias.getTag(),
+                criterias.getOffset(), criterias.getLimit(), criterias.getUser(), criterias.isPending(),
+                criterias.isRunning(), criterias.isFinished(), criterias.getSortParameters());
     }
     
-    // TODO PARAITA 
     private Page<TaskState> getTaskStates(TaskFilterCriteria criterias) {
-        return null;
+        return dbManager.getTaskStates(criterias.getFrom(), criterias.getTo(), criterias.getTag(),
+                criterias.getOffset(), criterias.getLimit(), criterias.getUser(), criterias.isPending(),
+                criterias.isRunning(), criterias.isFinished(), criterias.getSortParameters());
     }
     
-    private void assertSizes(Page<?> page, int nbTasksInPage, int totalNbTasks) {
+    private void assertTaskPageSizes(Page<?> page, int nbTasksInPage, int totalNbTasks) {
         assertEquals("Returned number of tasks is incorrect", nbTasksInPage, page.getList().size());
         assertEquals("Total number of tasks is incorrect", totalNbTasks, page.getSize());
     }
     
-    // TODO PARAITA
     private void assertTaskInfoPage(Page<TaskInfo> page, TaskFilterCriteria criterias) {
-        
-    }
-    
-    // TODO PARAITA
-    private void assertTaskStatePage(Page<TaskState> page, TaskFilterCriteria criterias) {
-        
-    }
-    
+        List<TaskInfo> taskInfos = page.getList();
+        for (TaskInfo taskInfo : taskInfos) {
+            
+            String taskStr = taskInfo.getName() +
+                    "," + taskInfo.getTaskId().getTag() +
+                    "," + String.valueOf(taskInfo.getFinishedTime()) +
+                    "," + taskInfo.getStatus();
+            System.out.println(taskStr);
+            
+            String tag = criterias.getTag();
+            
+            // tag
+            if (tag != null && "".compareTo(tag) != 0)
+                assertEquals("Tag is incorrect for task " + taskStr, tag, taskInfo.getTaskId().getTag());
 
+            // from
+            long from = criterias.getFrom();
+            if (from != 0)
+                assertEquals("startTime is incorrect", from, taskInfo.getStartTime());
+            
+            // to
+            long to = criterias.getTo();
+            if (to != 0)
+                assertEquals("finishedTime is incorrect", to, taskInfo.getFinishedTime());
+
+            // pagination
+            int pageSize = criterias.getLimit() - criterias.getOffset(); 
+            if (pageSize > 0) {
+                assertTrue("Page size is incorrect", pageSize >= taskInfos.size());
+            }
+            
+            // user
+            String user = criterias.getUser();
+            if (user != null && "".compareTo(user) != 0) {
+                assertEquals("user is incorrect", user, taskInfo.getJobInfo().getJobOwner());
+            }
+            
+            // status
+            // If the returned status of this task is one of those
+            // the corresponding criteria should be true
+            switch(taskInfo.getStatus()) {
+                case SUBMITTED:
+                case PENDING:
+                case NOT_STARTED: 
+                    assertTrue("Task status is incorrect", criterias.isPending());
+                    break;
+                case PAUSED:
+                case RUNNING:
+                case WAITING_ON_ERROR:
+                case WAITING_ON_FAILURE:
+                    assertTrue("Task status is incorrect", criterias.isRunning());
+                    break;
+                case FAILED:
+                case NOT_RESTARTED:
+                case ABORTED:
+                case FAULTY:
+                case FINISHED:
+                case SKIPPED:
+                    assertTrue("Task status is incorrect", criterias.isFinished());
+                    break;
+                default:
+                    fail("Incoherent task status");
+            }
+        }
+    }
     
+    private void assertTaskStatePage(Page<TaskState> page, TaskFilterCriteria criterias) {
+        int nbTaskStates = page.getList().size();
+        for (TaskState taskState : page.getList()) {
+            
+            String tag = criterias.getTag(); 
+            if (tag != null)
+                assertEquals("Tag is incorrect", tag, taskState.getTag());
+            
+         // from
+            long from = criterias.getFrom();
+            if (from != 0)
+                assertEquals("startTime is incorrect", from, taskState.getStartTime());
+            
+            // to
+            long to = criterias.getTo();
+            if (to != 0)
+                assertEquals("finishedTime is incorrect", to, taskState.getFinishedTime());
+
+            // pagination
+            int pageSize = criterias.getLimit() - criterias.getOffset(); 
+            if (pageSize > 0) {
+                assertTrue("Page size is incorrect", pageSize >= nbTaskStates);
+            }
+            
+            // user
+            String expectedUser = criterias.getUser();
+            String actualUser = taskState.getTaskInfo().getJobInfo().getJobOwner();
+            if (expectedUser != null && "".compareTo(expectedUser) != 0) {
+                assertEquals("user is incorrect", expectedUser, actualUser);
+            }
+            
+            // status
+            // If the returned status of this task is one of those
+            // the corresponding criteria should be true
+            switch(taskState.getStatus()) {
+                case SUBMITTED:
+                case PENDING:
+                case NOT_STARTED: 
+                    assertTrue("Task status is incorrect", criterias.isPending());
+                    break;
+                case PAUSED:
+                case RUNNING:
+                case WAITING_ON_ERROR:
+                case WAITING_ON_FAILURE:
+                    assertTrue("Task status is incorrect", criterias.isRunning());
+                    break;
+                case FAILED:
+                case NOT_RESTARTED:
+                case ABORTED:
+                case FAULTY:
+                case FINISHED:
+                case SKIPPED:
+                    assertTrue("Task status is incorrect", criterias.isFinished());
+                    break;
+                default:
+                    fail("Incoherent task status");
+            }
+        }
+    }
     
 }


### PR DESCRIPTION
The parameters `from` and `to` could not be used independently from each other. This has been fixed.
Functional tests are also added to cover the new SchedulerDBManager methods introduced by those REST resources.