### PR TITLE
Add new filterAfterSelection method to scheduling policy #2532

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -36,14 +36,6 @@
  */
 package org.ow2.proactive.scheduler.core;
 
-import java.security.PrivateKey;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.ActiveObjectCreationException;
 import org.objectweb.proactive.api.PAActiveObject;
@@ -77,6 +69,10 @@ import org.ow2.proactive.threading.TimeoutThreadPoolExecutor;
 import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
 import org.ow2.proactive.utils.Criteria;
 import org.ow2.proactive.utils.NodeSet;
+
+import java.security.PrivateKey;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -202,6 +198,8 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 }
 
                 NodeSet nodeSet = getRMNodes(jobMap, neededResourcesNumber, tasksToSchedule);
+
+                currentPolicy.filterAfterSelection(nodeSet, tasksToSchedule);
 
                 //start selected tasks
                 Node node = null;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
@@ -36,14 +36,6 @@
  */
 package org.ow2.proactive.scheduler.policy;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.List;
-import java.util.Properties;
-import java.util.Vector;
-
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.resourcemanager.common.RMState;
@@ -51,6 +43,15 @@ import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptor;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptor;
+import org.ow2.proactive.utils.NodeSet;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Properties;
+import java.util.Vector;
 
 
 /**
@@ -98,6 +99,19 @@ public abstract class Policy implements Serializable {
      * @return a vector of every tasks that are ready to be schedule.
      */
     public abstract Vector<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobs);
+
+
+    /**
+     * After the selection process, overriding this method allows to do some filtering on the nodes selected or the tasks scheduled
+     * This is useful, for example, when stateless selection scripts cannot completely determine if a node is eligible for execution.
+     * Here the scheduling policy can make further decisions and discard unsuited nodes.
+     *
+     * @param selectedNodes set of nodes which were selected to execute the tasks
+     * @param tasks         tasks scheduled
+     */
+    public void filterAfterSelection(NodeSet selectedNodes, List<EligibleTaskDescriptor> tasks) {
+        // do nothing by default
+    }
 
     /**
      * Set the RM state


### PR DESCRIPTION
Added the new method, empty by default, which needs to be overriden to perform post-selection filtering.