### PR TITLE
Add maxNumberOfNodes to Rm State.

### DIFF
--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/webapp/SessionSharingTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/webapp/SessionSharingTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.resourcemanager.common.RMState;
+import org.ow2.proactive.resourcemanager.common.RMStateNodeUrls;
 import org.ow2.proactive.resourcemanager.common.util.RMProxyUserInterface;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
@@ -84,7 +85,7 @@ public class SessionSharingTest {
     public void sessions_are_shared_scheduler_login() throws Exception {
         String sessionId = schedulerRest.login("login", "pw");
 
-        when(rmMock.getState()).thenReturn(new RMState(new HashSet<String>(), new HashSet<String>(), new HashSet<String>()));
+        when(rmMock.getState()).thenReturn(new RMState(new RMStateNodeUrls(new HashSet<String>(), new HashSet<String>(), new HashSet<String>()), Long.valueOf(-1)));
         RMState rmState = rmRest.getState(sessionId);
         assertNotNull(rmState);
 
@@ -119,7 +120,7 @@ public class SessionSharingTest {
         boolean frozen = schedulerRest.freezeScheduler(sessionId);
         assertTrue(frozen);
 
-        when(rmMock.getState()).thenReturn(new RMState(new HashSet<String>(), new HashSet<String>(), new HashSet<String>()));
+        when(rmMock.getState()).thenReturn(new RMState(new RMStateNodeUrls(new HashSet<String>(), new HashSet<String>(), new HashSet<String>()),Long.valueOf(-1)));
         RMState rmState = rmRest.getState(sessionId);
         assertNotNull(rmState);
 

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/RMState.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/RMState.java
@@ -45,7 +45,7 @@ import java.util.Set;
 
 
 /**
- * RMState represents informations about RM activity.
+ * RMState represents information about RM activity.
  *
  * @author The ProActive Team
  *
@@ -55,14 +55,20 @@ import java.util.Set;
 @XmlRootElement
 public class RMState implements Serializable {
 
-    private final Set<String> freeNodesUrls;
-    private final Set<String> aliveNodesUrls;
-    private final Set<String> allNodesUrls;
+    private final RMStateNodeUrls rmNodeUrls;
+    private final Long maxNumberOfNodes;
 
-    public RMState(Set<String> freeNodesUrls, Set<String> aliveNodesUrls, Set<String> allNodesUrls) {
-        this.freeNodesUrls = freeNodesUrls;
-        this.aliveNodesUrls = aliveNodesUrls;
-        this.allNodesUrls = allNodesUrls;
+    public RMState(RMStateNodeUrls rmNodeUrls, Long maxNumberOfNodes) {
+        this.rmNodeUrls = rmNodeUrls;
+        this.maxNumberOfNodes = maxNumberOfNodes;
+    }
+
+    public Long getMaxNumberOfNodes() {
+        return maxNumberOfNodes;
+    }
+
+    protected RMStateNodeUrls getRmNodeUrls() {
+        return rmNodeUrls;
     }
 
     /**
@@ -71,7 +77,7 @@ public class RMState implements Serializable {
      * @return true if the scheduler has free resources, false if not.
      */
     public BooleanWrapper hasFreeResources() {
-        return new BooleanWrapper(!freeNodesUrls.isEmpty());
+        return new BooleanWrapper(!getRmNodeUrls().getFreeNodesUrls().isEmpty());
     }
 
     /**
@@ -80,7 +86,7 @@ public class RMState implements Serializable {
      * @return free nodes number in the resource manager
      */
     public int getFreeNodesNumber() {
-        return freeNodesUrls.size();
+        return getRmNodeUrls().getFreeNodesUrls().size();
     }
 
     /**
@@ -89,7 +95,7 @@ public class RMState implements Serializable {
      * @return free nodes urls in the resource manager
      */
     public Set<String> getFreeNodes() {
-        return freeNodesUrls;
+        return getRmNodeUrls().getFreeNodesUrls();
     }
 
     /**
@@ -98,7 +104,7 @@ public class RMState implements Serializable {
      * @return total alive nodes number in the resource manager
      */
     public int getTotalAliveNodesNumber() {
-        return aliveNodesUrls.size();
+        return getRmNodeUrls().getAliveNodesUrls().size();
     }
 
     /**
@@ -107,7 +113,7 @@ public class RMState implements Serializable {
      * @return all alive nodes urls in the resource manager
      */
     public Set<String> getAliveNodes() {
-        return aliveNodesUrls;
+        return getRmNodeUrls().getAliveNodesUrls();
     }
 
     /**
@@ -116,7 +122,7 @@ public class RMState implements Serializable {
      * @return total nodes number in the resource manager
      */
     public int getTotalNodesNumber() {
-        return allNodesUrls.size();
+        return getRmNodeUrls().getAllNodesUrls().size();
     }
 
     /**
@@ -125,7 +131,7 @@ public class RMState implements Serializable {
      * @return all nodes urls in the resource manager
      */
     public Set<String> getAllNodes() {
-        return allNodesUrls;
+        return getRmNodeUrls().getAllNodesUrls();
     }
 
 

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/RMStateNodeUrls.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/RMStateNodeUrls.java
@@ -1,0 +1,63 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s): ActiveEon Team - http://www.activeeon.com
+ *
+ *  * $$ACTIVEEON_CONTRIBUTOR$$
+ */
+package org.ow2.proactive.resourcemanager.common;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public class RMStateNodeUrls implements Serializable {
+
+    private final Set<String> freeNodesUrls;
+    private final Set<String> aliveNodesUrls;
+    private final Set<String> allNodesUrls;
+
+    public RMStateNodeUrls(Set<String> freeNodesUrls, Set<String> aliveNodesUrls, Set<String> allNodesUrls) {
+        this.freeNodesUrls = freeNodesUrls;
+        this.aliveNodesUrls = aliveNodesUrls;
+        this.allNodesUrls = allNodesUrls;
+    }
+
+    public Set<String> getFreeNodesUrls() {
+        return freeNodesUrls;
+    }
+
+    public Set<String> getAliveNodesUrls() {
+        return aliveNodesUrls;
+    }
+
+    public Set<String> getAllNodesUrls() {
+        return allNodesUrls;
+    }
+}

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -61,6 +61,7 @@ import org.ow2.proactive.resourcemanager.cleaning.NodesCleaner;
 import org.ow2.proactive.resourcemanager.common.NodeState;
 import org.ow2.proactive.resourcemanager.common.RMConstants;
 import org.ow2.proactive.resourcemanager.common.RMState;
+import org.ow2.proactive.resourcemanager.common.RMStateNodeUrls;
 import org.ow2.proactive.resourcemanager.common.event.*;
 import org.ow2.proactive.resourcemanager.core.account.RMAccountsManager;
 import org.ow2.proactive.resourcemanager.core.history.UserHistory;
@@ -1425,7 +1426,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
      * {@inheritDoc}
      */
     public RMState getState() {
-        RMState state = new RMState(nodesListToUrlsSet(freeNodes), listAliveNodeUrls(), nodesListToUrlsSet(allNodes.values()));
+        RMStateNodeUrls rmStateNodeUrls = new RMStateNodeUrls(nodesListToUrlsSet(freeNodes), listAliveNodeUrls(), nodesListToUrlsSet(allNodes.values()));
+        RMState state = new RMState(rmStateNodeUrls, maximumNumberOfNodes);
         return state;
     }
 


### PR DESCRIPTION
Add maxNumberOfNodes to Rm State.

The maxNumberOfNodes value is added to the RM State. That allows the RM portal to receive the currently set alive nodes limit.