### PR TITLE
Give the executing thread some time to cleanup after it was interrupted.

### DIFF
--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -25,5 +25,5 @@ dependencies {
 
     runtime 'org.codehaus.groovy:groovy-all:2.4.6'
     runtime 'jsr223:jsr223-nativeshell:0.4.1'
-    runtime 'jsr223:jsr223-docker-compose:0.0.2'
+    runtime 'jsr223:jsr223-docker-compose:0.2.1'
 }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractor.java
@@ -46,7 +46,6 @@ import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
 import org.ow2.proactive.scheduler.task.SchedulerVars;
 import org.ow2.proactive.scheduler.task.TaskLauncherInitializer;
 import org.ow2.proactive.scheduler.task.executors.forked.env.ForkedTaskVariablesManager;
-import org.jetbrains.annotations.NotNull;
 
 public class TaskContextVariableExtractor implements Serializable {
     private final ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();


### PR DESCRIPTION
Give the executing thread some time to cleanup after it was interrupted.

The cleanup time is especially needed for docker-compose, because it needs to remove the containers in order to not have containers running after a task was killed. Like having a spark cluster running even though it was killed.