### PR TITLE
Adding a cache mechanism to dataspace #2619

### DIFF
--- a/config/workflows/templates/1/job.xml
+++ b/config/workflows/templates/1/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="Pre-Post-Clean Scripts" projectName="Basic Workflows"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
+        name="Pre-Post-Clean Scripts" projectName="Basic Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <description>
     <![CDATA[ Extra scripts are available to decorate a task with custom behavior.        Pre and post scripts are executed before and after a task.        A Clean script is executed even if the task failed. ]]>
   </description>

--- a/config/workflows/templates/2/job.xml
+++ b/config/workflows/templates/2/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="Selection Scripts" projectName="Basic Workflows"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="Selection Scripts" projectName="Basic Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <description>
     <![CDATA[ A selection script allows you to programmatically select a node to execute a given task.        The script will be executed on nodes and should set the variable 'selected' to true to mark it as        eligible for the task execution. ]]>
   </description>

--- a/config/workflows/templates/3/job.xml
+++ b/config/workflows/templates/3/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.3"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.3/schedulerjob.xsd"
-    name="Variables Propagation" projectName="Basic Workflows"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="Variables Propagation" projectName="Basic Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <variables>
     <variable name="numberOfLights" value="1"/>
     <variable name="minRequiredAngle" value="120"/>

--- a/config/workflows/templates/4/job.xml
+++ b/config/workflows/templates/4/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="Distributed Computation" projectName="Big Data Workflows"
-    priority="normal"
-    cancelJobOnError="true">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="Distributed Computation" projectName="Big Data Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <description>
     <![CDATA[ Computing PI according to MonteCarlo method. This job will launch 6 MonteCarlo tasks, then 2 tasks will average 3 results each. So a last task will average the 2 last        result. Finally this last task will be the final result. ]]>
   </description>

--- a/config/workflows/templates/5/job.xml
+++ b/config/workflows/templates/5/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="Data Management" projectName="Advanced Workflows"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="Data Management" projectName="Advanced Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <description>
     <![CDATA[ Dataspaces are automatically started with the Scheduler.        Here we write a file in a task and transfer it to the userspace.        Then in a dependent task, we transfer the file from the userspace and read it.        Patterns can be used to include or exclude input/output files. ]]>
   </description>

--- a/config/workflows/templates/6/job.xml
+++ b/config/workflows/templates/6/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="Multi-Node Task" projectName="Advanced Workflows"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="Multi-Node Task" projectName="Advanced Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <description>
     <![CDATA[ A multinode task will reserve several nodes and expose them to the task.        It is often used to run MPI jobs or task that use the ProActive Java API. ]]>
   </description>

--- a/config/workflows/templates/7/job.xml
+++ b/config/workflows/templates/7/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="MPI Job" projectName="Advanced Workflows"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="MPI Job" projectName="Advanced Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <description>
     <![CDATA[ A multinode task will reserve several nodes and expose them to the task.        It is often used to run MPI jobs or task that use the ProActive Java API. ]]>
   </description>

--- a/config/workflows/templates/8/job.xml
+++ b/config/workflows/templates/8/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="Cloud Automation" projectName="Advanced Workflows"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="Cloud Automation" projectName="Advanced Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <description>
     <![CDATA[ A workflow that simulates cloud automation. ]]>
   </description>

--- a/config/workflows/templates/9/job.xml
+++ b/config/workflows/templates/9/job.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.3"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.3/schedulerjob.xsd"
-    name="Docker Exec. Env." projectName="Cloud Automation"
-    priority="normal"
-    cancelJobOnError="false"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="Docker Exec. Env." projectName="Cloud Automation"
+        priority="normal"
+        onTaskError="continueJobExecution"
 >
   <description>
     <![CDATA[ This workflow demonstrates the usage of a Docker Fork Execution Environment. Including the usage of variables passing and Dataspaces ]]>

--- a/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
@@ -1,9 +1,6 @@
 package functionaltests;
 
-import functionaltests.AbstractRestFuncTestCase;
 import jline.WindowsTerminal;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.SchedulerState;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
@@ -33,6 +30,8 @@ public class AbstractFunctCmdTest extends AbstractRestFuncTestCase{
 
     protected ByteArrayOutputStream capturedOutput;
 
+    protected PrintStream stdOut;
+
 
     public void setUp() throws Exception {
         this.userInput = new StringBuffer();
@@ -54,6 +53,7 @@ public class AbstractFunctCmdTest extends AbstractRestFuncTestCase{
         System.setProperty(WindowsTerminal.DIRECT_CONSOLE, "false"); // to be able to type input on Windows
         capturedOutput = new ByteArrayOutputStream();
         PrintStream captureOutput = new PrintStream(capturedOutput);
+        stdOut = System.out;
         System.setOut(captureOutput);
         System.setIn(new ByteArrayInputStream(userInput.toString().getBytes()));
         new TestEntryPoint().runTest("-k", "-u", RestFuncTHelper.getRestServerUrl());

--- a/rest/rest-cli/src/test/java/functionaltests/TagCommandsFunctTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/TagCommandsFunctTest.java
@@ -1,23 +1,11 @@
 package functionaltests;
 
-import jline.WindowsTerminal;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.ow2.proactive.scheduler.common.Scheduler;
-import org.ow2.proactive.scheduler.common.SchedulerState;
 import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
-
-import static org.junit.Assert.*;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by Sandrine on 18/09/2015.
@@ -43,7 +31,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
             //submit a job with a loop and out and err outputs
             System.out.println("submit a job with loop, out and err outputs");
             jobId = submitJob("flow_loop_out.xml", JobStatus.FINISHED);
-            System.out.println("Job finished");
+            System.out.println("Job " + jobId + " finished");
         }
     }
 
@@ -55,6 +43,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListJobTaskIds:");
         System.out.println(out);
         assertTrue(out.contains("T1#1"));
         assertTrue(out.contains("Print1#1"));
@@ -74,6 +64,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListJobTaskIdsWithTag:");
         System.out.println(out);
         assertTrue(out.contains("T1#1"));
         assertTrue(out.contains("Print1#1"));
@@ -93,6 +85,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListJobTaskIdsWithUnknownTag:");
         System.out.println(out);
         assertTrue(!out.contains("T1#1"));
         assertTrue(!out.contains("Print1#1"));
@@ -112,6 +106,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListJobTaskIdsUnknownJob:");
         System.out.println(out);
         assertTrue(out.contains("error"));
         assertTrue(!out.contains("T1#1"));
@@ -131,6 +127,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListTaskStates:");
         System.out.println(out);
         assertTrue(out.contains("T1#1"));
         assertTrue(out.contains("Print1#1"));
@@ -150,6 +148,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListTaskStateWithTag:");
         System.out.println(out);
         assertTrue(out.contains("T1#1"));
         assertTrue(out.contains("Print1#1"));
@@ -169,6 +169,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListTaskStatesWithUnknownTag:");
         System.out.println(out);
         assertTrue(!out.contains("T1#1"));
         assertTrue(!out.contains("Print1#1"));
@@ -188,6 +190,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListTaskStatesUnknownJob:");
         System.out.println(out);
         assertTrue(out.contains("error"));
         assertTrue(!out.contains("T1#1"));
@@ -209,6 +213,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testJobOutput:");
         System.out.println(out);
         assertTrue(StringUtils.countMatches(out, "Task 1 : Test STDERR") == 2);
         assertTrue(StringUtils.countMatches(out, "Task 1 : Test STDOUT") == 2);
@@ -226,6 +232,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testJobOutputWithTag:");
         System.out.println(out);
         assertEquals(2, StringUtils.countMatches(out, "Task 1 : Test STDERR"));
         assertEquals(2, StringUtils.countMatches(out, "Task 1 : Test STDOUT"));
@@ -243,6 +251,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testJobOutputWithUnknownTag:");
         System.out.println(out);
         assertTrue(!out.contains("Task 1 : Test STDERR"));
         assertTrue(!out.contains("Task 1 : Test STDOUT"));
@@ -257,6 +267,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListJobOutputUnknownJob:");
         System.out.println(out);
         assertTrue(out.contains("error"));
     }
@@ -269,6 +281,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testJobResult:");
         System.out.println(out);
         assertTrue(out.contains("T1#1"));
         assertTrue(out.contains("Print1#1"));
@@ -288,6 +302,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testJobResultWithTag:");
         System.out.println(out);
         assertTrue(out.contains("T1#1"));
         assertTrue(out.contains("Print1#1"));
@@ -307,6 +323,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testJobResultWithUnknownTag:");
         System.out.println(out);
         assertTrue(!out.contains("T1#1"));
         assertTrue(!out.contains("Print1#1"));
@@ -326,6 +344,8 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         runCli();
 
         String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println("------------- testListJobResultUnknownJob:");
         System.out.println(out);
         assertTrue(out.contains("error"));
     }

--- a/rest/rest-cli/src/test/resources/functionaltests/config/flow_loop_out.xml
+++ b/rest/rest-cli/src/test/resources/functionaltests/config/flow_loop_out.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.2"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.2/schedulerjob.xsd"
-    name="flow_loop" projectName="myProject"
-    priority="normal"
-    cancelJobOnError="false">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.5"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.5/schedulerjob.xsd"
+        name="flow_loop" projectName="myProject"
+        priority="normal"
+        onTaskError="continueJobExecution">
   <genericInformation>
     <info name="var1" value="val1"/>
     <info name="var2" value="val2"/>

--- a/rest/rest-server/src/test/java/functionaltests/AbstractRestFuncTestCase.java
+++ b/rest/rest-server/src/test/java/functionaltests/AbstractRestFuncTestCase.java
@@ -36,10 +36,9 @@
  */
 package functionaltests;
 
-import java.security.Policy;
-
-import javax.ws.rs.core.MediaType;
-
+import functionaltests.jobs.NonTerminatingJob;
+import functionaltests.jobs.SimpleJob;
+import functionaltests.utils.RestFuncTUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -65,9 +64,8 @@ import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.OnTaskError;
 
-import functionaltests.jobs.NonTerminatingJob;
-import functionaltests.jobs.SimpleJob;
-import functionaltests.utils.RestFuncTUtils;
+import javax.ws.rs.core.MediaType;
+import java.security.Policy;
 
 
 public abstract class AbstractRestFuncTestCase {
@@ -77,9 +75,12 @@ public abstract class AbstractRestFuncTestCase {
         configureLog4j();
     }
 
+    static Logger logger;
+
     private static void configureLog4j() {
         BasicConfigurator.configure();
         Logger.getRootLogger().setLevel(Level.INFO);
+        logger = Logger.getLogger(AbstractRestFuncTestCase.class);
     }
 
     private static void configureSecurityManager() {

--- a/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
@@ -36,20 +36,13 @@
  */
 package functionaltests;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URL;
-import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-
+import com.jayway.awaitility.Duration;
+import functionaltests.utils.ProcessStreamReader;
+import functionaltests.utils.RestFuncTUtils;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.objectweb.proactive.api.PARemoteObject;
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.core.runtime.ProActiveRuntime;
@@ -66,14 +59,20 @@ import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.util.SchedulerStarter;
 import org.ow2.proactive.utils.CookieBasedProcessTreeKiller;
-import com.jayway.awaitility.Duration;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
 
-import functionaltests.utils.ProcessStreamReader;
-import functionaltests.utils.RestFuncTUtils;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Awaitility.await;
 
@@ -162,7 +161,7 @@ public class RestFuncTHelper {
         restServerUrl = "http://localhost:8080/rest/";
         restfulSchedulerUrl = restServerUrl + "scheduler";
 
-        await().atMost(Duration.ONE_MINUTE).until(restIsStarted());
+        await().atMost(Duration.FIVE_MINUTES).until(restIsStarted());
     }
 
     public static void stopRestfulSchedulerWebapp() {

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
@@ -65,7 +65,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class DataSpaceNodeConfigurationAgent implements Serializable {
 
-    private static Logger logger = Logger.getLogger(DataSpaceNodeConfigurationAgent.class);
+    private static transient Logger logger = Logger.getLogger(DataSpaceNodeConfigurationAgent.class);
 
     /**
      * This property is used by scheduling when configuring node to define the location of the scratch dir and must be renamed carefully.
@@ -112,17 +112,17 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
     /**
      * file system server controlling the cache
      */
-    private FileSystemServerDeployer cacheServer;
+    private transient FileSystemServerDeployer cacheServer;
 
     /**
      * Configuration of the cache server (used by the TaskLauncher to register the dataspace to the naming service
      */
-    private static InputOutputSpaceConfiguration cacheSpaceConfiguration;
+    private static transient InputOutputSpaceConfiguration cacheSpaceConfiguration;
 
     /**
      * VFS direct interface to the cache, used by the cleaning mechanism to delete files
      */
-    private static DefaultFileSystemManager fileSystemManager;
+    private static transient DefaultFileSystemManager fileSystemManager;
 
     /**
      * URL of the cache root folder
@@ -132,12 +132,12 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
     /**
      * Timer used by the cleaning mechanism
      */
-    private static Timer cleaningTimer;
+    private static transient Timer cleaningTimer;
 
     /**
      * Lock used by the cleaning mechanism to ensure that the cleaning is not run concurrently with a Task
      */
-    private static ReentrantReadWriteLock cacheCleaningRWLock = new ReentrantReadWriteLock();
+    private static transient ReentrantReadWriteLock cacheCleaningRWLock = new ReentrantReadWriteLock();
 
 
     /**
@@ -159,6 +159,8 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
             logger.error("Cannot configure dataSpace", t);
             return false;
         }
+
+        startCacheSpace();
         PAActiveObject.terminateActiveObject(false);
         return true;
     }
@@ -223,7 +225,7 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
             try {
                 String cacheLocation = getCacheDir();
                 cacheServer = new FileSystemServerDeployer(CACHESPACE_NAME, cacheLocation, true, true);
-                logger.info("Cache server started at " + cacheServer.getVFSRootURLs());
+                logger.info("Cache server started at " + Arrays.toString(cacheServer.getVFSRootURLs()));
                 String hostname = InetAddress.getLocalHost().getHostName();
                 cacheSpaceConfiguration = InputOutputSpaceConfiguration.createOutputSpaceConfiguration(Arrays.asList(cacheServer.getVFSRootURLs()), cacheLocation, hostname, CACHESPACE_NAME);
                 fileSystemManager = VFSFactory.createDefaultFileSystemManager();

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
@@ -36,13 +36,18 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.dataspace;
 
-import java.io.Serializable;
-
+import org.apache.log4j.Logger;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.objectweb.proactive.extensions.dataspaces.core.BaseScratchSpaceConfiguration;
 import org.objectweb.proactive.extensions.dataspaces.core.DataSpacesNodes;
-import org.apache.log4j.Logger;
+import org.objectweb.proactive.extensions.dataspaces.core.InputOutputSpaceConfiguration;
+import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
+
+import java.io.File;
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.Arrays;
 
 
 /**
@@ -55,11 +60,31 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
 
     private static Logger logger = Logger.getLogger(DataSpaceNodeConfigurationAgent.class);
 
-    /** 
-     * This property is used by scheduling when configuring node and must be renamed carefully.
+    /**
+     * This property is used by scheduling when configuring node to define the location of the scratch dir and must be renamed carefully.
      * It is also defined in TaskLauncher.
      */
     protected static final String NODE_DATASPACE_SCRATCHDIR = "node.dataspace.scratchdir";
+
+    /**
+     * This property is used by scheduling when configuring node to define the location of the scratch dir. If the property is not defined,
+     * the scratch location will be used to create the cache dir
+     */
+    protected static final String NODE_DATASPACE_CACHEDIR = "node.dataspace.cachedir";
+
+    /**
+     * Name of the CacheSpace for DataSpaces registration
+     */
+    public static final String CACHESPACE_NAME = "CACHESPACE";
+
+    /**
+     * Default subfolder name for the cache
+     **/
+    public static final String DEFAULT_CACHE_SUBFOLDER_NAME = "cache";
+
+
+    private FileSystemServerDeployer cacheServer;
+    private static InputOutputSpaceConfiguration cacheSpaceConfiguration;
 
     /**
      * Create a new instance of DataSpaceNodeConfigurationAgent
@@ -71,16 +96,9 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
     public boolean configureNode() {
         try {
             // configure node for Data Spaces
-            String scratchDir;
-            if (System.getProperty(NODE_DATASPACE_SCRATCHDIR) == null) {
-                //if scratch dir java property is not set, set to default
-                scratchDir = System.getProperty("java.io.tmpdir");
-            } else {
-                //else use the property
-                scratchDir = System.getProperty(NODE_DATASPACE_SCRATCHDIR);
-            }
+            String baseScratchDir = getBaseScratchDir();
             final BaseScratchSpaceConfiguration scratchConf = new BaseScratchSpaceConfiguration(
-                (String) null, scratchDir);
+                    (String) null, baseScratchDir);
             DataSpacesNodes.configureNode(PAActiveObject.getActiveObjectNode(PAActiveObject.getStubOnThis()),
                     scratchConf);
         } catch (Throwable t) {
@@ -91,8 +109,55 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
         return true;
     }
 
+    private String getBaseScratchDir() {
+        String scratchDir;
+        if (System.getProperty(NODE_DATASPACE_SCRATCHDIR) == null) {
+            //if scratch dir java property is not set, set to default
+            scratchDir = System.getProperty("java.io.tmpdir");
+        } else {
+            //else use the property
+            scratchDir = System.getProperty(NODE_DATASPACE_SCRATCHDIR);
+        }
+        return scratchDir;
+    }
+
+    private String getCacheDir() {
+        String cacheDir;
+        if (System.getProperty(NODE_DATASPACE_CACHEDIR) == null) {
+            //if scratch dir java property is not set, set to default
+            cacheDir = (new File(getBaseScratchDir(), DEFAULT_CACHE_SUBFOLDER_NAME)).getAbsolutePath();
+        } else {
+            // else use the property
+            cacheDir = System.getProperty(NODE_DATASPACE_CACHEDIR);
+        }
+        return cacheDir;
+    }
+
+    public static InputOutputSpaceConfiguration getCacheSpaceConfiguration() {
+        return cacheSpaceConfiguration;
+    }
+
+    public boolean startCacheSpace() {
+        if (cacheSpaceConfiguration == null) {
+            try {
+                cacheServer = new FileSystemServerDeployer(CACHESPACE_NAME, getCacheDir(), true, true);
+                logger.info("Cache server started at " + cacheServer.getVFSRootURLs());
+                String hostname = InetAddress.getLocalHost().getHostName();
+                cacheSpaceConfiguration = InputOutputSpaceConfiguration.createOutputSpaceConfiguration(Arrays.asList(cacheServer.getVFSRootURLs()), getCacheDir(), hostname, CACHESPACE_NAME);
+
+            } catch (Exception e) {
+                logger.error("Error occurred when starting the cache server", e);
+                return false;
+            }
+        }
+        return true;
+    }
+
     public BooleanWrapper closeNodeConfiguration() {
+
         try {
+            cacheServer.terminate();
+
             DataSpacesNodes.closeNodeConfig(PAActiveObject
                     .getActiveObjectNode(PAActiveObject.getStubOnThis()));
         } catch (Throwable t) {

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
@@ -36,18 +36,25 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.dataspace;
 
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.objectweb.proactive.extensions.dataspaces.core.BaseScratchSpaceConfiguration;
 import org.objectweb.proactive.extensions.dataspaces.core.DataSpacesNodes;
 import org.objectweb.proactive.extensions.dataspaces.core.InputOutputSpaceConfiguration;
+import org.objectweb.proactive.extensions.dataspaces.vfs.VFSFactory;
 import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
 
 import java.io.File;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.Arrays;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 
 /**
@@ -64,13 +71,23 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
      * This property is used by scheduling when configuring node to define the location of the scratch dir and must be renamed carefully.
      * It is also defined in TaskLauncher.
      */
-    protected static final String NODE_DATASPACE_SCRATCHDIR = "node.dataspace.scratchdir";
+    public static final String NODE_DATASPACE_SCRATCHDIR = "node.dataspace.scratchdir";
 
     /**
-     * This property is used by scheduling when configuring node to define the location of the scratch dir. If the property is not defined,
+     * This property is used by scheduling when configuring node to define the location of the cache dir. If the property is not defined,
      * the scratch location will be used to create the cache dir
      */
-    protected static final String NODE_DATASPACE_CACHEDIR = "node.dataspace.cachedir";
+    public static final String NODE_DATASPACE_CACHEDIR = "node.dataspace.cachedir";
+
+    /**
+     * This property contains the invalidation period for a file, in ms. If set with a value greater than 0, each file older than the specified period will be deleted.
+     */
+    public static final String NODE_DATASPACE_CACHE_INVALIDATION_PERIOD = "node.dataspace.cache.invalidation.period";
+
+    /**
+     * This property contains the interval period used to start the cache cleaning process.
+     */
+    public static final String NODE_DATASPACE_CACHE_CLEANING_PERIOD = "node.dataspace.cache.cleaning.period";
 
     /**
      * Name of the CacheSpace for DataSpaces registration
@@ -82,9 +99,46 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
      **/
     public static final String DEFAULT_CACHE_SUBFOLDER_NAME = "cache";
 
+    /**
+     * Default cache cleaning period (interval at which the cache is cleaned. Default to one hour
+     **/
+    public static final long DEFAULT_CACHE_CLEANING_PERIOD = 3600000L;
 
+    /**
+     * Default cache invalidation period (files older than this date will be deleted). Default to two weeks
+     **/
+    public static final long DEFAULT_CACHE_INVALIDATION_PERIOD = 1210000000L;
+
+    /**
+     * file system server controlling the cache
+     */
     private FileSystemServerDeployer cacheServer;
+
+    /**
+     * Configuration of the cache server (used by the TaskLauncher to register the dataspace to the naming service
+     */
     private static InputOutputSpaceConfiguration cacheSpaceConfiguration;
+
+    /**
+     * VFS direct interface to the cache, used by the cleaning mechanism to delete files
+     */
+    private static DefaultFileSystemManager fileSystemManager;
+
+    /**
+     * URL of the cache root folder
+     */
+    private static String rootCacheUri;
+
+    /**
+     * Timer used by the cleaning mechanism
+     */
+    private static Timer cleaningTimer;
+
+    /**
+     * Lock used by the cleaning mechanism to ensure that the cleaning is not run concurrently with a Task
+     */
+    private static ReentrantReadWriteLock cacheCleaningRWLock = new ReentrantReadWriteLock();
+
 
     /**
      * Create a new instance of DataSpaceNodeConfigurationAgent
@@ -133,17 +187,51 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
         return cacheDir;
     }
 
+    private static long getCacheCleaningPeriod() {
+        long cacheCleaningPeriod = DEFAULT_CACHE_CLEANING_PERIOD;
+        if (System.getProperty(NODE_DATASPACE_CACHE_CLEANING_PERIOD) != null) {
+            cacheCleaningPeriod = Long.parseLong(System.getProperty(NODE_DATASPACE_CACHE_CLEANING_PERIOD));
+        }
+        return cacheCleaningPeriod;
+    }
+
+    private static long getCacheInvalidationPeriod() {
+        long cacheInvalidationPeriod = DEFAULT_CACHE_INVALIDATION_PERIOD;
+        if (System.getProperty(NODE_DATASPACE_CACHE_INVALIDATION_PERIOD) != null) {
+            cacheInvalidationPeriod = Long.parseLong(System.getProperty(NODE_DATASPACE_CACHE_INVALIDATION_PERIOD));
+        }
+        return cacheInvalidationPeriod;
+    }
+
+    /**
+     * Returns the configuration of the server cache
+     *
+     * @return
+     */
     public static InputOutputSpaceConfiguration getCacheSpaceConfiguration() {
         return cacheSpaceConfiguration;
     }
 
+
+    /**
+     * Starts the Cache Space server
+     *
+     * @return
+     */
     public boolean startCacheSpace() {
         if (cacheSpaceConfiguration == null) {
             try {
-                cacheServer = new FileSystemServerDeployer(CACHESPACE_NAME, getCacheDir(), true, true);
+                String cacheLocation = getCacheDir();
+                cacheServer = new FileSystemServerDeployer(CACHESPACE_NAME, cacheLocation, true, true);
                 logger.info("Cache server started at " + cacheServer.getVFSRootURLs());
                 String hostname = InetAddress.getLocalHost().getHostName();
-                cacheSpaceConfiguration = InputOutputSpaceConfiguration.createOutputSpaceConfiguration(Arrays.asList(cacheServer.getVFSRootURLs()), getCacheDir(), hostname, CACHESPACE_NAME);
+                cacheSpaceConfiguration = InputOutputSpaceConfiguration.createOutputSpaceConfiguration(Arrays.asList(cacheServer.getVFSRootURLs()), cacheLocation, hostname, CACHESPACE_NAME);
+                fileSystemManager = VFSFactory.createDefaultFileSystemManager();
+                rootCacheUri = new File(cacheLocation).toURI().toURL().toExternalForm();
+
+                if (getCacheInvalidationPeriod() > 0) {
+                    startCacheCleaningDaemon();
+                }
 
             } catch (Exception e) {
                 logger.error("Error occurred when starting the cache server", e);
@@ -153,10 +241,39 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
         return true;
     }
 
+    /**
+     * This method must be used by the TaskLauncher to prevent the cleaning timer to run concurrently to a Task
+     * As a read lock is used, multiple readers can acquire the lock at the same time
+     *
+     * @throws InterruptedException
+     */
+    public static void lockCacheSpaceCleaning() throws InterruptedException {
+        cacheCleaningRWLock.readLock().lockInterruptibly();
+    }
+
+    /**
+     * This method must be used by the TaskLauncher at the end of a Task execution, allowing the cleaning timer to run
+     * <p>
+     * The cleaning timer will be released only when all read locks have been released.
+     *
+     * @throws InterruptedException
+     */
+    public static void unlockCacheSpaceCleaning() {
+        cacheCleaningRWLock.readLock().unlock();
+    }
+
+    private void startCacheCleaningDaemon() {
+        cleaningTimer = new Timer("CacheCleaningTimer", true);
+        long cleaningInterval = getCacheCleaningPeriod();
+        cleaningTimer.schedule(new CleanTimerTask(), cleaningInterval, cleaningInterval);
+    }
+
     public BooleanWrapper closeNodeConfiguration() {
 
         try {
             cacheServer.terminate();
+
+            cleaningTimer.cancel();
 
             DataSpacesNodes.closeNodeConfig(PAActiveObject
                     .getActiveObjectNode(PAActiveObject.getStubOnThis()));
@@ -166,6 +283,35 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
         }
         PAActiveObject.terminateActiveObject(false);
         return new BooleanWrapper(true);
+    }
+
+    /**
+     * This class contains the logic of the cleaning mechanism
+     */
+    private static class CleanTimerTask extends TimerTask {
+
+        @Override
+        public void run() {
+            try {
+                long invalidationPeriod = getCacheInvalidationPeriod();
+                long currentTime = System.currentTimeMillis();
+                // lock the timer in write mode, this will prevent any Task to start during the cleaning process
+                cacheCleaningRWLock.writeLock().lockInterruptibly();
+                try {
+                    FileObject rootFO = fileSystemManager.resolveFile(rootCacheUri);
+                    FileObject[] files = rootFO.findFiles(Selectors.EXCLUDE_SELF);
+                    for (FileObject file : files) {
+                        if (currentTime - file.getContent().getLastModifiedTime() > invalidationPeriod) {
+                            file.delete();
+                        }
+                    }
+                } finally {
+                    cacheCleaningRWLock.writeLock().unlock();
+                }
+            } catch (Exception e) {
+                logger.error("Error when cleaning files in cache", e);
+            }
+        }
     }
 
 }

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
@@ -397,7 +397,7 @@ public class RMNodeStarter {
             Node node = createLocalNode(createdNodeNames.get(nodeIndex));
             configureForDataSpace(node);
             nodes.add(node);
-            logger.debug("URL of node " + nodeIndex + " " + node.getNodeInformation().getURL());
+            logger.info("URL of node " + nodeIndex + " " + node.getNodeInformation().getURL());
         }
         return nodes;
     }
@@ -648,7 +648,6 @@ public class RMNodeStarter {
                 throw new NotConfiguredException(
                     "Failed to configure dataspaces, check the logs for more details");
             }
-            conf.startCacheSpace();
             closeDataSpaceOnShutdown(node);
             node.setProperty(DATASPACES_STATUS_PROP_NAME, Boolean.TRUE.toString());
         } catch (Throwable t) {

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
@@ -36,23 +36,11 @@
  */
 package org.ow2.proactive.resourcemanager.utils;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.security.KeyException;
-import java.security.Policy;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
-import javax.security.auth.login.LoginException;
-
+import org.apache.commons.cli.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.*;
+import org.hyperic.sigar.Sigar;
+import org.hyperic.sigar.SigarLoader;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.api.PAFuture;
 import org.objectweb.proactive.core.ProActiveException;
@@ -78,23 +66,22 @@ import org.ow2.proactive.resourcemanager.node.jmx.SigarExposer;
 import org.ow2.proactive.resourcemanager.nodesource.dataspace.DataSpaceNodeConfigurationAgent;
 import org.ow2.proactive.utils.CookieBasedProcessTreeKiller;
 import org.ow2.proactive.utils.Tools;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.io.FileUtils;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-import org.apache.log4j.PropertyConfigurator;
-import org.hyperic.sigar.Sigar;
-import org.hyperic.sigar.SigarLoader;
+
+import javax.security.auth.login.LoginException;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyException;
+import java.security.Policy;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static org.ow2.proactive.utils.ClasspathUtils.findSchedulerHome;
@@ -661,6 +648,7 @@ public class RMNodeStarter {
                 throw new NotConfiguredException(
                     "Failed to configure dataspaces, check the logs for more details");
             }
+            conf.startCacheSpace();
             closeDataSpaceOnShutdown(node);
             node.setProperty(DATASPACES_STATUS_PROP_NAME, Boolean.TRUE.toString());
         } catch (Throwable t) {

--- a/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
@@ -62,6 +62,7 @@ import org.ow2.tests.ProActiveSetup;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.rmi.AlreadyBoundException;
 import java.util.*;
@@ -361,6 +362,15 @@ public class RMTHelper {
         if (!vmParameters.containsKey(PAResourceManagerProperties.RM_HOME.getKey())) {
             vmParameters.put(PAResourceManagerProperties.RM_HOME.getKey(),
                     PAResourceManagerProperties.RM_HOME.getValueAsString());
+        }
+
+        if (!vmParameters.containsKey(CentralPAPropertyRepository.LOG4J.getName())) {
+            try {
+                File log4jFile = new File(CentralPAPropertyRepository.PA_HOME.getValue(), "config/log/node.properties");
+                vmParameters.put(CentralPAPropertyRepository.LOG4J.getName(), log4jFile.toURI().toURL().toString());
+            } catch (MalformedURLException ignore) {
+
+            }
         }
 
         for (Entry<String, String> entry : vmParameters.entrySet()) {

--- a/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
@@ -89,7 +89,7 @@ public class RMTHelper {
      */
     public static final int DEFAULT_NODES_NUMBER = 2;
 
-    private final static ProActiveSetup setup = new ProActiveSetup();
+    public final static ProActiveSetup setup = new ProActiveSetup();
 
     private static TestRM rm = new TestRM();
     static {

--- a/scheduler/scheduler-api/build.gradle
+++ b/scheduler/scheduler-api/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 apply plugin: 'trang'
 task convertSchemas
-['3.0', '3.1', '3.2', '3.3', '3.4', 'dev'].each { schemaVersion ->
+['3.0', '3.1', '3.2', '3.3', '3.4', '3.5', 'dev'].each { schemaVersion ->
     task("convertSchemasXsd-$schemaVersion", type: org.hsudbrock.tranggradleplugin.TrangTask) {
         sourceDirectory = project.file("src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/${schemaVersion}")
         targetDirectory = sourceDirectory

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerConstants.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerConstants.java
@@ -84,6 +84,8 @@ public class SchedulerConstants {
 
     public static final String DS_SCRATCH_BINDING_NAME = "localspace";
 
+    public static final String DS_CACHE_BINDING_NAME = "cachespace";
+
     public static final String DS_INPUT_BINDING_NAME = "inputspace";
 
     public static final String DS_OUTPUT_BINDING_NAME = "outputspace";

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Schemas.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Schemas.java
@@ -55,12 +55,15 @@ public enum Schemas {
     SCHEMA_3_4(
             "/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.4/schedulerjob.rng",
             "urn:proactive:jobdescriptor:3.4"),
+    SCHEMA_3_5(
+            "/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.rng",
+            "urn:proactive:jobdescriptor:3.5"),
     SCHEMA_DEV(
             "/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng",
             "urn:proactive:jobdescriptor:dev"),
 
     // should contain a reference to the last one declared, see #validate
-    SCHEMA_LATEST(SCHEMA_3_4.location, SCHEMA_3_4.namespace);
+    SCHEMA_LATEST(SCHEMA_3_5.location, SCHEMA_3_5.namespace);
 
     String location;
     String namespace;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/InputAccessMode.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/InputAccessMode.java
@@ -52,10 +52,28 @@ public enum InputAccessMode {
     TransferFromInputSpace("transferFromInputSpace"),
     /** Transfer files from OUTPUT space to LOCAL space */
     TransferFromOutputSpace("transferFromOutputSpace"),
-    /** GLOBAL to LOCAL */
+    /**
+     * Transfer files from GLOBAL space to LOCAL space
+     */
     TransferFromGlobalSpace("transferFromGlobalSpace"),
-    /** USER to LOCAL */
+    /** Transfer files from USER space to LOCAL space */
     TransferFromUserSpace("transferFromUserSpace"),
+    /**
+     * cache files from INPUT space to CACHE space
+     */
+    CacheFromInputSpace("cacheFromInputSpace"),
+    /**
+     * cache files from OUTPUT space to CACHE space
+     */
+    CacheFromOutputSpace("cacheFromOutputSpace"),
+    /**
+     * cache files from GLOBAL space to CACHE space
+     */
+    CacheFromGlobalSpace("cacheFromGlobalSpace"),
+    /**
+     * cache files from GLOBAL space to CACHE space
+     */
+    CacheFromUserSpace("cacheFromUserSpace"),
     /** Do nothing */
     none("none");
 
@@ -74,6 +92,14 @@ public enum InputAccessMode {
             return TransferFromGlobalSpace;
         } else if (TransferFromUserSpace.title.equalsIgnoreCase(accessMode)) {
             return TransferFromUserSpace;
+        } else if (CacheFromInputSpace.title.equalsIgnoreCase(accessMode)) {
+            return CacheFromInputSpace;
+        } else if (CacheFromOutputSpace.title.equalsIgnoreCase(accessMode)) {
+            return CacheFromOutputSpace;
+        } else if (CacheFromGlobalSpace.title.equalsIgnoreCase(accessMode)) {
+            return CacheFromGlobalSpace;
+        } else if (CacheFromUserSpace.title.equalsIgnoreCase(accessMode)) {
+            return CacheFromUserSpace;
         } else if (none.title.equalsIgnoreCase(accessMode)) {
             return none;
         } else {

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.rnc
@@ -1,5 +1,5 @@
-default namespace = "urn:proactive:jobdescriptor:dev"
-namespace jd = "urn:proactive:jobdescriptor:dev"
+default namespace = "urn:proactive:jobdescriptor:3.5"
+namespace jd = "urn:proactive:jobdescriptor:3.5"
 namespace xsi = "http://www.w3.org/2001/XMLSchema-instance"
 namespace doc = "http://relaxng.org/ns/compatibility/annotations/1.0"
 start = job

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.rng
@@ -1,0 +1,995 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="urn:proactive:jobdescriptor:3.5" xmlns:doc="http://relaxng.org/ns/compatibility/annotations/1.0"
+         xmlns:jd="urn:proactive:jobdescriptor:3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+    <start>
+        <ref name="job"/>
+    </start>
+    <define name="job">
+        <element name="job">
+            <doc:documentation>Definition of a job for the scheduler</doc:documentation>
+            <optional>
+                <ref name="variables"/>
+            </optional>
+            <optional>
+                <ref name="jobDescription"/>
+            </optional>
+            <ref name="jobName"/>
+            <optional>
+                <ref name="priority"/>
+            </optional>
+            <optional>
+                <ref name="onTaskError_j"/>
+            </optional>
+            <optional>
+                <ref name="restartTaskOnError_j"/>
+            </optional>
+            <optional>
+                <ref name="numberOfExecution_j"/>
+            </optional>
+            <optional>
+                <ref name="genericInformation"/>
+            </optional>
+            <optional>
+                <ref name="inputSpace"/>
+            </optional>
+            <optional>
+                <ref name="outputSpace"/>
+            </optional>
+            <optional>
+                <ref name="globalSpace"/>
+            </optional>
+            <optional>
+                <ref name="userSpace"/>
+            </optional>
+            <optional>
+                <ref name="projectName"/>
+            </optional>
+            <optional>
+                <attribute name="xsi:schemaLocation">
+                    <data type="anyURI"/>
+                </attribute>
+            </optional>
+            <ref name="taskFlow"/>
+        </element>
+    </define>
+    <define name="jobName">
+        <attribute name="name">
+            <doc:documentation>Identification of this job</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="variables">
+        <element name="variables">
+            <doc:documentation>Definition of variables which can be reused throughout this descriptor
+            </doc:documentation>
+            <oneOrMore>
+                <ref name="variable"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="variable">
+        <element name="variable">
+            <doc:documentation>Definition of one variable, the variable can be reused (even in another following
+                variable definition) by using the syntax ${name_of_variable}
+            </doc:documentation>
+            <ref name="variableName"/>
+            <ref name="variableValue"/>
+        </element>
+    </define>
+    <define name="variableName">
+        <attribute name="name">
+            <doc:documentation>Name of a variable</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="variableValue">
+        <attribute name="value">
+            <doc:documentation>The patterns ${variable_name} will be replaced by this value</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="priority">
+        <attribute name="priority">
+            <doc:documentation>Priority of the job</doc:documentation>
+            <choice>
+                <ref name="jobPriority"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="onTaskError_j">
+        <attribute name="onTaskError">
+            <doc:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue
+                job execution are possible settings. The onTaskError behavior is triggered on task failure, not node
+                failure. (default=continue job execution)
+            </doc:documentation>
+            <choice>
+                <ref name="onErrorTaskType"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="restartTaskOnError_j">
+        <attribute name="restartTaskOnError">
+            <doc:documentation>For each task, where does the task restart if an error occurred ? (default=anywhere)
+            </doc:documentation>
+            <choice>
+                <ref name="restartTaskType"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="numberOfExecution_j">
+        <attribute name="maxNumberOfExecution">
+            <doc:documentation>Maximum number of execution for each task (default=1)</doc:documentation>
+            <choice>
+                <data type="nonNegativeInteger"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="pathElement">
+        <element name="pathElement">
+            <doc:documentation>Path element (one pathElement for each classpath entry)</doc:documentation>
+            <attribute name="path">
+                <data type="string"/>
+            </attribute>
+        </element>
+    </define>
+    <define name="genericInformation">
+        <element name="genericInformation">
+            <doc:documentation>Definition of any information you would like to get in the policy</doc:documentation>
+            <oneOrMore>
+                <ref name="info"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="info">
+        <element name="info">
+            <doc:documentation>Information that you can get in the policy through the job content</doc:documentation>
+            <ref name="infoName"/>
+            <ref name="infoValue"/>
+        </element>
+    </define>
+    <define name="infoName">
+        <attribute name="name">
+            <doc:documentation>Name of the information variable</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="infoValue">
+        <attribute name="value">
+            <doc:documentation>Value of the information variable</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="projectName">
+        <attribute name="projectName">
+            <doc:documentation>Name of the project related to this job. It is also used in the policy to group some jobs
+                together
+            </doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="jobDescription">
+        <element name="description">
+            <doc:documentation>Textual description of this job</doc:documentation>
+            <text/>
+        </element>
+    </define>
+    <define name="taskFlow">
+        <element name="taskFlow">
+            <doc:documentation>A job composed of a flow of tasks with or without dependencies</doc:documentation>
+            <oneOrMore>
+                <ref name="task"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <!-- +++++++++++++ task -->
+    <define name="task">
+        <element name="task">
+            <doc:documentation>A task is the smallest computation unit for the scheduler</doc:documentation>
+            <ref name="taskName"/>
+            <optional>
+                <ref name="nodesNumber_t"/>
+            </optional>
+            <optional>
+                <ref name="onTaskError_t"/>
+            </optional>
+            <optional>
+                <ref name="restartTaskOnError_t"/>
+            </optional>
+            <optional>
+                <ref name="numberOfExecution_t"/>
+            </optional>
+            <optional>
+                <ref name="runAsMe"/>
+            </optional>
+            <optional>
+                <ref name="walltime"/>
+            </optional>
+            <optional>
+                <ref name="preciousResult"/>
+            </optional>
+            <optional>
+                <ref name="preciousLogs"/>
+            </optional>
+            <optional>
+                <ref name="resultPreviewClass"/>
+            </optional>
+            <optional>
+                <ref name="taskDescription"/>
+            </optional>
+            <optional>
+                <ref name="genericInformation"/>
+            </optional>
+            <optional>
+                <ref name="depends"/>
+            </optional>
+            <optional>
+                <ref name="inputFiles"/>
+            </optional>
+            <optional>
+                <ref name="parallel"/>
+            </optional>
+            <optional>
+                <ref name="selection"/>
+            </optional>
+            <optional>
+                <ref name="forkEnvironment"/>
+            </optional>
+            <optional>
+                <ref name="pre"/>
+            </optional>
+            <ref name="executable"/>
+            <optional>
+                <ref name="flow"/>
+            </optional>
+            <optional>
+                <ref name="post"/>
+            </optional>
+            <optional>
+                <ref name="cleaning"/>
+            </optional>
+            <optional>
+                <ref name="outputFiles"/>
+            </optional>
+        </element>
+    </define>
+    <define name="taskName">
+        <attribute name="name">
+            <doc:documentation>Identification of this task (identifier)</doc:documentation>
+            <data type="ID"/>
+        </attribute>
+    </define>
+    <define name="nodesNumber_t">
+        <attribute name="numberOfNodes">
+            <doc:documentation>number of cores needed for the task (identifier)</doc:documentation>
+            <choice>
+                <data type="positiveInteger"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="taskDescription">
+        <element name="description">
+            <doc:documentation>Textual description of this task</doc:documentation>
+            <text/>
+        </element>
+    </define>
+    <define name="walltime">
+        <attribute name="walltime">
+            <doc:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR
+                'hh:mm:ss')
+            </doc:documentation>
+            <choice>
+                <ref name="walltimePattern"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="onTaskError_t">
+        <attribute name="onTaskError">
+            <doc:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue
+                job execution are possible settings. The onTaskError behavior is triggered on task failure, not node
+                failure. (default=continue job execution)
+            </doc:documentation>
+            <choice>
+                <ref name="onErrorTaskType"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="restartTaskOnError_t">
+        <attribute name="restartTaskOnError">
+            <doc:documentation>Where does the task restart if an error occurred ?</doc:documentation>
+            <ref name="restartTaskType"/>
+        </attribute>
+    </define>
+    <define name="numberOfExecution_t">
+        <attribute name="maxNumberOfExecution">
+            <doc:documentation>Maximum number of execution for this task</doc:documentation>
+            <choice>
+                <data type="nonNegativeInteger"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="preciousResult">
+        <attribute name="preciousResult">
+            <doc:documentation>Do we keep the result among the job results</doc:documentation>
+            <choice>
+                <data type="boolean"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="preciousLogs">
+        <attribute name="preciousLogs">
+            <doc:documentation>Do we keep the logs as file on USERSPACE</doc:documentation>
+            <choice>
+                <data type="boolean"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="resultPreviewClass">
+        <attribute name="resultPreviewClass">
+            <doc:documentation>A class implementing the ResultPreview interface which can be used to display the result
+                of this task
+            </doc:documentation>
+            <choice>
+                <ref name="classPattern"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="depends">
+        <element name="depends">
+            <doc:documentation>A list of dependencies for this task</doc:documentation>
+            <oneOrMore>
+                <ref name="dependsTask"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="dependsTask">
+        <element name="task">
+            <doc:documentation>A task from which this task depends</doc:documentation>
+            <attribute name="ref">
+                <data type="IDREF"/>
+            </attribute>
+        </element>
+    </define>
+    <define name="parallel">
+        <element name="parallel">
+            <doc:documentation>An information related parallel task including nodes number and topology
+            </doc:documentation>
+            <ref name="nodesNumber_t"/>
+            <optional>
+                <ref name="topology"/>
+            </optional>
+        </element>
+    </define>
+    <define name="topology">
+        <element name="topology">
+            <doc:documentation>A topology descriptor of the parallel task</doc:documentation>
+            <choice>
+                <ref name="arbitrary"/>
+                <ref name="bestProximity"/>
+                <ref name="thresholdProximity"/>
+                <ref name="singleHost"/>
+                <ref name="singleHostExclusive"/>
+                <ref name="multipleHostsExclusive"/>
+                <ref name="differentHostsExclusive"/>
+            </choice>
+        </element>
+    </define>
+    <define name="selection">
+        <element name="selection">
+            <doc:documentation>A script used to select resources that can handle the task</doc:documentation>
+            <oneOrMore>
+                <ref name="selectionScript"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="flow">
+        <element name="controlFlow">
+            <doc:documentation>Flow control : block declaration, flow action</doc:documentation>
+            <optional>
+                <ref name="block"/>
+            </optional>
+            <optional>
+                <choice>
+                    <ref name="actionIf"/>
+                    <ref name="actionReplicate"/>
+                    <ref name="actionLoop"/>
+                </choice>
+            </optional>
+        </element>
+    </define>
+    <define name="block">
+        <attribute name="block">
+            <doc:documentation>block declaration</doc:documentation>
+            <ref name="blockAttr"/>
+        </attribute>
+    </define>
+    <define name="pre">
+        <element name="pre">
+            <doc:documentation>A script launched before the task execution in the task node</doc:documentation>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <define name="post">
+        <element name="post">
+            <doc:documentation>A script launched after the task execution in the task node</doc:documentation>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <define name="cleaning">
+        <element name="cleaning">
+            <doc:documentation>A script launched by the Resource Manager after the task or post script
+            </doc:documentation>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <define name="runAsMe">
+        <attribute name="runAsMe">
+            <doc:documentation>Do we run this task under the job owner user identity</doc:documentation>
+            <choice>
+                <data type="boolean"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <!-- +++++++++++++ scripts -->
+    <define name="simpleScript">
+        <element name="script">
+            <doc:documentation>Definition of a standard script</doc:documentation>
+            <choice>
+                <ref name="codeScript"/>
+                <ref name="fileScript"/>
+            </choice>
+        </element>
+    </define>
+    <define name="selectionScript">
+        <element name="script">
+            <doc:documentation>Definition of a specific script which is used for resource selection</doc:documentation>
+            <optional>
+                <ref name="scriptType"/>
+            </optional>
+            <choice>
+                <ref name="codeScript"/>
+                <ref name="fileScript"/>
+            </choice>
+        </element>
+    </define>
+    <define name="scriptType">
+        <attribute name="type">
+            <doc:documentation>Type of script for the infrastructure manager (default to dynamic)</doc:documentation>
+            <ref name="scriptTypeT"/>
+        </attribute>
+    </define>
+    <define name="codeScript">
+        <element name="code">
+            <doc:documentation>Definition of a script by writing directly the code inside the descriptor
+            </doc:documentation>
+            <attribute name="language">
+                <data type="string"/>
+            </attribute>
+            <text/>
+        </element>
+    </define>
+    <define name="fileScript">
+        <element name="file">
+            <doc:documentation>Definition of a script by loading a file</doc:documentation>
+            <choice>
+                <ref name="path"/>
+                <ref name="url"/>
+            </choice>
+            <optional>
+                <ref name="fileScriptArguments"/>
+            </optional>
+        </element>
+    </define>
+    <define name="path">
+        <attribute name="path">
+            <doc:documentation>File path to script definition</doc:documentation>
+            <choice>
+                <data type="anyURI"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="url">
+        <attribute name="url">
+            <doc:documentation>Remote script definition, reachable at the given url</doc:documentation>
+            <choice>
+                <data type="anyURI"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="fileScriptArguments">
+        <element name="arguments">
+            <doc:documentation>A list of arguments of this script</doc:documentation>
+            <oneOrMore>
+                <ref name="fileScriptArgument"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="fileScriptArgument">
+        <element name="argument">
+            <doc:documentation>An argument of this script</doc:documentation>
+            <attribute name="value">
+                <data type="string"/>
+            </attribute>
+        </element>
+    </define>
+    <!-- +++++++++++++ Topology -->
+    <define name="arbitrary">
+        <element name="arbitrary">
+            <doc:documentation>arbitrary topology</doc:documentation>
+            <empty/>
+        </element>
+    </define>
+    <define name="bestProximity">
+        <element name="bestProximity">
+            <doc:documentation>best nodes proximity</doc:documentation>
+            <empty/>
+        </element>
+    </define>
+    <define name="thresholdProximity">
+        <element name="thresholdProximity">
+            <doc:documentation>threshold nodes proximity</doc:documentation>
+            <ref name="threshold"/>
+        </element>
+    </define>
+    <define name="singleHost">
+        <element name="singleHost">
+            <doc:documentation>nodes on single host</doc:documentation>
+            <empty/>
+        </element>
+    </define>
+    <define name="singleHostExclusive">
+        <element name="singleHostExclusive">
+            <doc:documentation>nodes on single host exclusively</doc:documentation>
+            <empty/>
+        </element>
+    </define>
+    <define name="multipleHostsExclusive">
+        <element name="multipleHostsExclusive">
+            <doc:documentation>nodes on multiple hosts exclusively</doc:documentation>
+            <empty/>
+        </element>
+    </define>
+    <define name="differentHostsExclusive">
+        <element name="differentHostsExclusive">
+            <doc:documentation>nodes on single host exclusively</doc:documentation>
+            <empty/>
+        </element>
+    </define>
+    <define name="threshold">
+        <attribute name="threshold">
+            <doc:documentation>threshold value</doc:documentation>
+            <data type="nonNegativeInteger"/>
+        </attribute>
+    </define>
+    <!-- +++++++++++++ executables -->
+    <define name="executable">
+        <choice>
+            <doc:documentation>The task executable is the actual code that will be run on the selected resource. It can
+                be a native command or a Java class
+            </doc:documentation>
+            <ref name="nativeExecutable"/>
+            <ref name="javaExecutable"/>
+            <ref name="scriptExecutable"/>
+        </choice>
+    </define>
+    <define name="nativeExecutable">
+        <element name="nativeExecutable">
+            <doc:documentation>A native command call, it can be statically described or generated by a script
+            </doc:documentation>
+            <ref name="staticCommand"/>
+        </element>
+    </define>
+    <define name="staticCommand">
+        <element name="staticCommand">
+            <doc:documentation>A native command statically defined in the descriptor</doc:documentation>
+            <attribute name="value">
+                <data type="string"/>
+            </attribute>
+            <optional>
+                <ref name="commandArguments"/>
+            </optional>
+        </element>
+    </define>
+    <define name="workingDir_t">
+        <attribute name="workingDir">
+            <doc:documentation>working dir for native command to execute (ie launching dir, pwd...)</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="commandArguments">
+        <element name="arguments">
+            <doc:documentation>List of arguments to the native command (they will be appended at the end of the
+                command)
+            </doc:documentation>
+            <oneOrMore>
+                <ref name="commandArgument"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="commandArgument">
+        <element name="argument">
+            <attribute name="value">
+                <data type="string"/>
+            </attribute>
+        </element>
+    </define>
+    <define name="javaExecutable">
+        <element name="javaExecutable">
+            <doc:documentation>A Java class implementing the Executable interface</doc:documentation>
+            <ref name="class"/>
+            <optional>
+                <ref name="javaParameters"/>
+            </optional>
+        </element>
+    </define>
+    <define name="class">
+        <attribute name="class">
+            <doc:documentation>The fully qualified class name</doc:documentation>
+            <choice>
+                <ref name="classPattern"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="forkEnvironment">
+        <element name="forkEnvironment">
+            <doc:documentation>Fork environment if needed</doc:documentation>
+            <optional>
+                <ref name="workingDir_t"/>
+            </optional>
+            <optional>
+                <ref name="javaHome"/>
+            </optional>
+            <optional>
+                <ref name="sysProps"/>
+            </optional>
+            <optional>
+                <ref name="jvmArgs"/>
+            </optional>
+            <optional>
+                <ref name="additionalClasspath"/>
+            </optional>
+            <optional>
+                <ref name="envScript"/>
+            </optional>
+        </element>
+    </define>
+    <define name="javaHome">
+        <attribute name="javaHome">
+            <doc:documentation>Path to installed java directory, to this path '/bin/java' will be added, if attribute
+                does not exist only 'java' command will be called
+            </doc:documentation>
+            <choice>
+                <data type="anyURI"/>
+                <ref name="variableRefType"/>
+            </choice>
+        </attribute>
+    </define>
+    <define name="sysProps">
+        <element name="SystemEnvironment">
+            <doc:documentation>a list of sysProp</doc:documentation>
+            <oneOrMore>
+                <ref name="sysProp"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="sysProp">
+        <element name="variable">
+            <doc:documentation>A parameter in the form of key/value pair</doc:documentation>
+            <attribute name="name">
+                <data type="string"/>
+            </attribute>
+            <attribute name="value">
+                <data type="string"/>
+            </attribute>
+        </element>
+    </define>
+    <define name="jvmArgs">
+        <element name="jvmArgs">
+            <doc:documentation>A list of java properties or options</doc:documentation>
+            <oneOrMore>
+                <ref name="jvmArg"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="jvmArg">
+        <element name="jvmArg">
+            <doc:documentation>A list of java properties or options</doc:documentation>
+            <attribute name="value">
+                <data type="string"/>
+            </attribute>
+        </element>
+    </define>
+    <define name="additionalClasspath">
+        <element name="additionalClasspath">
+            <doc:documentation>classpath entries to add to the new java process</doc:documentation>
+            <oneOrMore>
+                <ref name="pathElement"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="envScript">
+        <element name="envScript">
+            <doc:documentation>environment script to execute for setting forked process environment</doc:documentation>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <define name="javaParameters">
+        <element name="parameters">
+            <doc:documentation>A list of parameters that will be given to the Java task through the init method
+            </doc:documentation>
+            <oneOrMore>
+                <ref name="javaParameter"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="javaParameter">
+        <element name="parameter">
+            <doc:documentation>A parameter in the form of key/value pair</doc:documentation>
+            <attribute name="name">
+                <data type="string"/>
+            </attribute>
+            <attribute name="value">
+                <data type="string"/>
+            </attribute>
+        </element>
+    </define>
+    <define name="scriptExecutable">
+        <element name="scriptExecutable">
+            <doc:documentation>A script to be executed as a task</doc:documentation>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <!-- +++++++++++++ DataSpaces -->
+    <define name="inputSpace">
+        <element name="inputSpace">
+            <doc:documentation>INPUT space for the job, this setting overrides the default input space provided by the
+                scheduler. It is typically used to store input files for a single job.
+            </doc:documentation>
+            <ref name="url"/>
+        </element>
+    </define>
+    <define name="outputSpace">
+        <element name="outputSpace">
+            <doc:documentation>OUTPUT space for the job, this setting overrides the default output space provided by the
+                scheduler. It is typically used to store output files for a single job.
+            </doc:documentation>
+            <ref name="url"/>
+        </element>
+    </define>
+    <define name="globalSpace">
+        <element name="globalSpace">
+            <doc:documentation>GLOBAL space for the job, this setting overrides the default global space provided by the
+                scheduler. It is typically used to store files shared by all users.
+            </doc:documentation>
+            <ref name="url"/>
+        </element>
+    </define>
+    <define name="userSpace">
+        <element name="userSpace">
+            <doc:documentation>USER space for the job, this setting overrides the default user space provided by the
+                scheduler. It is typically used to store files that a user needs across multiple jobs.
+            </doc:documentation>
+            <ref name="url"/>
+        </element>
+    </define>
+    <define name="inputFiles">
+        <element name="inputFiles">
+            <doc:documentation>selection of input files that will be accessible for the application and copied from
+                INPUT/OUTPUT to local system
+            </doc:documentation>
+            <oneOrMore>
+                <ref name="infiles_"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="infiles_">
+        <element name="files">
+            <doc:documentation>description of input files with include, exclude and an access mode</doc:documentation>
+            <ref name="includes_"/>
+            <optional>
+                <ref name="excludes_"/>
+            </optional>
+            <ref name="inaccessMode_"/>
+        </element>
+    </define>
+    <define name="inaccessMode_">
+        <attribute name="accessMode">
+            <doc:documentation>type of access on the selected files</doc:documentation>
+            <ref name="inaccessModeType"/>
+        </attribute>
+    </define>
+    <define name="outputFiles">
+        <element name="outputFiles">
+            <doc:documentation>selection of output files that will be copied from LOCALSPACE to OUTPUT
+            </doc:documentation>
+            <oneOrMore>
+                <ref name="outfiles_"/>
+            </oneOrMore>
+        </element>
+    </define>
+    <define name="outfiles_">
+        <element name="files">
+            <doc:documentation>description of output files with include, exclude and an access mode</doc:documentation>
+            <ref name="includes_"/>
+            <optional>
+                <ref name="excludes_"/>
+            </optional>
+            <ref name="outaccessMode_"/>
+        </element>
+    </define>
+    <define name="outaccessMode_">
+        <attribute name="accessMode">
+            <doc:documentation>type of access on the selected files</doc:documentation>
+            <ref name="outaccessModeType"/>
+        </attribute>
+    </define>
+    <define name="includes_">
+        <attribute name="includes">
+            <doc:documentation>Pattern of the files to include, relative to INPUT or OUTPUT spaces</doc:documentation>
+            <ref name="inexcludePattern"/>
+        </attribute>
+    </define>
+    <define name="excludes_">
+        <attribute name="excludes">
+            <doc:documentation>Pattern of the files to exclude among the included one, relative to INPUT or OUTPUT
+                spaces
+            </doc:documentation>
+            <ref name="inexcludePattern"/>
+        </attribute>
+    </define>
+    <!-- +++++++++++++ Control flow -->
+    <define name="actionIf">
+        <element name="if">
+            <doc:documentation>branching Control flow action</doc:documentation>
+            <ref name="target"/>
+            <ref name="targetElse"/>
+            <optional>
+                <ref name="targetContinuation"/>
+            </optional>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <define name="target">
+        <attribute name="target">
+            <doc:documentation>branching if target</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="targetElse">
+        <attribute name="else">
+            <doc:documentation>branching else target</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="targetContinuation">
+        <attribute name="continuation">
+            <doc:documentation>branching else target</doc:documentation>
+            <data type="string"/>
+        </attribute>
+    </define>
+    <define name="actionLoop">
+        <element name="loop">
+            <doc:documentation>looping control flow action</doc:documentation>
+            <ref name="target"/>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <define name="actionReplicate">
+        <element name="replicate">
+            <doc:documentation>replicate control flow action</doc:documentation>
+            <ref name="simpleScript"/>
+        </element>
+    </define>
+    <!-- +++++++++++++ User define types -->
+    <define name="jobPriority">
+        <choice>
+            <value>highest</value>
+            <value>high</value>
+            <value>normal</value>
+            <value>low</value>
+            <value>lowest</value>
+            <ref name="variableRefType"/>
+        </choice>
+    </define>
+    <define name="restartTaskType">
+        <choice>
+            <value>anywhere</value>
+            <value>elsewhere</value>
+            <ref name="variableRefType"/>
+        </choice>
+    </define>
+    <define name="onErrorTaskType">
+        <choice>
+            <value>cancelJob</value>
+            <value>suspendTask</value>
+            <value>pauseJob</value>
+            <value>continueJobExecution</value>
+            <value>none</value>
+            <ref name="variableRefType"/>
+        </choice>
+    </define>
+    <define name="inaccessModeType">
+        <choice>
+            <value>transferFromInputSpace</value>
+            <value>transferFromOutputSpace</value>
+            <value>transferFromGlobalSpace</value>
+            <value>transferFromUserSpace</value>
+            <value>cacheFromInputSpace</value>
+            <value>cacheFromOutputSpace</value>
+            <value>cacheFromGlobalSpace</value>
+            <value>cacheFromUserSpace</value>
+            <value>none</value>
+            <ref name="variableRefType"/>
+        </choice>
+    </define>
+    <define name="outaccessModeType">
+        <choice>
+            <value>transferToOutputSpace</value>
+            <value>transferToGlobalSpace</value>
+            <value>transferToUserSpace</value>
+            <value>none</value>
+            <ref name="variableRefType"/>
+        </choice>
+    </define>
+    <define name="classPattern">
+        <data type="string">
+            <param name="pattern">([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*</param>
+        </data>
+    </define>
+    <define name="walltimePattern">
+        <data type="string">
+            <param name="pattern">[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}</param>
+        </data>
+    </define>
+    <define name="variableRefType">
+        <data type="string">
+            <param name="pattern">$\{[A-Za-z0-9._]+\}</param>
+        </data>
+    </define>
+    <define name="inexcludePattern">
+        <data type="string">
+            <param name="pattern">.+(,.+)*</param>
+        </data>
+    </define>
+    <define name="controlFlowAction">
+        <choice>
+            <value>goto</value>
+            <value>replicate</value>
+            <value>continue</value>
+        </choice>
+    </define>
+    <define name="blockAttr">
+        <choice>
+            <value>start</value>
+            <value>end</value>
+            <value>none</value>
+        </choice>
+    </define>
+    <define name="scriptTypeT">
+        <choice>
+            <value>dynamic</value>
+            <value>static</value>
+            <ref name="variableRefType"/>
+        </choice>
+    </define>
+    <define name="propertyAppendChar">
+        <data type="string">
+            <param name="pattern">.</param>
+        </data>
+    </define>
+</grammar>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.xsd
@@ -1,0 +1,1288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+           targetNamespace="urn:proactive:jobdescriptor:3.5" xmlns:jd="urn:proactive:jobdescriptor:3.5"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <xs:import namespace="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="xsi.xsd"/>
+    <xs:element name="job">
+        <xs:annotation>
+            <xs:documentation>Definition of a job for the scheduler</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="jd:variables"/>
+                <xs:group minOccurs="0" ref="jd:jobDescription"/>
+                <xs:element minOccurs="0" ref="jd:genericInformation"/>
+                <xs:element minOccurs="0" ref="jd:inputSpace"/>
+                <xs:element minOccurs="0" ref="jd:outputSpace"/>
+                <xs:element minOccurs="0" ref="jd:globalSpace"/>
+                <xs:element minOccurs="0" ref="jd:userSpace"/>
+                <xs:element ref="jd:taskFlow"/>
+            </xs:sequence>
+            <xs:attributeGroup ref="jd:jobName"/>
+            <xs:attribute name="priority">
+                <xs:annotation>
+                    <xs:documentation>Priority of the job</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="jd:jobPriority jd:variableRefType"/>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="onTaskError">
+                <xs:annotation>
+                    <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and
+                        continue job execution are possible settings. The onTaskError behavior is triggered on task
+                        failure, not node failure. (default=continue job execution)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="restartTaskOnError">
+                <xs:annotation>
+                    <xs:documentation>For each task, where does the task restart if an error occurred ?
+                        (default=anywhere)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="maxNumberOfExecution">
+                <xs:annotation>
+                    <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="projectName" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Name of the project related to this job. It is also used in the policy to group
+                        some jobs together
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute ref="xsi:schemaLocation"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="jobName">
+        <xs:attribute name="name" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Identification of this job</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="variables">
+        <xs:annotation>
+            <xs:documentation>Definition of variables which can be reused throughout this descriptor</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group maxOccurs="unbounded" ref="jd:variable"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:group name="variable">
+        <xs:sequence>
+            <xs:element name="variable">
+                <xs:annotation>
+                    <xs:documentation>Definition of one variable, the variable can be reused (even in another following
+                        variable definition) by using the syntax ${name_of_variable}
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attributeGroup ref="jd:variableName"/>
+                    <xs:attributeGroup ref="jd:variableValue"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:attributeGroup name="variableName">
+        <xs:attribute name="name" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Name of a variable</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="variableValue">
+        <xs:attribute name="value" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The patterns ${variable_name} will be replaced by this value</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="priority">
+        <xs:attribute name="priority" use="required">
+            <xs:annotation>
+                <xs:documentation>Priority of the job</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="jd:jobPriority jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="onTaskError_j">
+        <xs:attribute name="onTaskError" use="required">
+            <xs:annotation>
+                <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue
+                    job execution are possible settings. The onTaskError behavior is triggered on task failure, not node
+                    failure. (default=continue job execution)
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="restartTaskOnError_j">
+        <xs:attribute name="restartTaskOnError" use="required">
+            <xs:annotation>
+                <xs:documentation>For each task, where does the task restart if an error occurred ? (default=anywhere)
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="numberOfExecution_j">
+        <xs:attribute name="maxNumberOfExecution" use="required">
+            <xs:annotation>
+                <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="pathElement">
+        <xs:annotation>
+            <xs:documentation>Path element (one pathElement for each classpath entry)</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="path" use="required" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="genericInformation">
+        <xs:annotation>
+            <xs:documentation>Definition of any information you would like to get in the policy</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="jd:info"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="info">
+        <xs:annotation>
+            <xs:documentation>Information that you can get in the policy through the job content</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="jd:infoName"/>
+            <xs:attributeGroup ref="jd:infoValue"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="infoName">
+        <xs:attribute name="name" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Name of the information variable</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="infoValue">
+        <xs:attribute name="value" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Value of the information variable</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="projectName">
+        <xs:attribute name="projectName" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Name of the project related to this job. It is also used in the policy to group some
+                    jobs together
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:group name="jobDescription">
+        <xs:sequence>
+            <xs:element name="description" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Textual description of this job</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:element name="taskFlow">
+        <xs:annotation>
+            <xs:documentation>A job composed of a flow of tasks with or without dependencies</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group maxOccurs="unbounded" ref="jd:task"/>
+        </xs:complexType>
+    </xs:element>
+    <!-- +++++++++++++ task -->
+    <xs:group name="task">
+        <xs:sequence>
+            <xs:element name="task">
+                <xs:annotation>
+                    <xs:documentation>A task is the smallest computation unit for the scheduler</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:group minOccurs="0" ref="jd:taskDescription"/>
+                        <xs:element minOccurs="0" ref="jd:genericInformation"/>
+                        <xs:element minOccurs="0" ref="jd:depends"/>
+                        <xs:element minOccurs="0" ref="jd:inputFiles"/>
+                        <xs:element minOccurs="0" ref="jd:parallel"/>
+                        <xs:element minOccurs="0" ref="jd:selection"/>
+                        <xs:element minOccurs="0" ref="jd:forkEnvironment"/>
+                        <xs:element minOccurs="0" ref="jd:pre"/>
+                        <xs:element ref="jd:executable"/>
+                        <xs:element minOccurs="0" ref="jd:controlFlow"/>
+                        <xs:element minOccurs="0" ref="jd:post"/>
+                        <xs:element minOccurs="0" ref="jd:cleaning"/>
+                        <xs:element minOccurs="0" ref="jd:outputFiles"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="jd:taskName"/>
+                    <xs:attribute name="numberOfNodes">
+                        <xs:annotation>
+                            <xs:documentation>number of cores needed for the task (identifier)</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="xs:positiveInteger jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="onTaskError">
+                        <xs:annotation>
+                            <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job
+                                and continue job execution are possible settings. The onTaskError behavior is triggered
+                                on task failure, not node failure. (default=continue job execution)
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="restartTaskOnError" type="jd:restartTaskType">
+                        <xs:annotation>
+                            <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="maxNumberOfExecution">
+                        <xs:annotation>
+                            <xs:documentation>Maximum number of execution for this task</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="runAsMe">
+                        <xs:annotation>
+                            <xs:documentation>Do we run this task under the job owner user identity</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="walltime">
+                        <xs:annotation>
+                            <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss'
+                                OR 'mm:ss' OR 'hh:mm:ss')
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="preciousResult">
+                        <xs:annotation>
+                            <xs:documentation>Do we keep the result among the job results</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="preciousLogs">
+                        <xs:annotation>
+                            <xs:documentation>Do we keep the logs as file on USERSPACE</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="resultPreviewClass">
+                        <xs:annotation>
+                            <xs:documentation>A class implementing the ResultPreview interface which can be used to
+                                display the result of this task
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:attributeGroup name="taskName">
+        <xs:attribute name="name" use="required" type="xs:ID">
+            <xs:annotation>
+                <xs:documentation>Identification of this task (identifier)</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="nodesNumber_t">
+        <xs:attribute name="numberOfNodes" use="required">
+            <xs:annotation>
+                <xs:documentation>number of cores needed for the task (identifier)</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:positiveInteger jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:group name="taskDescription">
+        <xs:sequence>
+            <xs:element name="description" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Textual description of this task</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:attributeGroup name="walltime">
+        <xs:attribute name="walltime" use="required">
+            <xs:annotation>
+                <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss'
+                    OR 'hh:mm:ss')
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="onTaskError_t">
+        <xs:attribute name="onTaskError" use="required">
+            <xs:annotation>
+                <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue
+                    job execution are possible settings. The onTaskError behavior is triggered on task failure, not node
+                    failure. (default=continue job execution)
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="restartTaskOnError_t">
+        <xs:attribute name="restartTaskOnError" use="required" type="jd:restartTaskType">
+            <xs:annotation>
+                <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="numberOfExecution_t">
+        <xs:attribute name="maxNumberOfExecution" use="required">
+            <xs:annotation>
+                <xs:documentation>Maximum number of execution for this task</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="preciousResult">
+        <xs:attribute name="preciousResult" use="required">
+            <xs:annotation>
+                <xs:documentation>Do we keep the result among the job results</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="preciousLogs">
+        <xs:attribute name="preciousLogs" use="required">
+            <xs:annotation>
+                <xs:documentation>Do we keep the logs as file on USERSPACE</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="resultPreviewClass">
+        <xs:attribute name="resultPreviewClass" use="required">
+            <xs:annotation>
+                <xs:documentation>A class implementing the ResultPreview interface which can be used to display the
+                    result of this task
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="depends">
+        <xs:annotation>
+            <xs:documentation>A list of dependencies for this task</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group maxOccurs="unbounded" ref="jd:dependsTask"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:group name="dependsTask">
+        <xs:sequence>
+            <xs:element name="task">
+                <xs:annotation>
+                    <xs:documentation>A task from which this task depends</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="ref" use="required" type="xs:IDREF"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:element name="parallel">
+        <xs:annotation>
+            <xs:documentation>An information related parallel task including nodes number and topology
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="jd:topology"/>
+            </xs:sequence>
+            <xs:attributeGroup ref="jd:nodesNumber_t"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="topology">
+        <xs:annotation>
+            <xs:documentation>A topology descriptor of the parallel task</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice>
+                <xs:element ref="jd:arbitrary"/>
+                <xs:element ref="jd:bestProximity"/>
+                <xs:element ref="jd:thresholdProximity"/>
+                <xs:element ref="jd:singleHost"/>
+                <xs:element ref="jd:singleHostExclusive"/>
+                <xs:element ref="jd:multipleHostsExclusive"/>
+                <xs:element ref="jd:differentHostsExclusive"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="selection">
+        <xs:annotation>
+            <xs:documentation>A script used to select resources that can handle the task</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group maxOccurs="unbounded" ref="jd:selectionScript"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="controlFlow">
+        <xs:annotation>
+            <xs:documentation>Flow control : block declaration, flow action</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice minOccurs="0">
+                <xs:element ref="jd:if"/>
+                <xs:element ref="jd:replicate"/>
+                <xs:element ref="jd:loop"/>
+            </xs:choice>
+            <xs:attribute name="block" type="jd:blockAttr">
+                <xs:annotation>
+                    <xs:documentation>block declaration</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="block">
+        <xs:attribute name="block" use="required" type="jd:blockAttr">
+            <xs:annotation>
+                <xs:documentation>block declaration</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="pre" type="jd:simpleScript">
+        <xs:annotation>
+            <xs:documentation>A script launched before the task execution in the task node</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="post" type="jd:simpleScript">
+        <xs:annotation>
+            <xs:documentation>A script launched after the task execution in the task node</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="cleaning" type="jd:simpleScript">
+        <xs:annotation>
+            <xs:documentation>A script launched by the Resource Manager after the task or post script</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:attributeGroup name="runAsMe">
+        <xs:attribute name="runAsMe" use="required">
+            <xs:annotation>
+                <xs:documentation>Do we run this task under the job owner user identity</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <!-- +++++++++++++ scripts -->
+    <xs:complexType name="simpleScript">
+        <xs:sequence>
+            <xs:element name="script">
+                <xs:annotation>
+                    <xs:documentation>Definition of a standard script</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element ref="jd:code"/>
+                        <xs:element ref="jd:file"/>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:group name="selectionScript">
+        <xs:sequence>
+            <xs:element name="script">
+                <xs:annotation>
+                    <xs:documentation>Definition of a specific script which is used for resource selection
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element ref="jd:code"/>
+                        <xs:element ref="jd:file"/>
+                    </xs:choice>
+                    <xs:attribute name="type" type="jd:scriptTypeT">
+                        <xs:annotation>
+                            <xs:documentation>Type of script for the infrastructure manager (default to dynamic)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:attributeGroup name="scriptType">
+        <xs:attribute name="type" use="required" type="jd:scriptTypeT">
+            <xs:annotation>
+                <xs:documentation>Type of script for the infrastructure manager (default to dynamic)</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="code">
+        <xs:annotation>
+            <xs:documentation>Definition of a script by writing directly the code inside the descriptor
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+            <xs:attribute name="language" use="required" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="file">
+        <xs:annotation>
+            <xs:documentation>Definition of a script by loading a file</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group minOccurs="0" ref="jd:fileScriptArguments"/>
+            <xs:attribute name="path">
+                <xs:annotation>
+                    <xs:documentation>File path to script definition</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="url">
+                <xs:annotation>
+                    <xs:documentation>Remote script definition, reachable at the given url</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="path">
+        <xs:attribute name="path" use="required">
+            <xs:annotation>
+                <xs:documentation>File path to script definition</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="url">
+        <xs:attribute name="url" use="required">
+            <xs:annotation>
+                <xs:documentation>Remote script definition, reachable at the given url</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:group name="fileScriptArguments">
+        <xs:sequence>
+            <xs:element name="arguments">
+                <xs:annotation>
+                    <xs:documentation>A list of arguments of this script</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:group maxOccurs="unbounded" ref="jd:fileScriptArgument"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:group name="fileScriptArgument">
+        <xs:sequence>
+            <xs:element name="argument">
+                <xs:annotation>
+                    <xs:documentation>An argument of this script</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="value" use="required" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <!-- +++++++++++++ Topology -->
+    <xs:element name="arbitrary">
+        <xs:annotation>
+            <xs:documentation>arbitrary topology</xs:documentation>
+        </xs:annotation>
+        <xs:complexType/>
+    </xs:element>
+    <xs:element name="bestProximity">
+        <xs:annotation>
+            <xs:documentation>best nodes proximity</xs:documentation>
+        </xs:annotation>
+        <xs:complexType/>
+    </xs:element>
+    <xs:element name="thresholdProximity">
+        <xs:annotation>
+            <xs:documentation>threshold nodes proximity</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="jd:threshold"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="singleHost">
+        <xs:annotation>
+            <xs:documentation>nodes on single host</xs:documentation>
+        </xs:annotation>
+        <xs:complexType/>
+    </xs:element>
+    <xs:element name="singleHostExclusive">
+        <xs:annotation>
+            <xs:documentation>nodes on single host exclusively</xs:documentation>
+        </xs:annotation>
+        <xs:complexType/>
+    </xs:element>
+    <xs:element name="multipleHostsExclusive">
+        <xs:annotation>
+            <xs:documentation>nodes on multiple hosts exclusively</xs:documentation>
+        </xs:annotation>
+        <xs:complexType/>
+    </xs:element>
+    <xs:element name="differentHostsExclusive">
+        <xs:annotation>
+            <xs:documentation>nodes on single host exclusively</xs:documentation>
+        </xs:annotation>
+        <xs:complexType/>
+    </xs:element>
+    <xs:attributeGroup name="threshold">
+        <xs:attribute name="threshold" use="required" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation>threshold value</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <!-- +++++++++++++ executables -->
+    <xs:element name="executable" abstract="true"/>
+    <xs:element name="nativeExecutable" substitutionGroup="jd:executable" type="jd:staticCommand">
+        <xs:annotation>
+            <xs:documentation>A native command call, it can be statically described or generated by a script
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="staticCommand">
+        <xs:sequence>
+            <xs:element ref="jd:staticCommand"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="staticCommand">
+        <xs:annotation>
+            <xs:documentation>A native command statically defined in the descriptor</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group minOccurs="0" ref="jd:commandArguments"/>
+            <xs:attribute name="value" use="required" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="workingDir_t">
+        <xs:attribute name="workingDir" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>working dir for native command to execute (ie launching dir, pwd...)
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:group name="commandArguments">
+        <xs:sequence>
+            <xs:element name="arguments">
+                <xs:annotation>
+                    <xs:documentation>List of arguments to the native command (they will be appended at the end of the
+                        command)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:group maxOccurs="unbounded" ref="jd:commandArgument"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:group name="commandArgument">
+        <xs:sequence>
+            <xs:element name="argument">
+                <xs:complexType>
+                    <xs:attribute name="value" use="required" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:element name="javaExecutable" substitutionGroup="jd:executable">
+        <xs:annotation>
+            <xs:documentation>A Java class implementing the Executable interface</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="jd:parameters"/>
+            </xs:sequence>
+            <xs:attributeGroup ref="jd:class"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="class">
+        <xs:attribute name="class" use="required">
+            <xs:annotation>
+                <xs:documentation>The fully qualified class name</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="forkEnvironment">
+        <xs:annotation>
+            <xs:documentation>Fork environment if needed</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" ref="jd:SystemEnvironment"/>
+                <xs:element minOccurs="0" ref="jd:jvmArgs"/>
+                <xs:element minOccurs="0" ref="jd:additionalClasspath"/>
+                <xs:element minOccurs="0" ref="jd:envScript"/>
+            </xs:sequence>
+            <xs:attribute name="workingDir" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>working dir for native command to execute (ie launching dir, pwd...)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="javaHome">
+                <xs:annotation>
+                    <xs:documentation>Path to installed java directory, to this path '/bin/java' will be added, if
+                        attribute does not exist only 'java' command will be called
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="javaHome">
+        <xs:attribute name="javaHome" use="required">
+            <xs:annotation>
+                <xs:documentation>Path to installed java directory, to this path '/bin/java' will be added, if attribute
+                    does not exist only 'java' command will be called
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="SystemEnvironment">
+        <xs:annotation>
+            <xs:documentation>a list of sysProp</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group maxOccurs="unbounded" ref="jd:sysProp"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:group name="sysProp">
+        <xs:sequence>
+            <xs:element name="variable">
+                <xs:annotation>
+                    <xs:documentation>A parameter in the form of key/value pair</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="name" use="required" type="xs:string"/>
+                    <xs:attribute name="value" use="required" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:element name="jvmArgs">
+        <xs:annotation>
+            <xs:documentation>A list of java properties or options</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="jd:jvmArg"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="jvmArg">
+        <xs:annotation>
+            <xs:documentation>A list of java properties or options</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="value" use="required" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="additionalClasspath">
+        <xs:annotation>
+            <xs:documentation>classpath entries to add to the new java process</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="jd:pathElement"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="envScript" type="jd:simpleScript">
+        <xs:annotation>
+            <xs:documentation>environment script to execute for setting forked process environment</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="parameters">
+        <xs:annotation>
+            <xs:documentation>A list of parameters that will be given to the Java task through the init method
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="jd:parameter"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="parameter">
+        <xs:annotation>
+            <xs:documentation>A parameter in the form of key/value pair</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+            <xs:attribute name="value" use="required" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="scriptExecutable" substitutionGroup="jd:executable" type="jd:simpleScript">
+        <xs:annotation>
+            <xs:documentation>A script to be executed as a task</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <!-- +++++++++++++ DataSpaces -->
+    <xs:element name="inputSpace">
+        <xs:annotation>
+            <xs:documentation>INPUT space for the job, this setting overrides the default input space provided by the
+                scheduler. It is typically used to store input files for a single job.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="jd:url"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="outputSpace">
+        <xs:annotation>
+            <xs:documentation>OUTPUT space for the job, this setting overrides the default output space provided by the
+                scheduler. It is typically used to store output files for a single job.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="jd:url"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="globalSpace">
+        <xs:annotation>
+            <xs:documentation>GLOBAL space for the job, this setting overrides the default global space provided by the
+                scheduler. It is typically used to store files shared by all users.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="jd:url"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="userSpace">
+        <xs:annotation>
+            <xs:documentation>USER space for the job, this setting overrides the default user space provided by the
+                scheduler. It is typically used to store files that a user needs across multiple jobs.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="jd:url"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="inputFiles">
+        <xs:annotation>
+            <xs:documentation>selection of input files that will be accessible for the application and copied from
+                INPUT/OUTPUT to local system
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group maxOccurs="unbounded" ref="jd:infiles_"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:group name="infiles_">
+        <xs:sequence>
+            <xs:element name="files">
+                <xs:annotation>
+                    <xs:documentation>description of input files with include, exclude and an access mode
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attributeGroup ref="jd:includes_"/>
+                    <xs:attribute name="excludes" type="jd:inexcludePattern">
+                        <xs:annotation>
+                            <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT
+                                or OUTPUT spaces
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attributeGroup ref="jd:inaccessMode_"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:attributeGroup name="inaccessMode_">
+        <xs:attribute name="accessMode" use="required" type="jd:inaccessModeType">
+            <xs:annotation>
+                <xs:documentation>type of access on the selected files</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="outputFiles">
+        <xs:annotation>
+            <xs:documentation>selection of output files that will be copied from LOCALSPACE to OUTPUT</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:group maxOccurs="unbounded" ref="jd:outfiles_"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:group name="outfiles_">
+        <xs:sequence>
+            <xs:element name="files">
+                <xs:annotation>
+                    <xs:documentation>description of output files with include, exclude and an access mode
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attributeGroup ref="jd:includes_"/>
+                    <xs:attribute name="excludes" type="jd:inexcludePattern">
+                        <xs:annotation>
+                            <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT
+                                or OUTPUT spaces
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attributeGroup ref="jd:outaccessMode_"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:attributeGroup name="outaccessMode_">
+        <xs:attribute name="accessMode" use="required" type="jd:outaccessModeType">
+            <xs:annotation>
+                <xs:documentation>type of access on the selected files</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="includes_">
+        <xs:attribute name="includes" use="required" type="jd:inexcludePattern">
+            <xs:annotation>
+                <xs:documentation>Pattern of the files to include, relative to INPUT or OUTPUT spaces</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="excludes_">
+        <xs:attribute name="excludes" use="required" type="jd:inexcludePattern">
+            <xs:annotation>
+                <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT or OUTPUT
+                    spaces
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <!-- +++++++++++++ Control flow -->
+    <xs:element name="if">
+        <xs:annotation>
+            <xs:documentation>branching Control flow action</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="jd:simpleScript">
+                    <xs:attributeGroup ref="jd:target"/>
+                    <xs:attributeGroup ref="jd:targetElse"/>
+                    <xs:attribute name="continuation" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>branching else target</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:attributeGroup name="target">
+        <xs:attribute name="target" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>branching if target</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="targetElse">
+        <xs:attribute name="else" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>branching else target</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="targetContinuation">
+        <xs:attribute name="continuation" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>branching else target</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:element name="loop">
+        <xs:annotation>
+            <xs:documentation>looping control flow action</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="jd:simpleScript">
+                    <xs:attributeGroup ref="jd:target"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="replicate" type="jd:simpleScript">
+        <xs:annotation>
+            <xs:documentation>replicate control flow action</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <!-- +++++++++++++ User define types -->
+    <xs:simpleType name="jobPriority">
+        <xs:union memberTypes="jd:variableRefType">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="highest"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="high"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="normal"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="low"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="lowest"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="restartTaskType">
+        <xs:union memberTypes="jd:variableRefType">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="anywhere"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="elsewhere"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="onErrorTaskType">
+        <xs:union memberTypes="jd:variableRefType">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="cancelJob"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="suspendTask"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="pauseJob"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="continueJobExecution"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="none"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="inaccessModeType">
+        <xs:union memberTypes="jd:variableRefType">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="transferFromInputSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="transferFromOutputSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="transferFromGlobalSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="transferFromUserSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="cacheFromInputSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="cacheFromOutputSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="cacheFromGlobalSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="cacheFromUserSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="none"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="outaccessModeType">
+        <xs:union memberTypes="jd:variableRefType">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="transferToOutputSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="transferToGlobalSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="transferToUserSpace"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="none"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="classPattern">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="walltimePattern">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="variableRefType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="$\{[A-Za-z0-9._]+\}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="inexcludePattern">
+        <xs:restriction base="xs:string">
+            <xs:pattern value=".+(,.+)*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="controlFlowAction">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="goto"/>
+            <xs:enumeration value="replicate"/>
+            <xs:enumeration value="continue"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="blockAttr">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="start"/>
+            <xs:enumeration value="end"/>
+            <xs:enumeration value="none"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="scriptTypeT">
+        <xs:union memberTypes="jd:variableRefType">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="dynamic"/>
+                </xs:restriction>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="static"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="propertyAppendChar">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="."/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
@@ -887,6 +887,10 @@
       <value>transferFromOutputSpace</value>
       <value>transferFromGlobalSpace</value>
       <value>transferFromUserSpace</value>
+      <value>cacheFromInputSpace</value>
+      <value>cacheFromOutputSpace</value>
+      <value>cacheFromGlobalSpace</value>
+      <value>cacheFromUserSpace</value>
       <value>none</value>
       <ref name="variableRefType"/>
     </choice>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd
@@ -1120,6 +1120,26 @@
       </xs:simpleType>
       <xs:simpleType>
         <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromInputSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromOutputSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromGlobalSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromUserSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
           <xs:enumeration value="none"/>
         </xs:restriction>
       </xs:simpleType>

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -57,6 +57,7 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.OutputSelector;
 import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
 import org.ow2.proactive.scheduler.common.util.logforwarder.AppenderProvider;
 import org.ow2.proactive.scheduler.task.containers.ExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.context.TaskContextVariableExtractor;
 import org.ow2.proactive.scheduler.task.data.TaskDataspaces;
@@ -154,18 +155,17 @@ public class TaskLauncher implements InitActive {
             progressFileReader.start(dataspaces.getScratchFolder(), taskId);
 
             TaskContext context = new TaskContext(executableContainer, initializer, previousTasksResults,
-                    dataspaces.getScratchURI(), dataspaces.getCacheURI(), dataspaces.getInputURI(), dataspaces.getOutputURI(),
-                    dataspaces.getUserURI(), dataspaces.getGlobalURI(), progressFileReader.getProgressFile()
+                    new NodeDataSpacesURIs(dataspaces.getScratchURI(), dataspaces.getCacheURI(), dataspaces.getInputURI(), dataspaces.getOutputURI(), dataspaces.getUserURI(), dataspaces.getGlobalURI()), progressFileReader.getProgressFile()
                     .toString(), getHostname(), decrypter);
 
             File workingDir = getTaskWorkingDir(context, dataspaces);
 
             logger.info("Task working dir: " + workingDir);
-            logger.info("Cache space: " + context.getCacheURI());
-            logger.info("Input space: " + context.getInputURI());
-            logger.info("Output space: " + context.getOutputURI());
-            logger.info("User space: " + context.getUserURI());
-            logger.info("Global space: " + context.getGlobalURI());
+            logger.info("Cache space: " + context.getNodeDataSpaceURIs().getCacheURI());
+            logger.info("Input space: " + context.getNodeDataSpaceURIs().getInputURI());
+            logger.info("Output space: " + context.getNodeDataSpaceURIs().getOutputURI());
+            logger.info("User space: " + context.getNodeDataSpaceURIs().getUserURI());
+            logger.info("Global space: " + context.getNodeDataSpaceURIs().getGlobalURI());
 
             wallTimer.start();
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -147,13 +147,14 @@ public class TaskLauncher implements InitActive {
             progressFileReader.start(dataspaces.getScratchFolder(), taskId);
 
             TaskContext context = new TaskContext(executableContainer, initializer, previousTasksResults,
-                    dataspaces.getScratchURI(), dataspaces.getInputURI(), dataspaces.getOutputURI(),
+                    dataspaces.getScratchURI(), dataspaces.getCacheURI(), dataspaces.getInputURI(), dataspaces.getOutputURI(),
                     dataspaces.getUserURI(), dataspaces.getGlobalURI(), progressFileReader.getProgressFile()
                     .toString(), getHostname(), decrypter);
 
             File workingDir = getTaskWorkingDir(context, dataspaces);
 
             logger.info("Task working dir: " + workingDir);
+            logger.info("Cache space: " + context.getCacheURI());
             logger.info("Input space: " + context.getInputURI());
             logger.info("Output space: " + context.getOutputURI());
             logger.info("User space: " + context.getUserURI());

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/NodeDataSpacesURIs.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/NodeDataSpacesURIs.java
@@ -1,0 +1,45 @@
+package org.ow2.proactive.scheduler.task.context;
+
+import java.io.Serializable;
+
+public class NodeDataSpacesURIs implements Serializable {
+    private final String scratchURI;
+    private final String cacheURI;
+    private final String inputURI;
+    private final String outputURI;
+    private final String userURI;
+    private final String globalURI;
+
+    public NodeDataSpacesURIs(String scratchURI, String cacheURI, String inputURI, String outputURI, String userURI, String globalURI) {
+        this.scratchURI = scratchURI;
+        this.cacheURI = cacheURI;
+        this.inputURI = inputURI;
+        this.outputURI = outputURI;
+        this.userURI = userURI;
+        this.globalURI = globalURI;
+    }
+
+    public String getScratchURI() {
+        return scratchURI;
+    }
+
+    public String getCacheURI() {
+        return cacheURI;
+    }
+
+    public String getInputURI() {
+        return inputURI;
+    }
+
+    public String getOutputURI() {
+        return outputURI;
+    }
+
+    public String getUserURI() {
+        return userURI;
+    }
+
+    public String getGlobalURI() {
+        return globalURI;
+    }
+}

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContext.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContext.java
@@ -60,41 +60,29 @@ public class TaskContext implements Serializable {
     private final Decrypter decrypter;
     private final TaskResult[] previousTasksResults;
 
-    private final String scratchURI;
+    private final NodeDataSpacesURIs nodeDataSpacesURIs;
 
-    private final String cacheURI;
-    private final String inputURI;
-    private final String outputURI;
-    private final String userURI;
-    private final String globalURI;
     private final String schedulerHome;
 
     private final String progressFilePath;
 
 
     public TaskContext(ExecutableContainer executableContainer, TaskLauncherInitializer initializer,
-                       TaskResult[] previousTasksResults, String scratchURI, String cacheURI, String inputURI, String outputURI,
-                       String userURI,
-                       String globalURI, String progressFilePath, String currentNodeHostname) throws NodeException {
-        this(executableContainer, initializer, previousTasksResults, scratchURI, cacheURI, inputURI, outputURI, userURI,
-                globalURI, progressFilePath, currentNodeHostname, null);
+                       TaskResult[] previousTasksResults,
+                       NodeDataSpacesURIs nodeDataSpacesURIs, String progressFilePath, String currentNodeHostname) throws NodeException {
+        this(executableContainer, initializer, previousTasksResults,
+                nodeDataSpacesURIs, progressFilePath, currentNodeHostname, null);
     }
 
 
     public TaskContext(ExecutableContainer executableContainer, TaskLauncherInitializer initializer,
-                       TaskResult[] previousTasksResults, String scratchURI, String cacheURI, String inputURI, String outputURI,
-                       String userURI,
-                       String globalURI, String progressFilePath, String currentNodeHostname,
+                       TaskResult[] previousTasksResults,
+                       NodeDataSpacesURIs nodeDataSpacesURIs, String progressFilePath, String currentNodeHostname,
                        Decrypter decrypter) throws NodeException {
         this.initializer = initializer;
         initializer.setNamingService(null);
         this.previousTasksResults = previousTasksResults;
-        this.scratchURI = scratchURI;
-        this.cacheURI = cacheURI;
-        this.inputURI = inputURI;
-        this.outputURI = outputURI;
-        this.userURI = userURI;
-        this.globalURI = globalURI;
+        this.nodeDataSpacesURIs = nodeDataSpacesURIs;
         this.progressFilePath = progressFilePath;
         this.schedulerHome = ClasspathUtils.findSchedulerHome();
         this.executableContainer = executableContainer;
@@ -160,28 +148,8 @@ public class TaskContext implements Serializable {
         return otherNodesURLs;
     }
 
-    public String getScratchURI() {
-        return scratchURI;
-    }
-
-    public String getCacheURI() {
-        return cacheURI;
-    }
-
-    public String getInputURI() {
-        return inputURI;
-    }
-
-    public String getOutputURI() {
-        return outputURI;
-    }
-
-    public String getUserURI() {
-        return userURI;
-    }
-
-    public String getGlobalURI() {
-        return globalURI;
+    public NodeDataSpacesURIs getNodeDataSpaceURIs() {
+        return nodeDataSpacesURIs;
     }
 
     public String getProgressFilePath() {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContext.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContext.java
@@ -34,10 +34,6 @@
  */
 package org.ow2.proactive.scheduler.task.context;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeException;
 import org.ow2.proactive.scheduler.common.task.TaskId;
@@ -48,6 +44,10 @@ import org.ow2.proactive.scheduler.task.containers.ExecutableContainer;
 import org.ow2.proactive.scheduler.task.utils.Decrypter;
 import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.utils.ClasspathUtils;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class TaskContext implements Serializable {
@@ -62,7 +62,7 @@ public class TaskContext implements Serializable {
 
     private final String scratchURI;
 
-
+    private final String cacheURI;
     private final String inputURI;
     private final String outputURI;
     private final String userURI;
@@ -73,23 +73,24 @@ public class TaskContext implements Serializable {
 
 
     public TaskContext(ExecutableContainer executableContainer, TaskLauncherInitializer initializer,
-            TaskResult[] previousTasksResults, String scratchURI, String inputURI, String outputURI,
-            String userURI,
-            String globalURI, String progressFilePath, String currentNodeHostname) throws NodeException {
-        this(executableContainer, initializer, previousTasksResults, scratchURI, inputURI, outputURI, userURI,
+                       TaskResult[] previousTasksResults, String scratchURI, String cacheURI, String inputURI, String outputURI,
+                       String userURI,
+                       String globalURI, String progressFilePath, String currentNodeHostname) throws NodeException {
+        this(executableContainer, initializer, previousTasksResults, scratchURI, cacheURI, inputURI, outputURI, userURI,
                 globalURI, progressFilePath, currentNodeHostname, null);
     }
 
 
     public TaskContext(ExecutableContainer executableContainer, TaskLauncherInitializer initializer,
-            TaskResult[] previousTasksResults, String scratchURI, String inputURI, String outputURI,
-            String userURI,
-            String globalURI, String progressFilePath, String currentNodeHostname,
-            Decrypter decrypter) throws NodeException {
+                       TaskResult[] previousTasksResults, String scratchURI, String cacheURI, String inputURI, String outputURI,
+                       String userURI,
+                       String globalURI, String progressFilePath, String currentNodeHostname,
+                       Decrypter decrypter) throws NodeException {
         this.initializer = initializer;
         initializer.setNamingService(null);
         this.previousTasksResults = previousTasksResults;
         this.scratchURI = scratchURI;
+        this.cacheURI = cacheURI;
         this.inputURI = inputURI;
         this.outputURI = outputURI;
         this.userURI = userURI;
@@ -161,6 +162,10 @@ public class TaskContext implements Serializable {
 
     public String getScratchURI() {
         return scratchURI;
+    }
+
+    public String getCacheURI() {
+        return cacheURI;
     }
 
     public String getInputURI() {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskDataspaces.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskDataspaces.java
@@ -34,13 +34,13 @@
  */
 package org.ow2.proactive.scheduler.task.data;
 
-import java.io.File;
-import java.io.Serializable;
-import java.util.List;
-
 import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputSelector;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputSelector;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.List;
 
 
 public interface TaskDataspaces extends Serializable {
@@ -48,6 +48,8 @@ public interface TaskDataspaces extends Serializable {
     File getScratchFolder();
 
     String getScratchURI();
+
+    String getCacheURI();
 
     String getInputURI();
 
@@ -57,7 +59,7 @@ public interface TaskDataspaces extends Serializable {
 
     String getGlobalURI();
 
-    void copyInputDataToScratch(List<InputSelector> inputFiles) throws FileSystemException;
+    void copyInputDataToScratch(List<InputSelector> inputFiles) throws FileSystemException, InterruptedException;
 
     void copyScratchDataToOutput(List<OutputSelector> outputFiles) throws FileSystemException;
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
@@ -402,6 +402,14 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
                             inputSelectors, inputSpaceFiles, outputSpaceFiles,
                             globalSpaceFiles, userSpaceFiles, inputSpaceCacheFiles, outputSpaceCacheFiles, globalSpaceCacheFiles, userSpaceCacheFiles);
 
+            if (exception != null) {
+                throw exception;
+            }
+
+            String inputSpaceUri = virtualResolve(INPUT);
+            String outputSpaceUri = virtualResolve(OUTPUT);
+            String globalSpaceUri = virtualResolve(GLOBAL);
+            String userSpaceUri = virtualResolve(USER);
 
             boolean cacheTransferPresent = !inputSpaceCacheFiles.isEmpty() || !outputSpaceCacheFiles.isEmpty() || !globalSpaceCacheFiles.isEmpty() || !userSpaceCacheFiles.isEmpty();
 
@@ -410,33 +418,12 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             }
             try {
 
-                if (exception != null) {
-                    throw exception;
-                }
-
-                String inputSpaceUri = virtualResolve(INPUT);
-                String outputSpaceUri = virtualResolve(OUTPUT);
-                String globalSpaceUri = virtualResolve(GLOBAL);
-                String userSpaceUri = virtualResolve(USER);
-
-                Map<String, DataSpacesFileObject> filesToCopyToScratch =
-                        createFolderHierarchySequentially(SCRATCH,
-                                inputSpaceUri, inputSpaceFiles,
-                                outputSpaceUri, outputSpaceFiles,
-                                globalSpaceUri, globalSpaceFiles,
-                                userSpaceUri, userSpaceFiles);
-
                 Map<String, DataSpacesFileObject> filesToCopyToCache =
                         createFolderHierarchySequentially(CACHE,
                                 inputSpaceUri, inputSpaceCacheFiles,
                                 outputSpaceUri, outputSpaceCacheFiles,
                                 globalSpaceUri, globalSpaceCacheFiles,
                                 userSpaceUri, userSpaceCacheFiles);
-
-                List<Future<Boolean>> transferFuturesScratch =
-                        doCopyInputDataToSpace(SCRATCH, filesToCopyToScratch);
-
-                handleResults(transferFuturesScratch);
 
                 List<Future<Boolean>> transferFuturesCache =
                         doCopyInputDataToSpace(CACHE, filesToCopyToCache);
@@ -447,6 +434,18 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
                     cacheTransferLock.unlock();
                 }
             }
+
+            Map<String, DataSpacesFileObject> filesToCopyToScratch =
+                    createFolderHierarchySequentially(SCRATCH,
+                            inputSpaceUri, inputSpaceFiles,
+                            outputSpaceUri, outputSpaceFiles,
+                            globalSpaceUri, globalSpaceFiles,
+                            userSpaceUri, userSpaceFiles);
+
+            List<Future<Boolean>> transferFuturesScratch =
+                    doCopyInputDataToSpace(SCRATCH, filesToCopyToScratch);
+
+            handleResults(transferFuturesScratch);
 
         } finally {
             // display dataspaces error and warns if any

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
@@ -44,11 +44,14 @@ import org.objectweb.proactive.extensions.dataspaces.api.FileSelector;
 import org.objectweb.proactive.extensions.dataspaces.api.FileType;
 import org.objectweb.proactive.extensions.dataspaces.api.PADataSpaces;
 import org.objectweb.proactive.extensions.dataspaces.core.DataSpacesNodes;
+import org.objectweb.proactive.extensions.dataspaces.core.InputOutputSpaceConfiguration;
+import org.objectweb.proactive.extensions.dataspaces.core.SpaceInstanceInfo;
 import org.objectweb.proactive.extensions.dataspaces.core.naming.NamingService;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
 import org.objectweb.proactive.utils.NamedThreadFactory;
-import org.objectweb.proactive.utils.StackTraceUtil;
 import org.objectweb.proactive.utils.OperatingSystem;
+import org.objectweb.proactive.utils.StackTraceUtil;
+import org.ow2.proactive.resourcemanager.nodesource.dataspace.DataSpaceNodeConfigurationAgent;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputSelector;
@@ -66,6 +69,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 
@@ -81,6 +85,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             "pa.node.dataspace.create_folder_hierarchy_sequentially";
 
     private DataSpacesFileObject SCRATCH;
+    private DataSpacesFileObject CACHE;
     private DataSpacesFileObject INPUT;
     private DataSpacesFileObject OUTPUT;
     private DataSpacesFileObject GLOBAL;
@@ -90,6 +95,8 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
     private NamingService namingService;
     private boolean runAsUser;
     private boolean linuxOS;
+
+    private static ReentrantLock cacheTransferLock = new ReentrantLock();
 
     private StringBuffer clientLogs = new StringBuffer();
 
@@ -202,6 +209,18 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             logger.warn("Missing permission to change write permissions to " + getScratchFolder());
         }
 
+        InputOutputSpaceConfiguration cacheConfiguration = DataSpaceNodeConfigurationAgent.getCacheSpaceConfiguration();
+        final String cacheName = cacheConfiguration.getName();
+
+        namingService.register(new SpaceInstanceInfo(appId, cacheConfiguration));
+
+        CACHE = initDataSpace(new Callable<DataSpacesFileObject>() {
+            @Override
+            public DataSpacesFileObject call() throws Exception {
+                return PADataSpaces.resolveOutput(cacheName);
+            }
+        }, "CACHE", false);
+
         INPUT = initDataSpace(new Callable<DataSpacesFileObject>() {
             @Override
             public DataSpacesFileObject call() throws Exception {
@@ -287,6 +306,14 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
     }
 
     @Override
+    public String getCacheURI() {
+        if (CACHE == null) {
+            return "";
+        }
+        return convertDataSpaceURIToFileIfPossible(CACHE.getRealURI(), false);
+    }
+
+    @Override
     public String getInputURI() {
         if (INPUT == null) {
             return "";
@@ -354,7 +381,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
     }
 
     @Override
-    public void copyInputDataToScratch(List<InputSelector> inputSelectors) throws FileSystemException {
+    public void copyInputDataToScratch(List<InputSelector> inputSelectors) throws FileSystemException, InterruptedException {
         try {
             if (inputSelectors == null) {
                 logger.debug("Input selector is empty, no file to copy");
@@ -365,43 +392,73 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             ArrayList<DataSpacesFileObject> outputSpaceFiles = new ArrayList<>();
             ArrayList<DataSpacesFileObject> globalSpaceFiles = new ArrayList<>();
             ArrayList<DataSpacesFileObject> userSpaceFiles = new ArrayList<>();
+            ArrayList<DataSpacesFileObject> inputSpaceCacheFiles = new ArrayList<>();
+            ArrayList<DataSpacesFileObject> outputSpaceCacheFiles = new ArrayList<>();
+            ArrayList<DataSpacesFileObject> globalSpaceCacheFiles = new ArrayList<>();
+            ArrayList<DataSpacesFileObject> userSpaceCacheFiles = new ArrayList<>();
 
             FileSystemException exception =
-                    findFilesToCopyFromInputToScratch(
+                    findFilesToCopyFromInput(
                             inputSelectors, inputSpaceFiles, outputSpaceFiles,
-                            globalSpaceFiles, userSpaceFiles);
+                            globalSpaceFiles, userSpaceFiles, inputSpaceCacheFiles, outputSpaceCacheFiles, globalSpaceCacheFiles, userSpaceCacheFiles);
 
-            if (exception != null) {
-                throw exception;
+
+            boolean cacheTransferPresent = !inputSpaceCacheFiles.isEmpty() || !outputSpaceCacheFiles.isEmpty() || !globalSpaceCacheFiles.isEmpty() || !userSpaceCacheFiles.isEmpty();
+
+            if (cacheTransferPresent) {
+                cacheTransferLock.lockInterruptibly();
+            }
+            try {
+
+                if (exception != null) {
+                    throw exception;
+                }
+
+                String inputSpaceUri = virtualResolve(INPUT);
+                String outputSpaceUri = virtualResolve(OUTPUT);
+                String globalSpaceUri = virtualResolve(GLOBAL);
+                String userSpaceUri = virtualResolve(USER);
+
+                Map<String, DataSpacesFileObject> filesToCopyToScratch =
+                        createFolderHierarchySequentially(SCRATCH,
+                                inputSpaceUri, inputSpaceFiles,
+                                outputSpaceUri, outputSpaceFiles,
+                                globalSpaceUri, globalSpaceFiles,
+                                userSpaceUri, userSpaceFiles);
+
+                Map<String, DataSpacesFileObject> filesToCopyToCache =
+                        createFolderHierarchySequentially(CACHE,
+                                inputSpaceUri, inputSpaceCacheFiles,
+                                outputSpaceUri, outputSpaceCacheFiles,
+                                globalSpaceUri, globalSpaceCacheFiles,
+                                userSpaceUri, userSpaceCacheFiles);
+
+                List<Future<Boolean>> transferFuturesScratch =
+                        doCopyInputDataToSpace(SCRATCH, filesToCopyToScratch);
+
+                handleResults(transferFuturesScratch);
+
+                List<Future<Boolean>> transferFuturesCache =
+                        doCopyInputDataToSpace(CACHE, filesToCopyToCache);
+
+                handleResults(transferFuturesCache);
+            } finally {
+                if (cacheTransferPresent) {
+                    cacheTransferLock.unlock();
+                }
             }
 
-            String inputSpaceUri = virtualResolve(INPUT);
-            String outputSpaceUri = virtualResolve(OUTPUT);
-            String globalSpaceUri = virtualResolve(GLOBAL);
-            String userSpaceUri = virtualResolve(USER);
-
-            Map<String, DataSpacesFileObject> filesToCopy =
-                    createFolderHierarchySequentially(
-                            inputSpaceUri, inputSpaceFiles,
-                            outputSpaceUri, outputSpaceFiles,
-                            globalSpaceUri, globalSpaceFiles,
-                            userSpaceUri, userSpaceFiles);
-
-            List<Future<Boolean>> transferFutures =
-                    doCopyInputDataToScratchSpace(filesToCopy);
-
-            handleResults(transferFutures);
         } finally {
             // display dataspaces error and warns if any
             displayDataspacesStatus();
         }
     }
 
-    private Map<String, DataSpacesFileObject> createFolderHierarchySequentially(String inputSpaceUri,
-            ArrayList<DataSpacesFileObject> inputSpaceFiles, String outputSpaceUri,
-            ArrayList<DataSpacesFileObject> outputSpaceFiles, String globalSpaceUri,
-            ArrayList<DataSpacesFileObject> globalSpaceFiles, String userSpaceUri,
-            ArrayList<DataSpacesFileObject> userSpaceFiles) throws FileSystemException {
+    private Map<String, DataSpacesFileObject> createFolderHierarchySequentially(DataSpacesFileObject space, String inputSpaceUri,
+                                                                                ArrayList<DataSpacesFileObject> inputSpaceFiles,
+                                                                                String outputSpaceUri, ArrayList<DataSpacesFileObject> outputSpaceFiles,
+                                                                                String globalSpaceUri, ArrayList<DataSpacesFileObject> globalSpaceFiles,
+                                                                                String userSpaceUri, ArrayList<DataSpacesFileObject> userSpaceFiles) throws FileSystemException {
 
         // This map will contain the files that have to be copied.
         Map<String, DataSpacesFileObject> result =
@@ -416,10 +473,10 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         // of the spaces when the previous situation occurs:
         // output, input, user and global space
         // Precedence is given to the more specific files
-        createFolderHierarchySequentially(SCRATCH, globalSpaceUri, globalSpaceFiles, result);
-        createFolderHierarchySequentially(SCRATCH, userSpaceUri, userSpaceFiles, result);
-        createFolderHierarchySequentially(SCRATCH, inputSpaceUri, inputSpaceFiles, result);
-        createFolderHierarchySequentially(SCRATCH, outputSpaceUri, outputSpaceFiles, result);
+        createFolderHierarchySequentially(space, globalSpaceUri, globalSpaceFiles, result);
+        createFolderHierarchySequentially(space, userSpaceUri, userSpaceFiles, result);
+        createFolderHierarchySequentially(space, inputSpaceUri, inputSpaceFiles, result);
+        createFolderHierarchySequentially(space, outputSpaceUri, outputSpaceFiles, result);
 
         return result;
     }
@@ -482,18 +539,21 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             if (isDebugEnabled) {
                 logger.debug("Creating folder " + target.getRealURI());
             }
+            if (!target.exists()) {
+                target.createFolder();
+                setFolderRightsForRunAsUserMode(target);
+            }
 
-            target.createFolder();
-            setFolderRightsForRunAsUserMode(target);
         } else if (FileType.FILE.equals(fileObjectType)) {
             DataSpacesFileObject parent = target.getParent();
 
             if (isDebugEnabled) {
                 logger.debug("Creating folder " + parent.getRealURI());
             }
-
-            parent.createFolder();
-            setFolderRightsForRunAsUserMode(parent);
+            if (!parent.exists()) {
+                parent.createFolder();
+                setFolderRightsForRunAsUserMode(parent);
+            }
         }
     }
 
@@ -572,9 +632,11 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         }
     }
 
-    private FileSystemException findFilesToCopyFromInputToScratch(List<InputSelector> inputSelectors,
-            ArrayList<DataSpacesFileObject> inResults, ArrayList<DataSpacesFileObject> outResults,
-            ArrayList<DataSpacesFileObject> globResults, ArrayList<DataSpacesFileObject> userResults) {
+    private FileSystemException findFilesToCopyFromInput(List<InputSelector> inputSelectors,
+                                                         ArrayList<DataSpacesFileObject> inResults, ArrayList<DataSpacesFileObject> outResults,
+                                                         ArrayList<DataSpacesFileObject> globResults, ArrayList<DataSpacesFileObject> userResults,
+                                                         ArrayList<DataSpacesFileObject> inResultsCache, ArrayList<DataSpacesFileObject> outResultsCache,
+                                                         ArrayList<DataSpacesFileObject> globResultsCache, ArrayList<DataSpacesFileObject> userResultsCache) {
 
         FileSystemException toBeThrown = null;
 
@@ -589,19 +651,35 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             switch (is.getMode()) {
                 case TransferFromInputSpace:
                     toBeThrown =
-                            findFilesToCopyFromInputToScratch(INPUT, "INPUT", is, selector, inResults);
+                            findFilesToCopyFromInput(INPUT, "INPUT", is, selector, inResults);
                     break;
                 case TransferFromOutputSpace:
                     toBeThrown =
-                            findFilesToCopyFromInputToScratch(OUTPUT, "OUTPUT", is, selector, outResults);
+                            findFilesToCopyFromInput(OUTPUT, "OUTPUT", is, selector, outResults);
                     break;
                 case TransferFromGlobalSpace:
                     toBeThrown =
-                            findFilesToCopyFromInputToScratch(GLOBAL, "GLOBAL", is, selector, globResults);
+                            findFilesToCopyFromInput(GLOBAL, "GLOBAL", is, selector, globResults);
                     break;
                 case TransferFromUserSpace:
                     toBeThrown =
-                            findFilesToCopyFromInputToScratch(USER, "USER", is, selector, userResults);
+                            findFilesToCopyFromInput(USER, "USER", is, selector, userResults);
+                    break;
+                case CacheFromInputSpace:
+                    toBeThrown =
+                            findFilesToCopyFromInput(INPUT, "INPUT", is, selector, inResultsCache);
+                    break;
+                case CacheFromOutputSpace:
+                    toBeThrown =
+                            findFilesToCopyFromInput(OUTPUT, "OUTPUT", is, selector, outResultsCache);
+                    break;
+                case CacheFromGlobalSpace:
+                    toBeThrown =
+                            findFilesToCopyFromInput(GLOBAL, "GLOBAL", is, selector, globResultsCache);
+                    break;
+                case CacheFromUserSpace:
+                    toBeThrown =
+                            findFilesToCopyFromInput(USER, "USER", is, selector, userResultsCache);
                 case none:
                     //do nothing
                     break;
@@ -611,13 +689,13 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         return toBeThrown;
     }
 
-    private List<Future<Boolean>> doCopyInputDataToScratchSpace(
-            Map<String, DataSpacesFileObject> filesToCopy) {
+    private List<Future<Boolean>> doCopyInputDataToSpace(
+            DataSpacesFileObject space, Map<String, DataSpacesFileObject> filesToCopy) {
 
         List<Future<Boolean>> transferFutures = new ArrayList<>(filesToCopy.size());
 
         for (Map.Entry<String, DataSpacesFileObject> entry : filesToCopy.entrySet()) {
-            transferFutures.add(parallelFileCopy(entry.getValue(), SCRATCH, entry.getKey(), true));
+            transferFutures.add(parallelFileCopy(entry.getValue(), space, entry.getKey(), true));
         }
 
         return transferFutures;
@@ -634,16 +712,27 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         return executorTransfer.submit(new Callable<Boolean>() {
             @Override
             public Boolean call() throws FileSystemException {
-                logger.info("Copying " + source.getRealURI() + " to "
-                        + destinationBase.getRealURI() + "/" + destinationRelativeToBase);
+
 
                 DataSpacesFileObject target = destinationBase.resolveFile(destinationRelativeToBase);
-                target.copyFrom(source, FileSelector.SELECT_SELF);
+                if (!target.exists()) {
+                    logger.info("Copying " + source.getRealURI() + " to "
+                            + destinationBase.getRealURI() + "/" + destinationRelativeToBase);
+                    target.copyFrom(source, FileSelector.SELECT_SELF);
+                } else if (source.getContent().getLastModifiedTime() > target.getContent().getLastModifiedTime()) {
+                    logger.info("Copying " + source.getRealURI() + " to "
+                            + destinationBase.getRealURI() + "/" + destinationRelativeToBase + " (newer version)");
+                    target.copyFrom(source, FileSelector.SELECT_SELF);
+                } else {
+                    logger.info("Destination file " + target.getRealURI() + " is already present and newer.");
+                }
+
+                target.refresh();
 
                 if (!target.exists()) {
                     String message =
                             "There was a problem during the copy of " + source.getRealURI() +
-                                    " to " + target.getRealURI() + "/" + destinationRelativeToBase +
+                                    " to " + target.getRealURI() +
                                     ". File not present after copy.";
                     logger.error(message);
                     logDataspacesStatus(message, DataspacesStatusLevel.ERROR);
@@ -657,7 +746,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         });
     }
 
-    private FileSystemException findFilesToCopyFromInputToScratch(
+    private FileSystemException findFilesToCopyFromInput(
             DataSpacesFileObject space, String spaceName, InputSelector inputSelector,
             org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector selector,
             List<DataSpacesFileObject> results) {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
@@ -34,18 +34,8 @@
  */
 package org.ow2.proactive.scheduler.task.executors;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.Serializable;
-import java.io.Writer;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
+import com.google.common.base.Stopwatch;
+import org.apache.commons.io.FileUtils;
 import org.ow2.proactive.scheduler.common.task.flow.FlowAction;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
@@ -60,8 +50,11 @@ import org.ow2.proactive.scripting.ScriptHandler;
 import org.ow2.proactive.scripting.ScriptLoader;
 import org.ow2.proactive.scripting.ScriptResult;
 import org.ow2.proactive.utils.PAProperties;
-import com.google.common.base.Stopwatch;
-import org.apache.commons.io.FileUtils;
+
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -93,10 +86,10 @@ public class InProcessTaskExecutor implements TaskExecutor {
             return "";
         } else {
             File directory;
-            if (taskContext.getScratchURI() == null || taskContext.getScratchURI().isEmpty()) {
+            if (taskContext.getNodeDataSpaceURIs().getScratchURI() == null || taskContext.getNodeDataSpaceURIs().getScratchURI().isEmpty()) {
                 directory = new File(".");
             } else {
-                directory = new File(taskContext.getScratchURI());
+                directory = new File(taskContext.getNodeDataSpaceURIs().getScratchURI());
             }
             File nodesFile = File.createTempFile(NODES_FILE_DIRECTORY_NAME, null, directory);
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
@@ -78,6 +78,7 @@ public class ForkedTaskVariablesManager implements Serializable {
         scriptHandler.addBinding(TaskScript.CREDENTIALS_VARIABLE, thirdPartyCredentials);
 
         scriptHandler.addBinding(SchedulerConstants.DS_SCRATCH_BINDING_NAME, taskContext.getScratchURI());
+        scriptHandler.addBinding(SchedulerConstants.DS_CACHE_BINDING_NAME, taskContext.getCacheURI());
         scriptHandler.addBinding(SchedulerConstants.DS_INPUT_BINDING_NAME, taskContext.getInputURI());
         scriptHandler.addBinding(SchedulerConstants.DS_OUTPUT_BINDING_NAME, taskContext.getOutputURI());
         scriptHandler.addBinding(SchedulerConstants.DS_GLOBAL_BINDING_NAME, taskContext.getGlobalURI());

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
@@ -77,12 +77,12 @@ public class ForkedTaskVariablesManager implements Serializable {
 
         scriptHandler.addBinding(TaskScript.CREDENTIALS_VARIABLE, thirdPartyCredentials);
 
-        scriptHandler.addBinding(SchedulerConstants.DS_SCRATCH_BINDING_NAME, taskContext.getScratchURI());
-        scriptHandler.addBinding(SchedulerConstants.DS_CACHE_BINDING_NAME, taskContext.getCacheURI());
-        scriptHandler.addBinding(SchedulerConstants.DS_INPUT_BINDING_NAME, taskContext.getInputURI());
-        scriptHandler.addBinding(SchedulerConstants.DS_OUTPUT_BINDING_NAME, taskContext.getOutputURI());
-        scriptHandler.addBinding(SchedulerConstants.DS_GLOBAL_BINDING_NAME, taskContext.getGlobalURI());
-        scriptHandler.addBinding(SchedulerConstants.DS_USER_BINDING_NAME, taskContext.getUserURI());
+        scriptHandler.addBinding(SchedulerConstants.DS_SCRATCH_BINDING_NAME, taskContext.getNodeDataSpaceURIs().getScratchURI());
+        scriptHandler.addBinding(SchedulerConstants.DS_CACHE_BINDING_NAME, taskContext.getNodeDataSpaceURIs().getCacheURI());
+        scriptHandler.addBinding(SchedulerConstants.DS_INPUT_BINDING_NAME, taskContext.getNodeDataSpaceURIs().getInputURI());
+        scriptHandler.addBinding(SchedulerConstants.DS_OUTPUT_BINDING_NAME, taskContext.getNodeDataSpaceURIs().getOutputURI());
+        scriptHandler.addBinding(SchedulerConstants.DS_GLOBAL_BINDING_NAME, taskContext.getNodeDataSpaceURIs().getGlobalURI());
+        scriptHandler.addBinding(SchedulerConstants.DS_USER_BINDING_NAME, taskContext.getNodeDataSpaceURIs().getUserURI());
 
         scriptHandler.addBinding(SchedulerConstants.MULTI_NODE_TASK_NODESURL_BINDING_NAME, taskContext.getOtherNodesURLs());
 

--- a/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorRunAsMeTest.java
+++ b/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorRunAsMeTest.java
@@ -53,7 +53,7 @@ public class ForkedTaskExecutorRunAsMeTest {
 
         container.setRunAsUser(true);
 
-        TaskContext taskContext = new TaskContext(container, initializer, null, "", "", "", "", "", "", "",
+        TaskContext taskContext = new TaskContext(container, initializer, null, "", "", "", "", "", "", "", "",
                 decrypter);
         TaskResultImpl result = taskExecutor.execute(taskContext, taskOutput.outputStream, taskOutput.error);
 

--- a/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorRunAsMeTest.java
+++ b/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorRunAsMeTest.java
@@ -12,6 +12,7 @@ import org.ow2.proactive.scheduler.task.TaskLauncherInitializer;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.TestTaskOutput;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.executors.ForkedTaskExecutor;
 import org.ow2.proactive.scheduler.task.utils.Decrypter;
@@ -53,7 +54,7 @@ public class ForkedTaskExecutorRunAsMeTest {
 
         container.setRunAsUser(true);
 
-        TaskContext taskContext = new TaskContext(container, initializer, null, "", "", "", "", "", "", "", "",
+        TaskContext taskContext = new TaskContext(container, initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", "",
                 decrypter);
         TaskResultImpl result = taskExecutor.execute(taskContext, taskOutput.outputStream, taskOutput.error);
 

--- a/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorTest.java
+++ b/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorTest.java
@@ -15,6 +15,7 @@ import org.ow2.proactive.scheduler.task.TaskLauncherInitializer;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.TestTaskOutput;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.executors.ForkedTaskExecutor;
 import org.ow2.proactive.scheduler.task.utils.Decrypter;
@@ -55,8 +56,8 @@ public class ForkedTaskExecutorTest {
                                                 new SimpleScript(
                                                         "result=System.getProperty('"
                                                                 + PASchedulerProperties.TASK_FORK.getKey() + "')"
-                                                        , "groovy"))), initializer, null, "", "", "", "", "", "",
-                                "", ""),
+                                                        , "groovy"))), initializer, null,
+                                new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""),
                         taskOutput.outputStream, taskOutput.error);
 
         Assert.assertEquals("true", result.value());
@@ -73,7 +74,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript("print('hello'); variables.put('var','foo'); result='hello'",
-                                "javascript"))), initializer, null, "", "", "", "", "", "", "", ""),
+                                "javascript"))), initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("hello%n"), taskOutput.output());
@@ -93,7 +94,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript("print('hello'); result='hello'", "javascript"))),
-                        initializer, null, "", "", "", "", "", "", "", ""),
+                        initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertNotNull(result.getException());
@@ -111,7 +112,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript("print('hello'); result='hello'", "javascript"))),
-                        initializer, null, "", "", "", "", "", "", "", ""),
+                        initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertNotNull(result.getException());
@@ -133,7 +134,7 @@ public class ForkedTaskExecutorTest {
 
         container.setRunAsUser(true);
 
-        TaskContext taskContext = new TaskContext(container, initializer, null, "", "", "", "", "", "", "", "",
+        TaskContext taskContext = new TaskContext(container, initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", "",
                 decrypter);
 
         TaskResultImpl result = taskExecutor.execute(taskContext, taskOutput.outputStream, taskOutput.error);
@@ -164,7 +165,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript(taskScript, "groovy"))),
-                        initializer, null, "", "", "", "", "", "", "", ""),
+                        initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""),
                 taskOutput.outputStream,
                 taskOutput.error);
 
@@ -189,8 +190,8 @@ public class ForkedTaskExecutorTest {
 
         taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(new TaskScript(new SimpleScript(
                         "println System.getenv('envVar'); " + "println System.getProperty('jvmArg'); " +
-                                "println new File('.').getCanonicalPath()", "groovy"))), initializer, null, "", "",
-                        "", "", "", "", "", ""), taskOutput.outputStream,
+                                "println new File('.').getCanonicalPath()", "groovy"))), initializer, null,
+                        new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals(String.format("envValue%njvmValue%n%s%n", new File(workingDir, ".").getCanonicalPath()),
@@ -216,8 +217,8 @@ public class ForkedTaskExecutorTest {
 
         taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(new TaskScript(new SimpleScript(
                         "println System.getenv('envVar'); " + "println System.getProperty('jvmArg'); "
-                                + "println new File('.').getCanonicalPath()", "groovy"))), initializer, null, "", "",
-                        "", "", "", "", "", ""),
+                                + "println new File('.').getCanonicalPath()", "groovy"))), initializer, null,
+                        new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("aValue%naValue%n%s%n", new File(workingDir, ".").getCanonicalPath()),
@@ -240,7 +241,7 @@ public class ForkedTaskExecutorTest {
         initializer.setForkEnvironment(forkEnvironment);
 
         TaskResultImpl taskResult = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
-                        new TaskScript(new SimpleScript("", "groovy"))), initializer, null, "", "", "", "", "", "", "",
+                        new TaskScript(new SimpleScript("", "groovy"))), initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "",
                         ""), taskOutput.outputStream,
                 taskOutput.error);
 

--- a/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorTest.java
+++ b/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorTest.java
@@ -55,7 +55,7 @@ public class ForkedTaskExecutorTest {
                                                 new SimpleScript(
                                                         "result=System.getProperty('"
                                                                 + PASchedulerProperties.TASK_FORK.getKey() + "')"
-                                                        , "groovy"))), initializer, null, "", "", "", "", "",
+                                                        , "groovy"))), initializer, null, "", "", "", "", "", "",
                                 "", ""),
                         taskOutput.outputStream, taskOutput.error);
 
@@ -73,7 +73,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript("print('hello'); variables.put('var','foo'); result='hello'",
-                                "javascript"))), initializer, null, "", "", "", "", "", "", ""),
+                                "javascript"))), initializer, null, "", "", "", "", "", "", "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("hello%n"), taskOutput.output());
@@ -93,7 +93,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript("print('hello'); result='hello'", "javascript"))),
-                        initializer, null, "", "", "", "", "", "", ""),
+                        initializer, null, "", "", "", "", "", "", "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertNotNull(result.getException());
@@ -111,7 +111,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript("print('hello'); result='hello'", "javascript"))),
-                        initializer, null, "", "", "", "", "", "", ""),
+                        initializer, null, "", "", "", "", "", "", "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertNotNull(result.getException());
@@ -133,7 +133,7 @@ public class ForkedTaskExecutorTest {
 
         container.setRunAsUser(true);
 
-        TaskContext taskContext = new TaskContext(container, initializer, null, "", "", "", "", "", "", "",
+        TaskContext taskContext = new TaskContext(container, initializer, null, "", "", "", "", "", "", "", "",
                 decrypter);
 
         TaskResultImpl result = taskExecutor.execute(taskContext, taskOutput.outputStream, taskOutput.error);
@@ -164,7 +164,7 @@ public class ForkedTaskExecutorTest {
 
         TaskResultImpl result = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
                         new TaskScript(new SimpleScript(taskScript, "groovy"))),
-                        initializer, null, "", "", "", "", "", "", ""),
+                        initializer, null, "", "", "", "", "", "", "", ""),
                 taskOutput.outputStream,
                 taskOutput.error);
 
@@ -190,7 +190,7 @@ public class ForkedTaskExecutorTest {
         taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(new TaskScript(new SimpleScript(
                         "println System.getenv('envVar'); " + "println System.getProperty('jvmArg'); " +
                                 "println new File('.').getCanonicalPath()", "groovy"))), initializer, null, "", "",
-                        "", "", "", "", ""), taskOutput.outputStream,
+                        "", "", "", "", "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals(String.format("envValue%njvmValue%n%s%n", new File(workingDir, ".").getCanonicalPath()),
@@ -217,7 +217,7 @@ public class ForkedTaskExecutorTest {
         taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(new TaskScript(new SimpleScript(
                         "println System.getenv('envVar'); " + "println System.getProperty('jvmArg'); "
                                 + "println new File('.').getCanonicalPath()", "groovy"))), initializer, null, "", "",
-                        "", "", "", "", ""),
+                        "", "", "", "", "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("aValue%naValue%n%s%n", new File(workingDir, ".").getCanonicalPath()),
@@ -240,7 +240,7 @@ public class ForkedTaskExecutorTest {
         initializer.setForkEnvironment(forkEnvironment);
 
         TaskResultImpl taskResult = taskExecutor.execute(new TaskContext(new ScriptExecutableContainer(
-                        new TaskScript(new SimpleScript("", "groovy"))), initializer, null, "", "", "", "", "", "",
+                        new TaskScript(new SimpleScript("", "groovy"))), initializer, null, "", "", "", "", "", "", "",
                         ""), taskOutput.outputStream,
                 taskOutput.error);
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
@@ -14,6 +14,7 @@ import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.executors.InProcessTaskExecutor;
 import org.ow2.proactive.scheduler.task.utils.Decrypter;
@@ -56,7 +57,7 @@ public class InProcessTaskExecutorTest {
                 new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("println('hello'); java.lang.Thread.sleep(5); result='hello'",
                                 "groovy"))),
-                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("pre%nhello%npost%n"), taskOutput.output());
         assertEquals("hello", result.value());
@@ -76,7 +77,7 @@ public class InProcessTaskExecutorTest {
         new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("print variables.get('PA_USER')", "python"))),
-                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(jobOwner, taskOutput.output().trim());
     }
@@ -91,7 +92,7 @@ public class InProcessTaskExecutorTest {
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("dsfsdfsdf", "groovy"))),
-                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertTrue(result.hadException());
         assertFalse(taskOutput.error().isEmpty());
@@ -112,7 +113,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(new SimpleScript(printEnvVariables, "groovy"))),
-                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         String[] lines = taskOutput.output().split("\\n");
         assertEquals("job@1000@task@42", lines[0]);
@@ -132,7 +133,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(new SimpleScript(script, "groovy"))),
-                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(42, result.value());
     }
@@ -152,7 +153,7 @@ public class InProcessTaskExecutorTest {
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
                                 "print(variables.get('var')); variables.put('var', 'task')", "groovy"))), initializer,
-                        null, "", "", "", "", "", "", "", ""),
+                        null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertEquals("valuepretask", taskOutput.output());
@@ -177,7 +178,7 @@ public class InProcessTaskExecutorTest {
         new InProcessTaskExecutor().execute(new TaskContext(new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("print(variables.get('var'));print(variables.get('PA_TASK_ID'))",
                                 "groovy"))),
-                        initializer, previousTasksResults, "", "", "", "", "", "", "", ""), taskOutput.outputStream,
+                        initializer, previousTasksResults, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
 
@@ -195,7 +196,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(new TaskContext(new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript("print(results[0]);", "groovy"))), initializer,
-                previousTasksResults, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                previousTasksResults, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals("aresult", taskOutput.output());
     }
@@ -209,7 +210,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(new SimpleScript("return 10/0", "groovy"))),
-                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals("", taskOutput.output());
         assertNotEquals("", taskOutput.error());
@@ -226,8 +227,8 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
-                        "", ""), taskOutput.outputStream,
+                                "print('hello'); result='hello'", "groovy"))), initializer, null,
+                        new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals("", taskOutput.output());
@@ -245,8 +246,8 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
-                        "", ""), taskOutput.outputStream,
+                                "print('hello'); result='hello'", "groovy"))), initializer, null,
+                        new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals("hello", taskOutput.output());
@@ -265,8 +266,8 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
-                        "", ""), taskOutput.outputStream,
+                                "print('hello'); result='hello'", "groovy"))), initializer, null,
+                        new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals(FlowActionType.REPLICATE, result.getAction().getType());
@@ -283,8 +284,8 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
-                        "", ""), taskOutput.outputStream,
+                                "print('hello'); result='hello'", "groovy"))), initializer, null,
+                        new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals("hello", taskOutput.output());
@@ -304,7 +305,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(
                 new TaskContext(new ScriptExecutableContainer(new TaskScript(new SimpleScript("", "groovy"))),
-                        initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream,
+                        initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals("Hello", taskOutput.output());
@@ -325,7 +326,7 @@ public class InProcessTaskExecutorTest {
         Decrypter decrypter = createCredentials("somebody_that_does_not_exists");
         TaskContext taskContext = new TaskContext(new ScriptExecutableContainer(new TaskScript(
                 new SimpleScript(printArgs, "groovy", new Serializable[] { "$credentials_PASSWORD",
-                        "${PA_JOB_ID}"}))), initializer, null, "", "", "", "", "", "", "", "", decrypter);
+                        "${PA_JOB_ID}"}))), initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", "", decrypter);
         new InProcessTaskExecutor().execute(taskContext, taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("p4ssw0rd1000%np4ssw0rd1000%np4ssw0rd1000%n"),
@@ -341,7 +342,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(new TaskContext(new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript("print(variables.get('PA_SCHEDULER_HOME'))", "groovy"))),
-                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, new NodeDataSpacesURIs("", "", "", "", "", ""), "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(ClasspathUtils.findSchedulerHome(), taskOutput.output());
     }
@@ -358,8 +359,8 @@ public class InProcessTaskExecutorTest {
                         new SimpleScript("print new File(variables.get('PA_NODESFILE')).text", "groovy")));
         printNodesFileTask.setNodes(mockedNodeSet());
 
-        TaskContext context = new TaskContext(printNodesFileTask, initializer, null, tmpFolder.newFolder()
-                .getAbsolutePath(), "", "", "", "", "", "", "thisHost");
+        TaskContext context = new TaskContext(printNodesFileTask, initializer, null, new NodeDataSpacesURIs(tmpFolder.newFolder()
+                .getAbsolutePath(), "", "", "", "", ""), "", "thisHost");
         TaskResultImpl taskResult = new InProcessTaskExecutor().execute(context, taskOutput.outputStream,
                 taskOutput.error);
 
@@ -379,7 +380,7 @@ public class InProcessTaskExecutorTest {
         printNodesFileTask.setNodes(mockedNodeSet());
 
         TaskContext context = new TaskContext(printNodesFileTask, initializer, null,
-                tmpFolder.newFolder().getAbsolutePath(), "", "", "", "", "", "", "thisHost");
+                new NodeDataSpacesURIs(tmpFolder.newFolder().getAbsolutePath(), "", "", "", "", ""), "", "thisHost");
         TaskResultImpl taskResult = new InProcessTaskExecutor().execute(context, taskOutput.outputStream,
                 taskOutput.error);
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
@@ -1,15 +1,8 @@
 package org.ow2.proactive.scheduler.task;
 
-import java.io.Serializable;
-import java.security.KeyException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.objectweb.proactive.core.node.NodeImpl;
 import org.objectweb.proactive.core.runtime.ProActiveRuntime;
 import org.objectweb.proactive.core.runtime.VMInformation;
@@ -28,15 +21,18 @@ import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
 import org.ow2.proactive.utils.ClasspathUtils;
 import org.ow2.proactive.utils.NodeSet;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.io.Serializable;
+import java.security.KeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.ow2.proactive.scheduler.task.TaskAssertions.assertTaskResultOk;
@@ -60,7 +56,7 @@ public class InProcessTaskExecutorTest {
                 new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("println('hello'); java.lang.Thread.sleep(5); result='hello'",
                                 "groovy"))),
-                initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("pre%nhello%npost%n"), taskOutput.output());
         assertEquals("hello", result.value());
@@ -80,7 +76,7 @@ public class InProcessTaskExecutorTest {
         new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("print variables.get('PA_USER')", "python"))),
-                initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(jobOwner, taskOutput.output().trim());
     }
@@ -95,7 +91,7 @@ public class InProcessTaskExecutorTest {
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("dsfsdfsdf", "groovy"))),
-                initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertTrue(result.hadException());
         assertFalse(taskOutput.error().isEmpty());
@@ -116,7 +112,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(new SimpleScript(printEnvVariables, "groovy"))),
-                initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         String[] lines = taskOutput.output().split("\\n");
         assertEquals("job@1000@task@42", lines[0]);
@@ -136,7 +132,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(new SimpleScript(script, "groovy"))),
-                initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(42, result.value());
     }
@@ -156,7 +152,7 @@ public class InProcessTaskExecutorTest {
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
                                 "print(variables.get('var')); variables.put('var', 'task')", "groovy"))), initializer,
-                        null, "", "", "", "", "", "", ""),
+                        null, "", "", "", "", "", "", "", ""),
                 taskOutput.outputStream, taskOutput.error);
 
         assertEquals("valuepretask", taskOutput.output());
@@ -181,7 +177,7 @@ public class InProcessTaskExecutorTest {
         new InProcessTaskExecutor().execute(new TaskContext(new ScriptExecutableContainer(new TaskScript(
                         new SimpleScript("print(variables.get('var'));print(variables.get('PA_TASK_ID'))",
                                 "groovy"))),
-                        initializer, previousTasksResults, "", "", "", "", "", "", ""), taskOutput.outputStream,
+                        initializer, previousTasksResults, "", "", "", "", "", "", "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
 
@@ -199,7 +195,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(new TaskContext(new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript("print(results[0]);", "groovy"))), initializer,
-                previousTasksResults, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                previousTasksResults, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals("aresult", taskOutput.output());
     }
@@ -213,7 +209,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                 new ScriptExecutableContainer(new TaskScript(new SimpleScript("return 10/0", "groovy"))),
-                initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals("", taskOutput.output());
         assertNotEquals("", taskOutput.error());
@@ -230,7 +226,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "",
+                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
                         "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
@@ -249,7 +245,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "",
+                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
                         "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
@@ -269,7 +265,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "",
+                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
                         "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
@@ -287,7 +283,7 @@ public class InProcessTaskExecutorTest {
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(
-                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "",
+                                "print('hello'); result='hello'", "groovy"))), initializer, null, "", "", "", "", "", "",
                         "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
@@ -308,7 +304,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(
                 new TaskContext(new ScriptExecutableContainer(new TaskScript(new SimpleScript("", "groovy"))),
-                        initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream,
+                        initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream,
                 taskOutput.error);
 
         assertEquals("Hello", taskOutput.output());
@@ -329,7 +325,7 @@ public class InProcessTaskExecutorTest {
         Decrypter decrypter = createCredentials("somebody_that_does_not_exists");
         TaskContext taskContext = new TaskContext(new ScriptExecutableContainer(new TaskScript(
                 new SimpleScript(printArgs, "groovy", new Serializable[] { "$credentials_PASSWORD",
-                        "${PA_JOB_ID}" }))), initializer, null, "", "", "", "", "", "", "", decrypter);
+                        "${PA_JOB_ID}"}))), initializer, null, "", "", "", "", "", "", "", "", decrypter);
         new InProcessTaskExecutor().execute(taskContext, taskOutput.outputStream, taskOutput.error);
 
         assertEquals(String.format("p4ssw0rd1000%np4ssw0rd1000%np4ssw0rd1000%n"),
@@ -345,7 +341,7 @@ public class InProcessTaskExecutorTest {
 
         new InProcessTaskExecutor().execute(new TaskContext(new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript("print(variables.get('PA_SCHEDULER_HOME'))", "groovy"))),
-                initializer, null, "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
+                initializer, null, "", "", "", "", "", "", "", ""), taskOutput.outputStream, taskOutput.error);
 
         assertEquals(ClasspathUtils.findSchedulerHome(), taskOutput.output());
     }
@@ -363,7 +359,7 @@ public class InProcessTaskExecutorTest {
         printNodesFileTask.setNodes(mockedNodeSet());
 
         TaskContext context = new TaskContext(printNodesFileTask, initializer, null, tmpFolder.newFolder()
-                .getAbsolutePath(), "", "", "", "", "", "thisHost");
+                .getAbsolutePath(), "", "", "", "", "", "", "thisHost");
         TaskResultImpl taskResult = new InProcessTaskExecutor().execute(context, taskOutput.outputStream,
                 taskOutput.error);
 
@@ -383,7 +379,7 @@ public class InProcessTaskExecutorTest {
         printNodesFileTask.setNodes(mockedNodeSet());
 
         TaskContext context = new TaskContext(printNodesFileTask, initializer, null,
-                tmpFolder.newFolder().getAbsolutePath(), "", "", "", "", "", "thisHost");
+                tmpFolder.newFolder().getAbsolutePath(), "", "", "", "", "", "", "thisHost");
         TaskResultImpl taskResult = new InProcessTaskExecutor().execute(context, taskOutput.outputStream,
                 taskOutput.error);
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/SlowDataspacesTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/SlowDataspacesTaskLauncherFactory.java
@@ -53,6 +53,11 @@ public class SlowDataspacesTaskLauncherFactory extends ProActiveForkedTaskLaunch
         }
 
         @Override
+        public String getCacheURI() {
+            return null;
+        }
+
+        @Override
         public String getInputURI() {
             return null;
         }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskContextTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskContextTest.java
@@ -3,6 +3,7 @@ package org.ow2.proactive.scheduler.task;
 import org.objectweb.proactive.core.node.NodeException;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scripting.ForkEnvironmentScript;
 import org.ow2.proactive.scripting.InvalidScriptException;
@@ -42,13 +43,7 @@ public class TaskContextTest {
                                         new SimpleScript("", "python")))),
                 taskLauncherInitializer,
                 null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null,
                 null);
     }
 }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskContextTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskContextTest.java
@@ -50,6 +50,7 @@ public class TaskContextTest {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TestTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TestTaskLauncherFactory.java
@@ -1,12 +1,6 @@
 package org.ow2.proactive.scheduler.task;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Semaphore;
-
+import org.apache.commons.io.FileUtils;
 import org.objectweb.proactive.extensions.dataspaces.core.naming.NamingService;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
 import org.ow2.proactive.scheduler.common.task.TaskId;
@@ -16,7 +10,13 @@ import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.data.TaskDataspaces;
 import org.ow2.proactive.scheduler.task.executors.ForkedTaskExecutor;
 import org.ow2.proactive.scheduler.task.executors.TaskExecutor;
-import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
 
 public class TestTaskLauncherFactory extends ProActiveForkedTaskLauncherFactory {
     private Semaphore taskRunning;
@@ -61,6 +61,7 @@ public class TestTaskLauncherFactory extends ProActiveForkedTaskLauncherFactory 
     public static class TaskFileDataspaces implements TaskDataspaces {
 
         private final File scratchFolder;
+        private final File cacheFolder;
         private final File userspaceFolder;
         private final File globalspaceFolder;
         private final File inputspaceFolder;
@@ -72,6 +73,7 @@ public class TestTaskLauncherFactory extends ProActiveForkedTaskLauncherFactory 
 
         public TaskFileDataspaces(File rootFolder) {
             scratchFolder = createDataspaceFolder(rootFolder, "scratch");
+            cacheFolder = createDataspaceFolder(rootFolder, "cache");
             userspaceFolder = createDataspaceFolder(rootFolder, "userspace");
             globalspaceFolder = createDataspaceFolder(rootFolder, "globalspace");
             inputspaceFolder = createDataspaceFolder(rootFolder, "inputspace");
@@ -98,6 +100,11 @@ public class TestTaskLauncherFactory extends ProActiveForkedTaskLauncherFactory 
         @Override
         public String getScratchURI() {
             return scratchFolder.getAbsolutePath();
+        }
+
+        @Override
+        public String getCacheURI() {
+            return cacheFolder.getAbsolutePath();
         }
 
         @Override

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextSerializerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextSerializerTest.java
@@ -1,8 +1,7 @@
 package org.ow2.proactive.scheduler.task.context;
 
-import java.io.File;
-import java.io.IOException;
-
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
 import org.objectweb.proactive.core.node.NodeException;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.TaskIdImpl;
@@ -12,11 +11,12 @@ import org.ow2.proactive.scripting.ForkEnvironmentScript;
 import org.ow2.proactive.scripting.InvalidScriptException;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class TaskContextSerializerTest {
 
@@ -55,6 +55,7 @@ public class TaskContextSerializerTest {
                                 new ForkEnvironmentScript(
                                         new SimpleScript("", "python")))),
                 taskLauncherInitializer,
+                null,
                 null,
                 null,
                 null,

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextSerializerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextSerializerTest.java
@@ -54,13 +54,7 @@ public class TaskContextSerializerTest {
                                         new SimpleScript("", "python")))),
                 taskLauncherInitializer,
                 null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null,
                 null);
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
@@ -1,12 +1,8 @@
 package org.ow2.proactive.scheduler.task.context;
 
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.ow2.proactive.scheduler.common.task.SimpleTaskLogs;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.task.TaskId;
-import org.ow2.proactive.scheduler.common.task.TaskLogs;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.util.Object2ByteConverter;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
@@ -17,8 +13,10 @@ import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -58,7 +56,7 @@ public class TaskContextVariableExtractorTest {
         TaskResult[] taskResultArray = { taskResult };
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, taskResultArray,
-                null, null,
+                null, null, null,
                 null, null, null, null, null);
 
         new TaskContextVariableExtractor().extractTaskVariables(taskContext, (TaskResult) null);
@@ -90,7 +88,7 @@ public class TaskContextVariableExtractorTest {
         TaskResult[] taskResultArray = { taskResult };
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, taskResultArray,
-                null, null,
+                null, null, null,
                 null, null, null, null, null);
 
 
@@ -109,7 +107,7 @@ public class TaskContextVariableExtractorTest {
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
 
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
                 null, null, null, null, null);
 
         Map<String, byte[]> taskResultVariables = new HashMap<>();
@@ -135,7 +133,7 @@ public class TaskContextVariableExtractorTest {
                         "print('hello'); result='hello'", "javascript")));
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
                 null, null, null, null, null);
         Map<String, Serializable> contextVariables
                 = new TaskContextVariableExtractor().extractTaskVariables(taskContext, nodesfileContent);
@@ -158,7 +156,7 @@ public class TaskContextVariableExtractorTest {
                         "print('hello'); result='hello'", "javascript")));
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
                 null, null, null, null, null);
 
         Map<String, Serializable> contextVariables
@@ -182,7 +180,7 @@ public class TaskContextVariableExtractorTest {
         ScriptExecutableContainer scriptContainer = new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript(
                         "print('hello'); result='hello'", "javascript")));
-        TaskContext taskContext = new TaskContext(scriptContainer, createTaskLauncherInitializer(), null,
+        TaskContext taskContext = new TaskContext(scriptContainer, createTaskLauncherInitializer(), null, null,
                 null, null, null, null, null, null, null);
 
         Map<String, Serializable> contextVariables

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
@@ -4,9 +4,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.ow2.proactive.scheduler.common.task.SimpleTaskLogs;
 import org.ow2.proactive.scheduler.common.task.TaskId;
-import org.ow2.proactive.scheduler.common.task.TaskLogs;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.util.Object2ByteConverter;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
@@ -57,8 +55,7 @@ public class TaskContextVariableExtractorTest {
         TaskResult[] taskResultArray = { taskResult };
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, taskResultArray,
-                null, null, null,
-                null, null, null, null, null);
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
         new TaskContextVariableExtractor().extractTaskVariables(taskContext, (TaskResult) null);
 
@@ -89,8 +86,7 @@ public class TaskContextVariableExtractorTest {
         TaskResult[] taskResultArray = { taskResult };
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, taskResultArray,
-                null, null, null,
-                null, null, null, null, null);
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
 
         Map<String, Serializable> contextVariables
@@ -108,8 +104,8 @@ public class TaskContextVariableExtractorTest {
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
 
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
-                null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
         Map<String, byte[]> taskResultVariables = new HashMap<>();
 
@@ -134,8 +130,8 @@ public class TaskContextVariableExtractorTest {
                         "print('hello'); result='hello'", "javascript")));
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
-                null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
         Map<String, Serializable> contextVariables
                 = new TaskContextVariableExtractor().extractTaskVariables(taskContext, nodesfileContent);
 
@@ -157,8 +153,8 @@ public class TaskContextVariableExtractorTest {
                         "print('hello'); result='hello'", "javascript")));
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
-                null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
         Map<String, Serializable> contextVariables
                 = new TaskContextVariableExtractor().extractTaskVariables(taskContext);
@@ -180,8 +176,8 @@ public class TaskContextVariableExtractorTest {
         ScriptExecutableContainer scriptContainer = new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript(
                         "print('hello'); result='hello'", "javascript")));
-        TaskContext taskContext = new TaskContext(scriptContainer, createTaskLauncherInitializer(), null, null,
-                null, null, null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, createTaskLauncherInitializer(), null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
         Map<String, Serializable> contextVariables
                 = new TaskContextVariableExtractor().extractTaskVariables(taskContext);

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreatorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreatorTest.java
@@ -1,11 +1,9 @@
 package org.ow2.proactive.scheduler.task.executors;
 
-import java.io.PrintStream;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.extensions.processbuilder.OSProcessBuilder;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
@@ -22,10 +20,12 @@ import org.ow2.proactive.scripting.InvalidScriptException;
 import org.ow2.proactive.scripting.ScriptResult;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -153,7 +153,7 @@ public class ForkedProcessBuilderCreatorTest {
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariableAndForkEnvironment();
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
-                null, null, null, null, null);
+                null, null, null, null, null, null);
         return taskContext;
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreatorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreatorTest.java
@@ -12,6 +12,7 @@ import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.TaskLauncherInitializer;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.context.TaskContextVariableExtractor;
 import org.ow2.proactive.scheduler.task.executors.forked.env.ForkedJvmTaskExecutionCommandCreator;
@@ -152,8 +153,8 @@ public class ForkedProcessBuilderCreatorTest {
                         "print('hello'); result='hello'", "javascript")));
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariableAndForkEnvironment();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
-                null, null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
         return taskContext;
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreatorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreatorTest.java
@@ -1,11 +1,6 @@
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.Test;
 import org.objectweb.proactive.core.node.NodeException;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.TaskId;
@@ -19,7 +14,12 @@ import org.ow2.proactive.scripting.InvalidScriptException;
 import org.ow2.proactive.scripting.ScriptResult;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -171,7 +171,7 @@ public class ForkedJvmTaskExecutionCommandCreatorTest {
                         "print('hello'); result='hello'", "javascript")));
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariableAndForkEnvironment();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
                 null, null, null, null, null);
         return taskContext;
     }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreatorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreatorTest.java
@@ -8,6 +8,7 @@ import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.TaskLauncherInitializer;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.executors.forked.env.command.JavaPrefixCommandExtractor;
 import org.ow2.proactive.scripting.InvalidScriptException;
@@ -171,8 +172,8 @@ public class ForkedJvmTaskExecutionCommandCreatorTest {
                         "print('hello'); result='hello'", "javascript")));
         TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariableAndForkEnvironment();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
-                null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
         return taskContext;
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManagerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManagerTest.java
@@ -1,15 +1,6 @@
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
-import java.io.Serializable;
-import java.lang.reflect.Field;
-import java.security.KeyException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.junit.Test;
 import org.objectweb.proactive.core.node.NodeException;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
@@ -28,7 +19,16 @@ import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.scripting.ScriptHandler;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.junit.Test;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.security.KeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -124,7 +124,7 @@ public class ForkedTaskVariablesManagerTest {
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
-                testSetString, null,
+                testSetString, null, null,
                 null, null, null, null, null);
 
         // Expect taskResultArray to be inside the map
@@ -135,12 +135,29 @@ public class ForkedTaskVariablesManagerTest {
     }
 
     @Test
-    public void testAddBindingsToScriptHandlerContainsInputURI() throws InvalidScriptException, NodeException, NoSuchFieldException, IllegalAccessException {
+    public void testAddBindingsToScriptHandlerContainsCacheURI() throws InvalidScriptException, NodeException, NoSuchFieldException, IllegalAccessException {
         ScriptExecutableContainer scriptContainer = createScriptContainer();
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null,
+                testSetString, null, null,
+                null, null, null, null);
+
+        // Expect taskResultArray to be inside the map
+        validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
+                new HashMap<String, Serializable>(),
+                new HashMap<String, String>(), SchedulerConstants.DS_CACHE_BINDING_NAME,
+                testSetString);
+    }
+
+    @Test
+    public void testAddBindingsToScriptHandlerContainsInputURI() throws InvalidScriptException, NodeException, NoSuchFieldException, IllegalAccessException {
+        ScriptExecutableContainer scriptContainer = createScriptContainer();
+        TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
+        taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
+
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
                 testSetString,
                 null, null, null, null, null);
 
@@ -157,7 +174,7 @@ public class ForkedTaskVariablesManagerTest {
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
                 testSetString, null, null, null, null);
 
         // Expect taskResultArray to be inside the map
@@ -173,7 +190,7 @@ public class ForkedTaskVariablesManagerTest {
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
                 null, testSetString, null, null, null);
 
         // Expect taskResultArray to be inside the map
@@ -190,7 +207,7 @@ public class ForkedTaskVariablesManagerTest {
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
-                null, null, testSetString, null, null);
+                null, null, null, testSetString, null, null);
 
         // Expect taskResultArray to be inside the map
         validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
@@ -208,7 +225,7 @@ public class ForkedTaskVariablesManagerTest {
         Decrypter decrypter = createCredentials(testUser, testPass);
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
-                null, null, null, null, null, decrypter);
+                null, null, null, null, null, null, decrypter);
 
         ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();
         Map<String, String> creds = forkedTaskVariablesManager.extractThirdPartyCredentials(taskContext);
@@ -260,7 +277,7 @@ public class ForkedTaskVariablesManagerTest {
     public void testExtractThirdPartyCredentialsThrowsExceptionIfTaskLauncherInitializerIsNull() throws Exception {
         ScriptExecutableContainer scriptContainer = createScriptContainer();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, null, null, null, null,
+        TaskContext taskContext = new TaskContext(scriptContainer, null, null, null, null, null,
                 null, null, null, null, null);
 
         ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();
@@ -295,7 +312,7 @@ public class ForkedTaskVariablesManagerTest {
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer,
-                previousTasksResults, null, null,
+                previousTasksResults, null, null, null,
                 null, null, null, null, null);
         return taskContext;
     }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManagerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManagerTest.java
@@ -12,6 +12,7 @@ import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.TaskLauncherInitializer;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
+import org.ow2.proactive.scheduler.task.context.NodeDataSpacesURIs;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.utils.Decrypter;
 import org.ow2.proactive.scripting.InvalidScriptException;
@@ -124,8 +125,7 @@ public class ForkedTaskVariablesManagerTest {
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
-                testSetString, null, null,
-                null, null, null, null, null);
+                new NodeDataSpacesURIs(testSetString, null, null, null, null, null), null, null);
 
         // Expect taskResultArray to be inside the map
         validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
@@ -140,9 +140,8 @@ public class ForkedTaskVariablesManagerTest {
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null,
-                testSetString, null, null,
-                null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, testSetString, null, null, null, null), null, null);
 
         // Expect taskResultArray to be inside the map
         validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
@@ -157,9 +156,8 @@ public class ForkedTaskVariablesManagerTest {
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
-                testSetString,
-                null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, testSetString, null, null, null), null, null);
 
         // Expect taskResultArray to be inside the map
         validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
@@ -174,8 +172,8 @@ public class ForkedTaskVariablesManagerTest {
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
-                testSetString, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, testSetString, null, null), null, null);
 
         // Expect taskResultArray to be inside the map
         validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
@@ -190,8 +188,8 @@ public class ForkedTaskVariablesManagerTest {
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null, null,
-                null, testSetString, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, testSetString, null), null, null);
 
         // Expect taskResultArray to be inside the map
         validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
@@ -206,8 +204,8 @@ public class ForkedTaskVariablesManagerTest {
         TaskLauncherInitializer taskLauncherInitializer = new TaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
-                null, null, null, testSetString, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, testSetString), null, null);
 
         // Expect taskResultArray to be inside the map
         validateThatScriptHandlerBindingsContain(new ScriptHandler(), taskContext,
@@ -224,8 +222,8 @@ public class ForkedTaskVariablesManagerTest {
 
         Decrypter decrypter = createCredentials(testUser, testPass);
 
-        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null, null, null,
-                null, null, null, null, null, null, decrypter);
+        TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null, decrypter);
 
         ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();
         Map<String, String> creds = forkedTaskVariablesManager.extractThirdPartyCredentials(taskContext);
@@ -277,8 +275,8 @@ public class ForkedTaskVariablesManagerTest {
     public void testExtractThirdPartyCredentialsThrowsExceptionIfTaskLauncherInitializerIsNull() throws Exception {
         ScriptExecutableContainer scriptContainer = createScriptContainer();
 
-        TaskContext taskContext = new TaskContext(scriptContainer, null, null, null, null, null,
-                null, null, null, null, null);
+        TaskContext taskContext = new TaskContext(scriptContainer, null, null,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
         ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();
         forkedTaskVariablesManager.extractThirdPartyCredentials(taskContext);
@@ -312,8 +310,8 @@ public class ForkedTaskVariablesManagerTest {
         taskLauncherInitializer.setForkEnvironment(new ForkEnvironment());
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer,
-                previousTasksResults, null, null, null,
-                null, null, null, null, null);
+                previousTasksResults,
+                new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
         return taskContext;
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpace.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpace.java
@@ -1,0 +1,119 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package functionaltests.dataspaces;
+
+import functionaltests.utils.SchedulerFunctionalTestNoRestart;
+import org.junit.Assert;
+import org.junit.Test;
+import org.ow2.proactive.resourcemanager.nodesource.dataspace.DataSpaceNodeConfigurationAgent;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TestCacheSpace
+ * <p>
+ * tests that files are correctly transferred to the cache space.
+ * That transferred files remain for subsequent jobs, and that modified files are updated in the cache
+ *
+ * @author The ProActive Team
+ */
+public class TestCacheSpace extends SchedulerFunctionalTestNoRestart {
+    static URL jobDescriptor1 = TestCacheSpace.class
+            .getResource("/functionaltests/descriptors/Job_CacheSpace1.xml");
+
+    static String dataToCopyFileName = "dataToCopy";
+    static String dataToUpdateFileName = "dataToUpdate";
+
+    @Test
+    public void testSubmitJobWithTransferFilesToCacheSpace() throws Throwable {
+
+        String userURI = schedulerHelper.getSchedulerInterface().getUserSpaceURIs().get(0);
+        assertTrue(userURI.startsWith("file:"));
+        log("User URI is " + userURI);
+        String userPath = new File(new URI(userURI)).getAbsolutePath();
+
+        // create two files, one which will be copied once
+        File dataToCopyFile = createFileInUserSpace(userPath, dataToCopyFileName);
+        // and one which will be copied once, updated on the server, and which should be then updated in the cache
+        File dataToUpdateFile = createFileInUserSpace(userPath, dataToUpdateFileName);
+
+        // submit the job to transfer files.
+        schedulerHelper.testJobSubmission(new File(jobDescriptor1.toURI())
+                .getAbsolutePath());
+
+        File cacheFolder = new File(System.getProperty("java.io.tmpdir"), DataSpaceNodeConfigurationAgent.DEFAULT_CACHE_SUBFOLDER_NAME);
+
+        File transferredDataToCopyFile = new File(cacheFolder, dataToCopyFileName);
+        File transferredDataToUpdateFile = new File(cacheFolder, dataToUpdateFileName);
+
+        Assert.assertTrue("File " + dataToCopyFileName + " must be present in the cache after the job execution", transferredDataToCopyFile.exists());
+        Assert.assertTrue("File " + dataToUpdateFileName + " must be present in the cache after the job execution", transferredDataToUpdateFile.exists());
+
+        long lastCopyFileModificationTime = transferredDataToCopyFile.lastModified();
+        long lastUpdateFileModificationTime = transferredDataToUpdateFile.lastModified();
+
+        // change the file to update
+        dataToUpdateFile.delete();
+        dataToUpdateFile.createNewFile();
+
+        // submit the job a second time.
+        schedulerHelper.testJobSubmission(new File(jobDescriptor1.toURI())
+                .getAbsolutePath());
+
+        Assert.assertTrue("File " + dataToCopyFileName + " must be present in the cache after the job execution", transferredDataToCopyFile.exists());
+        Assert.assertTrue("File " + dataToUpdateFileName + " must be present in the cache after the job execution", transferredDataToUpdateFile.exists());
+
+        // verify file modification.
+        Assert.assertTrue("File " + dataToCopyFileName + " must be the same than the previous transfer", transferredDataToCopyFile.lastModified() == lastCopyFileModificationTime);
+        Assert.assertTrue("File " + dataToUpdateFileName + " must be newer than the previous transfer", transferredDataToUpdateFile.lastModified() > lastUpdateFileModificationTime);
+
+
+    }
+
+    private File createFileInUserSpace(String userPath, String dataToCopyFileName) throws IOException {
+        File dataToCopyFile = new File(userPath, dataToCopyFileName);
+        if (dataToCopyFile.exists()) {
+            dataToCopyFile.delete();
+        }
+        dataToCopyFile.createNewFile();
+        return dataToCopyFile;
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpaceCleaning.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpaceCleaning.java
@@ -70,7 +70,7 @@ public class TestCacheSpaceCleaning extends SchedulerFunctionalTestWithCustomCon
     static String dataToCopyFileName = "dataToCopy";
     static String dataToUpdateFileName = "dataToUpdate";
 
-    static int NB_WAIT_PERIOD = 2 * 60 * 2;
+    static int NB_WAIT_PERIOD = 5 * 60 * 2;
 
     @BeforeClass
     public static void startDedicatedScheduler() throws Exception {
@@ -79,8 +79,8 @@ public class TestCacheSpaceCleaning extends SchedulerFunctionalTestWithCustomCon
         schedulerHelper = new SchedulerTHelper(true, true);
         List<String> arguments = new ArrayList<>();
         arguments.addAll(RMTHelper.setup.getJvmParametersAsList());
-        arguments.add("-D" + DataSpaceNodeConfigurationAgent.NODE_DATASPACE_CACHE_CLEANING_PERIOD + "=" + 5000);
-        arguments.add("-D" + DataSpaceNodeConfigurationAgent.NODE_DATASPACE_CACHE_INVALIDATION_PERIOD + "=" + 20000);
+        arguments.add("-D" + DataSpaceNodeConfigurationAgent.NODE_DATASPACE_CACHE_CLEANING_PERIOD + "=" + 2000);
+        arguments.add("-D" + DataSpaceNodeConfigurationAgent.NODE_DATASPACE_CACHE_INVALIDATION_PERIOD + "=" + 30000);
         schedulerHelper.createNodeSource("CleaningNS", 5, arguments);
     }
 
@@ -120,7 +120,7 @@ public class TestCacheSpaceCleaning extends SchedulerFunctionalTestWithCustomCon
         // wait until the first file is deleted by the cleaning mechanism
         int nbWait = 0;
         while (transferredDataToCopyFile.exists() && nbWait < NB_WAIT_PERIOD) {
-            Thread.sleep(500);
+            Thread.sleep(200);
             nbWait++;
         }
         // ensure that the second file (modified at a later date), remains

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpaceCleaning.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpaceCleaning.java
@@ -1,0 +1,148 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package functionaltests.dataspaces;
+
+import functionaltests.utils.RMTHelper;
+import functionaltests.utils.SchedulerFunctionalTestWithCustomConfigAndRestart;
+import functionaltests.utils.SchedulerTHelper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.ow2.proactive.resourcemanager.RMFactory;
+import org.ow2.proactive.resourcemanager.nodesource.dataspace.DataSpaceNodeConfigurationAgent;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * TestCacheSpaceCleaning
+ * <p>
+ * This test ensures that the cleaning mechanism of the cache space functions properly.
+ * It starts an empty scheduler and add nodes with modified variables to reduce the cleaning and invalidation periods.
+ * It then execute tasks to transfer files to the cache, and checks that files are deleted by the cleaning mechanism.
+ *
+ * @author The ProActive Team
+ */
+public class TestCacheSpaceCleaning extends SchedulerFunctionalTestWithCustomConfigAndRestart {
+
+    static URL jobDescriptor1 = TestCacheSpaceCleaning.class
+            .getResource("/functionaltests/descriptors/Job_CacheSpace2.xml");
+
+    static String dataToCopyFileName = "dataToCopy";
+    static String dataToUpdateFileName = "dataToUpdate";
+
+    static int NB_WAIT_PERIOD = 2 * 60 * 2;
+
+    @BeforeClass
+    public static void startDedicatedScheduler() throws Exception {
+        RMFactory.setOsJavaProperty();
+        // start an empty scheduler and add a node source with modified properties
+        schedulerHelper = new SchedulerTHelper(true, true);
+        List<String> arguments = new ArrayList<>();
+        arguments.addAll(RMTHelper.setup.getJvmParametersAsList());
+        arguments.add("-D" + DataSpaceNodeConfigurationAgent.NODE_DATASPACE_CACHE_CLEANING_PERIOD + "=" + 5000);
+        arguments.add("-D" + DataSpaceNodeConfigurationAgent.NODE_DATASPACE_CACHE_INVALIDATION_PERIOD + "=" + 20000);
+        schedulerHelper.createNodeSource("CleaningNS", 5, arguments);
+    }
+
+    @Test
+    public void testCacheSpaceCleaning() throws Throwable {
+        String userURI = schedulerHelper.getSchedulerInterface().getUserSpaceURIs().get(0);
+        assertTrue(userURI.startsWith("file:"));
+        log("User URI is " + userURI);
+        String userPath = new File(new URI(userURI)).getAbsolutePath();
+
+        // create two files, one which will be copied once
+        File dataToCopyFile = createFileInUserSpace(userPath, dataToCopyFileName);
+        // and one which will be copied once, updated on the server, and which should be then updated in the cache
+        File dataToUpdateFile = createFileInUserSpace(userPath, dataToUpdateFileName);
+
+        // submit the first job to transfer files.
+        schedulerHelper.testJobSubmission(new File(jobDescriptor1.toURI())
+                .getAbsolutePath());
+
+        File cacheFolder = new File(System.getProperty("java.io.tmpdir"), DataSpaceNodeConfigurationAgent.DEFAULT_CACHE_SUBFOLDER_NAME);
+
+        File transferredDataToCopyFile = new File(cacheFolder, dataToCopyFileName);
+        File transferredDataToUpdateFile = new File(cacheFolder, dataToUpdateFileName);
+
+        // ensure that files are present in the cache
+        Assert.assertTrue("File " + dataToCopyFileName + " must be present in the cache after the job execution", transferredDataToCopyFile.exists());
+        Assert.assertTrue("File " + dataToUpdateFileName + " must be present in the cache after the job execution", transferredDataToUpdateFile.exists());
+
+        // change the file to update
+        dataToUpdateFile.delete();
+        dataToUpdateFile.createNewFile();
+
+        // submit the job a second time.
+        schedulerHelper.testJobSubmission(new File(jobDescriptor1.toURI())
+                .getAbsolutePath());
+
+        // wait until the first file is deleted by the cleaning mechanism
+        int nbWait = 0;
+        while (transferredDataToCopyFile.exists() && nbWait < NB_WAIT_PERIOD) {
+            Thread.sleep(500);
+            nbWait++;
+        }
+        // ensure that the second file (modified at a later date), remains
+        Assert.assertFalse("File " + dataToCopyFileName + " must be deleted in the cache by the cleaning mechanism", transferredDataToCopyFile.exists());
+        Assert.assertTrue("File " + dataToUpdateFileName + " must be present in the cache after the first file is removed", transferredDataToUpdateFile.exists());
+
+        // wait until the second file is deleted by the cleaning mechanism
+        nbWait = 0;
+        while (transferredDataToUpdateFile.exists() && nbWait < NB_WAIT_PERIOD) {
+            Thread.sleep(500);
+            nbWait++;
+        }
+        Assert.assertFalse("File " + dataToUpdateFileName + " must be deleted in the cache by the cleaning mechanism", transferredDataToUpdateFile.exists());
+
+    }
+
+    private File createFileInUserSpace(String userPath, String dataToCopyFileName) throws IOException {
+        File dataToCopyFile = new File(userPath, dataToCopyFileName);
+        if (dataToCopyFile.exists()) {
+            dataToCopyFile.delete();
+        }
+        dataToCopyFile.createNewFile();
+        return dataToCopyFile;
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobCoverage.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobCoverage.java
@@ -37,12 +37,17 @@
 package functionaltests.workflow;
 
 import functionaltests.job.error.TestJobAborted;
-import functionaltests.utils.SchedulerFunctionalTestNoRestart;
+import functionaltests.utils.SchedulerFunctionalTestWithRestart;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.objectweb.proactive.utils.StackTraceUtil;
-import org.ow2.proactive.scheduler.common.job.*;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobInfo;
+import org.ow2.proactive.scheduler.common.job.JobResult;
+import org.ow2.proactive.scheduler.common.job.JobState;
+import org.ow2.proactive.scheduler.common.job.JobStatus;
+import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.StaxJobFactory;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
@@ -86,7 +91,7 @@ import static org.junit.Assert.*;
  * @author The ProActive Team
  * @since ProActive Scheduling 1.0
  */
-public class TestJobCoverage extends SchedulerFunctionalTestNoRestart {
+public class TestJobCoverage extends SchedulerFunctionalTestWithRestart {
 
     private static URL jobDescriptor = TestJobAborted.class
             .getResource("/functionaltests/descriptors/Job_Coverage.xml");
@@ -108,28 +113,6 @@ public class TestJobCoverage extends SchedulerFunctionalTestNoRestart {
         TaskFlowJob job = (TaskFlowJob) StaxJobFactory.getFactory().createJob(
                 new File(jobDescriptor.toURI()).getAbsolutePath());
         JobId id = schedulerHelper.submitJob(job);
-
-        //waiting for job termination
-        log("Waiting for job to finish...");
-        jinfo = schedulerHelper.waitForEventJobFinished(id);
-
-        //checking results
-        log("Checking results...");
-        JobResult result = schedulerHelper.getJobResult(id);
-        assertEquals(8, result.getAllResults().size());
-        assertEquals(2, result.getPreciousResults().size());
-        assertNotNull(result.getPreciousResults().get("task1"));
-        assertNotNull(result.getPreciousResults().get("task6"));
-
-        assertEquals("Working", result.getPreciousResults().get("task1").value());
-        assertTrue(StackTraceUtil.getStackTrace(result.getResult("task2").getException()).contains(
-                "WorkingAt3rd - Status : Number is 1"));
-        assertTrue(result.getResult("task3").value().toString()
-                .contains("WorkingAt3rd - Status : OK / File deleted :"));
-        assertTrue(result.getResult("task4").getException().getCause().getMessage().contains("Throwing"));
-        assertTrue(result.getResult("task5").getException().getCause().getMessage().contains("Throwing"));
-        assertNotNull(result.getResult("task7").getException());
-        assertNotNull(result.getResult("task8").getException());
 
         //checking all processes
         log("Checking all received events :");
@@ -269,6 +252,28 @@ public class TestJobCoverage extends SchedulerFunctionalTestNoRestart {
         tinfo = schedulerHelper.waitForEventTaskFinished(id, "task8");
         jstate.update(tinfo);
         assertEquals(TaskStatus.FAULTY, tinfo.getStatus());
+
+        //waiting for job termination
+        log("Waiting for job to finish...");
+        jinfo = schedulerHelper.waitForEventJobFinished(id);
+
+        //checking results
+        log("Checking results...");
+        JobResult result = schedulerHelper.getJobResult(id);
+        assertEquals(8, result.getAllResults().size());
+        assertEquals(2, result.getPreciousResults().size());
+        assertNotNull(result.getPreciousResults().get("task1"));
+        assertNotNull(result.getPreciousResults().get("task6"));
+
+        assertEquals("Working", result.getPreciousResults().get("task1").value());
+        assertTrue(StackTraceUtil.getStackTrace(result.getResult("task2").getException()).contains(
+                "WorkingAt3rd - Status : Number is 1"));
+        assertTrue(result.getResult("task3").value().toString()
+                .contains("WorkingAt3rd - Status : OK / File deleted :"));
+        assertTrue(result.getResult("task4").getException().getCause().getMessage().contains("Throwing"));
+        assertTrue(result.getResult("task5").getException().getCause().getMessage().contains("Throwing"));
+        assertNotNull(result.getResult("task7").getException());
+        assertNotNull(result.getResult("task8").getException());
 
         //checking end of the job...
         jstate.update(jinfo);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobLegacySchemas.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestJobLegacySchemas.java
@@ -67,7 +67,7 @@ import static functionaltests.utils.SchedulerTHelper.log;
 public class TestJobLegacySchemas extends SchedulerFunctionalTestWithRestart {
 
     private static String[] jobDescriptorsLoc = { "3_0/Job_Schemas.xml", "3_1/Job_Schemas.xml",
-            "3_2/Job_Schemas.xml" };
+            "3_2/Job_Schemas.xml", "3_3/Job_Schemas.xml", "3_4/Job_Schemas.xml", "3_5/Job_Schemas.xml"};
 
     private URL[] jobDescriptors = new URL[jobDescriptorsLoc.length];
 

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace1.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace1.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:proactive:jobdescriptor:3.4"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.4 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.4/schedulerjob.xsd"
+    name="JobCacheSpace1" 
+    priority="normal"
+    onTaskError="continueJobExecution"
+     maxNumberOfExecution="2"
+>
+  <taskFlow>
+    <task name="Split">
+      <description>
+        <![CDATA[ This task defines some input, here strings to be processed. ]]>
+      </description>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+      <controlFlow >
+        <replicate>
+          <script>
+            <code language="groovy">
+              <![CDATA[
+runs=3
+]]>
+            </code>
+          </script>
+        </replicate>
+      </controlFlow>
+    </task>
+    <task name="Process">
+      <description>
+        <![CDATA[ This task will be replicated according to the 'runs' value specified in the replication script.                The replication index is used in each task's instance to select the input. ]]>
+      </description>
+      <depends>
+        <task ref="Split"/>
+      </depends>
+      <inputFiles>
+        <files  includes="dataToCopy" accessMode="cacheFromUserSpace"/>
+        <files  includes="dataToUpdate" accessMode="cacheFromUserSpace"/>
+      </inputFiles>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+println cachespace
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+    <task name="Merge">
+      <description>
+        <![CDATA[ As a merge operation, we simply print the results from previous tasks. ]]>
+      </description>
+      <depends>
+        <task ref="Process"/>
+      </depends>
+      <scriptExecutable>
+        <script>
+          <code language="groovy">
+            <![CDATA[
+
+]]>
+          </code>
+        </script>
+      </scriptExecutable>
+    </task>
+  </taskFlow>
+</job>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace1.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace1.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="urn:proactive:jobdescriptor:3.4"
-     xsi:schemaLocation="urn:proactive:jobdescriptor:3.4 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.4/schedulerjob.xsd"
-    name="JobCacheSpace1" 
-    priority="normal"
-    onTaskError="continueJobExecution"
-     maxNumberOfExecution="2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:dev"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
+        name="JobCacheSpace1"
+        priority="normal"
+        onTaskError="continueJobExecution"
+        maxNumberOfExecution="2"
 >
   <taskFlow>
     <task name="Split">

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace2.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.4"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.4 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.4/schedulerjob.xsd"
+        name="JobCacheSpace1"
+        priority="normal"
+        onTaskError="continueJobExecution"
+        maxNumberOfExecution="2"
+>
+    <taskFlow>
+
+        <task name="Process">
+            <description>
+                <![CDATA[ This task will be replicated according to the 'runs' value specified in the replication script.                The replication index is used in each task's instance to select the input. ]]>
+            </description>
+            <inputFiles>
+                <files includes="dataToCopy" accessMode="cacheFromUserSpace"/>
+                <files includes="dataToUpdate" accessMode="cacheFromUserSpace"/>
+            </inputFiles>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+println cachespace
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+    </taskFlow>
+</job>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace2.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CacheSpace2.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="urn:proactive:jobdescriptor:3.4"
-        xsi:schemaLocation="urn:proactive:jobdescriptor:3.4 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.4/schedulerjob.xsd"
+        xmlns="urn:proactive:jobdescriptor:dev"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
         name="JobCacheSpace1"
         priority="normal"
         onTaskError="continueJobExecution"

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/schemas/3_3/Job_Schemas.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/schemas/3_3/Job_Schemas.xml
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns="urn:proactive:jobdescriptor:3.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.3 ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.3/schedulerjob.xsd"
+     name="TestJobLegacySchemas" projectName="TestJobLegacySchemas" priority="high" cancelJobOnError="false"
+     restartTaskOnError="anywhere" maxNumberOfExecution="1">
+    <!-- Tests many functionalities of the scheduler -->
+
+    <variables>
+        <!-- pa.rm.home is known as java property - ie : start with -Dpa.scheduler.home=value -->
+        <variable name="HOME"
+                  value="${pa.rm.home}/scheduler/scheduler-server/src/test/resources/functionaltests/schemas"/>
+        <variable name="DS" value="${pa.rm.home}/scheduler/scheduler-server/build/JobLegacySchemas_dataspace"/>
+    </variables>
+    <description>Tests various descriptor syntax.</description>
+    <genericInformation>
+        <info name="myinfo" value="myvalue"/>
+    </genericInformation>
+    <inputSpace url="${HOME}"/>
+    <outputSpace url="${DS}"/>
+    <globalSpace url="${DS}"/>
+    <userSpace url="${DS}"/>
+    <taskFlow>
+
+        <task name="CheckPreciousLog">
+            <description>Checks that the log file exists</description>
+            <inputFiles>
+                <files includes="TaskLogs-*.log" accessMode="transferFromOutputSpace"/>
+            </inputFiles>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="TaskLogs-*.log"/>
+                    <parameter name="outputFile" value="CheckPreciousLogOut"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="CheckPreciousLogOut" accessMode="transferToOutputSpace"/>
+            </outputFiles>
+        </task>
+
+        <!-- Tests JavaTask with ForkEnv and dependencies -->
+
+        <task name="Computation1">
+            <description>Compute Pi and return it</description>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+                <parameters>
+                    <parameter name="steps" value="2"/>
+                    <parameter name="iterations" value="10000"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="Computation2">
+            <description>Compute Pi and return it</description>
+            <forkEnvironment>
+                <jvmArgs>
+                    <jvmArg value="-Dproactive.test=true"/>
+                </jvmArgs>
+            </forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+                <parameters>
+                    <parameter name="steps" value="2"/>
+                    <parameter name="iterations" value="10000"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="LastAverage" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <depends>
+                <task ref="Computation1"/>
+                <task ref="Computation2"/>
+            </depends>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MonteCarloAverage"/>
+        </task>
+
+        <!-- Tests spaces -->
+
+        <task name="CopyFiles1">
+            <description>Copies a file to output</description>
+            <inputFiles>
+                <files includes="myfilein1" accessMode="transferFromInputSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfilein1"/>
+                    <parameter name="outputFile" value="myfileout1"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout1" accessMode="transferToOutputSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles2">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles1"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout1" accessMode="transferFromOutputSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout1"/>
+                    <parameter name="outputFile" value="myfileout2"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout2" accessMode="transferToGlobalSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles3">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles2"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout2" accessMode="transferFromGlobalSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout2"/>
+                    <parameter name="outputFile" value="myfileout3"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout3" accessMode="transferToUserSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles4">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles3"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout3" accessMode="transferFromUserSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout3"/>
+                    <parameter name="outputFile" value="myfileout4"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout4" accessMode="transferToUserSpace"/>
+            </outputFiles>
+        </task>
+
+        <!-- Tests topology -->
+
+        <task name="Topology1" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <arbitrary/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology2" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <bestProximity/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology3" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <thresholdProximity threshold="100"/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology4" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <singleHost/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology5" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <singleHostExclusive/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+                <parameters>
+                    <parameter name="numberToFind" value="10"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="Topology6" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <multipleHostsExclusive/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+                <parameters>
+                    <parameter name="numberToFind" value="10"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+
+
+        <!-- Tests pre/post/clean scripts -->
+
+        <task name="PrePost" preciousResult="true">
+            <description>Testing the pre and post scripts.</description>
+            <selection>
+                <script>
+                    <code language="javascript">selected=true;</code>
+                </script>
+            </selection>
+            <pre>
+                <script>
+                    <file path="${HOME}/set.groovy"/>
+                </script>
+            </pre>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.PropertyTask"/>
+            <post>
+                <script>
+                    <file path="${HOME}/unset.groovy"/>
+                </script>
+            </post>
+            <cleaning>
+                <script>
+                    <file path="${HOME}/clean.groovy"/>
+                </script>
+            </cleaning>
+        </task>
+
+        <!-- Tests dynamic commands -->
+
+        <task name="Static">
+            <forkEnvironment workingDir="$PA_SCHEDULER_HOME">
+            </forkEnvironment>
+            <nativeExecutable>
+                <staticCommand value="hostname">
+                </staticCommand>
+            </nativeExecutable>
+        </task>
+
+        <!-- Tests workflows -->
+
+        <task name="WF" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=80
+      // ]]> </description>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="start">
+                <replicate>
+                    <script>
+                        <code language="javascript">
+                            // <![CDATA[
+runs = 2;
+// ]]>
+                        </code>
+                    </script>
+                </replicate>
+            </controlFlow>
+        </task>
+        <task name="WF4" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=243,y=219
+      // ]]> </description>
+            <depends>
+                <task ref="WF1"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+        </task>
+        <task name="WF5" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=288
+      // ]]> </description>
+            <depends>
+                <task ref="WF4"/>
+                <task ref="WF3"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="end"/>
+        </task>
+        <task name="WF1" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=157
+      // ]]> </description>
+            <depends>
+                <task ref="WF"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="start"/>
+        </task>
+        <task name="WF3" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=154,y=221
+      // ]]> </description>
+            <depends>
+                <task ref="WF1"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+        </task>
+        <task name="WF2" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=203,y=362,a=354,b=233
+      // ]]> </description>
+            <depends>
+                <task ref="WF5"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="end">
+                <loop target="WF">
+                    <script>
+                        <code language="javascript">
+                            // <![CDATA[
+if (result < 15) {
+loop = true;
+} else {
+loop = false;
+}
+// ]]>
+                        </code>
+                    </script>
+                </loop>
+            </controlFlow>
+        </task>
+
+        <!-- Tests Script Executable -->
+        <task name="ScriptExecutable">
+            <scriptExecutable>
+                <script>
+                    <code language="javascript">
+                        result = '42'
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+
+    </taskFlow>
+</job>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/schemas/3_4/Job_Schemas.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/schemas/3_4/Job_Schemas.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns="urn:proactive:jobdescriptor:3.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.4 ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.4/schedulerjob.xsd"
+     name="TestJobLegacySchemas" projectName="TestJobLegacySchemas" priority="high" onTaskError="continueJobExecution"
+     restartTaskOnError="anywhere" maxNumberOfExecution="1">
+    <!-- Tests many functionalities of the scheduler -->
+
+    <variables>
+        <!-- pa.rm.home is known as java property - ie : start with -Dpa.scheduler.home=value -->
+        <variable name="HOME"
+                  value="${pa.rm.home}/scheduler/scheduler-server/src/test/resources/functionaltests/schemas"/>
+        <variable name="DS" value="${pa.rm.home}/scheduler/scheduler-server/build/JobLegacySchemas_dataspace"/>
+    </variables>
+    <description>Tests various descriptor syntax.</description>
+    <genericInformation>
+        <info name="myinfo" value="myvalue"/>
+    </genericInformation>
+    <inputSpace url="${HOME}"/>
+    <outputSpace url="${DS}"/>
+    <globalSpace url="${DS}"/>
+    <userSpace url="${DS}"/>
+    <taskFlow>
+        <task name="CheckPreciousLog">
+            <description>Checks that the log file exists</description>
+            <inputFiles>
+                <files includes="TaskLogs-*.log" accessMode="transferFromOutputSpace"/>
+            </inputFiles>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="TaskLogs-*.log"/>
+                    <parameter name="outputFile" value="CheckPreciousLogOut"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="CheckPreciousLogOut" accessMode="transferToOutputSpace"/>
+            </outputFiles>
+        </task>
+
+        <!-- Tests JavaTask with ForkEnv and dependencies -->
+
+        <task name="Computation1" onTaskError="cancelJob">
+            <description>Compute Pi and return it</description>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+                <parameters>
+                    <parameter name="steps" value="2"/>
+                    <parameter name="iterations" value="10000"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="Computation2">
+            <description>Compute Pi and return it</description>
+            <forkEnvironment>
+                <jvmArgs>
+                    <jvmArg value="-Dproactive.test=true"/>
+                </jvmArgs>
+            </forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+
+                <parameters>
+                    <parameter name="steps" value="2"/>
+                    <parameter name="iterations" value="10000"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="LastAverage" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <depends>
+                <task ref="Computation1"/>
+                <task ref="Computation2"/>
+            </depends>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MonteCarloAverage"/>
+        </task>
+
+        <!-- Tests spaces -->
+
+        <task name="CopyFiles1">
+            <description>Copies a file to output</description>
+            <inputFiles>
+                <files includes="myfilein1" accessMode="transferFromInputSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfilein1"/>
+                    <parameter name="outputFile" value="myfileout1"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout1" accessMode="transferToOutputSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles2">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles1"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout1" accessMode="transferFromOutputSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout1"/>
+                    <parameter name="outputFile" value="myfileout2"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout2" accessMode="transferToGlobalSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles3">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles2"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout2" accessMode="transferFromGlobalSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout2"/>
+                    <parameter name="outputFile" value="myfileout3"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout3" accessMode="transferToUserSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles4">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles3"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout3" accessMode="transferFromUserSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout3"/>
+                    <parameter name="outputFile" value="myfileout4"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout4" accessMode="transferToUserSpace"/>
+            </outputFiles>
+        </task>
+
+        <!-- Tests topology -->
+
+        <task name="Topology1" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <arbitrary/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology2" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <bestProximity/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology3" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <thresholdProximity threshold="100"/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology4" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <singleHost/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology5" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <singleHostExclusive/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+                <parameters>
+                    <parameter name="numberToFind" value="10"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="Topology6" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <multipleHostsExclusive/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+                <parameters>
+                    <parameter name="numberToFind" value="10"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+
+
+        <!-- Tests pre/post/clean scripts -->
+
+        <task name="PrePost" preciousResult="true">
+            <description>Testing the pre and post scripts.</description>
+            <selection>
+                <script>
+                    <code language="javascript">selected=true;</code>
+                </script>
+            </selection>
+            <pre>
+                <script>
+                    <file path="${HOME}/set.groovy"/>
+                </script>
+            </pre>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.PropertyTask"/>
+            <post>
+                <script>
+                    <file path="${HOME}/unset.groovy"/>
+                </script>
+            </post>
+            <cleaning>
+                <script>
+                    <file path="${HOME}/clean.groovy"/>
+                </script>
+            </cleaning>
+        </task>
+
+        <!-- Tests dynamic commands -->
+
+        <task name="Static">
+            <forkEnvironment workingDir="$PA_SCHEDULER_HOME"></forkEnvironment>
+            <nativeExecutable>
+                <staticCommand value="hostname">
+                </staticCommand>
+            </nativeExecutable>
+        </task>
+
+        <!-- Tests workflows -->
+
+        <task name="WF" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=80
+      // ]]> </description>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="start">
+                <replicate>
+                    <script>
+                        <code language="javascript">
+                            // <![CDATA[
+runs = 2;
+// ]]>
+                        </code>
+                    </script>
+                </replicate>
+            </controlFlow>
+        </task>
+        <task name="WF4" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=243,y=219
+      // ]]> </description>
+            <depends>
+                <task ref="WF1"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+        </task>
+        <task name="WF5" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=288
+      // ]]> </description>
+            <depends>
+                <task ref="WF4"/>
+                <task ref="WF3"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="end"/>
+        </task>
+        <task name="WF1" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=157
+      // ]]> </description>
+            <depends>
+                <task ref="WF"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="start"/>
+        </task>
+        <task name="WF3" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=154,y=221
+      // ]]> </description>
+            <depends>
+                <task ref="WF1"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+        </task>
+        <task name="WF2" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=203,y=362,a=354,b=233
+      // ]]> </description>
+            <depends>
+                <task ref="WF5"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="end">
+                <loop target="WF">
+                    <script>
+                        <code language="javascript">
+                            // <![CDATA[
+if (result < 15) {
+loop = true;
+} else {
+loop = false;
+}
+// ]]>
+                        </code>
+                    </script>
+                </loop>
+            </controlFlow>
+        </task>
+
+        <!-- Tests Script Executable -->
+        <task name="ScriptExecutable">
+            <scriptExecutable>
+                <script>
+                    <code language="javascript">
+                        result = '42'
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+
+    </taskFlow>
+</job>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/schemas/3_5/Job_Schemas.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/schemas/3_5/Job_Schemas.xml
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns="urn:proactive:jobdescriptor:3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:proactive:jobdescriptor:3.5 ../../src/scheduler/src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.xsd"
+     name="TestJobLegacySchemas" projectName="TestJobLegacySchemas" priority="high" onTaskError="continueJobExecution"
+     restartTaskOnError="anywhere" maxNumberOfExecution="1">
+    <!-- Tests many functionalities of the scheduler -->
+
+    <variables>
+        <!-- pa.rm.home is known as java property - ie : start with -Dpa.scheduler.home=value -->
+        <variable name="HOME"
+                  value="${pa.rm.home}/scheduler/scheduler-server/src/test/resources/functionaltests/schemas"/>
+        <variable name="DS" value="${pa.rm.home}/scheduler/scheduler-server/build/JobLegacySchemas_dataspace"/>
+    </variables>
+    <description>Tests various descriptor syntax.</description>
+    <genericInformation>
+        <info name="myinfo" value="myvalue"/>
+    </genericInformation>
+    <inputSpace url="${HOME}"/>
+    <outputSpace url="${DS}"/>
+    <globalSpace url="${DS}"/>
+    <userSpace url="${DS}"/>
+    <taskFlow>
+        <task name="CheckPreciousLog">
+            <description>Checks that the log file exists</description>
+            <inputFiles>
+                <files includes="TaskLogs-*.log" accessMode="transferFromOutputSpace"/>
+            </inputFiles>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="TaskLogs-*.log"/>
+                    <parameter name="outputFile" value="CheckPreciousLogOut"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="CheckPreciousLogOut" accessMode="transferToOutputSpace"/>
+            </outputFiles>
+        </task>
+
+        <!-- Tests JavaTask with ForkEnv and dependencies -->
+
+        <task name="Computation1" onTaskError="cancelJob">
+            <description>Compute Pi and return it</description>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+                <parameters>
+                    <parameter name="steps" value="2"/>
+                    <parameter name="iterations" value="10000"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="Computation2">
+            <description>Compute Pi and return it</description>
+            <forkEnvironment>
+                <jvmArgs>
+                    <jvmArg value="-Dproactive.test=true"/>
+                </jvmArgs>
+            </forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+
+                <parameters>
+                    <parameter name="steps" value="2"/>
+                    <parameter name="iterations" value="10000"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="LastAverage" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <depends>
+                <task ref="Computation1"/>
+                <task ref="Computation2"/>
+            </depends>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MonteCarloAverage"/>
+        </task>
+
+        <!-- Tests spaces -->
+
+        <task name="CopyFiles1">
+            <description>Copies a file to output</description>
+            <inputFiles>
+                <files includes="myfilein1" accessMode="transferFromInputSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfilein1"/>
+                    <parameter name="outputFile" value="myfileout1"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout1" accessMode="transferToOutputSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles2">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles1"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout1" accessMode="transferFromOutputSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout1"/>
+                    <parameter name="outputFile" value="myfileout2"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout2" accessMode="transferToGlobalSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles3">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles2"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout2" accessMode="transferFromGlobalSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout2"/>
+                    <parameter name="outputFile" value="myfileout3"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout3" accessMode="transferToUserSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles4">
+            <description>Copies a file to output</description>
+            <depends>
+                <task ref="CopyFiles3"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout3" accessMode="transferFromUserSpace"/>
+            </inputFiles>
+            <forkEnvironment></forkEnvironment>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.CopyFile">
+                <parameters>
+                    <parameter name="inputFile" value="myfileout3"/>
+                    <parameter name="outputFile" value="myfileout4"/>
+                </parameters>
+            </javaExecutable>
+            <outputFiles>
+                <files includes="myfileout4" accessMode="transferToUserSpace"/>
+            </outputFiles>
+        </task>
+        <task name="CopyFiles5">
+            <description>Copies a file to cache</description>
+            <inputFiles>
+                <files includes="myfilein1" accessMode="cacheFromInputSpace"/>
+            </inputFiles>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+            </javaExecutable>
+        </task>
+        <task name="CopyFiles6">
+            <description>Copies a file to cache</description>
+            <depends>
+                <task ref="CopyFiles1"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout1" accessMode="cacheFromOutputSpace"/>
+            </inputFiles>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+            </javaExecutable>
+        </task>
+        <task name="CopyFiles7">
+            <description>Copies a file to cache</description>
+            <depends>
+                <task ref="CopyFiles2"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout2" accessMode="cacheFromGlobalSpace"/>
+            </inputFiles>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+            </javaExecutable>
+        </task>
+        <task name="CopyFiles8">
+            <description>Copies a file to cache</description>
+            <depends>
+                <task ref="CopyFiles3"/>
+            </depends>
+            <inputFiles>
+                <files includes="myfileout3" accessMode="cacheFromUserSpace"/>
+            </inputFiles>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+            </javaExecutable>
+        </task>
+
+        <!-- Tests topology -->
+
+        <task name="Topology1" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <arbitrary/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology2" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <bestProximity/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology3" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <thresholdProximity threshold="100"/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology4" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <singleHost/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+            </javaExecutable>
+        </task>
+        <task name="Topology5" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <singleHostExclusive/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+                <parameters>
+                    <parameter name="numberToFind" value="10"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+        <task name="Topology6" preciousResult="true">
+            <description>Do the average and return it.</description>
+            <parallel numberOfNodes="2">
+                <topology>
+                    <multipleHostsExclusive/>
+                </topology>
+            </parallel>
+            <javaExecutable
+                    class="org.ow2.proactive.scheduler.examples.MultiNodeExample">
+                <parameters>
+                    <parameter name="numberToFind" value="10"/>
+                </parameters>
+            </javaExecutable>
+        </task>
+
+
+        <!-- Tests pre/post/clean scripts -->
+
+        <task name="PrePost" preciousResult="true">
+            <description>Testing the pre and post scripts.</description>
+            <selection>
+                <script>
+                    <code language="javascript">selected=true;</code>
+                </script>
+            </selection>
+            <pre>
+                <script>
+                    <file path="${HOME}/set.groovy"/>
+                </script>
+            </pre>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.PropertyTask"/>
+            <post>
+                <script>
+                    <file path="${HOME}/unset.groovy"/>
+                </script>
+            </post>
+            <cleaning>
+                <script>
+                    <file path="${HOME}/clean.groovy"/>
+                </script>
+            </cleaning>
+        </task>
+
+        <!-- Tests dynamic commands -->
+
+        <task name="Static">
+            <forkEnvironment workingDir="$PA_SCHEDULER_HOME"></forkEnvironment>
+            <nativeExecutable>
+                <staticCommand value="hostname">
+                </staticCommand>
+            </nativeExecutable>
+        </task>
+
+        <!-- Tests workflows -->
+
+        <task name="WF" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=80
+      // ]]> </description>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="start">
+                <replicate>
+                    <script>
+                        <code language="javascript">
+                            // <![CDATA[
+runs = 2;
+// ]]>
+                        </code>
+                    </script>
+                </replicate>
+            </controlFlow>
+        </task>
+        <task name="WF4" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=243,y=219
+      // ]]> </description>
+            <depends>
+                <task ref="WF1"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+        </task>
+        <task name="WF5" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=288
+      // ]]> </description>
+            <depends>
+                <task ref="WF4"/>
+                <task ref="WF3"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="end"/>
+        </task>
+        <task name="WF1" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=200,y=157
+      // ]]> </description>
+            <depends>
+                <task ref="WF"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="start"/>
+        </task>
+        <task name="WF3" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=154,y=221
+      // ]]> </description>
+            <depends>
+                <task ref="WF1"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+        </task>
+        <task name="WF2" maxNumberOfExecution="4">
+            <description>// <![CDATA[
+      x=203,y=362,a=354,b=233
+      // ]]> </description>
+            <depends>
+                <task ref="WF5"/>
+            </depends>
+            <javaExecutable class="org.ow2.proactive.scheduler.examples.IncrementJob">
+            </javaExecutable>
+            <controlFlow block="end">
+                <loop target="WF">
+                    <script>
+                        <code language="javascript">
+                            // <![CDATA[
+if (result < 15) {
+loop = true;
+} else {
+loop = false;
+}
+// ]]>
+                        </code>
+                    </script>
+                </loop>
+            </controlFlow>
+        </task>
+
+        <!-- Tests Script Executable -->
+        <task name="ScriptExecutable">
+            <scriptExecutable>
+                <script>
+                    <code language="javascript">
+                        result = '42'
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+
+    </taskFlow>
+</job>


### PR DESCRIPTION
- start a singleton VFS FileSystemServer when the proactive node is started. Only one server will be started per JVM.
- When the DataSpaces are initialized for the task, the CACHESPACE will be registered in the naming service associated with the task, and will be mounted.
- Reused already existing file transfer mechanism to transfer files to the cache. Improved this mechanism to check if the destination file is present or is older than the source.
- The new script variable "cachespace" will be bound to the cache location
- Added  node.dataspace.cachedir property to configure the cache location. By default, it is equals to the scratch_root_location/cache
- added a functional test which checks that the cache space behaves as expected and that newer files are updated
- added a cleaning mechanism to cache space which runs periodically and deletes old files
- added a functional test which ensures the cleaning mechanism selectively deletes files.
- added a new schema version 3.5
- updated templates to use newest schema
- updated parser to use newest schema
- added new workflows for TestJobLegacySchemas in order to test jobs using 3.3, 3.4 and 3.5 syntax
