### PR TITLE
Upgrade Groovy to 2.4.6 from 2.4.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ dependencies {
     nativeBundle 'org.jvnet.winp:winp:1.23-proactive:native'
     nativeBundle 'sigar:sigar:1.7.0-proactive:native'
 
-    compile 'org.codehaus.groovy:groovy-all:2.4.5'
+    compile 'org.codehaus.groovy:groovy-all:2.4.6'
     compile 'commons-io:commons-io:2.4'
 }
 

--- a/common/common-api/build.gradle
+++ b/common/common-api/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     testRuntime 'org.jruby:jruby-complete:9.0.1.0'
     testRuntime 'org.python:jython-standalone:2.7.0'
-    testRuntime 'org.codehaus.groovy:groovy-all:2.4.5'
+    testRuntime 'org.codehaus.groovy:groovy-all:2.4.6'
     testRuntime 'jsr223:jsr223-nativeshell:0.4.1'
     testCompile 'junit:junit:4.12'
 }

--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     runtime 'org.jruby:jruby-complete:9.0.1.0'
     runtime 'org.python:jython-standalone:2.7.0'
 
-    runtime 'org.codehaus.groovy:groovy-all:2.4.5'
+    runtime 'org.codehaus.groovy:groovy-all:2.4.6'
     runtime 'jsr223:jsr223-nativeshell:0.4.1'
     runtime 'jsr223:jsr223-docker-compose:0.0.2'
 }

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 
-    testCompile 'org.codehaus.groovy:groovy-all:2.4.5'
+    testCompile 'org.codehaus.groovy:groovy-all:2.4.6'
 
     testCompile 'org.jvnet.winp:winp:1.23-proactive'
     testCompile files("${System.properties['java.home']}/../lib/tools.jar")


### PR DESCRIPTION
Changelog is available below:

http://groovy-lang.org/changelogs/changelog-2.4.6.html