### PR TITLE
RollingFileAppender for the Sigar class, in order to reduce thread locking issues

### DIFF
--- a/config/log/node.properties
+++ b/config/log/node.properties
@@ -2,7 +2,7 @@ log4j.rootLogger=INFO, NODE
 
 log4j.logger.org.ow2.proactive.resourcemanager=INFO, CONSOLE
 
-log4j.logger.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=INFO, SIGAR
+log4j.logger.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=INFO, NODE
 log4j.additivity.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=false
 
 
@@ -28,10 +28,6 @@ log4j.appender.NODE.layout.ConversionPattern=[%d{ISO8601} %-5p] [%X{job.id}t%X{t
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 
-
-# SIGAR appender
-log4j.appender.SIGAR=org.apache.log4j.AsyncAppender
-log4j.appender.SIGAR.layout=org.apache.log4j.PatternLayout
 
 
 # Debug Task Launcher:

--- a/config/log/node.properties
+++ b/config/log/node.properties
@@ -2,6 +2,10 @@ log4j.rootLogger=INFO, NODE
 
 log4j.logger.org.ow2.proactive.resourcemanager=INFO, CONSOLE
 
+log4j.logger.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=INFO, SIGAR
+log4j.additivity.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=false
+
+
 log4j.logger.org.ow2.proactive.resourcemanager.utils.BroadcastDiscoveryClient=INFO, NODE
 log4j.additivity.org.ow2.proactive.resourcemanager.utils.BroadcastDiscoveryClient=false
 
@@ -23,6 +27,12 @@ log4j.appender.NODE.layout.ConversionPattern=[%d{ISO8601} %-5p] [%X{job.id}t%X{t
 # CONSOLE appender
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+
+
+# SIGAR appender
+log4j.appender.SIGAR=org.apache.log4j.AsyncAppender
+log4j.appender.SIGAR.layout=org.apache.log4j.PatternLayout
+
 
 # Debug Task Launcher:
 # log4j.logger.org.ow2.proactive.scheduler.task = DEBUG

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RRDSigarDataStore.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RRDSigarDataStore.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Set;
 
+import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.MBeanAttributeInfo;
@@ -50,8 +51,8 @@ import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeDataSupport;
 
-import org.ow2.proactive.jmx.RRDDataStore;
 import org.apache.log4j.Logger;
+import org.ow2.proactive.jmx.RRDDataStore;
 import org.rrd4j.core.RrdDb;
 import org.rrd4j.core.Sample;
 
@@ -196,16 +197,23 @@ public class RRDSigarDataStore extends RRDDataStore {
                     logger.trace("Non numeric value for " + dataSource + " / " + fullName + ": " +
                         ex.getMessage());
                 }
+            } catch (InstanceNotFoundException | AttributeNotFoundException e) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Cannot read attribute " + attrName + " for object " + objectName + ": " +
+                        e.getMessage());
+                }
+
             } catch (Exception e) {
-                logger.warn("Cannot read attribute " + attrName + " for object " + objectName + ": " +
-                    e.getMessage());
+                logger.warn("Error while reading attribute " + attrName + " for object " + objectName + ": ",
+                        e);
+
             }
         }
         try {
             sample.setTime(timeInMs / 1000);
             sample.update();
         } catch (Exception e) {
-            logger.warn("Cannot update RRD database: " + e.getMessage());
+            logger.error("Cannot update RRD database: " + e.getMessage());
         }
     }
 

--- a/rm/rm-node/src/main/resources/config/log/node.properties
+++ b/rm/rm-node/src/main/resources/config/log/node.properties
@@ -2,7 +2,7 @@ log4j.rootLogger=INFO, NODE, CONSOLE
 
 log4j.logger.org.ow2.proactive.resourcemanager=INFO
 
-log4j.logger.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=INFO, SIGAR
+log4j.logger.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=INFO, NODE
 log4j.additivity.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=false
 
 log4j.logger.org.ow2.proactive.resourcemanager.utils.BroadcastDiscoveryClient=INFO, NODE
@@ -26,7 +26,3 @@ log4j.appender.NODE.layout.ConversionPattern=[%d{ISO8601} %-5p] [NODE.%C{1}.%M] 
 # CONSOLE appender
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-
-# SIGAR appender
-log4j.appender.SIGAR=org.apache.log4j.AsyncAppender
-log4j.appender.SIGAR.layout=org.apache.log4j.PatternLayout

--- a/rm/rm-node/src/main/resources/config/log/node.properties
+++ b/rm/rm-node/src/main/resources/config/log/node.properties
@@ -2,6 +2,9 @@ log4j.rootLogger=INFO, NODE, CONSOLE
 
 log4j.logger.org.ow2.proactive.resourcemanager=INFO
 
+log4j.logger.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=INFO, SIGAR
+log4j.additivity.org.ow2.proactive.resourcemanager.node.jmx.SigarExposer=false
+
 log4j.logger.org.ow2.proactive.resourcemanager.utils.BroadcastDiscoveryClient=INFO, NODE
 log4j.additivity.org.ow2.proactive.resourcemanager.utils.BroadcastDiscoveryClient=false
 
@@ -24,3 +27,6 @@ log4j.appender.NODE.layout.ConversionPattern=[%d{ISO8601} %-5p] [NODE.%C{1}.%M] 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 
+# SIGAR appender
+log4j.appender.SIGAR=org.apache.log4j.AsyncAppender
+log4j.appender.SIGAR.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Sigar is keeping the console loggerAppender locked (keeps writing into it). 
Clean script is then BLOCKED. 

This solution is to reuse the existing RollingFileAppender even for the SigarExposer class  