### PR TITLE
#2475 : Improve Scheduler and Resource Manager testsuite stability

### DIFF
--- a/rm/rm-server/src/test/java/functionaltests/utils/TestRM.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/TestRM.java
@@ -34,13 +34,6 @@
  */
 package functionaltests.utils;
 
-import java.io.File;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.extensions.pnp.PNPConfig;
 import org.objectweb.proactive.utils.OperatingSystem;
@@ -48,6 +41,13 @@ import org.ow2.proactive.resourcemanager.authentication.RMAuthentication;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.resourcemanager.frontend.RMConnection;
 import org.ow2.proactive.utils.CookieBasedProcessTreeKiller;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 
 public class TestRM {
@@ -151,6 +151,7 @@ public class TestRM {
 
     public void kill() throws Exception {
         if (rmProcess != null) {
+            System.out.println("Destroying RM process.");
             rmProcess.destroy();
             rmProcess.waitFor();
             processTreeKiller.kill();

--- a/scheduler/scheduler-examples/src/main/java/org/ow2/proactive/scheduler/examples/KillJob.java
+++ b/scheduler/scheduler-examples/src/main/java/org/ow2/proactive/scheduler/examples/KillJob.java
@@ -36,10 +36,11 @@
  */
 package org.ow2.proactive.scheduler.examples;
 
-import java.io.Serializable;
-
+import org.objectweb.proactive.api.PAActiveObject;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.executable.JavaExecutable;
+
+import java.io.Serializable;
 
 
 /**
@@ -59,12 +60,12 @@ public class KillJob extends JavaExecutable {
     public Serializable execute(TaskResult... results) throws Throwable {
 
         try {
-            getOut().println("I will kill in 5 sec the node on which i was started with exit code = " +
-                exitcode);
+            getOut().println("I will kill in 5 sec the node on which i was started ");
 
             Thread.sleep(5000);
         } finally {
-            System.exit(exitcode);
+            String nodeName = PAActiveObject.getNode().getNodeInformation().getName();
+            PAActiveObject.getNode().getProActiveRuntime().killNode(nodeName);
             return null;
         }
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/taskkill/TestJobKilled.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/taskkill/TestJobKilled.java
@@ -36,7 +36,7 @@
  */
 package functionaltests.job.taskkill;
 
-import functionaltests.utils.SchedulerFunctionalTestWithRestart;
+import functionaltests.utils.SchedulerFunctionalTestWithCustomConfigAndRestart;
 import functionaltests.utils.SchedulerTHelper;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -65,7 +65,7 @@ import static org.junit.Assert.fail;
  * @author The ProActive Team
  * @since ProActive Scheduling 1.0
  */
-public class TestJobKilled extends SchedulerFunctionalTestWithRestart {
+public class TestJobKilled extends SchedulerFunctionalTestWithCustomConfigAndRestart {
 
     private static URL jobDescriptor = TestJobKilled.class
             .getResource("/functionaltests/descriptors/Job_Killed.xml");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -207,7 +207,7 @@ public class SchedulerTHelper {
             killScheduler();
             log("Starting Scheduler");
             scheduler.start(configuration);
-            RMTestUser.getInstance().connect(TestUsers.DEMO, scheduler.getUrl());
+            RMTestUser.getInstance().connect(TestUsers.DEMO, scheduler.getRMUrl());
         }
         currentTestConfiguration = configuration;
     }
@@ -846,11 +846,11 @@ public class SchedulerTHelper {
 
     public ResourceManager getResourceManager(TestUsers user) throws Exception {
         if (!RMTestUser.getInstance().is(user)) { // changing user on the fly
-            RMTestUser.getInstance().connect(user, scheduler.getUrl());
+            RMTestUser.getInstance().connect(user, scheduler.getRMUrl());
         }
 
         if (!RMTestUser.getInstance().isConnected()) {
-            RMTestUser.getInstance().connect(user, scheduler.getUrl());
+            RMTestUser.getInstance().connect(user, scheduler.getRMUrl());
         }
 
         return RMTestUser.getInstance().getResourceManager();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/TestScheduler.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/TestScheduler.java
@@ -65,6 +65,7 @@ public class TestScheduler {
 
     public static String schedulerUrl = "pnp://" + ProActiveInet.getInstance().getHostname() + ":" +
             PNP_PORT + "/";
+    public static String rmUrl;
     private static Process schedulerProcess;
 
     private static SchedulerAuthenticationInterface schedulerAuth;
@@ -142,6 +143,7 @@ public class TestScheduler {
         } else {
             rmToConnectTo = schedulerUrl;
         }
+        rmUrl = rmToConnectTo;
 
         System.out.println("Starting Scheduler process: " + commandLine);
 
@@ -231,6 +233,10 @@ public class TestScheduler {
 
     public static String getUrl() {
         return schedulerUrl;
+    }
+
+    public static String getRMUrl() {
+        return rmUrl;
     }
 
 }


### PR DESCRIPTION
- TestJobKilled : make sure the test task is killing the ProActive Node and not the JVM process (compatibilty with multiple Nodes per JVM)
- TestNSNodesPermissions : better handling of test nodes which are killed at each step and multiple users operations
- TestOperationsWhenUnlinked : disabled one test because it's not compatible witht the testsuite any more