### PR TITLE
Add dataspace api variable to script task #2649

### DIFF
--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
@@ -187,6 +187,7 @@ public class DataSpaceClient implements IDataSpaceClient {
 
             return true;
         } finally{
+
             if (response != null) {
                 response.close();
             }
@@ -324,7 +325,7 @@ public class DataSpaceClient implements IDataSpaceClient {
                 if (response.getStatus() == HttpURLConnection.HTTP_UNAUTHORIZED) {
                     throw new NotConnectedException("User not authenticated or session timeout.");
                 } else {
-                    throw new RuntimeException("Cannot delete file(s). Status code:" + response.getStatus());
+                    throw new RuntimeException("Cannot delete file(s). Status :" + response.getStatusInfo() + " Entity : " + response.getEntity());
                 }
             } else {
                 noContent = true;

--- a/rest/rest-client/src/test/resources/functionaltests/descriptors/dataspace_client_node_fork.groovy
+++ b/rest/rest-client/src/test/resources/functionaltests/descriptors/dataspace_client_node_fork.groovy
@@ -1,0 +1,2 @@
+userspaceapi.connect()
+globalspaceapi.connect()

--- a/rest/rest-client/src/test/resources/functionaltests/descriptors/dataspace_client_node_push_delete.groovy
+++ b/rest/rest-client/src/test/resources/functionaltests/descriptors/dataspace_client_node_push_delete.groovy
@@ -1,0 +1,20 @@
+REMOTE_DIR = "testDataSpaceNodeClientPushDelete"
+
+userspaceapi.connect()
+globalspaceapi.connect()
+inFile = new File("inFile.txt");
+inFile.write("HelloWorld")
+
+// push file
+userspaceapi.pushFile(inFile, REMOTE_DIR + "/inFile.txt")
+remotefiles = userspaceapi.listFiles(REMOTE_DIR, "*")
+if (remotefiles.size() != 1) throw new IllegalStateException("expected one file found")
+if (remotefiles.get(0) != "inFile.txt") throw new IllegalStateException("expected to find inFile.txt")
+
+// delete file
+userspaceapi.deleteFile(REMOTE_DIR + "/inFile.txt")
+remotefiles = userspaceapi.listFiles(REMOTE_DIR, "*")
+if (remotefiles.size() != 0) throw new IllegalStateException("expected zero file found")
+result = "OK"
+
+

--- a/rest/rest-client/src/test/resources/functionaltests/descriptors/dataspace_client_node_push_pull.groovy
+++ b/rest/rest-client/src/test/resources/functionaltests/descriptors/dataspace_client_node_push_pull.groovy
@@ -1,0 +1,22 @@
+import com.google.common.io.Files
+
+
+REMOTE_DIR = "testDataSpaceNodeClientPushPull"
+
+userspaceapi.connect()
+
+// push file
+inFile = new File("inFile.txt");
+inFile.write("HelloWorld")
+userspaceapi.pushFile(inFile, REMOTE_DIR + "/inFile.txt")
+remotefiles = userspaceapi.listFiles(REMOTE_DIR, "*")
+if (remotefiles.size() != 1) throw new IllegalStateException("expected one file found")
+if (remotefiles.get(0) != "inFile.txt") throw new IllegalStateException("expected to find inFile.txt")
+
+// pull file
+outFile = new File("outFile.txt")
+userspaceapi.pullFile(REMOTE_DIR + "/inFile.txt", outFile)
+if (!Files.equal(inFile, outFile)) throw new IllegalStateException("Donwloaded file should be the same as the original")
+result = outFile.text
+
+

--- a/rest/rest-client/src/test/resources/functionaltests/descriptors/scheduler_client_node.groovy
+++ b/rest/rest-client/src/test/resources/functionaltests/descriptors/scheduler_client_node.groovy
@@ -10,7 +10,7 @@ try {
     task = new ScriptTask()
     task.setName("HelloTask")
     inFile = new File("inFile.txt");
-    inFile.write("SchedulerNodeClientTask")
+    inFile.write("NodeClientTask")
     task.addInputFiles("inFile.txt", InputAccessMode.TransferFromUserSpace)
     task.addOutputFiles("outFile.txt", OutputAccessMode.TransferToUserSpace)
     task.setScript(new TaskScript(new SimpleScript("outFile = new File(\"outFile.txt\"); outFile.write(\"Hello \" + (new File(\"inFile.txt\").text) + \" I'm HelloTask\")", "groovy")))

--- a/rest/rest-client/src/test/resources/functionaltests/descriptors/scheduler_client_node_fork.groovy
+++ b/rest/rest-client/src/test/resources/functionaltests/descriptors/scheduler_client_node_fork.groovy
@@ -1,0 +1,1 @@
+schedulerapi.connect()

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerConstants.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerConstants.java
@@ -94,6 +94,10 @@ public class SchedulerConstants {
 
     public static final String DS_USER_BINDING_NAME = "userspace";
 
+    public static final String DS_GLOBAL_API_BINDING_NAME = "globalspaceapi";
+
+    public static final String DS_USER_API_BINDING_NAME = "userspaceapi";
+
     public static final String FORK_ENVIRONMENT_BINDING_NAME = "forkEnvironment";
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/RemoteSpace.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/dataspaces/RemoteSpace.java
@@ -62,7 +62,7 @@ public interface RemoteSpace {
      * * matches zero or more characters<br>
      * ? matches one character
      *
-     * @param remotePath path in the RemoteSpace where files should be listed
+     * @param remotePath path in the RemoteSpace where files should be listed. Use "." for remote root path.
      * @param pattern    pattern to locate files
      * @return a list of remote paths matching the pattern
      * @throws FileSystemException
@@ -75,7 +75,7 @@ public interface RemoteSpace {
      *
      * When pushing a file or directory, the remotePath must contain the target new file or directory
      * @param localPath path to the local file or directory
-     * @param remotePath path in the RemoteSpace where to put the file or folder
+     * @param remotePath path in the RemoteSpace where to put the file or folder. Use "." for remote root path.
      * @throws FileSystemException
      */
     void pushFile(File localPath, String remotePath) throws FileSystemException;
@@ -90,7 +90,7 @@ public interface RemoteSpace {
      *
      * @param localDirectory local directory used as base
      * @param pattern pattern to locate files inside the localDirectory
-     * @param remotePath path in the RemoteSpace where to put the files
+     * @param remotePath path in the RemoteSpace where to put the files. Use "." for remote root path.
      * @throws FileSystemException
      * @see "https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)"
      */

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.java
@@ -1,0 +1,154 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package org.ow2.proactive.scheduler.task.client;
+
+
+import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
+import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.task.dataspaces.FileSystemException;
+import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
+import org.ow2.proactive.scheduler.rest.ds.DataSpaceClient;
+import org.ow2.proactive.scheduler.rest.ds.IDataSpaceClient;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * DataSpace api available as a variable during the execution of a task. it is based on the RemoteSpace interface.
+ *
+ * @author ActiveEon Team
+ */
+@PublicAPI
+public class DataSpaceNodeClient implements RemoteSpace {
+
+    SchedulerNodeClient schedulerNodeClient;
+    DataSpaceClient dataSpaceClient;
+    IDataSpaceClient.Dataspace space;
+    String schedulerRestUrl;
+
+    RemoteSpace spaceProxy;
+
+
+    public DataSpaceNodeClient(SchedulerNodeClient schedulerNodeClient, IDataSpaceClient.Dataspace space, String schedulerRestUrl) {
+        this.schedulerNodeClient = schedulerNodeClient;
+        this.dataSpaceClient = new DataSpaceClient();
+        this.space = space;
+        this.schedulerRestUrl = schedulerRestUrl;
+        switch (space) {
+            case GLOBAL:
+                spaceProxy = dataSpaceClient.getGlobalSpace();
+                break;
+            case USER:
+                spaceProxy = dataSpaceClient.getUserSpace();
+                break;
+            default:
+                throw new IllegalStateException("Unkown space : " + space);
+        }
+    }
+
+    /**
+     * Connects to the dataspace at the default schedulerRestUrl, using the current user credentials
+     *
+     * @throws Exception
+     */
+    public void connect() throws Exception {
+        connect(schedulerRestUrl);
+    }
+
+    /**
+     * Connects to the dataspace at the specified schedulerRestUrl, using the current user credentials
+     *
+     * @param url schedulerRestUrl of the scheduler
+     * @throws Exception
+     */
+    public void connect(String url) throws Exception {
+        schedulerNodeClient.connect(url);
+        this.dataSpaceClient.init(url, schedulerNodeClient);
+    }
+
+    @Override
+    public List<String> listFiles(String remotePath, String pattern) throws FileSystemException {
+        return spaceProxy.listFiles(remotePath, pattern);
+    }
+
+    @Override
+    public void pushFile(File localPath, String remotePath) throws FileSystemException {
+        spaceProxy.pushFile(localPath, remotePath);
+    }
+
+    @Override
+    public void pushFiles(File localDirectory, String pattern, String remotePath) throws FileSystemException {
+        spaceProxy.pushFiles(localDirectory, pattern, remotePath);
+    }
+
+    @Override
+    public File pullFile(String remotePath, File localPath) throws FileSystemException {
+        return spaceProxy.pullFile(remotePath, localPath);
+    }
+
+    @Override
+    public Set<File> pullFiles(String remotePath, String pattern, File localPath) throws FileSystemException {
+        return spaceProxy.pullFiles(remotePath, pattern, localPath);
+    }
+
+    @Override
+    public void deleteFile(String remotePath) throws FileSystemException {
+        spaceProxy.deleteFile(remotePath);
+    }
+
+    @Override
+    public void deleteFiles(String remotePath, String pattern) throws FileSystemException {
+        spaceProxy.deleteFiles(remotePath, pattern);
+    }
+
+    @Override
+    public List<String> getSpaceURLs() throws NotConnectedException, PermissionException, FileSystemException {
+        return spaceProxy.getSpaceURLs();
+    }
+
+    @Override
+    public InputStream getInputStream(String remotePath) throws FileSystemException {
+        return spaceProxy.getInputStream(remotePath);
+    }
+
+    @Override
+    public OutputStream getOutputStream(String remotePath) throws FileSystemException {
+        return spaceProxy.getOutputStream(remotePath);
+    }
+}

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.java
@@ -102,53 +102,71 @@ public class DataSpaceNodeClient implements RemoteSpace {
         this.dataSpaceClient.init(url, schedulerNodeClient);
     }
 
+    private void renewSession() {
+        try {
+            schedulerNodeClient.renewSession();
+        } catch (NotConnectedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public List<String> listFiles(String remotePath, String pattern) throws FileSystemException {
+        renewSession();
         return spaceProxy.listFiles(remotePath, pattern);
     }
 
     @Override
     public void pushFile(File localPath, String remotePath) throws FileSystemException {
+        renewSession();
         spaceProxy.pushFile(localPath, remotePath);
     }
 
     @Override
     public void pushFiles(File localDirectory, String pattern, String remotePath) throws FileSystemException {
+        renewSession();
         spaceProxy.pushFiles(localDirectory, pattern, remotePath);
     }
 
     @Override
     public File pullFile(String remotePath, File localPath) throws FileSystemException {
+        renewSession();
         return spaceProxy.pullFile(remotePath, localPath);
     }
 
     @Override
     public Set<File> pullFiles(String remotePath, String pattern, File localPath) throws FileSystemException {
+        renewSession();
         return spaceProxy.pullFiles(remotePath, pattern, localPath);
     }
 
     @Override
     public void deleteFile(String remotePath) throws FileSystemException {
+        renewSession();
         spaceProxy.deleteFile(remotePath);
     }
 
     @Override
     public void deleteFiles(String remotePath, String pattern) throws FileSystemException {
+        renewSession();
         spaceProxy.deleteFiles(remotePath, pattern);
     }
 
     @Override
     public List<String> getSpaceURLs() throws NotConnectedException, PermissionException, FileSystemException {
+        renewSession();
         return spaceProxy.getSpaceURLs();
     }
 
     @Override
     public InputStream getInputStream(String remotePath) throws FileSystemException {
+        renewSession();
         return spaceProxy.getInputStream(remotePath);
     }
 
     @Override
     public OutputStream getOutputStream(String remotePath) throws FileSystemException {
+        renewSession();
         return spaceProxy.getOutputStream(remotePath);
     }
 }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.java
@@ -57,12 +57,12 @@ import java.util.Set;
 @PublicAPI
 public class DataSpaceNodeClient implements RemoteSpace {
 
-    SchedulerNodeClient schedulerNodeClient;
-    DataSpaceClient dataSpaceClient;
-    IDataSpaceClient.Dataspace space;
-    String schedulerRestUrl;
+    private final SchedulerNodeClient schedulerNodeClient;
+    private final DataSpaceClient dataSpaceClient;
+    private final IDataSpaceClient.Dataspace space;
+    private final String schedulerRestUrl;
 
-    RemoteSpace spaceProxy;
+    private final RemoteSpace spaceProxy;
 
 
     public DataSpaceNodeClient(SchedulerNodeClient schedulerNodeClient, IDataSpaceClient.Dataspace space, String schedulerRestUrl) {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkEnvironmentScriptExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkEnvironmentScriptExecutor.java
@@ -34,10 +34,9 @@
  */
 package org.ow2.proactive.scheduler.task.executors;
 
-import java.io.PrintStream;
-import java.io.Serializable;
-import java.util.Map;
-
+import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
+import org.ow2.proactive.scheduler.rest.ds.IDataSpaceClient;
+import org.ow2.proactive.scheduler.task.client.SchedulerNodeClient;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scheduler.task.context.TaskContextVariableExtractor;
 import org.ow2.proactive.scheduler.task.executors.forked.env.ForkedTaskVariablesManager;
@@ -45,6 +44,10 @@ import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.scripting.ScriptHandler;
 import org.ow2.proactive.scripting.ScriptLoader;
 import org.ow2.proactive.scripting.ScriptResult;
+
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.Map;
 
 public class ForkEnvironmentScriptExecutor implements Serializable {
     private final ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();
@@ -69,11 +72,16 @@ public class ForkEnvironmentScriptExecutor implements Serializable {
         ScriptHandler scriptHandler = ScriptLoader.createLocalHandler();
         Script<?> script = context.getInitializer().getForkEnvironment().getEnvScript();
 
+        SchedulerNodeClient schedulerNodeClient = forkedTaskVariablesManager.createSchedulerNodeClient(context);
+        RemoteSpace userSpaceClient = forkedTaskVariablesManager.createDataSpaceNodeClient(context, schedulerNodeClient, IDataSpaceClient.Dataspace.USER);
+        RemoteSpace globalSpaceClient = forkedTaskVariablesManager.createDataSpaceNodeClient(context, schedulerNodeClient, IDataSpaceClient.Dataspace.GLOBAL);
+
+
         forkedTaskVariablesManager
                 .addBindingsToScriptHandler(scriptHandler,
                         context,
                         variables,
-                        thirdPartyCredentials, null);
+                        thirdPartyCredentials, schedulerNodeClient, userSpaceClient, globalSpaceClient);
 
         forkedTaskVariablesManager.replaceScriptParameters(script,
                 thirdPartyCredentials,

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreator.java
@@ -46,10 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyException;
-import java.util.Set;
 
 public class ForkedProcessBuilderCreator implements Serializable {
     private final ForkedJvmTaskExecutionCommandCreator forkedJvmTaskExecutionCommandCreator = new ForkedJvmTaskExecutionCommandCreator();
@@ -98,6 +95,7 @@ public class ForkedProcessBuilderCreator implements Serializable {
         if (forkEnvironment != null) {
 
             if (forkEnvironment.getEnvScript() != null) {
+
                 forkEnvironmentScriptResult = forkEnvironmentScriptExecutor
                         .executeForkEnvironmentScript(context, outputSink, errorSink);
             }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
@@ -36,9 +36,11 @@ package org.ow2.proactive.scheduler.task.executors;
 
 import com.google.common.base.Stopwatch;
 import org.apache.commons.io.FileUtils;
+import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive.scheduler.common.task.flow.FlowAction;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
+import org.ow2.proactive.scheduler.rest.ds.IDataSpaceClient;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.client.SchedulerNodeClient;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
@@ -118,7 +120,9 @@ public class InProcessTaskExecutor implements TaskExecutor {
     public TaskResultImpl execute(TaskContext taskContext, PrintStream output, PrintStream error) {
         ScriptHandler scriptHandler = ScriptLoader.createLocalHandler();
         String nodesFile = null;
-        SchedulerNodeClient client = null;
+        SchedulerNodeClient schedulerNodeClient = null;
+        RemoteSpace userSpaceClient = null;
+        RemoteSpace globalSpaceClient = null;
         try {
             nodesFile = writeNodesFile(taskContext);
             Map<String, Serializable> variables = taskContextVariableExtractor.extractTaskVariables(
@@ -126,10 +130,12 @@ public class InProcessTaskExecutor implements TaskExecutor {
                     nodesFile);
             Map<String, String> thirdPartyCredentials = forkedTaskVariablesManager.extractThirdPartyCredentials(
                     taskContext);
-            client = forkedTaskVariablesManager.createSchedulerNodeClient(taskContext);
+            schedulerNodeClient = forkedTaskVariablesManager.createSchedulerNodeClient(taskContext);
+            userSpaceClient = forkedTaskVariablesManager.createDataSpaceNodeClient(taskContext, schedulerNodeClient, IDataSpaceClient.Dataspace.USER);
+            globalSpaceClient = forkedTaskVariablesManager.createDataSpaceNodeClient(taskContext, schedulerNodeClient, IDataSpaceClient.Dataspace.GLOBAL);
 
             forkedTaskVariablesManager.addBindingsToScriptHandler(scriptHandler, taskContext, variables,
-                    thirdPartyCredentials, client);
+                    thirdPartyCredentials, schedulerNodeClient, userSpaceClient, globalSpaceClient);
 
             Stopwatch stopwatch = Stopwatch.createUnstarted();
             TaskResultImpl taskResult;

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
@@ -38,8 +38,11 @@ package org.ow2.proactive.scheduler.task.executors.forked.env;
 import com.google.common.base.Strings;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
 import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
+import org.ow2.proactive.scheduler.rest.ds.IDataSpaceClient;
+import org.ow2.proactive.scheduler.task.client.DataSpaceNodeClient;
 import org.ow2.proactive.scheduler.task.client.SchedulerNodeClient;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
 import org.ow2.proactive.scripting.Script;
@@ -71,7 +74,7 @@ public class ForkedTaskVariablesManager implements Serializable {
 
 
     public void addBindingsToScriptHandler(ScriptHandler scriptHandler, TaskContext taskContext,
-            Map<String, Serializable> variables, Map<String, String> thirdPartyCredentials, SchedulerNodeClient client) {
+                                           Map<String, Serializable> variables, Map<String, String> thirdPartyCredentials, SchedulerNodeClient client, RemoteSpace userSpaceClient, RemoteSpace globalSpaceClient) {
         scriptHandler.addBinding(SchedulerConstants.VARIABLES_BINDING_NAME, variables);
 
         scriptHandler.addBinding(SchedulerConstants.GENERIC_INFO_BINDING_NAME, taskContext.getInitializer().getGenericInformation());
@@ -81,6 +84,8 @@ public class ForkedTaskVariablesManager implements Serializable {
         scriptHandler.addBinding(TaskScript.CREDENTIALS_VARIABLE, thirdPartyCredentials);
         if (client != null) {
             scriptHandler.addBinding(SchedulerConstants.SCHEDULER_CLIENT_BINDING_NAME, client);
+            scriptHandler.addBinding(SchedulerConstants.DS_USER_API_BINDING_NAME, userSpaceClient);
+            scriptHandler.addBinding(SchedulerConstants.DS_GLOBAL_API_BINDING_NAME, globalSpaceClient);
         }
 
         scriptHandler.addBinding(SchedulerConstants.DS_SCRATCH_BINDING_NAME, taskContext.getNodeDataSpaceURIs().getScratchURI());
@@ -111,6 +116,13 @@ public class ForkedTaskVariablesManager implements Serializable {
     public SchedulerNodeClient createSchedulerNodeClient(TaskContext container) {
         if (container.getDecrypter() != null && !Strings.isNullOrEmpty(container.getSchedulerRestUrl())) {
             return new SchedulerNodeClient(container.getDecrypter(), container.getSchedulerRestUrl());
+        }
+        return null;
+    }
+
+    public RemoteSpace createDataSpaceNodeClient(TaskContext container, SchedulerNodeClient schedulerNodeClient, IDataSpaceClient.Dataspace space) {
+        if (schedulerNodeClient != null) {
+            return new DataSpaceNodeClient(schedulerNodeClient, space, container.getSchedulerRestUrl());
         }
         return null;
     }


### PR DESCRIPTION
- created a DataSpaceNodeClient proxy class
- added "userspaceapi" and "globalspaceapi" variables in scripts based on the DataSpaceNodeClient/RemoteSpace implementation
- also added these bindings and the schedulerapi binding to fork environment scripts.
- added a unit test which checks that those bindings are correctly set
- added integration tests which ensures that the dataspace api can be used from a script