### PR TITLE
Preserve numberOfExecutionLeft after Scheduler restart

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -531,6 +531,8 @@ public class TaskData {
         internalTask.setRunAsMe(isRunAsMe());
         internalTask.setWallTime(getWallTime());
         internalTask.setMaxNumberOfExecution(getMaxNumberOfExecution());
+        internalTask.setNumberOfExecutionLeft(getNumberOfExecutionLeft());
+        internalTask.setNumberOfExecutionOnFailureLeft(getNumberOfExecutionOnFailureLeft());
         internalTask.setRestartTaskOnError(getRestartMode());
         internalTask.setFlowBlock(getFlowBlock());
         internalTask.setIterationIndex(getIteration());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -542,14 +542,20 @@ public abstract class InternalTask extends TaskState {
         this.taskInfo = (TaskInfoImpl) taskInfo;
     }
 
-    /**
-     * @see org.ow2.proactive.scheduler.common.task.CommonAttribute#setMaxNumberOfExecution(int)
-     */
+
     @Override
     public void setMaxNumberOfExecution(int numberOfExecution) {
         super.setMaxNumberOfExecution(numberOfExecution);
         this.taskInfo.setNumberOfExecutionLeft(numberOfExecution);
         this.taskInfo.setNumberOfExecutionOnFailureLeft(maxNumberOfExecutionOnFailure);
+    }
+
+    public void setNumberOfExecutionLeft(int numberOfExecutionLeft) {
+        this.taskInfo.setNumberOfExecutionLeft(numberOfExecutionLeft);
+    }
+
+    public void setNumberOfExecutionOnFailureLeft( int numberOfExecutionOnFailureLeft) {
+        this.taskInfo.setNumberOfExecutionOnFailureLeft(numberOfExecutionOnFailureLeft);
     }
 
     /**


### PR DESCRIPTION
The numberOfExecutionLeft is laoded at Scheduler startup from the database. But when the database data structure(Task Data) is converted into the internal data structure (InternalTask) the number of executions left are overwritten. 

This PR changes that behavior by providing two more setter methods which allow to set the number of executions left on node failure and task failure. Both setters are the utilized in the conversion process.