### PR TITLE
Make TaskLauncher close TaskProActiveDataspaces and its underlying thread pool

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -214,9 +214,11 @@ public class TaskLauncher implements InitActive {
         } finally {
             progressFileReader.stop();
             taskLogger.close();
+
             if (dataspaces != null) {
-                dataspaces.cleanScratchSpace();
+                dataspaces.close();
             }
+
             removeShutdownHook();
             terminate();
         }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskDataspaces.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskDataspaces.java
@@ -61,5 +61,6 @@ public interface TaskDataspaces extends Serializable {
 
     void copyScratchDataToOutput(List<OutputSelector> outputFiles) throws FileSystemException;
 
-    void cleanScratchSpace();
+    void close();
+
 }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
@@ -569,7 +569,15 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
     }
 
     @Override
-    public void cleanScratchSpace() {
+    public void close() {
+        if (!executorTransfer.shutdownNow().isEmpty()) {
+            logger.error("Remaining tasks to execute while closing thread pool used for data transfer");
+        }
+
+        cleanScratchSpace();
+    }
+
+    private void cleanScratchSpace() {
         try {
             File folder = getScratchFolder();
             FileUtils.deleteQuietly(folder);

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/SlowDataspacesTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/SlowDataspacesTaskLauncherFactory.java
@@ -91,7 +91,7 @@ public class SlowDataspacesTaskLauncherFactory extends ProActiveForkedTaskLaunch
         }
 
         @Override
-        public void cleanScratchSpace() {
+        public void close() {
 
         }
     }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
@@ -246,7 +246,7 @@ public class TaskLauncherTest {
         });
         runTaskLauncher(taskLauncher, executableContainer);
 
-        verify(dataspacesMock).cleanScratchSpace();
+        verify(dataspacesMock).close();
     }
 
     @Test

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TestTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TestTaskLauncherFactory.java
@@ -173,7 +173,7 @@ public class TestTaskLauncherFactory extends ProActiveForkedTaskLauncherFactory 
         }
 
         @Override
-        public void cleanScratchSpace() {
+        public void close() {
             FileUtils.deleteQuietly(getScratchFolder());
         }
     }


### PR DESCRIPTION
The executor service started by TaskProActiveDataspaces uses non-deamon threads.
Since the executor was not closed, the JVM associated to the task was not
terminated, thus leading to a lot of threads and resources kept in background.

Below is threads usage before the fix, using a Job with 1200 replicated tasks that use dataspaces in intput and output:

![capture d ecran de 2016-06-23 08-45-27](https://cloud.githubusercontent.com/assets/128898/16329942/2a5851c4-39e6-11e6-9c4b-58c8b93e88f9.png)

and after the fix:

![capture d ecran de 2016-06-23 09-09-19](https://cloud.githubusercontent.com/assets/128898/16329968/4beef612-39e6-11e6-8587-e74f215da438.png)

