### PR TITLE
Upgrade Jetty dependencies

### DIFF
--- a/rest/rest-cli/build.gradle
+++ b/rest/rest-cli/build.gradle
@@ -21,7 +21,7 @@ dependencies {
         
 
         testCompile 'com.eclipsesource.minimal-json:minimal-json:0.9.4'
-        testCompile 'org.eclipse.jetty:jetty-server:9.2.13.v20150730'
+        testCompile 'org.eclipse.jetty:jetty-server:9.2.14.v20151106'
 }
 
 task('functionalTest', type: Test).configure functionalTestConfiguration

--- a/rest/rest-server/build.gradle
+++ b/rest/rest-server/build.gradle
@@ -52,11 +52,10 @@ dependencies {
     testCompile 'org.jboss.resteasy:tjws:3.0.13.Final'
 
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.eclipse.jetty:jetty-client:9.2.13.v20150730'
+    testCompile 'org.eclipse.jetty:jetty-client:9.2.14.v20151106'
 
-    runtime 'org.eclipse.jetty.websocket:websocket-server:9.2.13.v20150730'
-    runtime 'org.eclipse.jetty:jetty-webapp:9.2.13.v20150730'
-    runtime 'javax.servlet:javax.servlet-api:3.0.1'
+    runtime 'org.eclipse.jetty.websocket:websocket-server:9.2.14.v20151106'
+    runtime 'org.eclipse.jetty:jetty-webapp:9.2.14.v20151106'
 
     runtime "org.objectweb.proactive:programming-extension-pamr:${programmingVersion}"
 }

--- a/rest/rest-server/src/main/webapp/WEB-INF/web.xml
+++ b/rest/rest-server/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		 http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
 
     <display-name>Scheduler's Rest API</display-name>
 

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile 'joda-time:joda-time:2.9.1'
     compile 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final'
     compile 'org.hibernate:hibernate-core:4.3.11.Final'
-    compile 'org.eclipse.jetty:jetty-webapp:9.2.13.v20150730'
+    compile 'org.eclipse.jetty:jetty-webapp:9.2.14.v20151106'
     compile "org.objectweb.proactive:programming-core:${programmingVersion}"
 
     compile project(':common:common-api')


### PR DESCRIPTION
Jetty update is mainly to fix a memory leak with QueuedThreadPool.

See release notes:

https://github.com/eclipse/jetty.project/blob/master/VERSION.txt