### PR TITLE
Variables in selection script may contain information of the wrong task #2605

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparator.java
@@ -100,6 +100,8 @@ public class SchedulingTaskComparator {
         //if the parallel environment is specified for any of tasks => not equal
         boolean isParallel = task.isParallel() || tcomp.task.isParallel();
 
+        boolean selectionScriptUseVariables = (doesSelectionScriptsUseVariables(task) || doesSelectionScriptsUseVariables(tcomp.task));
+
         boolean requireNodeWithTokern = task.getGenericInformation().containsKey(
                 SchedulerConstants.NODE_ACCESS_TOKEN) ||
             tcomp.task.getGenericInformation().containsKey(SchedulerConstants.NODE_ACCESS_TOKEN);
@@ -109,7 +111,18 @@ public class SchedulingTaskComparator {
         // checked before
 
         //add the 6 tests to the returned value
-        return sameSsHash && sameNodeEx && sameOwner && samePriority && !isParallel && !requireNodeWithTokern;
+        return sameSsHash && sameNodeEx && sameOwner && samePriority && !isParallel && !selectionScriptUseVariables && !requireNodeWithTokern;
+    }
+
+    private boolean doesSelectionScriptsUseVariables(InternalTask task) {
+        if (task.getSelectionScripts() != null) {
+            for (SelectionScript script : task.getSelectionScripts()) {
+                if (script.getScript().contains(SchedulerConstants.VARIABLES_BINDING_NAME.toString())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparatorTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparatorTest.java
@@ -57,6 +57,17 @@ public class SchedulingTaskComparatorTest {
     }
 
     @Test
+    public void testSelectionScriptsUseVariables() throws Exception {
+        Mockito.when(task1.getSelectionScripts()).thenReturn(ImmutableList.of(new SelectionScript("variables.get(\"PA_JOB\");selected = true", "javascript")));
+        Mockito.when(task2.getSelectionScripts()).thenReturn(ImmutableList.of(new SelectionScript("selected = true", "javascript")));
+        Assert.assertFalse((new SchedulingTaskComparator(task1, job1)).equals(new SchedulingTaskComparator(task2, job2)));
+
+        Mockito.when(task1.getSelectionScripts()).thenReturn(ImmutableList.of(new SelectionScript("selected = true", "javascript")));
+        Mockito.when(task2.getSelectionScripts()).thenReturn(ImmutableList.of(new SelectionScript("variables.get(\"PA_JOB\");selected = false", "javascript")));
+        Assert.assertFalse((new SchedulingTaskComparator(task1, job1)).equals(new SchedulingTaskComparator(task2, job2)));
+    }
+
+    @Test
     public void testJobOwnerDiffers() throws Exception {
         Mockito.when(job2.getOwner()).thenReturn("notadmin");
         Assert.assertFalse((new SchedulingTaskComparator(task1, job1)).equals(new SchedulingTaskComparator(task2, job2)));


### PR DESCRIPTION
- declared tasks which contain selection scripts using variables as incompatible.
- Added a unit test which verifies this assertion

 This fix solves the problem without impacting the whole selection mechanism performance. I.e, only tasks having selection scripts using variables will be scheduled at a slower pace than other tasks (similarly to task using topology.