### PR TITLE
Remove definition of web app specific properties from JettyStarter

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
@@ -86,12 +86,6 @@ public class JettyStarter {
             boolean httpsEnabled = Boolean.parseBoolean(properties.getProperty("web.https", "false"));
             String httpProtocol = httpsEnabled ? "https" : "http";
 
-            // for web portals
-            String defaultRestUrl = httpProtocol + "://localhost:" + restPort + "/rest";
-            setSystemPropertyIfNotDefined("rest.url", defaultRestUrl);
-            setSystemPropertyIfNotDefined("sched.rest.url", defaultRestUrl);
-            setSystemPropertyIfNotDefined("rm.rest.url", defaultRestUrl);
-
             Server server = createHttpServer(properties, restPort, httpsEnabled);
             server.setStopAtShutdown(true);
 


### PR DESCRIPTION
The properties which have been removed are Java system properties that have precedence over properties defined in configuration file. Consequently, it was impossible to change the value of these properties without editing code and recompiling.

Since the properties which have been removed are Web apps specific, they should be defined by them only. Although Web apps are deployed by default on the same host where the scheduler is, it is not always the case in real world scenarios.  