### PR TITLE
Fix the dataspace cache tests issues

### DIFF
--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpace.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpace.java
@@ -92,6 +92,7 @@ public class TestCacheSpace extends SchedulerFunctionalTestNoRestart {
 
         // change the file to update
         dataToUpdateFile.delete();
+        Thread.sleep(500);
         dataToUpdateFile.createNewFile();
 
         // submit the job a second time.

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpaceCleaning.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestCacheSpaceCleaning.java
@@ -111,6 +111,7 @@ public class TestCacheSpaceCleaning extends SchedulerFunctionalTestWithCustomCon
 
         // change the file to update
         dataToUpdateFile.delete();
+        Thread.sleep(500);
         dataToUpdateFile.createNewFile();
 
         // submit the job a second time.


### PR DESCRIPTION
The tests were failing because of timestamps that didn't between a deletion and creation of a file with the same name.