### PR TITLE
Fix workflows, replace cancelJobOnError with onTaskError

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
@@ -49,6 +49,11 @@ public class JobInfoData {
     private int numberOfPendingTasks;
     private int numberOfRunningTasks;
     private int numberOfFinishedTasks;
+
+    private int numberOfFailedTasks;
+    private int numberOfFaultyTasks;
+    private int numberOfInErrorTasks;
+
     private JobPriorityData priority;
     private String jobOwner;
     private boolean toBeRemoved = false;
@@ -99,6 +104,30 @@ public class JobInfoData {
 
     public void setNumberOfFinishedTasks(int numberOfFinishedTasks) {
         this.numberOfFinishedTasks = numberOfFinishedTasks;
+    }
+
+    public int getNumberOfFailedTasks() {
+        return numberOfFailedTasks;
+    }
+
+    public void setNumberOfFailedTasks(int numberOfFailedTasks) {
+        this.numberOfFailedTasks = numberOfFailedTasks;
+    }
+
+    public int getNumberOfFaultyTasks() {
+        return numberOfFaultyTasks;
+    }
+
+    public void setNumberOfFaultyTasks(int numberOfFaultyTasks) {
+        this.numberOfFaultyTasks = numberOfFaultyTasks;
+    }
+
+    public int getNumberOfInErrorTasks() {
+        return numberOfInErrorTasks;
+    }
+
+    public void setNumberOfInErrorTasks(int numberOfInErrorTasks) {
+        this.numberOfInErrorTasks = numberOfInErrorTasks;
     }
 
     public String getJobOwner() {
@@ -159,10 +188,24 @@ public class JobInfoData {
 
     @Override
     public String toString() {
-        return "JobInfoData{" + "startTime=" + startTime + ", finishedTime=" + finishedTime +
-            ", submittedTime=" + submittedTime + ", status='" + status + '\'' + ", jobId=" + jobId +
-            ", totalNumberOfTasks=" + totalNumberOfTasks + ", numberOfPendingTasks=" + numberOfPendingTasks +
-            ", numberOfRunningTasks=" + numberOfRunningTasks + ", numberOfFinishedTasks=" +
-            numberOfFinishedTasks + ", priority='" + priority + '\'' + ", jobOwner='" + jobOwner + '\'' + '}';
+        return "JobInfoData{" +
+                "startTime=" + startTime +
+                ", finishedTime=" + finishedTime +
+                ", submittedTime=" + submittedTime +
+                ", removedTime=" + removedTime +
+                ", status=" + status +
+                ", jobId=" + jobId +
+                ", totalNumberOfTasks=" + totalNumberOfTasks +
+                ", numberOfPendingTasks=" + numberOfPendingTasks +
+                ", numberOfRunningTasks=" + numberOfRunningTasks +
+                ", numberOfFinishedTasks=" + numberOfFinishedTasks +
+                ", numberOfFailedTasks=" + numberOfFailedTasks +
+                ", numberOfFaultyTasks=" + numberOfFaultyTasks +
+                ", numberOfInErrorTasks=" + numberOfInErrorTasks +
+                ", priority=" + priority +
+                ", jobOwner='" + jobOwner + '\'' +
+                ", toBeRemoved=" + toBeRemoved +
+                '}';
     }
+
 }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
@@ -55,6 +55,10 @@ public class JobInfoImpl implements JobInfo {
     private int numberOfRunningTasks = 0;
     private int numberOfFinishedTasks = 0;
 
+    private int numberOfFailedTasks = 0;
+    private int numberOfFaultyTasks = 0;
+    private int numberOfInErrorTasks = 0;
+
     private JobPriority jobPriority = JobPriority.NORMAL;
     private JobStatus jobStatus = JobStatus.PENDING;
     private boolean toBeRemoved;
@@ -115,6 +119,33 @@ public class JobInfoImpl implements JobInfo {
 
     public void setJobPriority(JobPriority jobPriority) {
         this.jobPriority = jobPriority;
+    }
+
+    @Override
+    public int getNumberOfFailedTasks() {
+        return numberOfFailedTasks;
+    }
+
+    public void setNumberOfFailedTasks(int numberOfFailedTasks) {
+        this.numberOfFailedTasks = numberOfFailedTasks;
+    }
+
+    @Override
+    public int getNumberOfFaultyTasks() {
+        return numberOfFaultyTasks;
+    }
+
+    public void setNumberOfFaultyTasks(int numberOfFaultyTasks) {
+        this.numberOfFaultyTasks = numberOfFaultyTasks;
+    }
+
+    @Override
+    public int getNumberOfInErrorTasks() {
+        return numberOfInErrorTasks;
+    }
+
+    public void setNumberOfInErrorTasks(int numberOfInErrorTasks) {
+        this.numberOfInErrorTasks = numberOfInErrorTasks;
     }
 
     @Override

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
@@ -122,6 +122,28 @@ public interface JobInfo extends Serializable {
     int getNumberOfRunningTasks();
 
     /**
+     * To get the numberOfFailedTasks
+     *
+     * @return the numberOfFailedTasks
+     */
+    int getNumberOfFailedTasks();
+
+    /**
+     * To get the numberOfFaultyTasks
+     *
+     * @return the numberOfFaultyTasks
+     */
+    int getNumberOfFaultyTasks();
+
+
+    /**
+     * To get the numberOfInErrorTasks
+     *
+     * @return the numberOfInErrorTasks
+     */
+    int getNumberOfInErrorTasks();
+
+    /**
      * To get the priority.
      *
      * @return the priority.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
@@ -42,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.task.TaskId;
@@ -53,6 +51,8 @@ import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.util.PageBoundaries;
 import org.ow2.proactive.scheduler.common.util.Pagination;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 
 
 /**
@@ -342,6 +342,33 @@ public abstract class JobState extends Job implements Comparable<JobState> {
      */
     public int getNumberOfRunningTasks() {
         return getJobInfo().getNumberOfRunningTasks();
+    }
+
+    /**
+     * To get the numberOfFailedTask
+     *
+     * @return the numberOfFailedTask
+     */
+    public int getNumberOfFailedTasks() {
+        return getJobInfo().getNumberOfFailedTasks();
+    }
+
+    /**
+     * To get the numberOfFailedTask
+     *
+     * @return the numberOfFailedTask
+     */
+    public int getNumberOfFaultyTasks() {
+        return getJobInfo().getNumberOfFaultyTasks();
+    }
+
+    /**
+     * To get the numberOfInErrorTask
+     *
+     * @return the numberOfInErrorTask
+     */
+    public int getNumberOfInErrorTasks() {
+        return getJobInfo().getNumberOfInErrorTasks();
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
@@ -172,7 +172,7 @@ public class Job2XMLTransformer {
         setAttribute(rootJob, XMLAttributes.JOB_PRIORITY, job.getPriority().toString());
         if (job.getOnTaskErrorProperty().isSet()) {
             setAttribute(rootJob, XMLAttributes.COMMON_ON_TASK_ERROR,job
-                    .getOnTaskErrorProperty().getValue().toString());
+                    .getOnTaskErrorProperty().getValue().toString(), true);
         }
         if (job.getMaxNumberOfExecutionProperty().isSet()) {
             setAttribute(rootJob, XMLAttributes.COMMON_MAX_NUMBER_OF_EXECUTION, Integer.toString(job
@@ -357,7 +357,7 @@ public class Job2XMLTransformer {
 
         if (task.getOnTaskErrorProperty().isSet()) {
         setAttribute(taskE, XMLAttributes.COMMON_ON_TASK_ERROR,
-                task.getOnTaskErrorProperty().getValue().toString());
+                task.getOnTaskErrorProperty().getValue().toString(), true);
         }
         if (task.getMaxNumberOfExecutionProperty().isSet()) {
             setAttribute(taskE, XMLAttributes.COMMON_MAX_NUMBER_OF_EXECUTION, Integer.toString(task

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
@@ -84,6 +84,9 @@ public abstract class CommonAttribute implements Serializable {
     /** Common user informations */
     protected Map<String, BigString> genericInformations = new HashMap<String, BigString>();
 
+    /**
+     * OnTaskError defines the behavior happening when a task fails.
+     */
     protected UpdatableProperties<OnTaskError> onTaskError = new UpdatableProperties<>(
            OnTaskError.NONE);
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/OnTaskError.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/OnTaskError.java
@@ -70,7 +70,7 @@ public class OnTaskError implements Serializable {
 
     /**
      * Get a OnTaskError instance based on a descriptor string. If the descriptor string is not found,
-     * 'not set' is returned.
+     * 'none' is returned.
      * @param descriptor Descriptor string.
      * @return OnTaskError instance or 'not set' if descriptor string is not recognized.
      */
@@ -87,10 +87,6 @@ public class OnTaskError implements Serializable {
             default:
                 return NONE;
         }
-    }
-
-    String getDescriptor() {
-        return this.descriptor;
     }
 
     @Override
@@ -117,5 +113,4 @@ public class OnTaskError implements Serializable {
     public int hashCode() {
         return this.descriptor.hashCode();
     }
-
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
@@ -699,6 +699,7 @@ public abstract class Task extends CommonAttribute {
         return "Task \'" + name + "\' : " + nl +
                 "\tDescription = '" + description + "'" + nl +
                 (restartTaskOnError.isSet() ? "\trestartTaskOnError = '" + restartTaskOnError.getValue() + '\'' + nl : "") +
+                (onTaskError.isSet() ? "\tonTaskError = '" + onTaskError.getValue() + '\'' + nl : "") +
                 (maxNumberOfExecution.isSet() ? "\tmaxNumberOfExecution = '" + maxNumberOfExecution.getValue().getIntegerValue() + '\'' + nl : "") +
                 "\ttag = " + tag + nl +
                 "\tgenericInformations = {" + nl + Joiner.on('\n').withKeyValueSeparator("=").join(genericInformations) + nl + "}" + nl +

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
@@ -102,7 +102,7 @@ public class TestJobFactory {
         assertEquals("output/space", tfJob.getOutputSpace());
         //Check task 1 properties
         assertEquals(tfJob.getTask("task1").getName(), "task1");
-        assertEquals(tfJob.getTask("task1").getOnTaskErrorProperty(), OnTaskError.NONE);
+        assertEquals(tfJob.getTask("task1").getOnTaskErrorProperty().getValue(), OnTaskError.CANCEL_JOB); // The job factory overwrites the task settings with the job settings if they are set to none.
         assertEquals(tfJob.getTask("task1").isPreciousResult(), false);
         assertEquals(tfJob.getTask("task1").getRestartTaskOnError(), RestartMode.ANYWHERE);
         assertEquals(tfJob.getTask("task1").getMaxNumberOfExecution(), 1);

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/OnTaskErrorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/OnTaskErrorTest.java
@@ -1,0 +1,60 @@
+package org.ow2.proactive.scheduler.common.task;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class OnTaskErrorTest {
+
+    @Test
+    public void testGetInstanceAndToString() throws Exception {
+        testThatGetInstanceReturnsExpectedInstance(OnTaskError.CANCEL_JOB.toString(), OnTaskError.CANCEL_JOB);
+        testThatGetInstanceReturnsExpectedInstance(OnTaskError.PAUSE_JOB.toString(), OnTaskError.PAUSE_JOB);
+        testThatGetInstanceReturnsExpectedInstance(OnTaskError.CONTINUE_JOB_EXECUTION.toString(),
+                OnTaskError.CONTINUE_JOB_EXECUTION);
+        testThatGetInstanceReturnsExpectedInstance(OnTaskError.PAUSE_TASK.toString(), OnTaskError.PAUSE_TASK);
+        testThatGetInstanceReturnsExpectedInstance(OnTaskError.NONE.toString(), OnTaskError.NONE);
+        testThatGetInstanceReturnsExpectedInstance("arbitrary", OnTaskError.NONE);
+    }
+
+    @Test
+    public void testEquals() {
+        assertThat("Equals method returns not equals but instances are equal.", OnTaskError.CANCEL_JOB,
+                is(OnTaskError.CANCEL_JOB));
+        assertThat("Equals method returns not equals but instances are equal.", OnTaskError.PAUSE_JOB,
+                is(OnTaskError.PAUSE_JOB));
+        assertThat("Equals method returns not equals but instances are equal.",
+                OnTaskError.CONTINUE_JOB_EXECUTION, is(OnTaskError.CONTINUE_JOB_EXECUTION));
+        assertThat("Equals method returns not equals but instances are equal.", OnTaskError.PAUSE_TASK,
+                is(OnTaskError.PAUSE_TASK));
+        assertThat("Equals method returns not equals but instances are equal.", OnTaskError.NONE,
+                is(OnTaskError.NONE));
+        assertThat("Equals method returns equals but instances are not equal.", OnTaskError.NONE.equals(null),
+                is(false));
+        assertThat("Equals method returns equals but instances are not equal.", OnTaskError.NONE,
+                not(OnTaskError.PAUSE_TASK));
+        assertThat("Equals method returns equals but instances are not equal.", OnTaskError.NONE,
+                not(new Object()));
+    }
+
+    @Test
+    public void testHashCode() {
+        assertThat("Hashcode returns not equal hashcode but instances are equal.", OnTaskError.CANCEL_JOB.hashCode(),
+                is(OnTaskError.CANCEL_JOB.hashCode()));
+        assertThat("Hashcode returns not equal hashcode but instances are equal.", OnTaskError.PAUSE_JOB.hashCode(),
+                is(OnTaskError.PAUSE_JOB.hashCode()));
+        assertThat("Hashcode returns not equal hashcode but instances are equal.", OnTaskError.CONTINUE_JOB_EXECUTION.hashCode(),
+                is(OnTaskError.CONTINUE_JOB_EXECUTION.hashCode()));
+        assertThat("Hashcode returns not equal hashcode but instances are equal.", OnTaskError.PAUSE_TASK.hashCode(),
+                is(OnTaskError.PAUSE_TASK.hashCode()));
+        assertThat("Hashcode returns not equal hashcode but instances are equal.", OnTaskError.NONE.hashCode(),
+                is(OnTaskError.NONE.hashCode()));
+    }
+
+    private void testThatGetInstanceReturnsExpectedInstance(String descriptor, OnTaskError expectedInstance) {
+        assertThat("getInstance method returned unexpected result.", OnTaskError.getInstance(descriptor),
+                is(expectedInstance));
+    }
+}

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_generic_information_xml_element.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_generic_information_xml_element.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	 xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	 name="${job_name}" cancelJobOnError="false" priority="normal">
+	 name="${job_name}" onTaskError="continueJobExecution" priority="normal">
 	<description>Test</description>
 	<taskFlow>
 		<task name="task" preciousResult="true">

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_parameter_xml_element.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_parameter_xml_element.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	 xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	 name="${job_name}" cancelJobOnError="false" priority="normal">
+	 name="${job_name}" onTaskError="continueJobExecution" priority="normal">
 	<description>Test</description>
 	<taskFlow>
 		<task name="task" preciousResult="true">

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_variable_xml_element.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_variable_xml_element.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	 xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	 name="${job_name}" cancelJobOnError="false" priority="normal">
+	 name="${job_name}" onTaskError="continueJobExecution" priority="normal">
 	<variables>
 		<variable name="name1" value="value1" />
 		<variable value="value2" name="name2" />

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_update_variables.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_update_variables.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-    name="${job_name}" cancelJobOnError="false" priority="normal">
+    name="${job_name}" onTaskError="continueJobExecution" priority="normal">
     <variables>
         <variable name="job_name" value="updated_job_name" />
         <variable name="task_generic_info" value="updated_task_generic_info_value" />

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_update_variables_using_system_properties.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_update_variables_using_system_properties.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-    name="update_variables_using_system_properties" cancelJobOnError="false" priority="normal">
+    name="update_variables_using_system_properties" onTaskError="continueJobExecution" priority="normal">
     <variables>
         <variable name="system_property" value="${system_property}" />
     </variables>

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -64,6 +64,8 @@ public final class ClientJobState extends JobState {
 
         this.clientJobSerializationHelper = new ClientJobSerializationHelper();
 
+        this.setOnTaskError(jobState.getOnTaskErrorProperty().getValue());
+
         List<ClientTaskState> clientTaskStates = new ArrayList<>(taskStates.size());
         for (TaskState ts : taskStates) {
             clientTaskStates.add(new ClientTaskState(ts));

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
@@ -99,6 +99,15 @@ public class JobInfoImpl implements JobInfo {
     /** number of finished tasks */
     private int numberOfFinishedTasks = 0;
 
+    /** number of failed tasks */
+    private int numberOfFailedTasks = 0;
+
+    /** number of faulty tasks */
+    private int numberOfFaultyTasks = 0;
+
+    /** number of in-error tasks */
+    private int numberOfInErrorTasks = 0;
+
     /** job priority */
     private JobPriority priority = JobPriority.NORMAL;
 
@@ -275,6 +284,33 @@ public class JobInfoImpl implements JobInfo {
      */
     public int getNumberOfRunningTasks() {
         return numberOfRunningTasks;
+    }
+
+    @Override
+    public int getNumberOfFailedTasks() {
+        return numberOfFailedTasks;
+    }
+
+    public void setNumberOfFailedTasks(int numberOfFailedTasks) {
+        this.numberOfFailedTasks = numberOfFailedTasks;
+    }
+
+    @Override
+    public int getNumberOfFaultyTasks() {
+        return numberOfFaultyTasks;
+    }
+
+    public void setNumberOfFaultyTasks(int numberOfFaultyTasks) {
+        this.numberOfFaultyTasks = numberOfFaultyTasks;
+    }
+
+    @Override
+    public int getNumberOfInErrorTasks() {
+        return numberOfInErrorTasks;
+    }
+
+    public void setNumberOfInErrorTasks(int numberOfInErrorTasks) {
+        this.numberOfInErrorTasks = numberOfInErrorTasks;
     }
 
     /**

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/ClientTaskState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/ClientTaskState.java
@@ -59,6 +59,8 @@ public final class ClientTaskState extends TaskState {
         this.setParallelEnvironment(taskState.getParallelEnvironment());
         this.setGenericInformations(taskState.getGenericInformation());
 
+        this.setOnTaskError(taskState.getOnTaskErrorProperty().getValue());
+
         // Store only task IDs here; #restoreDependences is later called by
         // ClientJobState in order for this instance to store references to the
         // same ClientTaskState instances as the ones held in the

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.common.NotificationData;
 import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.exception.TaskAbortedException;
@@ -42,6 +41,7 @@ import org.ow2.proactive.scheduler.task.internal.InternalTask;
 import org.ow2.proactive.scheduler.util.JobLogger;
 import org.ow2.proactive.scheduler.util.TaskLogger;
 import org.ow2.proactive.utils.TaskIdWrapper;
+import org.apache.log4j.Logger;
 
 
 class LiveJobs {
@@ -151,7 +151,8 @@ class LiveJobs {
             dbManager.changeJobPriority(jobId, priority);
 
             listener.jobStateUpdated(jobData.job.getOwner(), new NotificationData<JobInfo>(
-                SchedulerEvent.JOB_CHANGE_PRIORITY, new JobInfoImpl((JobInfoImpl) jobData.job.getJobInfo())));
+                    SchedulerEvent.JOB_CHANGE_PRIORITY,
+                    new JobInfoImpl((JobInfoImpl) jobData.job.getJobInfo())));
         } finally {
             jobData.unlock();
         }
@@ -287,16 +288,21 @@ class LiveJobs {
         task.decreaseNumberOfExecutionOnFailureLeft();
         tlogger.info(task.getId(),
                 "number of retry on failure left " + task.getNumberOfExecutionOnFailureLeft());
+
+        InternalJob job = jobData.job;
+
         if (task.getNumberOfExecutionOnFailureLeft() > 0) {
             task.setStatus(TaskStatus.WAITING_ON_FAILURE);
-            jobData.job.newWaitingTask();
-            listener.taskStateUpdated(jobData.job.getOwner(),
+
+            job.newWaitingTask();
+            listener.taskStateUpdated(job.getOwner(),
                     new NotificationData<TaskInfo>(SchedulerEvent.TASK_WAITING_FOR_RESTART,
-                        new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
-            jobData.job.reStartTask(task);
-            dbManager.taskRestarted(jobData.job, task, null);
+                            new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
+            job.reStartTask(task);
+            dbManager.taskRestarted(job, task, null);
             tlogger.info(task.getId(), " is waiting for restart");
         } else {
+            job.incrementNumberOfFailedTasksBy(1);
             endJob(jobData, terminationData, task, null, errorMsg, JobStatus.FAILED);
         }
     }
@@ -341,7 +347,8 @@ class LiveJobs {
         job.newWaitingTask();
         dbManager.updateAfterTaskFinished(job, task, result);
         listener.taskStateUpdated(job.getOwner(), new NotificationData<TaskInfo>(
-            SchedulerEvent.TASK_WAITING_FOR_RESTART, new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
+                SchedulerEvent.TASK_WAITING_FOR_RESTART,
+                new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
 
         terminationData.addRestartData(task.getId(), waitTime);
 
@@ -398,7 +405,7 @@ class LiveJobs {
         dbManager.jobTaskStarted(job, task, firstTaskStarted);
 
         listener.taskStateUpdated(job.getOwner(), new NotificationData<TaskInfo>(
-            SchedulerEvent.TASK_PENDING_TO_RUNNING, new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
+                SchedulerEvent.TASK_PENDING_TO_RUNNING, new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
 
         //fill previous task progress with 0, means task has started
         task.setProgress(0);
@@ -464,9 +471,10 @@ class LiveJobs {
                 if (numberOfExecutionLeft <= 0 && onErrorPolicyInterpreter.requiresCancelJobOnError(task)) {
                     logger.info("No retry left and task is tagged with cancel job on error");
 
+                    jobData.job.increaseNumberOfFaultyTasks(taskId);
                     endJob(jobData, terminationData, task, result,
                             "An error occurred in your task and the maximum number of executions has been reached. " +
-                                "You also ask to cancel the job in such a situation!",
+                                    "You also ask to cancel the job in such a situation!",
                             JobStatus.CANCELED);
 
                     logger.info("Job has been canceled");
@@ -490,6 +498,8 @@ class LiveJobs {
 
                         return terminationData;
                     } else {
+                        jobData.job.increaseNumberOfFaultyTasks(taskId);
+
                         long waitTime = jobData.job
                                 .getNextWaitingTime(task.getMaxNumberOfExecution() - numberOfExecutionLeft);
                         restartTaskOnError(jobData, task, TaskStatus.WAITING_ON_ERROR, result, waitTime,
@@ -499,6 +509,8 @@ class LiveJobs {
 
                         return terminationData;
                     }
+                } else if (numberOfExecutionLeft <= 0) {
+                    jobData.job.increaseNumberOfFaultyTasks(taskId);
                 }
             }
 
@@ -511,19 +523,21 @@ class LiveJobs {
     }
 
     private void suspendTaskOnError(JobData jobData, InternalTask task) {
-        jobData.job.setTaskPausedOnError(task);
-        jobData.job.setStatus(JobStatus.IN_ERROR);
+        InternalJob job = jobData.job;
+        job.setTaskPausedOnError(task);
+        job.setStatus(JobStatus.IN_ERROR);
+        job.incrementNumberOfInErrorTasksBy(1);
 
-        dbManager.updateJobAndTasksState(jobData.job);
+        dbManager.updateJobAndTasksState(job);
 
-        updateTaskPausedOnerrorState(jobData.job, task.getId());
-        updateJobInSchedulerState(jobData.job, SchedulerEvent.JOB_IN_ERROR);
+        updateTaskPausedOnerrorState(job, task.getId());
+        updateJobInSchedulerState(job, SchedulerEvent.JOB_IN_ERROR);
     }
 
     void restartInErrorTask(JobId jobId, String taskName) throws UnknownTaskException {
         JobData jobData = lockJob(jobId);
         try {
-            jobData.job.setUnPauseTaskOnError(jobData.job.getTask(taskName));
+            jobData.job.restartInErrorTask(jobData.job.getTask(taskName));
             jobData.job.newWaitingTask();
             dbManager.updateJobAndTasksState(jobData.job);
             updateJobInSchedulerState(jobData.job, SchedulerEvent.JOB_RESTARTED_FROM_ERROR);
@@ -555,14 +569,16 @@ class LiveJobs {
             terminationData.addTaskData(taskData, false);
 
             TaskResultImpl taskResult = new TaskResultImpl(task.getId(),
-                new TaskRestartedException("Aborted by user"), new SimpleTaskLogs("", "Aborted by user"),
-                System.currentTimeMillis() - task.getStartTime());
+                    new TaskRestartedException("Aborted by user"), new SimpleTaskLogs("", "Aborted by user"),
+                    System.currentTimeMillis() - task.getStartTime());
+
+            task.decreaseNumberOfExecutionLeft();
 
             if (task.getNumberOfExecutionLeft() <= 0 &&
-                onErrorPolicyInterpreter.requiresCancelJobOnError(task)) {
+                    onErrorPolicyInterpreter.requiresCancelJobOnError(task)) {
                 endJob(jobData, terminationData, task, taskResult,
                         "An error occurred in your task and the maximum number of executions has been reached. " +
-                            "You also ask to cancel the job in such a situation !",
+                                "You also ask to cancel the job in such a situation !",
                         JobStatus.CANCELED);
                 return terminationData;
             } else if (task.getNumberOfExecutionLeft() > 0) {
@@ -601,9 +617,9 @@ class LiveJobs {
             terminationData.addTaskData(taskData, false);
 
             TaskResultImpl taskResult = new TaskResultImpl(task.getId(),
-                new TaskPreemptedException("Preempted by admin"),
-                new SimpleTaskLogs("", "Preempted by admin"),
-                System.currentTimeMillis() - task.getStartTime());
+                    new TaskPreemptedException("Preempted by admin"),
+                    new SimpleTaskLogs("", "Preempted by admin"),
+                    System.currentTimeMillis() - task.getStartTime());
 
             long waitTime = restartDelay * 1000L;
             restartTaskOnError(jobData, task, TaskStatus.PENDING, taskResult, waitTime, terminationData);
@@ -634,12 +650,12 @@ class LiveJobs {
             terminationData.addTaskData(taskData, false);
 
             TaskResultImpl taskResult = new TaskResultImpl(task.getId(),
-                new TaskAbortedException("Aborted by user"), new SimpleTaskLogs("", "Aborted by user"),
-                System.currentTimeMillis() - task.getStartTime());
+                    new TaskAbortedException("Aborted by user"), new SimpleTaskLogs("", "Aborted by user"),
+                    System.currentTimeMillis() - task.getStartTime());
 
             if (onErrorPolicyInterpreter.requiresCancelJobOnError(task)) {
                 endJob(jobData, terminationData, task, taskResult, "The task has been manually killed. " +
-                    "You also ask to cancel the job in such a situation!", JobStatus.CANCELED);
+                        "You also ask to cancel the job in such a situation!", JobStatus.CANCELED);
             } else {
                 terminateTask(jobData, task, true, taskResult, terminationData);
             }
@@ -681,14 +697,15 @@ class LiveJobs {
 
         //send event
         listener.taskStateUpdated(job.getOwner(), new NotificationData<TaskInfo>(
-            SchedulerEvent.TASK_RUNNING_TO_FINISHED, new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
+                SchedulerEvent.TASK_RUNNING_TO_FINISHED,
+                new TaskInfoImpl((TaskInfoImpl) task.getTaskInfo())));
         //if this job is finished (every task have finished)
         jlogger.info(job.getId(), "finished tasks " + job.getNumberOfFinishedTasks() + ", total tasks " +
-            job.getTotalNumberOfTasks() + ", finished " + jobFinished);
+                job.getTotalNumberOfTasks() + ", finished " + jobFinished);
         if (jobFinished) {
             //send event to client
             listener.jobStateUpdated(job.getOwner(), new NotificationData<JobInfo>(
-                SchedulerEvent.JOB_RUNNING_TO_FINISHED, new JobInfoImpl((JobInfoImpl) job.getJobInfo())));
+                    SchedulerEvent.JOB_RUNNING_TO_FINISHED, new JobInfoImpl((JobInfoImpl) job.getJobInfo())));
         }
     }
 
@@ -728,7 +745,7 @@ class LiveJobs {
             jlogger.info(job.getId(), "ending request");
         }
 
-        for (Iterator<RunningTaskData> i = runningTasksData.values().iterator(); i.hasNext();) {
+        for (Iterator<RunningTaskData> i = runningTasksData.values().iterator(); i.hasNext(); ) {
             RunningTaskData taskData = i.next();
             if (taskData.getTask().getJobId().equals(jobId)) {
                 i.remove();
@@ -752,7 +769,7 @@ class LiveJobs {
             boolean noResult = (jobStatus == JobStatus.CANCELED && taskResult == null);
             if (jobStatus == JobStatus.FAILED || noResult) {
                 taskResult = new TaskResultImpl(task.getId(), new Exception(errorMsg),
-                    new SimpleTaskLogs("", errorMsg), -1);
+                        new SimpleTaskLogs("", errorMsg), -1);
             }
 
             dbManager.updateAfterJobFailed(job, task, taskResult, tasksToUpdate);
@@ -808,7 +825,7 @@ class LiveJobs {
     private void updateJobInSchedulerState(InternalJob currentJob, SchedulerEvent eventType) {
         try {
             listener.jobStateUpdated(currentJob.getOwner(), new NotificationData<JobInfo>(eventType,
-                new JobInfoImpl((JobInfoImpl) currentJob.getJobInfo())));
+                    new JobInfoImpl((JobInfoImpl) currentJob.getJobInfo())));
         } catch (Throwable t) {
             //Just to prevent update method error
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/NodePingThread.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/NodePingThread.java
@@ -1,7 +1,7 @@
 package org.ow2.proactive.scheduler.core;
 
-import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.apache.log4j.Logger;
 
 
 class NodePingThread extends Thread {
@@ -10,8 +10,8 @@ class NodePingThread extends Thread {
 
     static final Logger logger = Logger.getLogger(SchedulingService.class);
 
-    private static final long SCHEDULER_NODE_PING_FREQUENCY = PASchedulerProperties.SCHEDULER_NODE_PING_FREQUENCY
-            .getValueAsInt() * 1000;
+    private static final long SCHEDULER_NODE_PING_FREQUENCY =
+            PASchedulerProperties.SCHEDULER_NODE_PING_FREQUENCY.getValueAsInt() * 1000;
 
     NodePingThread(SchedulingService service) {
         super("NodePingThread");
@@ -32,7 +32,7 @@ class NodePingThread extends Thread {
             } catch (InterruptedException e) {
                 break;
             } catch (Exception e) {
-                logger.info("Nodes pingining failed", e);
+                logger.info("Node ping failed for a running task", e);
             }
         }
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -68,6 +68,17 @@ public class JobData {
 
     private int numberOfFinishedTasks;
 
+    /*
+     * The next three fields are there to prevent
+     * expensive queries in order to display the number of "Issues".
+     */
+    private int numberOfFailedTasks;
+
+    private int numberOfFaultyTasks;
+
+    private int numberOfInErrorTasks;
+
+
     private int maxNumberOfExecution;
 
     private String onTaskErrorString;
@@ -99,6 +110,9 @@ public class JobData {
         jobInfo.setNumberOfPendingTasks(getNumberOfPendingTasks());
         jobInfo.setNumberOfRunningTasks(getNumberOfRunningTasks());
         jobInfo.setNumberOfFinishedTasks(getNumberOfFinishedTasks());
+        jobInfo.setNumberOfFailedTasks(getNumberOfFailedTasks());
+        jobInfo.setNumberOfFaultyTasks(getNumberOfFaultyTasks());
+        jobInfo.setNumberOfInErrorTasks(getNumberOfInErrorTasks());
         jobInfo.setPriority(getPriority());
         jobInfo.setRemovedTime(getRemovedTime());
         jobInfo.setStartTime(getStartTime());
@@ -165,6 +179,9 @@ public class JobData {
         jobRuntimeData.setNumberOfPendingTasks(job.getNumberOfPendingTasks());
         jobRuntimeData.setNumberOfRunningTasks(job.getNumberOfRunningTasks());
         jobRuntimeData.setNumberOfFinishedTasks(job.getNumberOfFinishedTasks());
+        jobRuntimeData.setNumberOfFailedTasks(job.getNumberOfFailedTasks());
+        jobRuntimeData.setNumberOfFaultyTasks(job.getNumberOfFaultyTasks());
+        jobRuntimeData.setNumberOfInErrorTasks(job.getNumberOfInErrorTasks());
         jobRuntimeData.setTotalNumberOfTasks(job.getTotalNumberOfTasks());
 
         return jobRuntimeData;
@@ -370,6 +387,33 @@ public class JobData {
 
     public void setNumberOfFinishedTasks(int numberOfFinishedTasks) {
         this.numberOfFinishedTasks = numberOfFinishedTasks;
+    }
+
+    @Column(name = "FAILED_TASKS")
+    public int getNumberOfFailedTasks() {
+        return numberOfFailedTasks;
+    }
+
+    public void setNumberOfFailedTasks(int numberOfFailedTasks) {
+        this.numberOfFailedTasks = numberOfFailedTasks;
+    }
+
+    @Column(name = "FAULTY_TASKS")
+    public int getNumberOfFaultyTasks() {
+        return numberOfFaultyTasks;
+    }
+
+    public void setNumberOfFaultyTasks(int numberOfFaultyTasks) {
+        this.numberOfFaultyTasks = numberOfFaultyTasks;
+    }
+
+    @Column(name = "IN_ERROR_TASKS")
+    public int getNumberOfInErrorTasks() {
+        return numberOfInErrorTasks;
+    }
+
+    public void setNumberOfInErrorTasks(int numberOfInErrorTasks) {
+        this.numberOfInErrorTasks = numberOfInErrorTasks;
     }
 
     @Column(name = "PRIORITY", nullable = false)

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -88,8 +88,7 @@ public class SchedulerDBManager {
     protected static final Set<JobStatus> PENDING_JOB_STATUSES = ImmutableSet.of(JobStatus.PENDING);
 
     protected static final Set<JobStatus> RUNNING_JOB_STATUSES = ImmutableSet.of(JobStatus.PAUSED,
-            JobStatus.IN_ERROR,
-            JobStatus.STALLED, JobStatus.RUNNING);
+            JobStatus.IN_ERROR, JobStatus.STALLED, JobStatus.RUNNING);
 
     protected static final Set<JobStatus> NOT_FINISHED_JOB_STATUSES = ImmutableSet
             .copyOf(Iterables.concat(RUNNING_JOB_STATUSES, PENDING_JOB_STATUSES));
@@ -98,8 +97,8 @@ public class SchedulerDBManager {
             TaskStatus.PENDING, TaskStatus.NOT_STARTED);
 
     protected static final Set<TaskStatus> RUNNING_TASKS = ImmutableSet.of(TaskStatus.PAUSED,
-            TaskStatus.IN_ERROR,
-            TaskStatus.RUNNING, TaskStatus.WAITING_ON_ERROR, TaskStatus.WAITING_ON_FAILURE);
+            TaskStatus.IN_ERROR, TaskStatus.RUNNING, TaskStatus.WAITING_ON_ERROR,
+            TaskStatus.WAITING_ON_FAILURE);
 
     protected static final Set<TaskStatus> FINISHED_TASKS = ImmutableSet.of(TaskStatus.FAILED,
             TaskStatus.NOT_RESTARTED, TaskStatus.ABORTED, TaskStatus.FAULTY, TaskStatus.FINISHED,
@@ -127,7 +126,7 @@ public class SchedulerDBManager {
 
             if (logger.isInfoEnabled()) {
                 logger.info("Starting Scheduler DB Manager " + "with drop DB = " + drop +
-                        " and configuration file = " + configFile.getAbsolutePath());
+                    " and configuration file = " + configFile.getAbsolutePath());
             }
 
             return new SchedulerDBManager(configuration, drop);
@@ -181,7 +180,7 @@ public class SchedulerDBManager {
         }
 
         DBJobDataParameters params = new DBJobDataParameters(offset, limit, user, pending, running, finished,
-                sortParameters);
+            sortParameters);
         int totalNbJobs = getTotalNumberOfJobs(params);
         final Set<JobStatus> jobStatuses = params.getStatuses();
         List<JobInfo> lJobs = runWithoutTransaction(new SessionWork<List<JobInfo>>() {
@@ -226,7 +225,7 @@ public class SchedulerDBManager {
                                 break;
                             default:
                                 throw new IllegalArgumentException(
-                                        "Unsupported sort paramter: " + param.getParameter());
+                                    "Unsupported sort paramter: " + param.getParameter());
                         }
                         criteria.addOrder(sortOrder);
                     }
@@ -252,7 +251,7 @@ public class SchedulerDBManager {
             final boolean finished, SortSpecifierContainer sortParams) {
 
         DBTaskDataParameters parameters = new DBTaskDataParameters(tag, from, to, offset, limit, user,
-                pending, running, finished, sortParams);
+            pending, running, finished, sortParams);
         int totalNbTasks = getTotalNumberOfTasks(parameters);
         List<TaskState> lTasks = runWithoutTransaction(TaskDBUtils.taskStateSessionWork(parameters));
 
@@ -264,7 +263,7 @@ public class SchedulerDBManager {
             final boolean finished) {
 
         DBTaskDataParameters parameters = new DBTaskDataParameters(tag, from, to, offset, limit, user,
-                pending, running, finished, SortSpecifierContainer.EMPTY_CONTAINER);
+            pending, running, finished, SortSpecifierContainer.EMPTY_CONTAINER);
         int totalNbTasks = getTotalNumberOfTasks(parameters);
         List<TaskInfo> lTaskInfo = runWithoutTransaction(TaskDBUtils.taskInfoSessionWork(parameters));
 
@@ -293,7 +292,7 @@ public class SchedulerDBManager {
                     boolean hasUser = params.getUser() != null && "".compareTo(params.getUser()) != 0;
 
                     StringBuilder queryString = new StringBuilder(
-                            "select count(*) from JobData where removedTime = -1 ");
+                        "select count(*) from JobData where removedTime = -1 ");
 
                     if (hasUser)
                         queryString.append("and owner = :user ");
@@ -454,7 +453,7 @@ public class SchedulerDBManager {
             public Long executeWork(Session session) {
                 Query query = session
                         .createQuery("select count(*) from TaskData task where taskStatus in (:taskStatus) " +
-                                "and task.jobData.status in (:jobStatus) and task.jobData.removedTime = -1")
+                            "and task.jobData.status in (:jobStatus) and task.jobData.removedTime = -1")
                         .setParameterList("jobStatus", NOT_FINISHED_JOB_STATUSES)
                         .setParameterList("taskStatus", Arrays.asList(TaskStatus.RUNNING));
 
@@ -662,7 +661,7 @@ public class SchedulerDBManager {
                 Query tasksQuery = session
                         .createQuery(
                                 "select count(*), sum(task.finishedTime) - sum(task.startTime) from TaskData task " +
-                                        "where task.finishedTime > 0 and task.jobData.owner = :username")
+                                    "where task.finishedTime > 0 and task.jobData.owner = :username")
                         .setParameter("username", username);
 
                 int taskCount;
@@ -681,7 +680,7 @@ public class SchedulerDBManager {
 
                 Query jobQuery = session
                         .createQuery("select count(*), sum(finishedTime) - sum(startTime) from JobData" +
-                                " where owner = :username and finishedTime > 0")
+                            " where owner = :username and finishedTime > 0")
                         .setParameter("username", username);
 
                 Object[] jobResult = (Object[]) jobQuery.uniqueResult();
@@ -701,7 +700,7 @@ public class SchedulerDBManager {
     private void removeJobScripts(Session session, long jobId) {
         session.createQuery(
                 "update TaskData set envScript = null, preScript = null, postScript = null,flowScript = null," +
-                        "cleanScript = null  where id.jobId = :jobId")
+                    "cleanScript = null  where id.jobId = :jobId")
                 .setParameter("jobId", jobId).executeUpdate();
         session.createQuery("delete from ScriptData where taskData.id.jobId = :jobId")
                 .setParameter("jobId", jobId).executeUpdate();
@@ -963,8 +962,8 @@ public class SchedulerDBManager {
                 long jobId = jobId(job);
 
                 String jobUpdate = "update JobData set status = :status, " +
-                        "startTime = :startTime, numberOfPendingTasks = :numberOfPendingTasks, " +
-                        "numberOfRunningTasks = :numberOfRunningTasks where id = :jobId";
+                    "startTime = :startTime, numberOfPendingTasks = :numberOfPendingTasks, " +
+                    "numberOfRunningTasks = :numberOfRunningTasks where id = :jobId";
 
                 JobInfo jobInfo = job.getJobInfo();
 
@@ -977,7 +976,7 @@ public class SchedulerDBManager {
                 if (taskStatusToPending) {
                     JobData job = (JobData) session.load(JobData.class, jobId);
                     String taskStatusUpdate = "update TaskData task set task.taskStatus = :taskStatus " +
-                            "where task.jobData = :job";
+                        "where task.jobData = :job";
                     session.createQuery(taskStatusUpdate).setParameter("taskStatus", TaskStatus.PENDING)
                             .setParameter("job", job).executeUpdate();
                 }
@@ -985,8 +984,8 @@ public class SchedulerDBManager {
                 TaskData.DBTaskId taskId = taskId(task);
 
                 String taskUpdate = "update TaskData task set task.taskStatus = :taskStatus, " +
-                        "task.startTime = :startTime, task.finishedTime = :finishedTime, " +
-                        "task.executionHostName = :executionHostName where task.id = :taskId";
+                    "task.startTime = :startTime, task.finishedTime = :finishedTime, " +
+                    "task.executionHostName = :executionHostName where task.id = :taskId";
 
                 TaskInfo taskInfo = task.getTaskInfo();
 
@@ -1009,22 +1008,28 @@ public class SchedulerDBManager {
                 long jobId = jobId(job);
 
                 String jobUpdate = "update JobData set status = :status, " +
-                        "numberOfPendingTasks = :numberOfPendingTasks, " +
-                        "numberOfRunningTasks = :numberOfRunningTasks where id = :jobId";
+                    "numberOfPendingTasks = :numberOfPendingTasks, " +
+                    "numberOfRunningTasks = :numberOfRunningTasks, " +
+                    "numberOfFailedTasks = :numberOfFailedTasks, " +
+                    "numberOfFaultyTasks = :numberOfFaultyTasks, " +
+                    "numberOfInErrorTasks = :numberOfInErrorTasks " + "where id = :jobId";
 
                 JobInfo jobInfo = job.getJobInfo();
 
                 session.createQuery(jobUpdate).setParameter("status", jobInfo.getStatus())
                         .setParameter("numberOfPendingTasks", jobInfo.getNumberOfPendingTasks())
                         .setParameter("numberOfRunningTasks", jobInfo.getNumberOfRunningTasks())
+                        .setParameter("numberOfFailedTasks", jobInfo.getNumberOfFailedTasks())
+                        .setParameter("numberOfFaultyTasks", jobInfo.getNumberOfFaultyTasks())
+                        .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
                         .setParameter("jobId", jobId).executeUpdate();
 
                 TaskData.DBTaskId taskId = taskId(task);
 
                 String taskUpdate = "update TaskData set taskStatus = :taskStatus, " +
-                        "numberOfExecutionLeft = :numberOfExecutionLeft," +
-                        "numberOfExecutionOnFailureLeft = :numberOfExecutionOnFailureLeft" +
-                        " where id = :taskId";
+                    "numberOfExecutionLeft = :numberOfExecutionLeft," +
+                    "numberOfExecutionOnFailureLeft = :numberOfExecutionOnFailureLeft" +
+                    " where id = :taskId";
 
                 TaskInfo taskInfo = task.getTaskInfo();
 
@@ -1051,10 +1056,13 @@ public class SchedulerDBManager {
             @Override
             public Void executeWork(Session session) {
                 String jobUpdate = "update JobData set status = :status, " +
-                        "finishedTime = :finishedTime, numberOfPendingTasks = :numberOfPendingTasks, " +
-                        "numberOfFinishedTasks = :numberOfFinishedTasks, " +
-                        "numberOfRunningTasks = :numberOfRunningTasks, " +
-                        "totalNumberOfTasks =:totalNumberOfTasks where id = :jobId";
+                    "finishedTime = :finishedTime, numberOfPendingTasks = :numberOfPendingTasks, " +
+                    "numberOfFinishedTasks = :numberOfFinishedTasks, " +
+                    "numberOfRunningTasks = :numberOfRunningTasks, " +
+                    "totalNumberOfTasks =:totalNumberOfTasks, " +
+                    "numberOfFailedTasks = :numberOfFailedTasks, " +
+                    "numberOfFaultyTasks = :numberOfFaultyTasks, " +
+                    "numberOfInErrorTasks = :numberOfInErrorTasks " + "where id = :jobId";
 
                 long jobId = jobId(job);
 
@@ -1065,13 +1073,16 @@ public class SchedulerDBManager {
                         .setParameter("numberOfPendingTasks", jobInfo.getNumberOfPendingTasks())
                         .setParameter("numberOfFinishedTasks", jobInfo.getNumberOfFinishedTasks())
                         .setParameter("numberOfRunningTasks", jobInfo.getNumberOfRunningTasks())
+                        .setParameter("numberOfFailedTasks", jobInfo.getNumberOfFailedTasks())
+                        .setParameter("numberOfFaultyTasks", jobInfo.getNumberOfFaultyTasks())
+                        .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
                         .setParameter("totalNumberOfTasks", jobInfo.getTotalNumberOfTasks())
                         .setParameter("jobId", jobId).executeUpdate();
 
                 JobData jobRuntimeData = (JobData) session.load(JobData.class, jobId);
 
                 List<DBTaskId> taskIds = new ArrayList<>(
-                        changesInfo.getSkippedTasks().size() + changesInfo.getUpdatedTasks().size());
+                    changesInfo.getSkippedTasks().size() + changesInfo.getUpdatedTasks().size());
                 for (TaskId id : changesInfo.getSkippedTasks()) {
                     taskIds.add(taskId(id));
                 }
@@ -1146,14 +1157,20 @@ public class SchedulerDBManager {
             public Void executeWork(Session session) {
 
                 for (TaskState task : job.getTasks()) {
-                    updateTaskStatus(task, session);
+                    updateTaskData(task, session);
                 }
 
-                String jobUpdate = "update JobData set status = :status where id = :jobId";
+                String jobUpdate = "update JobData set status = :status, " +
+                    "numberOfFailedTasks = :numberOfFailedTasks, " +
+                    "numberOfFaultyTasks = :numberOfFaultyTasks, " +
+                    "numberOfInErrorTasks = :numberOfInErrorTasks " + "where id = :jobId";
 
                 JobInfo jobInfo = job.getJobInfo();
 
                 session.createQuery(jobUpdate).setParameter("status", jobInfo.getStatus())
+                        .setParameter("numberOfFailedTasks", jobInfo.getNumberOfFailedTasks())
+                        .setParameter("numberOfFaultyTasks", jobInfo.getNumberOfFaultyTasks())
+                        .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
                         .setParameter("jobId", jobId(job)).executeUpdate();
 
                 return null;
@@ -1166,7 +1183,7 @@ public class SchedulerDBManager {
         runWithTransaction(new SessionWork<Void>() {
             @Override
             public Void executeWork(Session session) {
-                updateTaskStatus(task, session);
+                updateTaskData(task, session);
 
                 return null;
             }
@@ -1174,14 +1191,20 @@ public class SchedulerDBManager {
         });
     }
 
-    private int updateTaskStatus(final TaskState task, Session session) {
-        String taskUpdate = "update TaskData task set task.taskStatus = :taskStatus where task.id = :taskId";
+    private int updateTaskData(final TaskState task, Session session) {
+
+        String taskUpdate = "update TaskData task set task.taskStatus = :taskStatus, " +
+            "task.numberOfExecutionLeft = :numberOfExecutionLeft, " +
+            "task.numberOfExecutionOnFailureLeft = :numberOfExecutionOnFailureLeft " +
+            "where task.id = :taskId";
 
         Query taskUpdateQuery = session.createQuery(taskUpdate);
 
         TaskInfo taskInfo = task.getTaskInfo();
 
         return taskUpdateQuery.setParameter("taskStatus", taskInfo.getStatus())
+                .setParameter("numberOfExecutionLeft", taskInfo.getNumberOfExecutionLeft())
+                .setParameter("numberOfExecutionOnFailureLeft", taskInfo.getNumberOfExecutionOnFailureLeft())
                 .setParameter("taskId", taskId(task.getId())).executeUpdate();
     }
 
@@ -1205,7 +1228,7 @@ public class SchedulerDBManager {
 
                 Query query = session
                         .createQuery("update TaskData task set task." + fieldName + " = :newTime " + //NOSONAR
-                                "where task.id.jobId = :jobId and task.id.taskId= :taskId")
+                            "where task.id.jobId = :jobId and task.id.taskId= :taskId")
                         .setParameter("newTime", time).setParameter("jobId", jobId)
                         .setParameter("taskId", taskId);
 
@@ -1229,9 +1252,12 @@ public class SchedulerDBManager {
                 long jobId = jobId(job);
 
                 String jobUpdate = "update JobData set status = :status, " +
-                        "finishedTime = :finishedTime, numberOfPendingTasks = :numberOfPendingTasks, " +
-                        "numberOfFinishedTasks = :numberOfFinishedTasks, " +
-                        "numberOfRunningTasks = :numberOfRunningTasks where id = :jobId";
+                    "finishedTime = :finishedTime, numberOfPendingTasks = :numberOfPendingTasks, " +
+                    "numberOfFinishedTasks = :numberOfFinishedTasks, " +
+                    "numberOfRunningTasks = :numberOfRunningTasks, " +
+                    "numberOfFailedTasks = :numberOfFailedTasks, " +
+                    "numberOfFaultyTasks = :numberOfFaultyTasks, " +
+                    "numberOfInErrorTasks = :numberOfInErrorTasks " + " where id = :jobId";
 
                 JobInfo jobInfo = job.getJobInfo();
 
@@ -1240,11 +1266,16 @@ public class SchedulerDBManager {
                         .setParameter("numberOfPendingTasks", jobInfo.getNumberOfPendingTasks())
                         .setParameter("numberOfFinishedTasks", jobInfo.getNumberOfFinishedTasks())
                         .setParameter("numberOfRunningTasks", jobInfo.getNumberOfRunningTasks())
+                        .setParameter("numberOfFailedTasks", jobInfo.getNumberOfFailedTasks())
+                        .setParameter("numberOfFaultyTasks", jobInfo.getNumberOfFaultyTasks())
+                        .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
                         .setParameter("jobId", jobId).executeUpdate();
 
                 String taskUpdate = "update TaskData task set task.taskStatus = :taskStatus, " +
-                        "task.finishedTime = :finishedTime, " + "task.executionDuration = :executionDuration " +
-                        "where task.id = :taskId";
+                    "task.numberOfExecutionLeft = :numberOfExecutionLeft, " +
+                    "task.numberOfExecutionOnFailureLeft = :numberOfExecutionOnFailureLeft, " +
+                    "task.finishedTime = :finishedTime, " + "task.executionDuration = :executionDuration " +
+                    "where task.id = :taskId";
 
                 Query taskUpdateQuery = session.createQuery(taskUpdate);
 
@@ -1259,6 +1290,9 @@ public class SchedulerDBManager {
                     TaskInfo taskInfo = task.getTaskInfo();
 
                     taskUpdateQuery.setParameter("taskStatus", taskInfo.getStatus())
+                            .setParameter("numberOfExecutionLeft", taskInfo.getNumberOfExecutionLeft())
+                            .setParameter("numberOfExecutionOnFailureLeft",
+                                    taskInfo.getNumberOfExecutionOnFailureLeft())
                             .setParameter("finishedTime", taskInfo.getFinishedTime())
                             .setParameter("executionDuration", taskInfo.getExecutionDuration())
                             .setParameter("taskId", taskId).executeUpdate();
@@ -1329,14 +1363,14 @@ public class SchedulerDBManager {
 
                 Query query = session
                         .createQuery("select taskResult, " + "task.id, " + "task.taskName, " +
-                                "task.preciousResult from TaskResultData as taskResult join taskResult.taskRuntimeData as task " +
-                                "where task.id in (:tasksIds) order by task.id, taskResult.resultTime desc")
+                            "task.preciousResult from TaskResultData as taskResult join taskResult.taskRuntimeData as task " +
+                            "where task.id in (:tasksIds) order by task.id, taskResult.resultTime desc")
                         .setParameterList("tasksIds", dbTaskIds);
 
                 JobResultImpl jobResult = loadJobResult(session, query, job, jobId);
                 if (jobResult == null) {
                     throw new DatabaseManagerException(
-                            "Failed to load result for tasks " + taskIds + " (job: " + jobId + ")");
+                        "Failed to load result for tasks " + taskIds + " (job: " + jobId + ")");
                 }
 
                 Map<TaskId, TaskResult> resultsMap = new HashMap<>(taskIds.size());
@@ -1350,7 +1384,7 @@ public class SchedulerDBManager {
                     }
                     if (taskResult == null) {
                         throw new DatabaseManagerException(
-                                "Failed to load result for task " + taskId + " (job: " + jobId + ")");
+                            "Failed to load result for task " + taskId + " (job: " + jobId + ")");
                     } else {
                         resultsMap.put(taskId, taskResult);
                     }
@@ -1358,7 +1392,7 @@ public class SchedulerDBManager {
 
                 if (jobResult.getAllResults().size() != taskIds.size()) {
                     throw new DatabaseManagerException(
-                            "Results: " + jobResult.getAllResults().size() + " " + taskIds.size());
+                        "Results: " + jobResult.getAllResults().size() + " " + taskIds.size());
                 }
 
                 return resultsMap;
@@ -1383,8 +1417,8 @@ public class SchedulerDBManager {
 
                 Query query = session
                         .createQuery("select taskResult, " + "task.id, " + "task.taskName, " +
-                                "task.preciousResult from TaskResultData as taskResult left outer join taskResult.taskRuntimeData as task " +
-                                "where task.jobData = :job order by task.id, taskResult.resultTime desc")
+                            "task.preciousResult from TaskResultData as taskResult left outer join taskResult.taskRuntimeData as task " +
+                            "where task.jobData = :job order by task.id, taskResult.resultTime desc")
                         .setParameter("job", job);
 
                 return loadJobResult(session, query, job, jobId);
@@ -1441,13 +1475,13 @@ public class SchedulerDBManager {
 
                 Object[] taskSearchResult = (Object[]) session
                         .createQuery("select id, taskName from TaskData where " +
-                                "taskName = :taskName and jobData = :job")
+                            "taskName = :taskName and jobData = :job")
                         .setParameter("taskName", taskName)
                         .setParameter("job", session.load(JobData.class, id)).uniqueResult();
 
                 if (taskSearchResult == null) {
                     throw new DatabaseManagerException(
-                            "Failed to load result for task '" + taskName + ", job: " + jobId);
+                        "Failed to load result for task '" + taskName + ", job: " + jobId);
                 }
 
                 DBTaskId dbTaskId = (DBTaskId) taskSearchResult[0];
@@ -1546,7 +1580,7 @@ public class SchedulerDBManager {
                 }
                 taskRuntimeData.setDependentTasks(dependencies);
             } else {
-                taskRuntimeData.setDependentTasks(Collections.<DBTaskId>emptyList());
+                taskRuntimeData.setDependentTasks(Collections.<DBTaskId> emptyList());
             }
             if (task.getIfBranch() != null) {
                 InternalTask ifBranch = task.getIfBranch();
@@ -1561,7 +1595,7 @@ public class SchedulerDBManager {
                 }
                 taskRuntimeData.setJoinedBranches(joinedBranches);
             } else {
-                taskRuntimeData.setJoinedBranches(Collections.<DBTaskId>emptyList());
+                taskRuntimeData.setJoinedBranches(Collections.<DBTaskId> emptyList());
             }
         }
     }
@@ -1603,7 +1637,7 @@ public class SchedulerDBManager {
 
     private boolean isScriptTask(InternalTask task) {
         return task.getClass().equals(InternalForkedScriptTask.class) ||
-                task.getClass().equals(InternalScriptTask.class);
+            task.getClass().equals(InternalScriptTask.class);
     }
 
     private TaskData queryScriptTaskData(Session session, InternalTask task) {
@@ -1632,8 +1666,8 @@ public class SchedulerDBManager {
                 for (Object obj : list) {
                     Object[] nameAndCount = (Object[]) obj;
                     users.add(new SchedulerUserInfo(null, nameAndCount[0].toString(), 0,
-                            Long.parseLong(nameAndCount[2].toString()),
-                            Integer.parseInt(nameAndCount[1].toString())));
+                        Long.parseLong(nameAndCount[2].toString()),
+                        Integer.parseInt(nameAndCount[1].toString())));
                 }
                 return users;
             }
@@ -1714,8 +1748,7 @@ public class SchedulerDBManager {
             @Override
             public Void executeWork(Session session) {
                 session.saveOrUpdate(new ThirdPartyCredentialData(username, key,
-                        encryptedCredential.getEncryptedSymmetricKey(),
-                        encryptedCredential.getEncryptedData()));
+                    encryptedCredential.getEncryptedSymmetricKey(), encryptedCredential.getEncryptedData()));
                 return null;
             }
         });
@@ -1757,7 +1790,7 @@ public class SchedulerDBManager {
             public Map<String, HybridEncryptedData> executeWork(Session session) {
                 Query query = session
                         .createQuery("select key, encryptedSymmetricKey, encryptedValue " +
-                                "from ThirdPartyCredentialData " + "where username = :username")
+                            "from ThirdPartyCredentialData " + "where username = :username")
                         .setParameter("username", username);
                 List<Object[]> rows = query.list();
                 Map<String, HybridEncryptedData> thirdPartyCredentialsMap = new HashMap<>(rows.size());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSubmitJobWithUnaccessibleDataSpaces.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestSubmitJobWithUnaccessibleDataSpaces.java
@@ -56,6 +56,8 @@ public class TestSubmitJobWithUnaccessibleDataSpaces extends SchedulerFunctional
 
     static URL jobDescriptor = TestSubmitJobWithUnaccessibleDataSpaces.class
             .getResource("/functionaltests/dataspaces/Job_DataSpaceUnacc.xml");
+    static URL jobDescriptor33 = TestSubmitJobWithUnaccessibleDataSpaces.class
+            .getResource("/functionaltests/dataspaces/Job_DataSpaceUnacc3.3.xml");
 
     static URL configFile = TestSubmitJobWithUnaccessibleDataSpaces.class
             .getResource("/functionaltests/dataspaces/schedulerPropertiesWrongSpaces.ini");
@@ -69,6 +71,13 @@ public class TestSubmitJobWithUnaccessibleDataSpaces extends SchedulerFunctional
     public void testSubmitJobWithUnaccessibleDataSpaces() throws Throwable {
 
         schedulerHelper.testJobSubmission(new File(jobDescriptor.toURI())
+                .getAbsolutePath());
+    }
+
+    @Test
+    public void testSubmitJobWithUnaccessibleDataSpacesSchema33Compatability() throws Throwable {
+
+        schedulerHelper.testJobSubmission(new File(jobDescriptor33.toURI())
                 .getAbsolutePath());
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TestPreemptRestartKillTaskSchema33.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TestPreemptRestartKillTaskSchema33.java
@@ -36,8 +36,9 @@
  */
 package functionaltests.job;
 
-import functionaltests.utils.SchedulerFunctionalTestWithRestart;
-import org.junit.Test;
+import java.io.File;
+import java.net.URL;
+
 import org.ow2.proactive.scheduler.common.exception.TaskAbortedException;
 import org.ow2.proactive.scheduler.common.exception.TaskPreemptedException;
 import org.ow2.proactive.scheduler.common.exception.TaskRestartedException;
@@ -49,12 +50,13 @@ import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
-
-import java.io.File;
-import java.net.URL;
+import functionaltests.utils.SchedulerFunctionalTestWithRestart;
+import org.junit.Test;
 
 import static functionaltests.utils.SchedulerTHelper.log;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -77,14 +79,15 @@ import static org.junit.Assert.*;
  * @author The ProActive Team
  * @since ProActive Scheduling 3.0
  */
-public class TestPreemptRestartKillTask extends SchedulerFunctionalTestWithRestart {
+public class TestPreemptRestartKillTaskSchema33 extends SchedulerFunctionalTestWithRestart {
 
-    private static URL jobDescriptor = TestPreemptRestartKillTask.class
-            .getResource("/functionaltests/descriptors/Job_preempt_restart_kill.xml");
+    private static URL jobDescriptor33 = TestPreemptRestartKillTaskSchema33.class
+            .getResource("/functionaltests/descriptors/Job_preempt_restart_kill_Schema33.xml");
+
 
     @Test
-    public void testPreemptRestartKillTask() throws Throwable {
-        String jobDescriptorPath = new File(jobDescriptor.toURI()).getAbsolutePath();
+    public void testPreemptRestartKillTaskCompatibilitySchema33() throws Throwable {
+        String jobDescriptorPath = new File(jobDescriptor33.toURI()).getAbsolutePath();
         TestPreemtRestartKillTask(jobDescriptorPath);
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobAborted.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobAborted.java
@@ -66,17 +66,29 @@ public class TestJobAborted extends SchedulerFunctionalTestNoRestart {
 
     private static URL jobDescriptor = TestJobAborted.class
             .getResource("/functionaltests/descriptors/Job_Aborted.xml");
+    private static URL jobDescriptor33 = TestJobAborted.class
+            .getResource("/functionaltests/descriptors/Job_Aborted_Schema33.xml");
 
     @Test
     public void testJobAborted() throws Throwable {
+        String jobDescriptorPath = new File(jobDescriptor.toURI()).getAbsolutePath();
+        testJobAborted(jobDescriptorPath);
+    }
 
+    @Test
+    public void testJobAbortedCompatibilitySchema33() throws Throwable {
+        String jobDescriptorPath = new File(jobDescriptor33.toURI()).getAbsolutePath();
+        testJobAborted(jobDescriptorPath);
+    }
+
+    private void testJobAborted(String jobDescriptorPath) throws Exception {
         String task1Name = "task1";
         String task2Name = "task2";
 
         log("Test 1 : Submitting job...");
 
         //job submission
-        JobId id = schedulerHelper.submitJob(new File(jobDescriptor.toURI()).getAbsolutePath());
+        JobId id = schedulerHelper.submitJob(jobDescriptorPath);
 
         //check events reception
         log("Job submitted, id " + id.toString());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobCanceledWithReplicationSchema33.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestJobCanceledWithReplicationSchema33.java
@@ -64,14 +64,15 @@ import static org.junit.Assert.*;
  * @author The ProActive Team
  * @since ProActive Scheduling 3.1
  */
-public class TestJobCanceledWithReplication extends SchedulerFunctionalTestNoRestart {
+public class TestJobCanceledWithReplicationSchema33 extends SchedulerFunctionalTestNoRestart {
 
-    private static URL jobDescriptor = TestJobCanceledWithReplication.class
-            .getResource("/functionaltests/descriptors/Job_Aborted_With_Replication.xml");
+    private static URL jobDescriptor33 = TestJobCanceledWithReplicationSchema33.class
+            .getResource("/functionaltests/descriptors/Job_Aborted_With_Replication_Schema33.xml");
+
 
     @Test
-    public void testJobCanceledWithReplication() throws Throwable {
-        String jobDescriptorPath = new File(jobDescriptor.toURI()).getAbsolutePath();
+    public void testJobCanceledWithReplicationCompatibilitySchema33() throws Throwable {
+        String jobDescriptorPath = new File(jobDescriptor33.toURI()).getAbsolutePath();
         testJobCanceledWithReplication(jobDescriptorPath);
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestTaskNotExecuted.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/error/TestTaskNotExecuted.java
@@ -65,11 +65,33 @@ public class TestTaskNotExecuted extends SchedulerFunctionalTestNoRestart {
     private static URL jobDescriptor3 = TestTaskNotExecuted.class
             .getResource("/functionaltests/descriptors/Job_TaskSkipped.xml");
 
+    private static URL jobDescriptor1_Schema33 = TestTaskNotExecuted.class
+            .getResource("/functionaltests/descriptors/Job_TaskCouldNotStart_Schema33.xml");
+    private static URL jobDescriptor2_Schema33 = TestTaskNotExecuted.class
+            .getResource("/functionaltests/descriptors/Job_TaskCouldNotRestart_Schema33.xml");
+    private static URL jobDescriptor3_Schema33 = TestTaskNotExecuted.class
+            .getResource("/functionaltests/descriptors/Job_TaskSkipped_Schema33.xml");
+
     @Test
     public void testTaskNotExecuted() throws Throwable {
+        String jobDescriptorPath1 = new File(jobDescriptor1.toURI()).getAbsolutePath();
+        String jobDescriptorPath2 = new File(jobDescriptor2.toURI()).getAbsolutePath();
+        String jobDescriptorPath3 = new File(jobDescriptor3.toURI()).getAbsolutePath();
+        testTaskNotExecuted(jobDescriptorPath1, jobDescriptorPath2, jobDescriptorPath3);
+    }
 
+    @Test
+    public void testTaskNotExecutedCompatibilitySchema33() throws Throwable {
+        String jobDescriptorPath1 = new File(jobDescriptor1_Schema33.toURI()).getAbsolutePath();
+        String jobDescriptorPath2 = new File(jobDescriptor2_Schema33.toURI()).getAbsolutePath();
+        String jobDescriptorPath3 = new File(jobDescriptor3_Schema33.toURI()).getAbsolutePath();
+        testTaskNotExecuted(jobDescriptorPath1, jobDescriptorPath2, jobDescriptorPath3);
+    }
+
+    private void testTaskNotExecuted(String jobDescriptorPath1, String jobDescriptorPath2,
+            String jobDescriptorPath3) throws Exception {
         log("Submitting job 1");
-        JobId id1 = schedulerHelper.submitJob(new File(jobDescriptor1.toURI()).getAbsolutePath());
+        JobId id1 = schedulerHelper.submitJob(jobDescriptorPath1);
         log("Wait for event job 1 submitted");
         schedulerHelper.waitForEventJobSubmitted(id1);
         log("Wait for event t1 running");
@@ -81,7 +103,7 @@ public class TestTaskNotExecuted extends SchedulerFunctionalTestNoRestart {
         assertTrue(tr1.getException() instanceof TaskCouldNotStartException);
 
         log("Submitting job 2");
-        JobId id2 = schedulerHelper.submitJob(new File(jobDescriptor2.toURI()).getAbsolutePath());
+        JobId id2 = schedulerHelper.submitJob(jobDescriptorPath2);
         log("Wait for event job 2 submitted");
         schedulerHelper.waitForEventJobSubmitted(id2);
         log("Wait for event t2 running");
@@ -100,7 +122,7 @@ public class TestTaskNotExecuted extends SchedulerFunctionalTestNoRestart {
         assertTrue(tr2.getException() instanceof TaskCouldNotRestartException);
 
         log("Submitting job 3");
-        JobId id3 = schedulerHelper.submitJob(new File(jobDescriptor3.toURI()).getAbsolutePath());
+        JobId id3 = schedulerHelper.submitJob(jobDescriptorPath3);
         log("Wait for event job 3 submitted");
         schedulerHelper.waitForEventJobSubmitted(id3);
         log("Wait for event T T1 T2 finished");
@@ -112,7 +134,6 @@ public class TestTaskNotExecuted extends SchedulerFunctionalTestNoRestart {
 
         assertNull(tr3_1.getException());
         assertTrue(tr3_2.getException() instanceof TaskSkippedException);
-
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowIterationAwareness.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowIterationAwareness.java
@@ -73,6 +73,12 @@ public class TestWorkflowIterationAwareness extends SchedulerFunctionalTestNoRes
     private static final URL native_job = TestWorkflowIterationAwareness.class
             .getResource("/functionaltests/workflow/descriptors/flow_it_2.xml");
 
+    private static final URL java_job_Schema33 = TestWorkflowIterationAwareness.class
+            .getResource("/functionaltests/workflow/descriptors/flow_it_1_Schema33.xml");
+
+    private static final URL native_job_Schema33 = TestWorkflowIterationAwareness.class
+            .getResource("/functionaltests/workflow/descriptors/flow_it_2_Schema33.xml");
+
     private static final String tmpFolder = System.getProperty("java.io.tmpdir");
 
     private static final String preScript = //
@@ -92,17 +98,30 @@ public class TestWorkflowIterationAwareness extends SchedulerFunctionalTestNoRes
      */
     @Test
     public void testWorkflowIterationAwareness() throws Throwable {
-        testJavaJob();
-        testNativeJob();
+        testJavaJob(new File(java_job.toURI()).getAbsolutePath());
+        testNativeJob(new File(native_job.toURI()).getAbsolutePath());
+    }
+
+    /**
+     * Checks Java and Native executables workflows in schema 33
+     * on a loop/replicate job for propagation of iteration and replication indexes in :
+     * native arguments, java arguments, pre/post scripts, native environment variables, java properties
+     *
+     * @throws Throwable
+     */
+    @Test
+    public void testWorkflowIterationAwarenessCompatibilitySchema33() throws Throwable {
+        testJavaJob(new File(java_job_Schema33.toURI()).getAbsolutePath());
+        testNativeJob(new File(native_job_Schema33.toURI()).getAbsolutePath());
     }
 
     /**
      * java task through xml
      */
-    private void testJavaJob() throws Throwable {
+    private void testJavaJob(String jobDescriptorPath) throws Throwable {
 
         TaskFlowJob job = (TaskFlowJob) StaxJobFactory.getFactory().createJob(
-                new File(java_job.toURI()).getAbsolutePath());
+                jobDescriptorPath);
         ((JavaTask) job.getTask("T1")).setPreScript(new SimpleScript(preScript, "groovy"));
         ((JavaTask) job.getTask("T1")).setPostScript(new SimpleScript(postScript, "groovy"));
 
@@ -134,9 +153,9 @@ public class TestWorkflowIterationAwareness extends SchedulerFunctionalTestNoRes
     /**
      * native task through xml
      */
-    private void testNativeJob() throws Throwable {
+    private void testNativeJob(String jobDescriptorPath) throws Throwable {
         TaskFlowJob job = (TaskFlowJob) StaxJobFactory.getFactory().createJob(
-                new File(native_job.toURI()).getAbsolutePath());
+                jobDescriptorPath);
         switch (OperatingSystem.getOperatingSystem()) {
             case windows:
                 ((NativeTask) job.getTask("T1")).setPreScript(new SimpleScript(preScript, "groovy"));

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingServiceTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingServiceTest.java
@@ -42,7 +42,8 @@ public class SchedulingServiceTest {
 		MockitoAnnotations.initMocks(this);
 		Mockito.when(recoveredState.getPendingJobs()).thenReturn(new Vector<InternalJob>());
 		Mockito.when(recoveredState.getRunningJobs()).thenReturn(new Vector<InternalJob>());
-		
+		Mockito.when(recoveredState.getFinishedJobs()).thenReturn(new Vector<InternalJob>());
+
 		Mockito.when(infrastructure.getRMProxiesManager()).thenReturn(rmProxiesManager);
 		Mockito.when(rmProxiesManager.getRmUrl()).thenReturn(null);
 		

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestLoadSchedulerClientState.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestLoadSchedulerClientState.java
@@ -157,7 +157,7 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
         task1.setWallTime(440000);
         JavaTask task2 = createDefaultTask("task2");
         task2.setDescription("d2");
-        task2.setOnTaskError(OnTaskError.NONE);
+        task2.setOnTaskError(OnTaskError.NONE); // If it is set to none, the job level behavior will overwrite the task level none behavior.
         task2.setMaxNumberOfExecution(3);
         task2.setPreciousLogs(false);
         task2.setPreciousResult(false);

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/dataspaces/Job_DataSpaceUnacc3.3.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/dataspaces/Job_DataSpaceUnacc3.3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-		name="TestSubmitJobWithUnaccessibleDataSpaces" onTaskError="cancelJob">
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+		name="TestSubmitJobWithUnaccessibleDataSpaces" cancelJobOnError="true">
 
 
 	<taskFlow>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_Aborted_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_Aborted_Schema33.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_killer" priority="normal" onTaskError="continueJobExecution">
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+	name="job_killer" priority="normal" cancelJobOnError="false">
 	<description>The second task of this job will throw an exception and so the job will be canceled</description>
 	<taskFlow>
 		<task name="task1">
@@ -13,7 +13,7 @@
 				</parameters>
 			</javaExecutable>
 		</task>
-		<task name="task2" preciousResult="true" onTaskError="cancelJob">
+		<task name="task2" preciousResult="true" cancelJobOnError="true">
 			<description>task will throw an exception</description>
 			<javaExecutable class="org.ow2.proactive.scheduler.examples.AbortJob">
 			</javaExecutable>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_Aborted_With_Replication_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_Aborted_With_Replication_Schema33.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_aborted_with_replication" priority="normal" onTaskError="continueJobExecution">
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+	name="job_aborted_with_replication" priority="normal" cancelJobOnError="false">
 	<description>The second task of this job will throw an exception and so the job will be canceled</description>
 	<taskFlow>
-        <task name="task2replicate" preciousResult="true" onTaskError="cancelJob">
+        <task name="task2replicate" preciousResult="true" cancelJobOnError="true">
             <description>replicate task2</description>
             <javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
             </javaExecutable>
@@ -20,13 +20,13 @@ runs=2;
                 </replicate>
             </controlFlow>
         </task>
-		<task name="task2" preciousResult="true" onTaskError="cancelJob">
+		<task name="task2" preciousResult="true" cancelJobOnError="true">
 			<description>task with replication id = 1 will throw an exception</description>
 			<depends><task ref="task2replicate" /></depends>
 			<javaExecutable class="org.ow2.proactive.scheduler.examples.FailTaskConditionally">
 			</javaExecutable>
 		</task>
-        <task name="task2merge" preciousResult="true" onTaskError="cancelJob">
+        <task name="task2merge" preciousResult="true" cancelJobOnError="true">
             <description>merge task</description>
             <depends><task ref="task2" /></depends>
             <javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_Killed.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_Killed.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_killer" priority="normal" cancelJobOnError="false">
+	name="job_killer" priority="normal" onTaskError="continueJobExecution">
 	<description>The second task of this job will kill the node on which it has been started</description>
 	<taskFlow>
 		<task name="task1">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_PI_recover.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_PI_recover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_PI_recover" priority="normal" cancelJobOnError="true">
+	name="job_PI_recover" priority="normal" onTaskError="cancelJob">
 	<description> Computing PI according to MonteCarlo method. </description>
 	<taskFlow>
 		<task name="Computation1">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_PropagatedVariables_Timeout.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_PropagatedVariables_Timeout.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-     name="job_walltime_vars" cancelJobOnError="false" priority="normal">
+     name="job_walltime_vars" onTaskError="continueJobExecution" priority="normal">
     <variables>
         <variable name="var" value="var-value"/>
     </variables>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_SCHEDULING_2034_unix.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_SCHEDULING_2034_unix.xml
@@ -2,7 +2,7 @@
 
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-    name="Job_SCHEDULING_2034" cancelJobOnError="false" priority="normal">
+    name="Job_SCHEDULING_2034" onTaskError="continueJobExecution" priority="normal">
     <variables>
         <variable name="var" value="var-value" />
     </variables>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_TaskCouldNotRestart_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_TaskCouldNotRestart_Schema33.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_killer" priority="normal" onTaskError="cancelJob">
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+	name="job_killer" priority="normal" cancelJobOnError="true">
 	<description>The task will fail to restart</description>
 	<taskFlow>
 		<task name="t2" maxNumberOfExecution="10">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_TaskCouldNotStart_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_TaskCouldNotStart_Schema33.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_killer" priority="normal" onTaskError="cancelJob">
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+	name="job_killer" priority="normal" cancelJobOnError="true">
 	<description>The second task of this job will not be started</description>
 	<taskFlow>
         <task name="t0">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_TaskSkipped_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_TaskSkipped_Schema33.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_killer" priority="normal" onTaskError="continueJobExecution">
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+	name="job_killer" priority="normal" cancelJobOnError="false">
 	<description>The second task will be skipped</description>
     <taskFlow>
         <task name="T" maxNumberOfExecution="1">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_fill_working_dir_script_task.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_fill_working_dir_script_task.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-     name="fill_working_dir_job" cancelJobOnError="false" priority="normal">
+     name="fill_working_dir_job" onTaskError="continueJobExecution" priority="normal">
     <taskFlow>
         <task name="fill_working_dir_task">
             <scriptExecutable>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_invalidSS.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_invalidSS.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_invalidSS" priority="normal" cancelJobOnError="false">
+	name="job_invalidSS" priority="normal" onTaskError="continueJobExecution">
 	<description>The second task of this job will try to get a node with an invalid selection script</description>
 	<taskFlow>
 		<task name="task1">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_modify_propagated_vars.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_modify_propagated_vars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-    name="job_propagate_vars" cancelJobOnError="false" priority="normal">
+    name="job_propagate_vars" onTaskError="continueJobExecution" priority="normal">
     <variables>
         <variable name="var" value="var-value" />
     </variables>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_modify_propagated_vars_on_unix.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_modify_propagated_vars_on_unix.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-    name="job_propagate_vars_on_unix" cancelJobOnError="false" priority="normal">
+    name="job_propagate_vars_on_unix" onTaskError="continueJobExecution" priority="normal">
     <variables>
         <variable name="var" value="var-value" />
         <variable name="home" value="${pa.scheduler.home}" />

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_native_4_hosts.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_native_4_hosts.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_native_4_hosts" priority="normal" cancelJobOnError="false">
+	name="job_native_4_hosts" priority="normal" onTaskError="continueJobExecution">
 	<variables>
 		<!-- pa.scheduler.home is known as java property - ie : start with -Dpa.scheduler.home=value -->
 		<variable name="WORK_DIR" value="${pa.scheduler.home}/scheduler/scheduler-server/src/test/resources/functionaltests/executables"/>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_pre_post.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_pre_post.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_pre_post" cancelJobOnError="true" priority="normal">
+	name="job_pre_post" onTaskError="continueJobExecution" priority="normal">
 	<variables>
 		<!-- pa.scheduler.home is known as java property - ie : start with -Dpa.scheduler.home=value -->
 		<variable name="WORK_DIR" value="${pa.scheduler.home}/samples/scripts/misc"/>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_preempt_restart_kill_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_preempt_restart_kill_Schema33.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
 	name="job_prt">
 	<taskFlow>
 		<task name="t1" maxNumberOfExecution="2">
@@ -27,7 +27,7 @@
 				</parameters>
 			</javaExecutable>
 		</task>
-		<task name="t4" onTaskError="cancelJob" maxNumberOfExecution="3">
+		<task name="t4" cancelJobOnError="true" maxNumberOfExecution="3">
 			<javaExecutable class="org.ow2.proactive.scheduler.examples.WaitAndPrint">
 				<parameters>
 					<parameter name="sleepTime" value="120"/>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_propagate_vars.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_propagate_vars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-    name="job_propagate_vars" cancelJobOnError="false" priority="normal">
+    name="job_propagate_vars" onTaskError="continueJobExecution" priority="normal">
     <variables>
         <variable name="var" value="var-value" />
     </variables>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_test_workingDir_static_command.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_test_workingDir_static_command.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-	name="job_native_workingDir" priority="normal" cancelJobOnError="false">
+	name="job_native_workingDir" priority="normal" onTaskError="continueJobExecution">
 	<!-- description also test that description can contain more than 255 char -->
 	<variables>
 		<!-- values are coming from system properties upon submission -->

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_crash_int_2.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_crash_int_2.xml
@@ -2,7 +2,7 @@
 <job xmlns="urn:proactive:jobdescriptor:dev" 
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-     name="Job" priority="low" projectName="myProject" cancelJobOnError="true">
+     name="Job" priority="low" projectName="myProject" onTaskError="cancelJob">
   <taskFlow>
     <task name="T" maxNumberOfExecution="4">
       <description> // <![CDATA[

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_it_1.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_it_1.xml
@@ -2,7 +2,7 @@
 <job xmlns="urn:proactive:jobdescriptor:dev" 
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-     name="Job" priority="low" projectName="myProject" cancelJobOnError="true">
+     name="Job" priority="low" projectName="myProject" onTaskError="cancelJob">
 
   <taskFlow>
     <task name="T" maxNumberOfExecution="4">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_it_1_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_it_1_Schema33.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" 
+<job xmlns="urn:proactive:jobdescriptor:3.3" 
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-     name="Job" priority="low" projectName="myProject" onTaskError="cancelJob">
-
-  <variables>
-    <variable name="bin" value="${pa.scheduler.home}/scheduler/scheduler-server/src/test/resources/functionaltests/workflow" />
-    <variable name="tmp_folder" value="${java.io.tmpdir}/" />
-  </variables>
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+     name="Job" priority="low" projectName="myProject" cancelJobOnError="true">
 
   <taskFlow>
     <task name="T" maxNumberOfExecution="4">
@@ -20,7 +15,7 @@
         <replicate>
           <script>
             <code language="javascript">
-// <![CDATA[
+// <![CDATA[ 
 runs=2;
 // ]]>
             </code>
@@ -35,15 +30,12 @@ runs=2;
       <depends>
         <task ref ="T" />
       </depends>
-	  <nativeExecutable>
-        <staticCommand value="${bin}/it.sh">
-		  <arguments>
-			<argument value="$tmp_folder" />
-			<argument value="$PA_TASK_ITERATION" />
-			<argument value="$PA_TASK_REPLICATION" />
-		  </arguments>
-		</staticCommand>
-	  </nativeExecutable>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.IterationAwareJob">
+		<parameters>
+		  <parameter name="it" value="$PA_TASK_ITERATION" />
+		  <parameter name="dup" value="$PA_TASK_REPLICATION" />
+		</parameters>
+      </javaExecutable>
     </task>
     <task name="T2" maxNumberOfExecution="4">
       <description> // <![CDATA[
@@ -59,7 +51,6 @@ runs=2;
           <script>
             <code language="groovy">
 // <![CDATA[
-
 def ID   = 3;
 def RUNS = 2;
 def f = new File(java.lang.System.getProperty("java.io.tmpdir"), "test_flow_lock_" + ID);

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_it_2_Schema33.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/flow_it_2_Schema33.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job xmlns="urn:proactive:jobdescriptor:dev" 
+<job xmlns="urn:proactive:jobdescriptor:3.3" 
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
-     name="Job" priority="low" projectName="myProject" onTaskError="cancelJob">
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+     name="Job" priority="low" projectName="myProject" cancelJobOnError="true">
 
   <variables>
     <variable name="bin" value="${pa.scheduler.home}/scheduler/scheduler-server/src/test/resources/functionaltests/workflow" />

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/recovery_pending_job.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/recovery_pending_job.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job cancelJobOnError="false" name="TestTaskRestore_pending" priority="normal" projectName="Not Assigned"
+<job onTaskError="continueJobExecution" name="TestTaskRestore_pending" priority="normal" projectName="Not Assigned"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:proactive:jobdescriptor:dev"
      xmlns="urn:proactive:jobdescriptor:dev">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/recovery_replicate.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/workflow/descriptors/recovery_replicate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<job cancelJobOnError="false" maxNumberOfExecution="1" name="RecoveryReplicate" priority="normal" projectName="Not Assigned"
+<job onTaskError="continueJobExecution" maxNumberOfExecution="1" name="RecoveryReplicate" priority="normal" projectName="Not Assigned"
      restartTaskOnError="anywhere" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:proactive:jobdescriptor:dev" xmlns="urn:proactive:jobdescriptor:dev">
     <description>No description</description>


### PR DESCRIPTION
Current tests use the dev xsd. The xsd was updated, therefore tests fail. In those tests CancelJobOnError is replaced with OnTaskError.