### PR TITLE
Allow parallel environments with 1 node.

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/ParallelEnvironment.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/ParallelEnvironment.java
@@ -75,7 +75,7 @@ public class ParallelEnvironment implements Serializable {
      * @param nodesNumber the number of nodes required by task.
      */
     public ParallelEnvironment(int nodesNumber) {
-        if (nodesNumber <= 1) {
+        if (nodesNumber < 1) {
             throw new IllegalArgumentException("nodesNumber must be greater than 1");
         }
         this.nodesNumber = nodesNumber;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
@@ -430,7 +430,7 @@ public abstract class Task extends CommonAttribute {
      * @return true if the task is parallel, false otherwise.
      */
     public boolean isParallel() {
-        return parallelEnvironment != null && parallelEnvironment.getNodesNumber() > 1;
+        return parallelEnvironment != null && parallelEnvironment.getNodesNumber() >= 1;
     }
 
     /**


### PR DESCRIPTION
Allow parallel environments with 1 node.

Tasks which cannot be scheduled in parallel, because e.g. their selection scripts calculate resource allocations (and those change after the task is scheduled, so in the next loop) profit from being part of a parallel environment.
A parallel environment forbids to schedule other tasks at the same time, that means that the scheduling decision including running a task's selection script happen for one task at a time. Running the selection scripts for only one task lowers the likelyhood to allocate more resources than a host actually has due to race conditions.