### PR TITLE
Replace return type of scheduling Policy's getOrderedTasks by LinkedList<EligibleTaskDescriptor> #2552

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -76,7 +76,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 import java.util.concurrent.TimeUnit;
 
 
@@ -185,7 +184,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
 
             // ask the policy all the tasks to be schedule according to the jobs list.
 
-            Vector<EligibleTaskDescriptor> taskRetrievedFromPolicy = currentPolicy
+            LinkedList<EligibleTaskDescriptor> taskRetrievedFromPolicy = currentPolicy
                     .getOrderedTasks(descriptors);
 
             //if there is no task to scheduled, return
@@ -330,14 +329,14 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
      * @return the number of nodes needed to start every task present in the 'toFill' argument at the end of the method.
      */
     protected int getNextcompatibleTasks(Map<JobId, JobDescriptor> jobsMap,
-                                         Vector<EligibleTaskDescriptor> bagOfTasks, int maxResource,
+                                         LinkedList<EligibleTaskDescriptor> bagOfTasks, int maxResource,
                                          LinkedList<EligibleTaskDescriptor> toFill) {
         if (toFill == null || bagOfTasks == null) {
             throw new IllegalArgumentException("The two given lists must not be null !");
         }
         int neededResource = 0;
         if (maxResource > 0 && !bagOfTasks.isEmpty()) {
-            EligibleTaskDescriptor etd = bagOfTasks.remove(0);
+            EligibleTaskDescriptor etd = bagOfTasks.removeFirst();
             ((EligibleTaskDescriptorImpl) etd).addAttempt();
             InternalJob currentJob = jobsMap.get(etd.getJobId()).getInternal();
             InternalTask internalTask = currentJob.getIHMTasks().get(etd.getTaskId());
@@ -348,7 +347,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 if (!firstLoop) {
                     //if bagOfTasks is not empty
                     if (!bagOfTasks.isEmpty()) {
-                        etd = bagOfTasks.remove(0);
+                        etd = bagOfTasks.removeFirst();
                         ((EligibleTaskDescriptorImpl) etd).addAttempt();
                         currentJob = jobsMap.get(etd.getJobId()).getInternal();
                         internalTask = currentJob.getIHMTasks().get(etd.getTaskId());
@@ -372,7 +371,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                         maxResource -= neededNodes;
                         toFill.add(etd);
                     } else {
-                        bagOfTasks.add(0, etd);
+                        bagOfTasks.addFirst(etd);
                         break;
                     }
                 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/DefaultPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/DefaultPolicy.java
@@ -36,14 +36,14 @@
  */
 package org.ow2.proactive.scheduler.policy;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Vector;
-
 import org.ow2.proactive.scheduler.common.job.JobPriority;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptor;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptor;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
 
 
 /**
@@ -74,8 +74,8 @@ public class DefaultPolicy extends Policy {
      * @see org.ow2.proactive.scheduler.policy.Policy#getOrderedTasks(java.util.List)
      */
     @Override
-    public Vector<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobs) {
-        Vector<EligibleTaskDescriptor> toReturn = new Vector<>();
+    public LinkedList<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobs) {
+        LinkedList<EligibleTaskDescriptor> toReturn = new LinkedList<>();
 
         Collections.sort(jobs, FIFO_BY_PRIORITY_COMPARATOR);
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
@@ -36,17 +36,16 @@
  */
 package org.ow2.proactive.scheduler.policy;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Vector;
-
 import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptor;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptor;
 import org.ow2.proactive.scheduler.util.policy.ISO8601DateUtil;
-import org.ow2.proactive.scheduler.util.policy.ISO8601DateUtil;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
 
 
 /**
@@ -73,9 +72,9 @@ public class ExtendedSchedulerPolicy extends DefaultPolicy {
      * execution cycle.
      */
     @Override
-    public Vector<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobDescList) {
+    public LinkedList<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobDescList) {
         Date now = new Date();
-        Vector<EligibleTaskDescriptor> executionCycleTasks = new Vector<>();
+        LinkedList<EligibleTaskDescriptor> executionCycleTasks = new LinkedList<>();
 
         Collections.sort(jobDescList, FIFO_BY_PRIORITY_COMPARATOR);
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
@@ -49,9 +49,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
-import java.util.Vector;
 
 
 /**
@@ -93,12 +93,13 @@ public abstract class Policy implements Serializable {
     /**
      * Return the tasks that have to be scheduled.
      * The tasks must be in the desired scheduling order.
-     * The first task to be schedule must be the first in the returned Vector.
+     * The first task to be schedule must be the first in the returned list.
+     * The list will be modified by the scheduling loop, so it may be necessary to copy the list before returning it
      *
      * @param jobs the list of pending or running job descriptors.
-     * @return a vector of every tasks that are ready to be schedule.
+     * @return a linked list of every tasks that are ready to be scheduled.
      */
-    public abstract Vector<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobs);
+    public abstract LinkedList<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobs);
 
 
     /**

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/DefaultPolicyTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/DefaultPolicyTest.java
@@ -13,8 +13,8 @@ import org.ow2.proactive.scheduler.task.internal.InternalTask;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +26,7 @@ public class DefaultPolicyTest {
 
     @Test
     public void empty_list_of_tasks() throws Exception {
-        Vector<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(Collections
+        LinkedList<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(Collections
                 .<JobDescriptor> emptyList());
 
         assertTrue(orderedTasks.isEmpty());
@@ -37,7 +37,7 @@ public class DefaultPolicyTest {
         JobDescriptorImpl job = createSingleTaskJob();
         List<JobDescriptor> jobs = submitJobs(job);
 
-        Vector<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(jobs);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(jobs);
 
         assertEquals(1, orderedTasks.size());
     }
@@ -50,7 +50,7 @@ public class DefaultPolicyTest {
 
         List<JobDescriptor> jobs = submitJobs(jobHigh, jobLow, jobNormal);
 
-        Vector<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(jobs);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(jobs);
 
         assertEquals(jobHigh.getJobId(), orderedTasks.get(0).getJobId());
         assertEquals(jobNormal.getJobId(), orderedTasks.get(1).getJobId());
@@ -65,7 +65,7 @@ public class DefaultPolicyTest {
 
         List<JobDescriptor> jobs = submitJobs(job1, job3, job2);
 
-        Vector<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(jobs);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = new DefaultPolicy().getOrderedTasks(jobs);
 
         assertEquals(job1.getJobId(), orderedTasks.get(0).getJobId());
         assertEquals(job2.getJobId(), orderedTasks.get(1).getJobId());

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicyTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicyTest.java
@@ -36,17 +36,6 @@
  */
 package org.ow2.proactive.scheduler.policy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.ow2.proactive.scheduler.common.task.CommonAttribute.GENERIC_INFO_START_AT_KEY;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Vector;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
@@ -59,6 +48,15 @@ import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalScriptTask;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 import org.ow2.proactive.scheduler.util.policy.ISO8601DateUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.ow2.proactive.scheduler.common.task.CommonAttribute.GENERIC_INFO_START_AT_KEY;
 
 
 /**
@@ -84,28 +82,28 @@ public class ExtendedSchedulerPolicyTest {
     @Test
     public void testWithoutStartAt() throws Exception {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(null, null, null));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks != null && orderedTasks.size() == 2);
     }
 
     @Test
     public void testJobStartAtNow() throws Exception {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(now, null, null));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks != null && orderedTasks.size() == 2);
     }
 
     @Test
     public void testJobStartAtLater() throws Exception {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(later, null, null));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks != null && orderedTasks.size() == 0);
     }
 
     @Test
     public void testTaskStartAtNow() {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(null, now, null));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks != null && orderedTasks.size() == 2);
 
     }
@@ -113,7 +111,7 @@ public class ExtendedSchedulerPolicyTest {
     @Test
     public void testTaskStartLater() {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(null, later, null));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks != null && orderedTasks.size() == 1);
         assertNull(startAtValue(first(orderedTasks)));
     }
@@ -121,7 +119,7 @@ public class ExtendedSchedulerPolicyTest {
     @Test
     public void testOneTaskStartNowOtherLater() {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(null, now, later));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks.size() == 1);
         assertEquals(now, startAtValue(first(orderedTasks)));
     }
@@ -129,7 +127,7 @@ public class ExtendedSchedulerPolicyTest {
     @Test
     public void testJobStartNowOneTaskStartLater() {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(now, later, null));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks.size() == 1);
         String startAtValue = startAtValue(first(orderedTasks));
         assertNull(startAtValue);
@@ -138,7 +136,7 @@ public class ExtendedSchedulerPolicyTest {
     @Test
     public void testJobStartNowOneTaskStartLater2() {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(now, later, now));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks.size() == 1);
         String startAtValue = startAtValue(first(orderedTasks));
         assertEquals(now, startAtValue);
@@ -147,7 +145,7 @@ public class ExtendedSchedulerPolicyTest {
     @Test
     public void testJobStartLaterOneTaskStartNow() {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(later, now, null));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks.size() == 1);
         String startAtValue = startAtValue(first(orderedTasks));
         assertEquals(now, startAtValue);
@@ -156,7 +154,7 @@ public class ExtendedSchedulerPolicyTest {
     @Test
     public void testJobStartLaterOneTaskStartNow2() {
         List<JobDescriptor> jobDescList = asModifiableList(createJobDescWithTwoTasks(later, now, later));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks.size() == 1);
         String startAtValue = startAtValue(first(orderedTasks));
         assertEquals(now, startAtValue);
@@ -166,7 +164,7 @@ public class ExtendedSchedulerPolicyTest {
     public void testMalformedTaskStartAt() {
         List<JobDescriptor> jobDescList = asModifiableList(
                 createJobDescWithTwoTasks(later, now, "malformed-start-at"));
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
         assertTrue(orderedTasks != null && orderedTasks.size() == 2);
     }
 
@@ -178,7 +176,7 @@ public class ExtendedSchedulerPolicyTest {
 
         List<JobDescriptor> jobDescList = asModifiableList(job1, job3, job2);
 
-        Vector<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
+        LinkedList<EligibleTaskDescriptor> orderedTasks = policy.getOrderedTasks(jobDescList);
 
         assertEquals(job1.getJobId(), orderedTasks.get(0).getJobId());
         assertEquals(job2.getJobId(), orderedTasks.get(2).getJobId());


### PR DESCRIPTION
Current return type is Vector and implies a list copy in the SchedulingMethodImpl class.

By directly returning a LinkedList, we would avoid this copy