### PR TITLE
Make VFSZipper.ZIP able to unzip a file hierarchy

### DIFF
--- a/rest/rest-server/build.gradle
+++ b/rest/rest-server/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.eclipse.jetty:jetty-client:9.2.14.v20151106'
+    testCompile 'org.zeroturnaround:zt-zip:1.9'
 
     runtime 'org.eclipse.jetty.websocket:websocket-server:9.2.14.v20151106'
     runtime 'org.eclipse.jetty:jetty-webapp:9.2.14.v20151106'

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipper.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipper.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 
-
 public class VFSZipper {
 
     private VFSZipper() {
@@ -84,10 +83,16 @@ public class VFSZipper {
                 ZipEntry zipEntry = zis.getNextEntry();
                 while (zipEntry != null) {
                     FileObject entryFile = outfileObj.resolveFile(zipEntry.getName());
-                    if (!entryFile.exists()) {
-                        entryFile.createFile();
+
+                    if (zipEntry.isDirectory()) {
+                        entryFile.createFolder();
+                    } else {
+                        if (!entryFile.exists()) {
+                            entryFile.createFile();
+                        }
+                        Zipper.ZIP.unzipEntry(zis, entryFile.getContent().getOutputStream());
                     }
-                    Zipper.ZIP.unzipEntry(zis, entryFile.getContent().getOutputStream());
+
                     zipEntry = zis.getNextEntry();
                 }
             } catch (IOException ioe) {

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipperZIPTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipperZIPTest.java
@@ -1,0 +1,201 @@
+package org.ow2.proactive_grid_cloud_portal.dataspace.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemManager;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.ow2.proactive_grid_cloud_portal.dataspace.FileSystem;
+import org.zeroturnaround.zip.ZipEntryCallback;
+import org.zeroturnaround.zip.ZipUtil;
+
+
+/**
+ * Unit tests related to {@link org.ow2.proactive_grid_cloud_portal.dataspace.util.VFSZipper.ZIP}.
+ *
+ * @author ActiveEon Team
+ */
+public class VFSZipperZIPTest {
+
+    private static final String DEFAULT_ARCHIVE_NAME = "archive.zip";
+
+    private static final int HIERARCHY_DEPTH = 10;
+
+    private static final int HIERARCHY_CODEPOINT_ROOT = 'a';
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private Path archivePath;
+
+    private Path outputPath;
+
+    private FileSystemManager fileSystemManager;
+
+    private Path temporaryPath;
+
+    @Before
+    public void setUp() throws IOException {
+        fileSystemManager = VFS.getManager();
+        temporaryPath = temporaryFolder.newFolder().toPath();
+
+        archivePath = getArchivePath();
+        outputPath = getOutputPath();
+    }
+
+    @Test
+    public void testZipFolderWithFileHierarchy() throws IOException {
+        createFileHierarchy(temporaryPath);
+        testZip(temporaryPath);
+        assertZipWithFileHierarchy(archivePath);
+    }
+
+    @Test
+    public void testZipEmptyFolder() throws IOException {
+        testZip(temporaryPath);
+        assertThat(Files.exists(archivePath)).isTrue();
+    }
+
+    @Test
+    public void testUnzipArchiveWithFileHierarchy() throws IOException {
+        createFileHierarchy(temporaryPath);
+
+        // Zips using third-party library that is tested and known to work as expected
+        ZipUtil.pack(temporaryPath.toFile(), archivePath.toFile());
+
+        testUnzip(outputPath);
+    }
+
+    @Test
+    public void testUnzipEmptyContent() throws IOException, InterruptedException {
+        Files.createFile(archivePath);
+
+        FileSystemManager fsManager = VFS.getManager();
+
+        VFSZipper.ZIP.unzip(Files.newInputStream(archivePath), fsManager.resolveFile(outputPath.toUri()));
+
+        assertThat(outputPath.toFile().listFiles()).isNull();
+    }
+
+    @Test
+    public void testZipUnzipZipUnzip() throws IOException, InterruptedException {
+        Path pathToZip = temporaryPath;
+        Path resultPath = outputPath;
+
+        createFileHierarchy(temporaryPath);
+
+        for (int i = 0; i < 2; i++) {
+            testZip(pathToZip);
+            assertZipWithFileHierarchy(archivePath);
+
+            testUnzip(resultPath);
+            assertUnzippedFileHierarchy(resultPath);
+
+            pathToZip = resultPath;
+            resultPath = temporaryPath.resolve("output" + (i + 1));
+
+            Files.delete(archivePath);
+        }
+    }
+
+    /**
+     * Creates the following file hierarchy from the specified root:
+     * .
+     * ├── a.txt
+     * └── folder0
+     *     ├── b.txt
+     *     └── folder...
+     *         ├── ....txt
+     *         └── folderN
+     *             └── N_{ascii}.txt
+     * <p>
+     * where N is the equals to HIERARCHY_DEPTH.
+     */
+    private void createFileHierarchy(Path root) throws IOException {
+        int codepoint = HIERARCHY_CODEPOINT_ROOT;
+
+        createFile(root, codepoint);
+
+        for (int i = 0; i < HIERARCHY_DEPTH; i++) {
+            codepoint++;
+            Path folder = createFolder(root, "folder" + i);
+            createFile(folder, codepoint);
+            root = folder;
+        }
+    }
+
+    private void testZip(Path pathToZip) throws IOException {
+        List<FileObject> files = FileSystem.findFiles(fileSystemManager.resolveFile(pathToZip.toUri()), null,
+                null);
+
+        VFSZipper.ZIP.zip(fileSystemManager.resolveFile(pathToZip.toUri()), files,
+                Files.newOutputStream(archivePath));
+    }
+
+    private void assertZipWithFileHierarchy(Path archivePath) {
+        final int[] nbEntries = { 0 };
+
+        // Reads ZIP content using a third-party library
+        ZipUtil.iterate(archivePath.toFile(), new ZipEntryCallback() {
+            @Override
+            public void process(InputStream in, ZipEntry zipEntry) throws IOException {
+                nbEntries[0]++;
+            }
+        });
+
+        assertThat(nbEntries[0]).isEqualTo(HIERARCHY_DEPTH + 1);
+    }
+
+    private void testUnzip(Path resultPath) throws IOException {
+        VFSZipper.ZIP.unzip(Files.newInputStream(archivePath),
+                fileSystemManager.resolveFile(resultPath.toUri()));
+
+        assertUnzippedFileHierarchy(outputPath);
+    }
+
+    private void assertUnzippedFileHierarchy(Path root) {
+        int codepoint = HIERARCHY_CODEPOINT_ROOT;
+
+        Path file = getFile(root, codepoint);
+        assertThat(Files.exists(file)).isTrue();
+
+        for (int i = 0; i < HIERARCHY_DEPTH; i++) {
+            root = root.resolve("folder" + i);
+            assertThat(Files.exists(root)).isTrue();
+        }
+    }
+
+    private Path getArchivePath() {
+        return temporaryPath.getParent().resolve(DEFAULT_ARCHIVE_NAME);
+    }
+
+    private Path getOutputPath() throws IOException {
+        return temporaryPath.resolve("output");
+    }
+
+    private Path createFile(Path root, int codepoint) throws IOException {
+        return Files.createFile(getFile(root, codepoint));
+    }
+
+    private Path getFile(Path root, int codepoint) {
+        return root.resolve(Character.toString((char) codepoint) + ".txt");
+    }
+
+    private Path createFolder(Path root, String name) throws IOException {
+        Path folder = root.resolve(name);
+        Files.createDirectories(folder);
+        return folder;
+    }
+
+}


### PR DESCRIPTION
Revert "Revert "Make VFSZipper.ZIP able to unzip a file hierarchy"" is because the fix was pushed by accident in branch 7.15.X without review.

This patch fixes ow2-proactive/scheduling#2659.