### PR TITLE
Due to job locking mechanism, low priority tasks can be scheduled ove…

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -159,9 +159,8 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
 
         // If there are some jobs which could not be locked it is not possible to do any priority scheduling decision,
         // we wait for next scheduling loop
-        if (jobMap.size() < schedulingService.totalNumberOfJobs()) {
-            schedulingService.unlockJobsToSchedule(jobMap.values());
-            return 0;
+        if (jobMap.isEmpty()) {
+            return numberOfTaskStarted;
         }
 
         try {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -303,10 +303,6 @@ public class SchedulingService {
         return jobs.lockJobsToSchedule();
     }
 
-    public int totalNumberOfJobs() {
-        return jobs.totalNumberOfJobs();
-    }
-
     /*
      * Should be called only by scheduling method impl after job scheduling finished
      */


### PR DESCRIPTION
…r high priority ones #2544

- Implemented a finer algorithm which explicitly checks for priority conflicts in the LiveJobs.lockJobsToSchedule method.

 - Added a unit test which verifies that priority conflicts are correctly spotted