### PR TITLE
Prevent Paused and In Error jobs to switch to Stalled.

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -289,7 +289,7 @@ public abstract class InternalJob extends JobState {
         setNumberOfPendingTasks(getNumberOfPendingTasks() + 1);
         setNumberOfRunningTasks(getNumberOfRunningTasks() - 1);
         if (getNumberOfRunningTasks() == 0 &&
-            (getStatus() != JobStatus.PAUSED || getStatus() != JobStatus.IN_ERROR)) {
+            !(getStatus() == JobStatus.PAUSED || getStatus() == JobStatus.IN_ERROR)) {
             setStatus(JobStatus.STALLED);
         }
     }


### PR DESCRIPTION
Prevent Paused and In Error jobs to switch to Stalled.

This fixes #2529. Instead of writing state is NOT Paused OR NOT In Error it is now:    NOT ( Paused Or In Error ) .