### PR TITLE
Improve rest DataSpaceClient API

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
@@ -43,32 +43,32 @@ import java.util.List;
 
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
 public class ListFile {
-    private List<String> directories;
-    private List<String> files;
-    private List<String> all;
+    private List<String> directoryListing;
+    private List<String> fileListing;
+    private List<String> fullListing;
 
-    public List<String> getDirectories() {
-        return directories;
+    public List<String> getDirectoryListing() {
+        return directoryListing;
     }
 
-    public void setDirectories(List<String> directories) {
-        this.directories = directories;
+    public void setDirectoryListing(List<String> directoryListing) {
+        this.directoryListing = directoryListing;
     }
 
-    public List<String> getFiles() {
-        return files;
+    public List<String> getFileListing() {
+        return fileListing;
     }
 
-    public void setFiles(List<String> files) {
-        this.files = files;
+    public void setFileListing(List<String> fileListing) {
+        this.fileListing = fileListing;
     }
 
-    public void setAll(List<String> all) {
-        this.all = all;
+    public void setFullListing(List<String> fullListing) {
+        this.fullListing = fullListing;
     }
 
-    public List<String> getAll() {
-        return all;
+    public List<String> getFullListing() {
+        return fullListing;
     }
 
 

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
@@ -36,15 +36,16 @@
  */
 package org.ow2.proactive_grid_cloud_portal.dataspace.dto;
 
-import java.util.List;
-
 import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+import java.util.List;
 
 
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
 public class ListFile {
     private List<String> directories;
     private List<String> files;
+    private List<String> all;
 
     public List<String> getDirectories() {
         return directories;
@@ -61,4 +62,14 @@ public class ListFile {
     public void setFiles(List<String> files) {
         this.files = files;
     }
+
+    public void setAll(List<String> all) {
+        this.all = all;
+    }
+
+    public List<String> getAll() {
+        return all;
+    }
+
+
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerRestClient.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerRestClient.java
@@ -34,8 +34,32 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.client;
 
-import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import com.google.common.net.UrlEscapers;
+import org.codehaus.jackson.map.DeserializationConfig;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
+import org.ow2.proactive_grid_cloud_portal.common.exceptionmapper.ExceptionToJson;
+import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
+import org.ow2.proactive_grid_cloud_portal.scheduler.client.utils.Zipper;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobIdData;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.*;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -52,39 +76,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericEntity;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.core.Variant;
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
-
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
-import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
-import org.ow2.proactive_grid_cloud_portal.common.exceptionmapper.ExceptionToJson;
-import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
-import org.ow2.proactive_grid_cloud_portal.scheduler.client.utils.Zipper;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobIdData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
-
-import com.google.common.collect.Maps;
-import com.google.common.io.Files;
-import com.google.common.net.UrlEscapers;
+import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
 
 
 public class SchedulerRestClient {

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
@@ -407,7 +407,7 @@ public class DataSpaceClient implements IDataSpaceClient {
             List<String> answer = new LinkedList<>();
             try {
                 ListFile listFiles = DataSpaceClient.this.list(source, recursive);
-                for (String fileOrDirectory : listFiles.getAll()) {
+                for (String fileOrDirectory : listFiles.getFullListing()) {
                     answer.add(fileOrDirectory);
                 }
                 return answer;

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
@@ -44,11 +44,12 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+import org.ow2.proactive.authentication.ConnectionInfo;
 import org.ow2.proactive.http.HttpClientBuilder;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.task.dataspaces.FileSystemException;
 import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
-import org.ow2.proactive.authentication.ConnectionInfo;
 import org.ow2.proactive.scheduler.rest.ISchedulerClient;
 import org.ow2.proactive.scheduler.rest.SchedulerClient;
 import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
@@ -57,13 +58,19 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.*;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 
 public class DataSpaceClient implements IDataSpaceClient {
@@ -73,6 +80,7 @@ public class DataSpaceClient implements IDataSpaceClient {
     private String restDataspaceUrl;
     private String sessionId;
     private ClientHttpEngine httpEngine;
+    private ISchedulerClient client;
 
     public DataSpaceClient() {
     }
@@ -88,6 +96,7 @@ public class DataSpaceClient implements IDataSpaceClient {
                         new HttpClientBuilder().disableContentCompression().useSystemProperties().build());
         this.restDataspaceUrl = restDataspaceUrl(restServerUrl);
         this.sessionId = client.getSession();
+        this.client = client;
     }
 
     public void init(ConnectionInfo connectionInfo) throws Exception {
@@ -242,21 +251,30 @@ public class DataSpaceClient implements IDataSpaceClient {
 
     @Override
     public RemoteSpace getGlobalSpace() {
-        throw new UnsupportedOperationException();
+        return new RestRemoteSpace(Dataspace.GLOBAL);
     }
 
     @Override
     public RemoteSpace getUserSpace() {
-        throw new UnsupportedOperationException();
+        return new RestRemoteSpace(Dataspace.USER);
     }
 
     @Override
-    public ListFile list(IRemoteSource source) throws NotConnectedException, PermissionException {
+    public ListFile list(IRemoteSource source, boolean recursive) throws NotConnectedException, PermissionException {
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(
                 source.getDataspace().value());
         ResteasyClient client = new ResteasyClientBuilder().httpEngine(httpEngine).build();
         ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath()).queryParam(
-                "comp", "list");
+                "comp", recursive ? "recursive" : "list");
+
+        List<String> includes = source.getIncludes();
+        if (includes != null && !includes.isEmpty()) {
+            target = target.queryParam("includes", includes.toArray(new Object[includes.size()]));
+        }
+        List<String> excludes = source.getExcludes();
+        if (excludes != null && !excludes.isEmpty()) {
+            target = target.queryParam("excludes", excludes.toArray(new Object[excludes.size()]));
+        }
         Response response = null;
         try {
             response = target.request().header("sessionid", sessionId).get();
@@ -361,6 +379,164 @@ public class DataSpaceClient implements IDataSpaceClient {
     private String restDataspaceUrl(String restServerUrl) {
         return (new StringBuffer()).append(restServerUrl).append((restServerUrl.endsWith("/") ? "" : "/"))
                 .append("data/").toString();
+    }
+
+    class RestRemoteSpace implements RemoteSpace {
+
+        IDataSpaceClient.Dataspace space;
+
+        public RestRemoteSpace(IDataSpaceClient.Dataspace space) {
+            this.space = space;
+        }
+
+
+        @Override
+        public List<String> listFiles(String remotePath, boolean recursive) throws FileSystemException {
+            RemoteSource source = new RemoteSource(space, remotePath);
+            return findFiles(source, recursive);
+        }
+
+        @Override
+        public List<String> listFiles(String remotePath, String pattern) throws FileSystemException {
+            RemoteSource source = new RemoteSource(space, remotePath);
+            source.setIncludes(pattern);
+            return findFiles(source, true);
+        }
+
+        private List<String> findFiles(RemoteSource source, boolean recursive) throws FileSystemException {
+            List<String> answer = new LinkedList<>();
+            try {
+                ListFile listFiles = DataSpaceClient.this.list(source, recursive);
+                for (String fileOrDirectory : listFiles.getAll()) {
+                    answer.add(fileOrDirectory);
+                }
+                return answer;
+            } catch (Exception e) {
+                throw new FileSystemException(e);
+            }
+        }
+
+        @Override
+        public void pushFile(File localPath, String remotePath) throws FileSystemException {
+            if (!localPath.exists()) {
+                throw new FileSystemException("" + localPath + " does not exist");
+            }
+            ILocalSource source;
+            if (localPath.isDirectory()) {
+                source = new LocalDirSource(localPath);
+            } else {
+                source = new LocalFileSource(localPath);
+            }
+
+            try {
+                DataSpaceClient.this.upload(source, new RemoteDestination(space, remotePath));
+            } catch (Exception e) {
+                throw new FileSystemException(e);
+            }
+        }
+
+
+        @Override
+        public void pushFiles(File localDirectory, String pattern, String remotePath) throws FileSystemException {
+            if (!localDirectory.exists()) {
+                throw new FileSystemException("" + localDirectory + " does not exist");
+            }
+            if (!localDirectory.isDirectory()) {
+                throw new FileSystemException("" + localDirectory + " is not a directory");
+            }
+            LocalDirSource source = new LocalDirSource(localDirectory);
+            source.setIncludes(pattern);
+
+            try {
+                DataSpaceClient.this.upload(source, new RemoteDestination(space, remotePath));
+            } catch (Exception e) {
+                throw new FileSystemException(e);
+            }
+        }
+
+        @Override
+        public File pullFile(String remotePath, File localPath) throws FileSystemException {
+            RemoteSource source = new RemoteSource(space, remotePath);
+            LocalDestination dest = new LocalDestination(localPath);
+            try {
+                DataSpaceClient.this.download(source, dest);
+            } catch (Exception e) {
+                throw new FileSystemException(e);
+            }
+            if (!localPath.exists()) {
+                throw new IllegalStateException("File not present after download : " + localPath);
+            }
+            return localPath;
+        }
+
+        @Override
+        public Set<File> pullFiles(String remotePath, String pattern, File localPath) throws FileSystemException {
+            RemoteSource source = new RemoteSource(space, remotePath);
+            source.setIncludes(pattern);
+            LocalDestination dest = new LocalDestination(localPath);
+            try {
+                DataSpaceClient.this.download(source, dest);
+            } catch (Exception e) {
+                throw new FileSystemException(e);
+            }
+            Set<File> answer = new LinkedHashSet<>();
+            try {
+                for (Path foundFile : Files.newDirectoryStream(localPath.toPath(), pattern)) {
+                    answer.add(foundFile.toFile());
+                }
+            } catch (IOException e) {
+                throw new FileSystemException(e);
+            }
+            return answer;
+        }
+
+        @Override
+        public void deleteFile(String remotePath) throws FileSystemException {
+            RemoteSource source = new RemoteSource(space, remotePath);
+            try {
+                DataSpaceClient.this.delete(source);
+            } catch (Exception e) {
+                throw new FileSystemException(e);
+            }
+        }
+
+        @Override
+        public void deleteFiles(String remotePath, String pattern) throws FileSystemException {
+            RemoteSource source = new RemoteSource(space, remotePath);
+            source.setIncludes(pattern);
+            try {
+                DataSpaceClient.this.delete(source);
+            } catch (Exception e) {
+                throw new FileSystemException(e);
+            }
+        }
+
+        @Override
+        public List<String> getSpaceURLs() throws FileSystemException {
+            if (space == Dataspace.GLOBAL) {
+                try {
+                    return DataSpaceClient.this.client.getGlobalSpaceURIs();
+                } catch (Exception e) {
+                    throw new FileSystemException(e);
+                }
+            } else {
+                try {
+                    return DataSpaceClient.this.client.getUserSpaceURIs();
+                } catch (Exception e) {
+                    throw new FileSystemException(e);
+                }
+            }
+        }
+
+        @Override
+        public InputStream getInputStream(String remotePath) throws FileSystemException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public OutputStream getOutputStream(String remotePath) throws FileSystemException {
+            throw new UnsupportedOperationException();
+        }
     }
 
 }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/IDataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/IDataSpaceClient.java
@@ -93,7 +93,7 @@ public interface IDataSpaceClient {
      *             if the user does not have permission to upload the file to
      *             the specified location in the server
      */
-    ListFile list(IRemoteSource source) throws NotConnectedException, PermissionException;
+    ListFile list(IRemoteSource source, boolean recursive) throws NotConnectedException, PermissionException;
 
     /**
      * Deletes the specified directory or the file from the <i>dataspace</i>.

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/IDataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/IDataSpaceClient.java
@@ -93,7 +93,7 @@ public interface IDataSpaceClient {
      *             if the user does not have permission to upload the file to
      *             the specified location in the server
      */
-    ListFile list(IRemoteSource source, boolean recursive) throws NotConnectedException, PermissionException;
+    ListFile list(IRemoteSource source) throws NotConnectedException, PermissionException;
 
     /**
      * Deletes the specified directory or the file from the <i>dataspace</i>.

--- a/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
@@ -287,11 +287,11 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
 
         ListFile listFile = client.list(source, false);
 
-        List<String> directories = listFile.getDirectories();
+        List<String> directories = listFile.getDirectoryListing();
         assertEquals(1, directories.size());
         assertEquals("tempDir", directories.get(0));
 
-        List<String> files = listFile.getFiles();
+        List<String> files = listFile.getFileListing();
         assertEquals(1, files.size());
         assertEquals("tempFile.txt", files.get(0));
 
@@ -317,11 +317,11 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
 
         ListFile listFile = client.list(source, true);
 
-        List<String> directories = listFile.getDirectories();
+        List<String> directories = listFile.getDirectoryListing();
         assertEquals(1, directories.size());
         assertEquals("tempDir", directories.get(0));
 
-        List<String> files = listFile.getFiles();
+        List<String> files = listFile.getFileListing();
         assertEquals(2, files.size());
         assertEquals("tempFile.tmp", files.get(0));
         assertEquals("tempFile.txt", files.get(1));
@@ -344,10 +344,10 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
 
         ListFile listFile = client.list(source, true);
 
-        List<String> directories = listFile.getDirectories();
+        List<String> directories = listFile.getDirectoryListing();
         assertEquals(0, directories.size());
 
-        List<String> files = listFile.getFiles();
+        List<String> files = listFile.getFileListing();
         assertEquals(1, files.size());
         assertEquals("tempFile.tmp", files.get(0));
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
@@ -101,7 +101,7 @@ public class FileSystem {
         ListFile list = new ListFile();
         List<String> dirList = Lists.newArrayList();
         List<String> fileList = Lists.newArrayList();
-        List<String> allList = Lists.newArrayList();
+        List<String> fullList = Lists.newArrayList();
         List<FileObject> foundFileObjects = new LinkedList<>();
         if ((isNullOrEmpty(includes) && isNullOrEmpty(excludes))) {
             if (recursive) {
@@ -120,19 +120,19 @@ public class FileSystem {
             switch (type) {
                 case FOLDER:
                     dirList.add(baseName(child));
-                    allList.add(fo.getName().getRelativeName(childName));
+                    fullList.add(fo.getName().getRelativeName(childName));
                     break;
                 case FILE:
                     fileList.add(baseName(child));
-                    allList.add(fo.getName().getRelativeName(childName));
+                    fullList.add(fo.getName().getRelativeName(childName));
                     break;
                 default:
                     throw new RuntimeException("Unknown : " + type);
             }
         }
-        list.setDirectories(dirList);
-        list.setFiles(fileList);
-        list.setAll(allList);
+        list.setDirectoryListing(dirList);
+        list.setFileListing(fileList);
+        list.setFullListing(fullList);
         return list;
     }
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -157,6 +157,7 @@ import org.ow2.proactive_grid_cloud_portal.common.Session;
 import org.ow2.proactive_grid_cloud_portal.common.SessionStore;
 import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
 import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
+import org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobIdData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobInfoData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobResultData;
@@ -209,19 +210,14 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
     private final SessionStore sessionStore = SharedSessionStore.getInstance();
 
-    private static FileSystemManager fsManager = null;
+    private static RestDataspaceImpl dataspaceRestApi = new RestDataspaceImpl();
 
     private static Map<String, String> sortableTaskAttrMap = null;
 
     private static final int TASKS_PAGE_SIZE = PASchedulerProperties.TASKS_PAGE_SIZE.getValueAsInt();
 
     static {
-        try {
-            fsManager = VFSFactory.createDefaultFileSystemManager();
-            sortableTaskAttrMap = createSortableTaskAttrMap();
-        } catch (FileSystemException e) {
-            logger.error("Could not create Default FileSystem Manager", e);
-        }
+        sortableTaskAttrMap = createSortableTaskAttrMap();
     }
 
     protected static final List<SortParameter<JobSortParameter>> DEFAULT_JOB_SORT_PARAMS = Arrays.asList(
@@ -2254,6 +2250,22 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
+    private String normalizeFilePath(String filePath, String fileName) {
+        if (filePath == null) {
+            filePath = "";
+        }
+        if (fileName != null && filePath.length() > 0 && !filePath.endsWith("/")) {
+            filePath = (filePath + "/" + fileName);
+        } else if (fileName != null) {
+            filePath = fileName;
+        }
+
+        if (filePath.length() > 0 && filePath.startsWith("/")) {
+            filePath = filePath.substring(1);
+        }
+        return filePath;
+    }
+
     /**
      * Pushes a file from the local file system into the given DataSpace
      * 
@@ -2277,7 +2289,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             @PathParam("spaceName") String spaceName, @PathParam("filePath") String filePath,
             MultipartFormDataInput multipart)
             throws IOException, NotConnectedRestException, PermissionRestException {
-        Scheduler s = checkAccess(sessionId, "pushFile");
+        checkAccess(sessionId, "pushFile");
+
+        Session session = dataspaceRestApi.checkSessionValidity(sessionId);
 
         Map<String, List<InputPart>> formDataMap = multipart.getFormDataMap();
 
@@ -2299,19 +2313,13 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             throw new IllegalArgumentException("Wrong file name : " + fileName);
         }
 
-        String spaceURI = resolveSpaceUri(s, spaceName);
-        if (filePath == null) {
-            filePath = "";
-        }
-        if (!filePath.startsWith("/")) {
-            filePath = "/" + filePath;
-        }
-        String destUri = spaceURI + filePath;
-        if (!destUri.endsWith("/")) {
-            destUri += "/";
-        }
-        destUri += fileName;
-        FileObject destfo = fsManager.resolveFile(destUri);
+        filePath = normalizeFilePath(filePath, fileName);
+
+        FileObject destfo = dataspaceRestApi.resolveFile(session, spaceName, filePath);
+
+        URL targetUrl = destfo.getURL();
+        logger.info("[pushFile] pushing file to " + targetUrl);
+
         if (!destfo.isWriteable()) {
             RuntimeException ex = new IllegalArgumentException(
                 "File " + filePath + " is not writable in space " + spaceName);
@@ -2323,38 +2331,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
         // used to create the necessary directories if needed
         destfo.createFile();
-        URL targetUrl = destfo.getURL();
 
-        if (targetUrl.toString().startsWith("file:")) {
-            // if the url is a file:// url, we push directly the InputStream to
-            // the destination file
-            File targetFile = null;
-            try {
-                targetFile = new File(targetUrl.toURI());
-            } catch (URISyntaxException e) {
-                throw new IllegalStateException(e);
-            }
-            logger.info("[pushFile] pushing input file to " + targetFile);
-            try {
-                FileUtils.copyInputStreamToFile(fileContent, targetFile);
-            } catch (IOException e) {
-                if (targetFile.exists()) {
-                    targetFile.delete();
-                }
-                throw e;
-            }
-        } else {
-            // in the other case, we need to push the inputStream to a tempFile
-            // and then transfer the file via dataspaces
-            File tmpFile = File.createTempFile("pushedFile", ".tmp");
-            try {
-                FileUtils.copyInputStreamToFile(fileContent, tmpFile);
-                FileObject sourcefo = fsManager.resolveFile(tmpFile.getCanonicalPath());
-                destfo.copyFrom(sourcefo, Selectors.SELECT_SELF);
-            } finally {
-                tmpFile.delete();
-            }
-        }
+        dataspaceRestApi.writeFile(fileContent, destfo, null);
 
         return true;
     }
@@ -2380,17 +2358,13 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             @PathParam("spaceName") String spaceName, @PathParam("filePath") String filePath)
             throws IOException, NotConnectedRestException, PermissionRestException {
 
-        Scheduler s = checkAccess(sessionId, "pullFile");
+        checkAccess(sessionId, "pullFile");
+        Session session = dataspaceRestApi.checkSessionValidity(sessionId);
 
-        String spaceURI = resolveSpaceUri(s, spaceName);
-        if (filePath == null) {
-            filePath = "";
-        }
-        if (!filePath.startsWith("/")) {
-            filePath = "/" + filePath;
-        }
-        String destUri = spaceURI + filePath;
-        FileObject sourcefo = fsManager.resolveFile(destUri);
+        filePath = normalizeFilePath(filePath, null);
+
+        FileObject sourcefo = dataspaceRestApi.resolveFile(session, spaceName, filePath);
+
         if (!sourcefo.exists() || !sourcefo.isReadable()) {
             RuntimeException ex = new IllegalArgumentException(
                 "File " + filePath + " does not exist or is not readable in space " + spaceName);
@@ -2435,18 +2409,14 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     public boolean deleteFile(@HeaderParam("sessionid") String sessionId,
             @PathParam("spaceName") String spaceName, @PathParam("filePath") String filePath)
             throws IOException, NotConnectedRestException, PermissionRestException {
-        Scheduler s = checkAccess(sessionId, "deleteFile");
+        checkAccess(sessionId, "deleteFile");
 
-        String spaceURI = resolveSpaceUri(s, spaceName);
-        if (filePath == null) {
-            filePath = "";
-        }
-        if (!filePath.startsWith("/")) {
-            filePath = "/" + filePath;
-        }
-        String destUri = spaceURI + filePath;
+        Session session = dataspaceRestApi.checkSessionValidity(sessionId);
 
-        FileObject sourcefo = fsManager.resolveFile(destUri);
+        filePath = normalizeFilePath(filePath, null);
+
+        FileObject sourcefo = dataspaceRestApi.resolveFile(session, spaceName, filePath);
+
         if (!sourcefo.exists() || !sourcefo.isWriteable()) {
             RuntimeException ex = new IllegalArgumentException(
                 "File or Folder " + filePath + " does not exist or is not writable in space " + spaceName);
@@ -2466,26 +2436,6 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             throw ex;
         }
         return true;
-    }
-
-    private String resolveSpaceUri(Scheduler s, String spaceName)
-            throws NotConnectedRestException, PermissionRestException {
-        try {
-            if (SchedulerConstants.GLOBALSPACE_NAME.equals(spaceName)) {
-                return s.getGlobalSpaceURIs().get(0);
-
-            } else if (SchedulerConstants.USERSPACE_NAME.equals(spaceName)) {
-                return s.getUserSpaceURIs().get(0);
-            } else {
-                RuntimeException ex = new IllegalArgumentException("Wrong Data Space name : " + spaceName);
-                logger.error(ex);
-                throw ex;
-            }
-        } catch (NotConnectedException e) {
-            throw new NotConnectedRestException(e);
-        } catch (PermissionException e) {
-            throw new PermissionRestException(e);
-        }
     }
 
     /**

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestJobLogsTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestJobLogsTest.java
@@ -34,10 +34,12 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler;
 
-import java.io.File;
-import java.io.InputStream;
-import java.util.Collections;
-
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.ow2.proactive.scheduler.common.task.SimpleTaskLogs;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
 import org.ow2.proactive.scheduler.job.InternalTaskFlowJob;
@@ -47,14 +49,13 @@ import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalScriptTask;
 import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStoreTestUtils;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.*;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -126,6 +127,7 @@ public class SchedulerStateRestJobLogsTest {
 
         when(mockScheduler.getJobState("123")).thenReturn(jobState);
         when(mockScheduler.getUserSpaceURIs()).thenReturn(Collections.singletonList(logFile.getParent()));
+        when(mockScheduler.getGlobalSpaceURIs()).thenReturn(Collections.singletonList(logFile.getParent()));
 
         InputStream fullLogs = restScheduler.jobFullLogs(validSessionId, "123", validSessionId);
 
@@ -148,6 +150,7 @@ public class SchedulerStateRestJobLogsTest {
 
         when(mockScheduler.getJobState("123")).thenReturn(jobState);
         when(mockScheduler.getUserSpaceURIs()).thenReturn(Collections.singletonList(logFile.getParent()));
+        when(mockScheduler.getGlobalSpaceURIs()).thenReturn(Collections.singletonList(logFile.getParent()));
 
         InputStream fullLogs = restScheduler.jobFullLogs(validSessionId, "123", validSessionId);
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/RemoteSpace.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/RemoteSpace.java
@@ -34,12 +34,15 @@
  */
 package org.ow2.proactive.scheduler.common.task.dataspaces;
 
+import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
+import org.ow2.proactive.scheduler.common.exception.PermissionException;
+
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Set;
-
-import org.objectweb.proactive.annotation.PublicAPI;
 
 
 /**
@@ -52,11 +55,38 @@ import org.objectweb.proactive.annotation.PublicAPI;
 public interface RemoteSpace {
 
     /**
+     * List the content of the given remote directory
+     *
+     * @param remotePath  path in the RemoteSpace where files should be listed
+     * @param recursive if recursive listing should be performed
+     * @return a list of remote paths
+     * @throws FileSystemException
+     * @see "https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)"
+     */
+    List<String> listFiles(String remotePath, boolean recursive) throws FileSystemException;
+
+
+    /**
+     * List the content of the given remote directory, using a glob pattern
+     * <p>
+     * The following special characters can be used inside the pattern : <br>
+     * ** matches zero or more directories <br>
+     * * matches zero or more characters<br>
+     * ? matches one character
+     *
+     * @param remotePath path in the RemoteSpace where files should be listed
+     * @param pattern    pattern to locate files
+     * @return a list of remote paths matching the pattern
+     * @throws FileSystemException
+     * @see "https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)"
+     */
+    List<String> listFiles(String remotePath, String pattern) throws FileSystemException;
+
+    /**
      * Push the given file or directory(including its content) from the local space to the remote space.
      *
-     * Several scenarios can occur :
-     * - If the localPath is a file and the remotePath represents a directory, the file will be copied inside the remote directory
-     * @param localPath path to the local file or folder
+     * When pushing a file or directory, the remotePath must contain the target new file or directory
+     * @param localPath path to the local file or directory
      * @param remotePath path in the RemoteSpace where to put the file or folder
      * @throws FileSystemException
      */
@@ -70,16 +100,19 @@ public interface RemoteSpace {
      *  * matches zero or more characters<br>
      *  ? matches one character
      *
-     * @param pattern pattern to locate files inside the LocalSpace
+     * @param localDirectory local directory used as base
+     * @param pattern pattern to locate files inside the localDirectory
      * @param remotePath path in the RemoteSpace where to put the files
      * @throws FileSystemException
+     * @see "https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)"
      */
-    void pushFiles(String pattern, String remotePath) throws FileSystemException;
+    void pushFiles(File localDirectory, String pattern, String remotePath) throws FileSystemException;
 
     /**
      * Pull the given file or folder(including its content) from the remote space to the local space
+     *
      * @param remotePath path to the remote file (relative to the RemoteSpace root)
-     * @param localPath path in the LocalSpace where to put the file or folder
+     * @param localPath path in the local file system where to put the file or folder
      * @return the path to the file or directory pulled
      * @throws FileSystemException
      */
@@ -93,12 +126,14 @@ public interface RemoteSpace {
      *  * matches zero or more characters<br>
      *  ? matches one character
      *
+     * @param remotePath path in the RemoteSpace used as base for the pattern (e.g. "/")
      * @param pattern pattern to locate files inside the RemoteSpace
-     * @param localPath path in the LocalSpace where to put the files
+     * @param localPath path in the local file system where to put the files
      * @return a set of files pulled
      * @throws FileSystemException
+     * @see "https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)"
      */
-    Set<File> pullFiles(String pattern, String localPath) throws FileSystemException;
+    Set<File> pullFiles(String remotePath, String pattern, File localPath) throws FileSystemException;
 
     /**
      * Delete the given file or folder(including its content) inside the remote space
@@ -115,16 +150,18 @@ public interface RemoteSpace {
      *  * matches zero or more characters<br>
      *  ? matches one character
      *
+     * @param remotePath path in the RemoteSpace used as base for the pattern (e.g. "/")
      * @param pattern pattern to locate files inside the RemoteSpace
      * @throws FileSystemException
+     * @see "https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)"
      */
-    void deleteFiles(String pattern) throws FileSystemException;
+    void deleteFiles(String remotePath, String pattern) throws FileSystemException;
 
     /**
-     * Returns the root URL of the RemoteSpace
+     * Returns the URLs of the RemoteSpace
      * @return URL to the space
      */
-    String getSpaceURL();
+    List<String> getSpaceURLs() throws NotConnectedException, PermissionException, FileSystemException;
 
     /**
      * Returns an input stream on the specified remote file. It will throw an exception if the file does not exist.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/RemoteSpace.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/RemoteSpace.java
@@ -55,18 +55,6 @@ import java.util.Set;
 public interface RemoteSpace {
 
     /**
-     * List the content of the given remote directory
-     *
-     * @param remotePath  path in the RemoteSpace where files should be listed
-     * @param recursive if recursive listing should be performed
-     * @return a list of remote paths
-     * @throws FileSystemException
-     * @see "https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)"
-     */
-    List<String> listFiles(String remotePath, boolean recursive) throws FileSystemException;
-
-
-    /**
      * List the content of the given remote directory, using a glob pattern
      * <p>
      * The following special characters can be used inside the pattern : <br>


### PR DESCRIPTION
 This change does the following improvements to the REST DataSpace API:
 - In the rest server, improves handling of the retrieve method "list" component to allow usage of include/exclude patterns and recursive listing. Before it was only possible to list the content of a single directory, with no filtering. Improved as well some error log messages
 - improved the RemoteSpace interface by adding listing methods, and changing some signatures for clarity.
  - DataSpaceClient's methods getGlobalSpace() and getUserSpace() are now implemented and return a RemotSpace interface, implemented in an internal class.
  - Added tests in DataTransferTest to test the RemoteSpace interface, along with the DataSpaceClient