### PR TITLE
Progress file and folder permissions are not open enough for RunAsMe …

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProgressFileReader.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProgressFileReader.java
@@ -2,6 +2,7 @@ package org.ow2.proactive.scheduler.task;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.common.task.TaskId;
+import org.ow2.proactive.scheduler.task.utils.ForkerUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -81,10 +82,10 @@ public class ProgressFileReader {
 
         try {
             Files.createDirectories(progressFileDir);
-
+            ForkerUtils.setSharedPermissions(progressFileDir.toFile(), true);
             progressFile = progressFileDir.resolve(progressFileName);
-
             Files.createFile(progressFile);
+            ForkerUtils.setSharedPermissions(progressFile.toFile(), false);
         } catch (FileAlreadyExistsException e) {
             // ignore file already exists exception
         }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/ForkerUtils.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/ForkerUtils.java
@@ -36,12 +36,13 @@
  */
 package org.ow2.proactive.scheduler.task.utils;
 
-import java.security.KeyException;
-
+import org.apache.log4j.Logger;
 import org.objectweb.proactive.extensions.processbuilder.OSUser;
 import org.objectweb.proactive.extensions.processbuilder.PAOSProcessBuilderFactory;
 import org.ow2.proactive.authentication.crypto.CredData;
-import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.security.KeyException;
 
 
 /**
@@ -130,6 +131,13 @@ public final class ForkerUtils {
             CredData data = decrypter.decrypt();
 
             // TODO: use polymorphism to avoid branches
+            if (ForkMethod.NONE == FORK_METHOD_VALUE) {
+                OSUser u = new OSUser(data.getLogin());
+                if (data.getDomain() != null) {
+                    u.setDomain(data.getDomain());
+                }
+                return u;
+            }
             if (ForkMethod.PWD == FORK_METHOD_VALUE) {
                 if (data.getPassword() == null) {
                     throw new IllegalAccessException(
@@ -156,6 +164,14 @@ public final class ForkerUtils {
                 FORK_METHOD_KEY + " is not configured.");
         } else {
             throw new IllegalArgumentException("Decrypter could not be null");
+        }
+    }
+
+    public static void setSharedPermissions(File file, boolean setExecutable) {
+        file.setReadable(true, false);
+        file.setWritable(true, false);
+        if (setExecutable) {
+            file.setExecutable(true, false);
         }
     }
 


### PR DESCRIPTION
…mode

 The permissions of progress file and folder should be opened to allow it to work in RunAsMe mode.

The error received (inside a R task) was the following:
Writing progress to file '/tmp/PA_JVM323121899/SSH-xstoocky-3_12/309/-590803201/.tasks-progress/job-309-task-0-ada46071-b960-4179-8f70-ab927f1b5084.progress' with value '100' failed 

When looking at the folder permission and content, it showed the following:
[305t0@xstoocky13.mgps.inra.fr;17:34:18] total 8 
[305t0@xstoocky13.mgps.inra.fr;17:34:18] drwxr-xr-x 2 proagent MGPSgenmic 4096 Jun 20 17:34 . 
[305t0@xstoocky13.mgps.inra.fr;17:34:18] drwxrwxrwx 3 proagent MGPSgenmic 4096 Jun 20 17:34 .. 
[305t0@xstoocky13.mgps.inra.fr;17:34:18] -rw-r--r-- 1 proagent MGPSgenmic 0 Jun 20 17:34 job-305-task-0-6dd94948-7315-4d5d-bb3b-7605cf5eec16.progress 

The progress file does not have write permissions for other users.
