### PR TITLE
changing the tests methods called run

### DIFF
--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/TestSchedulerEvent.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/TestSchedulerEvent.java
@@ -51,7 +51,7 @@ import org.junit.Test;
 public class TestSchedulerEvent {
 
     @Test
-    public void run() throws Throwable {
+    public void testSchedulerEvent() throws Throwable {
         Assert.assertEquals(SchedulerEvent.FROZEN.ordinal(), 0);
         Assert.assertEquals(SchedulerEvent.RESUMED.ordinal(), 1);
         Assert.assertEquals(SchedulerEvent.SHUTDOWN.ordinal(), 2);

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
@@ -36,6 +36,9 @@
  */
 package org.ow2.proactive.scheduler.common.job.factories;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -43,6 +46,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
@@ -54,10 +59,6 @@ import org.ow2.proactive.scheduler.common.task.RestartMode;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
-import org.junit.Assert;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 
 /**
@@ -75,7 +76,7 @@ public class TestJobFactory {
             .getResource("Job_MultiNodes.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testJobFactory() throws Throwable {
         //test default behavior as well (null is STAX)
         log("TEST jobFactory STAX");
         run_(null);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/SchedulerUsageTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/SchedulerUsageTest.java
@@ -34,10 +34,14 @@
  */
 package functionaltests.api;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import java.security.PublicKey;
 import java.util.Date;
 import java.util.List;
 
+import org.junit.Test;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.scheduler.common.Scheduler;
@@ -45,18 +49,15 @@ import org.ow2.proactive.scheduler.common.SchedulerAuthenticationInterface;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.usage.JobUsage;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.TestUsers;
-
-import static org.junit.Assert.*;
 
 
 public class SchedulerUsageTest extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Exception {
+    public void testSchedulerUsage() throws Exception {
 
         SchedulerAuthenticationInterface auth = schedulerHelper.getSchedulerAuth();
         PublicKey pubKey = auth.getPublicKey();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/TestJobInstantGetTaskResult.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/TestJobInstantGetTaskResult.java
@@ -36,14 +36,14 @@
  */
 package functionaltests.api;
 
+import org.junit.Test;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
-import org.junit.Test;
 
-import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.executables.ResultAsArray;
+import functionaltests.utils.SchedulerFunctionalTest;
 
 
 /**
@@ -58,7 +58,7 @@ import functionaltests.executables.ResultAsArray;
 public class TestJobInstantGetTaskResult extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testJobInstantGetTaskResult() throws Throwable {
         //create Scheduler client as an active object
         SubmitJob client = (SubmitJob) PAActiveObject.newActive(SubmitJob.class.getName(), new Object[] {});
         //begin to use the client : must be a futur result in order to start the scheduler at next step

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/TestMultipleUsersMakingMassivGetResultRequest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/TestMultipleUsersMakingMassivGetResultRequest.java
@@ -36,6 +36,9 @@
  */
 package functionaltests.api;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+
+import org.junit.Test;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.scheduler.common.Scheduler;
@@ -45,12 +48,9 @@ import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.examples.EmptyTask;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.TestUsers;
-
-import static functionaltests.utils.SchedulerTHelper.log;
 
 
 /**
@@ -72,7 +72,7 @@ public class TestMultipleUsersMakingMassivGetResultRequest extends SchedulerFunc
     private static int nbFinished = 0;//will be increase to count terminated threads
 
     @Test
-    public void run() throws Throwable {
+    public void testMultipleUsersMakingMassivGetResultRequest() throws Throwable {
 
         final SchedulerAuthenticationInterface auth = schedulerHelper.getSchedulerAuth();
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/TestSchedulerMiscEvents.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/TestSchedulerMiscEvents.java
@@ -36,18 +36,17 @@
  */
 package functionaltests.api;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.SchedulerStatus;
 
-import org.junit.Test;
-
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.UserType;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -61,7 +60,7 @@ import static org.junit.Assert.assertTrue;
 public class TestSchedulerMiscEvents extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testSchedulerMiscEvents() throws Throwable {
 
         Scheduler schedAdminInterface = schedulerHelper.getSchedulerInterface(UserType.ADMIN);
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/credentials/TaskUsingCredentialsTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/credentials/TaskUsingCredentialsTest.java
@@ -34,10 +34,14 @@
  */
 package functionaltests.credentials;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 import java.util.Set;
 
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobId;
@@ -46,11 +50,8 @@ import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory;
 import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
-import functionaltests.utils.SchedulerFunctionalTest;
-import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import functionaltests.utils.SchedulerFunctionalTest;
 
 
 public class TaskUsingCredentialsTest extends SchedulerFunctionalTest {
@@ -58,7 +59,7 @@ public class TaskUsingCredentialsTest extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_UsingCredentials.xml");
 
     @Test
-    public void run() throws Exception {
+    public void testTaskUsingCredentials() throws Exception {
         jobs_using_third_party_credentials();
         third_party_credentials_api();
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestDataspaceScripts.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestDataspaceScripts.java
@@ -36,6 +36,9 @@
  */
 package functionaltests.dataspaces;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -43,6 +46,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
@@ -51,13 +57,8 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scripting.SimpleScript;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static org.junit.Assert.*;
 
 
 /**
@@ -98,7 +99,7 @@ public class TestDataspaceScripts extends SchedulerFunctionalTest {
      * Creates a task with a Pre/Post/Flow scripts that copy files from input files to output files
      */
     @Test
-    public void run() throws Throwable {
+    public void testDataspaceScripts() throws Throwable {
         File input = tmpFolder.newFolder("input");
         File output = tmpFolder.newFolder("output");
         File global = tmpFolder.newFolder("global");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestGlobalSpace.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestGlobalSpace.java
@@ -36,6 +36,10 @@
  */
 package functionaltests.dataspaces;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -44,6 +48,13 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URI;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.objectweb.proactive.extensions.dataspaces.vfs.VFSFactory;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobId;
@@ -53,18 +64,8 @@ import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
 import org.ow2.proactive.scripting.SimpleScript;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemManager;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -149,7 +150,7 @@ public class TestGlobalSpace extends SchedulerFunctionalTest {
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     @Test
-    public void run() throws Throwable {
+    public void testGlobalSpace() throws Throwable {
 
         File in = tmpFolder.newFolder("input_space");
         String inPath = in.getAbsolutePath();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestJobDataspaceSubmission.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestJobDataspaceSubmission.java
@@ -42,6 +42,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
 import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
 import org.objectweb.proactive.utils.OperatingSystem;
@@ -52,7 +53,6 @@ import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
-import org.junit.Assert;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 
@@ -99,7 +99,7 @@ public class TestJobDataspaceSubmission extends SchedulerFunctionalTest {
      * @throws Throwable any exception that can be thrown during the test.
      */
     @org.junit.Test
-    public void run() throws Throwable {
+    public void testJobDataspaceSubmission() throws Throwable {
 
         //create initial directories and files
         setup();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSpecialCharacterFileName.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSpecialCharacterFileName.java
@@ -36,6 +36,8 @@
  */
 package functionaltests.dataspaces;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -44,15 +46,14 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import org.objectweb.proactive.utils.OperatingSystem;
-import org.ow2.proactive.process_tree_killer.ProcessTree;
-import functionaltests.utils.SchedulerFunctionalTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.objectweb.proactive.utils.OperatingSystem;
+import org.ow2.proactive.process_tree_killer.ProcessTree;
 
-import static org.junit.Assume.assumeTrue;
+import functionaltests.utils.SchedulerFunctionalTest;
 
 
 /**
@@ -127,7 +128,7 @@ public class TestSpecialCharacterFileName extends SchedulerFunctionalTest {
      * @throws Throwable any exception that can be thrown during the test.
      */
     @Test
-    public void run() throws Throwable {
+    public void testSpecialCharacterFileName() throws Throwable {
 
         // Now we launch the scheduler from the generated script, to consider the -Dfile.encoding parameter
         schedulerHelper.killScheduler();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSubmitJobWithPartiallyUnaccessibleDataSpaces.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSubmitJobWithPartiallyUnaccessibleDataSpaces.java
@@ -34,21 +34,21 @@
  */
 package functionaltests.dataspaces;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.Charset;
 
-import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static org.junit.Assert.*;
 
 
 /**
@@ -93,7 +93,7 @@ public class TestSubmitJobWithPartiallyUnaccessibleDataSpaces extends SchedulerF
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testSubmitJobWithPartiallyUnaccessibleDataSpaces() throws Throwable {
 
         schedulerHelper.testJobSubmissionAndVerifyAllResults(new File(jobDescriptor.toURI())
                 .getAbsolutePath());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSubmitJobWithUnaccessibleDataSpaces.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSubmitJobWithUnaccessibleDataSpaces.java
@@ -60,7 +60,7 @@ public class TestSubmitJobWithUnaccessibleDataSpaces extends SchedulerFunctional
             .getResource("/functionaltests/dataspaces/schedulerPropertiesWrongSpaces.ini");
 
     @Test
-    public void run() throws Throwable {
+    public void testSubmitJobWithUnaccessibleDataSpaces() throws Throwable {
         schedulerHelper.startScheduler((new File(configFile.toURI())).getAbsolutePath());
         schedulerHelper.testJobSubmissionAndVerifyAllResults(new File(jobDescriptor.toURI())
                 .getAbsolutePath());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestUserSpace.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestUserSpace.java
@@ -36,6 +36,9 @@
  */
 package functionaltests.dataspaces;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -44,6 +47,13 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URI;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.objectweb.proactive.extensions.dataspaces.vfs.VFSFactory;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobId;
@@ -54,18 +64,8 @@ import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
 import org.ow2.proactive.scripting.SimpleScript;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemManager;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -137,7 +137,7 @@ public class TestUserSpace extends SchedulerFunctionalTest {
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     @Test
-    public void run() throws Throwable {
+    public void testUserSpace() throws Throwable {
 
         File in = tmpFolder.newFolder("input_space");
         String inPath = in.getAbsolutePath();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestWorkflowDataspace.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestWorkflowDataspace.java
@@ -42,6 +42,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
@@ -50,8 +52,6 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
 import org.ow2.proactive.scheduler.common.task.flow.FlowBlock;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
-import org.junit.Assert;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.workflow.JobWorkflowDataspace;
@@ -67,7 +67,7 @@ import functionaltests.workflow.TWorkflowJobs;
 public class TestWorkflowDataspace extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowDataspace() throws Throwable {
         testJavaTask();
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobRemoved.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobRemoved.java
@@ -36,17 +36,17 @@
  */
 package functionaltests.job;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.SchedulerState;
 import org.ow2.proactive.scheduler.common.job.JobId;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -65,7 +65,7 @@ public class TestJobRemoved extends SchedulerFunctionalTest {
     private final static int EVENT_TIMEOUT = 5000;
 
     @Test
-    public void run() throws Throwable {
+    public void testJobRemoved() throws Throwable {
 
         SchedulerState state = schedulerHelper.getSchedulerInterface().getState();
         int jobsNumber = state.getFinishedJobs().size() + state.getPendingJobs().size() +

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobSchedulerHome.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobSchedulerHome.java
@@ -36,22 +36,34 @@
  */
 package functionaltests.job;
 
-import functionaltests.executables.PAHomeExecutable;
-import functionaltests.utils.SchedulerFunctionalTest;
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
-import org.ow2.proactive.scheduler.common.job.*;
-import org.ow2.proactive.scheduler.common.task.*;
+import org.ow2.proactive.scheduler.common.job.Job;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobInfo;
+import org.ow2.proactive.scheduler.common.job.JobResult;
+import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
+import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
+import org.ow2.proactive.scheduler.common.task.JavaTask;
+import org.ow2.proactive.scheduler.common.task.NativeTask;
+import org.ow2.proactive.scheduler.common.task.ScriptTask;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
 
-import java.io.File;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
+import functionaltests.executables.PAHomeExecutable;
+import functionaltests.utils.SchedulerFunctionalTest;
 
 
 /**
@@ -69,7 +81,7 @@ public class TestJobSchedulerHome extends SchedulerFunctionalTest {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testJobSchedulerHome() throws Throwable {
         pahomeJavaTask();
         pahomeForkedJavaTask();
         pahomeNativeTask();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobWalltime.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobWalltime.java
@@ -36,6 +36,12 @@
  */
 package functionaltests.job;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.exception.WalltimeExceededException;
 import org.ow2.proactive.scheduler.common.job.Job;
@@ -50,13 +56,9 @@ import org.ow2.proactive.scheduler.common.task.ScriptTask;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.junit.Test;
 
 import functionaltests.executables.EndlessExecutable;
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -67,7 +69,7 @@ public class TestJobWalltime extends SchedulerFunctionalTest {
     private static final long TIMEOUT = 30000;
 
     @Test
-    public void run() throws Throwable {
+    public void testJobWalltime() throws Throwable {
         JobId walltimeJavaTask = walltimeJavaTask();
         JobId walltimeForkedJavaTask = walltimeForkedJavaTask();
         JobId walltimeNativeTask = walltimeNativeTask();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TestPreemptRestartKillTask.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TestPreemptRestartKillTask.java
@@ -36,9 +36,15 @@
  */
 package functionaltests.job;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.exception.TaskAbortedException;
 import org.ow2.proactive.scheduler.common.exception.TaskPreemptedException;
 import org.ow2.proactive.scheduler.common.exception.TaskRestartedException;
@@ -50,12 +56,8 @@ import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -84,7 +86,7 @@ public class TestPreemptRestartKillTask extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_preempt_restart_kill.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testPreemptRestartKillTask() throws Throwable {
 
         log("Submitting job");
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestErrorAndFailure.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestErrorAndFailure.java
@@ -36,8 +36,12 @@
  */
 package functionaltests.job.error;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+
 import java.util.Map;
 
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
@@ -48,13 +52,9 @@ import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.examples.NativeTestWithRandomDefault;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.TestScheduler;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -75,7 +75,7 @@ import static org.junit.Assert.*;
 public class TestErrorAndFailure extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testErrorAndFailure() throws Throwable {
 
         String javaCmd = System.getProperty("java.home") + "/bin/java";
         log("Test 1 : Creating job...");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobAborted.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobAborted.java
@@ -36,22 +36,23 @@
  */
 package functionaltests.job.error;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 import java.net.URL;
 import java.util.Map;
 
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
 import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -72,7 +73,7 @@ public class TestJobAborted extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_Aborted.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testJobAborted() throws Throwable {
 
         String task1Name = "task1";
         String task2Name = "task2";

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobCanceledWithReplication.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobCanceledWithReplication.java
@@ -36,10 +36,16 @@
  */
 package functionaltests.job.error;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 import java.util.Map;
 
+import org.junit.Test;
 import org.objectweb.proactive.utils.StackTraceUtil;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
@@ -48,12 +54,8 @@ import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.examples.FailTaskConditionally;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -75,7 +77,7 @@ public class TestJobCanceledWithReplication extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_Aborted_With_Replication.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testJobCanceledWithReplication() throws Throwable {
         schedulerHelper.addExtraNodes(3);
 
         String faultyTaskName = "task2*1";

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestTaskNotExecuted.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestTaskNotExecuted.java
@@ -36,9 +36,15 @@
  */
 package functionaltests.job.error;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.exception.TaskCouldNotRestartException;
 import org.ow2.proactive.scheduler.common.exception.TaskCouldNotStartException;
 import org.ow2.proactive.scheduler.common.exception.TaskSkippedException;
@@ -47,13 +53,8 @@ import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
-import org.junit.Assert;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 public class TestTaskNotExecuted extends SchedulerFunctionalTest {
@@ -66,7 +67,7 @@ public class TestTaskNotExecuted extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_TaskSkipped.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testTaskNotExecuted() throws Throwable {
 
         log("Submitting job 1");
         JobId id1 = schedulerHelper.submitJob(new File(jobDescriptor1.toURI()).getAbsolutePath());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/multinodes/TestJobMultiNodesWalltime.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/multinodes/TestJobMultiNodesWalltime.java
@@ -39,8 +39,8 @@ package functionaltests.job.multinodes;
 import java.io.File;
 import java.net.URL;
 
-import org.ow2.proactive.scheduler.common.job.JobId;
 import org.junit.Test;
+import org.ow2.proactive.scheduler.common.job.JobId;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 
@@ -57,7 +57,7 @@ public class TestJobMultiNodesWalltime extends SchedulerFunctionalTest {
     private static final long TIMEOUT = 30000;
 
     @Test
-    public void run() throws Throwable {
+    public void testJobMultiNodesWalltime() throws Throwable {
         //submit job
         JobId id = schedulerHelper.submitJob(new File(jobDescriptor.toURI()).getAbsolutePath());
         //connect to RM

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/multinodes/TestMultipleHostsRequest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/multinodes/TestMultipleHostsRequest.java
@@ -36,9 +36,14 @@
  */
 package functionaltests.job.multinodes;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
@@ -49,13 +54,9 @@ import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.SchedulerTHelper;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -79,7 +80,7 @@ public class TestMultipleHostsRequest extends SchedulerFunctionalTest {
             .getResource("/functionaltests/executables/test_multiple_hosts_request.bat");
 
     @Test
-    public void run() throws Throwable {
+    public void testMultipleHostsRequest() throws Throwable {
 
         String task1Name = "task1";
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/taskkill/TestProcessTreeKiller.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/taskkill/TestProcessTreeKiller.java
@@ -36,6 +36,9 @@
  */
 package functionaltests.job.taskkill;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -43,6 +46,11 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.process_tree_killer.ProcessTree;
 import org.ow2.proactive.scheduler.common.exception.UserException;
@@ -55,16 +63,8 @@ import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -100,7 +100,7 @@ public class TestProcessTreeKiller extends SchedulerFunctionalTest {
     public Timeout testTimeout = new Timeout(10, TimeUnit.MINUTES);
 
     @Test
-    public void run() throws Throwable {
+    public void testProcessTreeKiller() throws Throwable {
         schedulerHelper.addExtraNodes(2);
 
         Logger.getLogger(ProcessTree.class).setLevel(Level.DEBUG);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/workingdir/TestWorkingDirStaticCommand.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/workingdir/TestWorkingDirStaticCommand.java
@@ -41,6 +41,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
@@ -52,8 +54,6 @@ import org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory;
 import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
-import org.junit.Assert;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.SchedulerTHelper;
@@ -84,7 +84,7 @@ public class TestWorkingDirStaticCommand extends SchedulerFunctionalTest {
             .getResource("/functionaltests/executables");
 
     @Test
-    public void run() throws Throwable {
+    public void testWorkingDirStaticCommand() throws Throwable {
 
         String task1Name = "task1";
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/rm/nodesource/TestJobNodeAccessToken.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/rm/nodesource/TestJobNodeAccessToken.java
@@ -71,7 +71,7 @@ public class TestJobNodeAccessToken extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_simple_with_token.xml");
     
     @Test
-    public void run() throws Throwable {
+    public void testJobNodeAccessToken() throws Throwable {
     	
         JobId id = schedulerHelper.submitJob(new File(simpleJob.toURI()).getAbsolutePath());
         SchedulerTHelper.log("Job submitted, id " + id.toString());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestScriptEngines.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestScriptEngines.java
@@ -34,20 +34,22 @@
  */
 package functionaltests.scripts;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 import java.util.Map;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
-import org.junit.Assert;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -65,7 +67,7 @@ public class TestScriptEngines extends SchedulerFunctionalTest {
         jobDescriptorsLoc);
 
     @Test
-    public void run() throws Throwable {
+    public void testScriptEngines() throws Throwable {
         log("Testing submission of job descriptor : " + jobDescriptor);
         JobId id = schedulerHelper.testJobSubmission(new File(jobDescriptor.toURI()).getAbsolutePath());
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestScriptTask.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestScriptTask.java
@@ -36,9 +36,16 @@
  */
 package functionaltests.scripts;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.job.JobState;
@@ -48,13 +55,9 @@ import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
 import org.ow2.proactive.scheduler.task.exceptions.ForkedJvmProcessException;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.SchedulerStartForFunctionalTest;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
 
 
 public class TestScriptTask extends SchedulerFunctionalTest {
@@ -66,7 +69,7 @@ public class TestScriptTask extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_null_returning_script_task.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testScriptTask() throws Throwable {
         forkedTasks();
         test_getTaskResult_nullReturningScriptTask_shouldSucceed();
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/scripts/selection/TestJobSelScriptSubmission.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/scripts/selection/TestJobSelScriptSubmission.java
@@ -50,7 +50,7 @@ public class TestJobSelScriptSubmission extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_with_select_script.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testJobSelScriptSubmission() throws Throwable {
         schedulerHelper.testJobSubmissionAndVerifyAllResults(new File(jobDescriptor.toURI())
                 .getAbsolutePath());
         schedulerHelper.checkNodesAreClean();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/scripts/selection/TestJobWithInvalidSelectionScript.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/scripts/selection/TestJobWithInvalidSelectionScript.java
@@ -36,22 +36,25 @@
  */
 package functionaltests.scripts.selection;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.net.URL;
 import java.util.Map;
 
+import org.junit.Test;
 import org.objectweb.proactive.core.ProActiveTimeoutException;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
 import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -70,7 +73,7 @@ public class TestJobWithInvalidSelectionScript extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_invalidSS.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testJobWithInvalidSelectionScript() throws Throwable {
 
         String task1Name = "task1";
         String task2Name = "task2";

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestGenericInformation.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestGenericInformation.java
@@ -39,6 +39,8 @@ package functionaltests.workflow;
 import java.io.Serializable;
 import java.util.HashMap;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobState;
@@ -49,8 +51,6 @@ import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.task.executable.JavaExecutable;
 import org.ow2.proactive.scheduler.common.task.flow.FlowBlock;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
-import org.junit.Assert;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.utils.SchedulerTHelper;
@@ -74,7 +74,7 @@ public class TestGenericInformation extends SchedulerFunctionalTest {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testGenericInformation() throws Throwable {
         testRegularJob();
         testWithReplication();
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobCoverage.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobCoverage.java
@@ -36,9 +36,17 @@
  */
 package functionaltests.workflow;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
 import org.objectweb.proactive.utils.StackTraceUtil;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
@@ -49,15 +57,9 @@ import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
-import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
 
-import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.job.error.TestJobAborted;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
+import functionaltests.utils.SchedulerFunctionalTest;
 
 
 /**
@@ -98,7 +100,7 @@ public class TestJobCoverage extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_Coverage.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testJobCoverage() throws Throwable {
         JobState jstate;
         TaskInfo tinfo;
         JobInfo jinfo;

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobLegacySchemas.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobLegacySchemas.java
@@ -36,20 +36,20 @@
  */
 package functionaltests.workflow;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
-import org.apache.commons.io.FileUtils;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
 
 
 /**
@@ -80,7 +80,7 @@ public class TestJobLegacySchemas extends SchedulerFunctionalTest {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testJobLegacySchemas() throws Throwable {
         for (URL jobDescriptor : jobDescriptors) {
             log("Testing submission of job descriptor : " + jobDescriptor);
             prepareDataspaceFolder();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowFailedScript.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowFailedScript.java
@@ -39,14 +39,14 @@ package functionaltests.workflow;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
-import org.junit.Assert;
-import org.junit.Test;
 
 
 /**
@@ -63,7 +63,7 @@ public class TestWorkflowFailedScript extends TRepJobs {
     private static final String ifScriptContent = "throw new java.lang.Exception(\"test exception\");";
 
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowFailedScript() throws Throwable {
         testIf();
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowIterationAwareness.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowIterationAwareness.java
@@ -36,12 +36,16 @@
  */
 package functionaltests.workflow;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
 import java.util.Map.Entry;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobResult;
@@ -51,12 +55,8 @@ import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scripting.SimpleScript;
-import org.junit.Assert;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -92,7 +92,7 @@ public class TestWorkflowIterationAwareness extends SchedulerFunctionalTest {
      * @throws Throwable
      */
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowIterationAwareness() throws Throwable {
         testJavaJob();
         testNativeJob();
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowSubmission.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowSubmission.java
@@ -39,11 +39,11 @@ package functionaltests.workflow;
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
-import org.junit.Assert;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerTHelper;
 
@@ -65,7 +65,7 @@ public class TestWorkflowSubmission extends TRepJobs {
     private static final int jobs_fail = 44;
 
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowSubmission() throws Throwable {
         testFail();
         testValid();
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestXMLTransformer.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestXMLTransformer.java
@@ -36,25 +36,26 @@
  */
 package functionaltests.workflow;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 
-import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
-import org.ow2.proactive.scheduler.common.job.factories.Job2XMLTransformer;
-import org.ow2.proactive.scheduler.common.job.factories.JobComparator;
-import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
-import org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory;
-import functionaltests.job.multinodes.TestMultipleHostsRequest;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
+import org.ow2.proactive.scheduler.common.job.factories.Job2XMLTransformer;
+import org.ow2.proactive.scheduler.common.job.factories.JobComparator;
+import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
+import org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory;
 
-import static functionaltests.utils.SchedulerTHelper.log;
+import functionaltests.job.multinodes.TestMultipleHostsRequest;
 
 
 /**
@@ -100,7 +101,7 @@ public class TestXMLTransformer {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testXMLTransformer() throws Throwable {
         File folder = new File(jobDescriptorsFolder.toURI());
         Collection<File> testJobDescrFiles = FileUtils.listFiles(folder, new String[] { "xml" }, true);
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs.java
@@ -50,7 +50,7 @@ import functionaltests.workflow.TRepJobs;
  */
 public class TestWorkflowComplexJobs extends TRepJobs {
     @org.junit.Test
-    public void run() throws Throwable {
+    public void testWorkflowComplexJobs() throws Throwable {
         String prefix = "/functionaltests/workflow/descriptors/flow_complex_";
 
         TRepCase t1 = new TRepCase(prefix + "1.xml", 20, "T,2,12 T4,4,32 T5,4,68 T1,4,28 T3,4,32 T2,2,70");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs2.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs2.java
@@ -36,8 +36,8 @@
  */
 package functionaltests.workflow.complex;
 
-import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.junit.Test;
+import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 
 import functionaltests.workflow.TRepJobs;
 
@@ -51,7 +51,7 @@ import functionaltests.workflow.TRepJobs;
  */
 public class TestWorkflowComplexJobs2 extends TRepJobs {
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowComplexJobs2() throws Throwable {
         String prefix = "/functionaltests/workflow/descriptors/flow_complex_2_";
 
         TRepCase t1 = new TRepCase(prefix + "1.xml", 87,

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs3.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs3.java
@@ -36,9 +36,8 @@
  */
 package functionaltests.workflow.complex;
 
-import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
-
 import org.junit.Test;
+import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 
 import functionaltests.workflow.TWorkflowJobs;
 
@@ -111,7 +110,7 @@ public class TestWorkflowComplexJobs3 extends TWorkflowJobs {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowComplexJobs3() throws Throwable {
         internalRun();
     }
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs4.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs4.java
@@ -37,7 +37,6 @@
 package functionaltests.workflow.complex;
 
 import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
-import org.junit.Ignore;
 
 import functionaltests.workflow.TRepJobs;
 
@@ -51,7 +50,7 @@ import functionaltests.workflow.TRepJobs;
  */
 public class TestWorkflowComplexJobs4 extends TRepJobs {
     @org.junit.Test
-    public void run() throws Throwable {
+    public void testWorkflowComplexJobs4() throws Throwable {
         String prefix = "/functionaltests/workflow/descriptors/flow_complex_4_";
 
         TRepCase t1 = new TRepCase(prefix + "1.xml", 14, "T,1,0 T4,3,9 T5,1,10 T1,3,3 T3,3,-3 T2,3,6");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs5.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowComplexJobs5.java
@@ -36,8 +36,8 @@
  */
 package functionaltests.workflow.complex;
 
-import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.junit.Test;
+import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 
 import functionaltests.workflow.TRepJobs;
 
@@ -51,7 +51,7 @@ import functionaltests.workflow.TRepJobs;
  */
 public class TestWorkflowComplexJobs5 extends TRepJobs {
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowComplexJobs5() throws Throwable {
         String prefix = "/functionaltests/workflow/descriptors/flow_complex_5_";
 
         TRepCase t1 = new TRepCase(prefix + "1.xml", 38, "T,1,0 T4,9,54 T5,1,28 T1,9,36 T3,9,-9 T2,9,45");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowIfJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowIfJobs.java
@@ -36,8 +36,8 @@
  */
 package functionaltests.workflow.complex;
 
-import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.junit.Test;
+import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 
 import functionaltests.workflow.TWorkflowJobs;
 
@@ -81,7 +81,7 @@ public class TestWorkflowIfJobs extends TWorkflowJobs {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowIfJobs() throws Throwable {
         internalRun();
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowLoopJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowLoopJobs.java
@@ -106,7 +106,7 @@ public class TestWorkflowLoopJobs extends TWorkflowJobs {
     }
 
     @org.junit.Test
-    public void run() throws Throwable {
+    public void testWorkflowLoopJobs() throws Throwable {
         internalRun();
     }
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowLoopJobs2.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowLoopJobs2.java
@@ -36,8 +36,8 @@
  */
 package functionaltests.workflow.complex;
 
-import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.junit.Test;
+import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 
 import functionaltests.workflow.TWorkflowJobs;
 
@@ -101,7 +101,7 @@ public class TestWorkflowLoopJobs2 extends TWorkflowJobs {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowLoopJobs2() throws Throwable {
         internalRun();
     }
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowReplicateJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowReplicateJobs.java
@@ -49,7 +49,7 @@ import functionaltests.workflow.TRepJobs;
  */
 public class TestWorkflowReplicateJobs extends TRepJobs {
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowReplicateJobs() throws Throwable {
         String prefix = "/functionaltests/workflow/descriptors/flow_duplicate_";
 
         TRepCase t1 = new TRepCase(prefix + "1.xml", 4, "T,1,0 T1,2,2 T2,1,3");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowReplicateJobs2.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowReplicateJobs2.java
@@ -49,7 +49,7 @@ import functionaltests.workflow.TRepJobs;
  */
 public class TestWorkflowReplicateJobs2 extends TRepJobs {
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowReplicateJobs2() throws Throwable {
         String prefix = "/functionaltests/workflow/descriptors/flow_duplicate_2_";
 
         TRepCase t1 = new TRepCase(prefix + "1.xml", 38,

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowReplicateJobs3.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/complex/TestWorkflowReplicateJobs3.java
@@ -50,7 +50,7 @@ import functionaltests.workflow.TRepJobs;
  */
 public class TestWorkflowReplicateJobs3 extends TRepJobs {
     @Test
-    public void run() throws Throwable {
+    public void testWorkflowReplicateJobs3() throws Throwable {
         String prefix = "/functionaltests/workflow/descriptors/flow_duplicate_3_";
 
         TRepCase t1 = new TRepCase(prefix + "1.xml", 9, "A,1,0 B,2,2 C,3,6 D,2,8 E,1,9");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/javatask/ComplexTypeArgsTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/javatask/ComplexTypeArgsTest.java
@@ -36,25 +36,24 @@
  */
 package functionaltests.workflow.javatask;
 
+import static org.junit.Assert.assertFalse;
+
 import java.io.Serializable;
 
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 
-import org.junit.Test;
-
-import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.executables.ComplexParamsExecutable;
-
-import static org.junit.Assert.assertFalse;
+import functionaltests.utils.SchedulerFunctionalTest;
 
 
 public class ComplexTypeArgsTest extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testComplexTypeArgs() throws Throwable {
         TaskFlowJob submittedJob = new TaskFlowJob();
         JavaTask task = new JavaTask();
         task.setName("t1");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/nativetask/TestJobNativeSubmission.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/nativetask/TestJobNativeSubmission.java
@@ -36,6 +36,10 @@
  */
 package functionaltests.workflow.nativetask;
 
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
@@ -45,12 +49,8 @@ import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
 
 
 /**
@@ -75,7 +75,7 @@ import static org.junit.Assert.*;
 public class TestJobNativeSubmission extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testJobNativeSubmission() throws Throwable {
 
         //test submission and event reception
         TaskFlowJob job = new TaskFlowJob();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/nativetask/TestNativeTaskPaths.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/nativetask/TestNativeTaskPaths.java
@@ -42,6 +42,10 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobId;
@@ -51,10 +55,6 @@ import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 
@@ -79,7 +79,7 @@ public class TestNativeTaskPaths extends SchedulerFunctionalTest {
         OutVarsFileD + "\n";
 
     @Test
-    public void run() throws Throwable {
+    public void testNativeTaskPaths() throws Throwable {
 
         File in = File.createTempFile("input", "space");
         in.delete();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestModifyPropagatedVariables.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestModifyPropagatedVariables.java
@@ -36,16 +36,16 @@
  */
 package functionaltests.workflow.variables;
 
+import static functionaltests.utils.SchedulerTHelper.setExecutable;
+import static org.objectweb.proactive.utils.OperatingSystem.unix;
+
 import java.io.File;
 import java.net.URL;
 
-import org.objectweb.proactive.utils.OperatingSystem;
 import org.junit.Test;
+import org.objectweb.proactive.utils.OperatingSystem;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static functionaltests.utils.SchedulerTHelper.setExecutable;
-import static org.objectweb.proactive.utils.OperatingSystem.unix;
 
 
 public class TestModifyPropagatedVariables extends SchedulerFunctionalTest {
@@ -58,7 +58,7 @@ public class TestModifyPropagatedVariables extends SchedulerFunctionalTest {
             .getResource("/functionaltests/vars/test-vars.sh");
 
     @Test
-    public void run() throws Throwable {
+    public void testModifyPropagatedVariables() throws Throwable {
         schedulerHelper.testJobSubmissionAndVerifyAllResults(absolutePath(job_desc));
         OperatingSystem os = OperatingSystem.getOperatingSystem();
         if (unix == os) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestPropagatedVariables.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestPropagatedVariables.java
@@ -38,21 +38,21 @@ package functionaltests.workflow.variables;
 
 import java.util.HashMap;
 
+import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.scheduler.common.exception.UserException;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.NativeTask;
-import org.junit.Test;
 
-import functionaltests.utils.SchedulerFunctionalTest;
 import functionaltests.executables.PropagateVariablesExec;
+import functionaltests.utils.SchedulerFunctionalTest;
 
 
 public class TestPropagatedVariables extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testPropagatedVariables() throws Throwable {
         schedulerHelper.testJobSubmissionAndVerifyAllResults(createTaskFlowJob(),
                 "TestPropagatedVariables.TestFlowJob");
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestPropagatedVariablesWalltime.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestPropagatedVariablesWalltime.java
@@ -34,22 +34,23 @@
  */
 package functionaltests.workflow.variables;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
-import org.junit.Test;
 
 import functionaltests.utils.SchedulerFunctionalTest;
-
-import static org.junit.Assert.*;
 
 
 public class TestPropagatedVariablesWalltime extends SchedulerFunctionalTest {
 
     @Test
-    public void run() throws Throwable {
+    public void testPropagatedVariablesWalltime() throws Throwable {
         JobId jobId = schedulerHelper.submitJob(absolutePath(
           TestPropagatedVariablesWalltime.class.getResource(
             "/functionaltests/descriptors/Job_PropagatedVariables_Timeout.xml")));

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/Test_SCHEDULING_2034.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/Test_SCHEDULING_2034.java
@@ -40,8 +40,8 @@ package functionaltests.workflow.variables;
 import java.io.File;
 import java.net.URL;
 
-import org.objectweb.proactive.utils.OperatingSystem;
 import org.junit.Test;
+import org.objectweb.proactive.utils.OperatingSystem;
 
 import functionaltests.utils.SchedulerFunctionalTest;
 
@@ -52,7 +52,7 @@ public class Test_SCHEDULING_2034 extends SchedulerFunctionalTest {
             .getResource("/functionaltests/descriptors/Job_SCHEDULING_2034_unix.xml");
 
     @Test
-    public void run() throws Throwable {
+    public void testSCHEDULING_2034() throws Throwable {
         if (OperatingSystem.unix == OperatingSystem.getOperatingSystem()) {
             schedulerHelper.testJobSubmissionAndVerifyAllResults(absolutePath(job_desc_unix));
         }

--- a/scheduler/scheduler-smartproxy/src/test/java/functionaltests/TestSmartProxy.java
+++ b/scheduler/scheduler-smartproxy/src/test/java/functionaltests/TestSmartProxy.java
@@ -1,9 +1,12 @@
 package functionaltests;
 
-import functionaltests.monitor.EventMonitor;
-import functionaltests.utils.SchedulerFunctionalTest;
-import functionaltests.utils.SchedulerTHelper;
-import functionaltests.utils.TestUsers;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+
 import org.apache.log4j.Level;
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,12 +26,10 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
 import org.ow2.proactive.scheduler.smartproxy.SmartProxyImpl;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-
-import static org.junit.Assume.assumeTrue;
+import functionaltests.monitor.EventMonitor;
+import functionaltests.utils.SchedulerFunctionalTest;
+import functionaltests.utils.SchedulerTHelper;
+import functionaltests.utils.TestUsers;
 
 
 /**
@@ -212,7 +213,7 @@ public class TestSmartProxy extends SchedulerFunctionalTest {
     }
 
     @Test
-    public void run() throws Throwable {
+    public void testSmartProxy() throws Throwable {
         if (true) {
             return;
         }


### PR DESCRIPTION
The test methods called run are badly handled in Jenkins causing tests outputs to be unreadeble