### PR TITLE
Add PAM authentication module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ dependencies {
 
     nativeBundle 'org.jvnet.winp:winp:1.23-proactive:native'
     nativeBundle 'sigar:sigar:1.7.0-proactive:native'
+    nativeBundle 'net.sf.jpam:libjpam:1.1-proactive:native'
 
     compile 'org.codehaus.groovy:groovy-all:2.4.6'
     compile 'commons-io:commons-io:2.4'

--- a/common/common-client/build.gradle
+++ b/common/common-client/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     compile 'commons-codec:commons-codec:1.10'
     compile 'org.rrd4j:rrd4j:2.2.1'
     compile 'org.ow2.proactive:process-tree-killer:1.0.0'
+    compile group: 'net.sf.jpam', name: 'jpam', version: '1.1'
 
     compile "org.objectweb.proactive:programming-core:${programmingVersion}"
     compile "org.objectweb.proactive:programming-extension-annotation:${programmingVersion}"

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/FileLoginModule.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/FileLoginModule.java
@@ -36,14 +36,9 @@
  */
 package org.ow2.proactive.authentication;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Properties;
+import org.apache.log4j.Logger;
+import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
+import org.ow2.proactive.authentication.principals.UserNamePrincipal;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
@@ -52,10 +47,14 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.FailedLoginException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
-
-import org.apache.log4j.Logger;
-import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
-import org.ow2.proactive.authentication.principals.UserNamePrincipal;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
 
 
 /**
@@ -160,7 +159,7 @@ public abstract class FileLoginModule implements Loggable, LoginModule {
                 throw new FailedLoginException("No username has been specified for authentication");
             }
 
-            succeeded = logUser(username, password);
+            succeeded = logUser(username, password, true);
             return succeeded;
 
         } catch (java.io.IOException ioe) {
@@ -178,13 +177,19 @@ public abstract class FileLoginModule implements Loggable, LoginModule {
      * check group membership from group file.
      * @param username user's login
      * @param password user's password
+     * @param printErrorMessage if a message should be printed if the password is incorrect.
      * @return true user login and password are correct, and requested group is authorized for the user
      * @throws LoginException if authentication or group membership fails.
      */
-    protected boolean logUser(String username, String password) throws LoginException {
+    protected boolean logUser(String username, String password, boolean printErrorMessage) throws LoginException {
 
         if (!authenticateUserFromFile(username, password)) {
-            logger.info("Incorrect Username/Password");
+            String message = "[" + FileLoginModule.class.getSimpleName() + "] Incorrect Username/Password";
+            if (printErrorMessage) {
+                logger.info(message);
+            } else {
+                logger.debug(message);
+            }
             throw new FailedLoginException("Incorrect Username/Password");
         }
 

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPLoginModule.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPLoginModule.java
@@ -36,8 +36,9 @@
  */
 package org.ow2.proactive.authentication;
 
-import java.util.Hashtable;
-import java.util.Map;
+import org.apache.log4j.Logger;
+import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
+import org.ow2.proactive.authentication.principals.UserNamePrincipal;
 
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -53,10 +54,8 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.FailedLoginException;
 import javax.security.auth.login.LoginException;
-
-import org.apache.log4j.Logger;
-import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
-import org.ow2.proactive.authentication.principals.UserNamePrincipal;
+import java.util.Hashtable;
+import java.util.Map;
 
 
 /**
@@ -282,15 +281,14 @@ public abstract class LDAPLoginModule extends FileLoginModule implements Loggabl
      * @return true user login and password are correct, and requested group is authorized for the user
      * @throws LoginException if authentication and group membership fails.
      */
-    @Override
     protected boolean logUser(String username, String password) throws LoginException {
-        try {
-            if (fallbackUserAuth) {
-                return super.logUser(username, password);
-            } else {
+        if (fallbackUserAuth) {
+            try {
+                return super.logUser(username, password, false);
+            } catch (LoginException ex) {
                 return internalLogUser(username, password);
             }
-        } catch (LoginException ex) {
+        } else {
             return internalLogUser(username, password);
         }
     }

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/PAMLoginModule.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/PAMLoginModule.java
@@ -1,0 +1,227 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$PROACTIVE_INITIAL_DEV$$
+ */
+package org.ow2.proactive.authentication;
+
+import net.sf.jpam.Pam;
+import net.sf.jpam.PamReturnValue;
+import org.apache.log4j.Logger;
+import org.ow2.proactive.authentication.principals.UserNamePrincipal;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.util.Map;
+
+
+/**
+ * Authentication based on user and group file.
+ *
+ * @author The ProActive Team
+ * @since ProActive Scheduling 0.9.1
+ */
+public abstract class PAMLoginModule extends FileLoginModule implements Loggable {
+
+    /**
+     * connection logger
+     */
+    private final Logger logger = getLogger();
+
+    /**
+     * PAM module name to be installed in the pam configuration
+     **/
+    public static final String PAM_MODULE_NAME = "proactive-jpam";
+
+    /**
+     * authentication status
+     */
+    private boolean succeeded = false;
+
+    private final Pam pam;
+
+    public PAMLoginModule() {
+        pam = new Pam(PAM_MODULE_NAME);
+    }
+
+    /**
+     * @see LoginModule#initialize(Subject, CallbackHandler, Map, Map)
+     */
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState,
+                           Map<String, ?> options) {
+
+        this.subject = subject;
+        this.callbackHandler = callbackHandler;
+
+    }
+
+    /**
+     * Authenticate the user by getting the user name and password from the
+     * CallbackHandler.
+     * <p>
+     * <p>
+     *
+     * @return true in all cases since this <code>PAMLoginModule</code>
+     * should not be ignored.
+     * @throws FailedLoginException if the authentication fails.
+     *                              <p>
+     * @throws LoginException       if this <code>LDAPLoginModule</code> is unable to
+     *                              perform the authentication.
+     */
+    @Override
+    public boolean login() throws LoginException {
+        succeeded = false;
+        if (callbackHandler == null) {
+            throw new LoginException("Error: no CallbackHandler available "
+                    + "to garner authentication information from the user");
+        }
+
+        try {
+
+            Callback[] callbacks = new Callback[]{new NoCallback()};
+
+            // gets the user name, password, group Membership, and group Hierarchy from call back handler
+            callbackHandler.handle(callbacks);
+            Map<String, Object> params = ((NoCallback) callbacks[0]).get();
+            String username = (String) params.get("username");
+            String password = (String) params.get("pw");
+
+            params.clear();
+            ((NoCallback) callbacks[0]).clear();
+
+            if (username == null) {
+                logger.info("No username has been specified for authentication");
+                throw new FailedLoginException("No username has been specified for authentication");
+            }
+
+            succeeded = logUser(username, password);
+            return succeeded;
+
+        } catch (java.io.IOException ioe) {
+            throw new LoginException(ioe.toString());
+        } catch (UnsupportedCallbackException uce) {
+            throw new LoginException("Error: " + uce.getCallback().toString() +
+                    " not available to garner authentication information " + "from the user");
+        }
+    }
+
+    /**
+     * Check user and password from file, or authenticate with PAM.
+     *
+     * @param username user's login
+     * @param password user's password
+     * @return true user login and password are correct, and requested group is authorized for the user
+     * @throws LoginException if authentication and group membership fails.
+     */
+    protected boolean logUser(String username, String password) throws LoginException {
+        try {
+            return super.logUser(username, password, false);
+        } catch (LoginException ex) {
+            return pamLogUser(username, password);
+        }
+    }
+
+    private boolean pamLogUser(String username, String password) throws LoginException {
+        logger.debug("Authenticating user " + username + " with PAM.");
+        PamReturnValue answer = pam.authenticate(username, password);
+        if (answer.equals(PamReturnValue.PAM_SUCCESS)) {
+            subject.getPrincipals().add(new UserNamePrincipal(username));
+            super.groupMembershipFromFile(username);
+            return true;
+        } else {
+            logger.info("PAM authentication failed for user " + username + ": " + answer);
+            throw new FailedLoginException(answer.toString());
+        }
+    }
+
+    /**
+     * <p>
+     * This method is called if the LoginContext's overall authentication
+     * succeeded (the relevant REQUIRED, REQUISITE, SUFFICIENT and OPTIONAL
+     * LoginModules succeeded).
+     * <p>
+     *
+     * @return true if this LDAPLoginModule's own login and commit attempts
+     * succeeded, or false otherwise.
+     * @throws LoginException if the commit fails.
+     */
+    @Override
+    public boolean commit() throws LoginException {
+        return succeeded;
+    }
+
+    /**
+     * <p>
+     * This method is called if the LoginContext's overall authentication
+     * failed. (the relevant REQUIRED, REQUISITE, SUFFICIENT and OPTIONAL
+     * LoginModules did not succeed).
+     * <p>
+     * <p>
+     * If this LDAPLoginModule's own authentication attempt succeeded (checked
+     * by retrieving the private state saved by the <code>login</code> and
+     * <code>commit</code> methods), then this method cleans up any state that
+     * was originally saved.
+     * <p>
+     * <p>
+     *
+     * @return false if this LoginModule's own login and/or commit attempts
+     * failed, and true otherwise.
+     * @throws LoginException if the abort fails.
+     */
+    @Override
+    public boolean abort() throws LoginException {
+        boolean result = succeeded;
+        succeeded = false;
+        return result;
+    }
+
+    /**
+     * Logout the user.
+     * <p>
+     *
+     * @return true in all cases since this <code>LoginModule</code> should
+     * not be ignored.
+     * @throws LoginException if the logout fails.
+     */
+    @Override
+    public boolean logout() throws LoginException {
+        succeeded = false;
+        return true;
+    }
+}

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/jaas.config
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/jaas.config
@@ -8,6 +8,10 @@ SchedulerLDAPLoginMethod {
 	org.ow2.proactive.scheduler.authentication.SchedulerLDAPLoginModule required ;
 };
 
+SchedulerPAMLoginMethod {
+	org.ow2.proactive.scheduler.authentication.SchedulerPAMLoginModule required serviceName="proactive-jpam";
+};
+
 RMFileLoginMethod {
 	org.ow2.proactive.resourcemanager.authentication.RMFileLoginModule required ;
 };
@@ -15,3 +19,8 @@ RMFileLoginMethod {
 RMLDAPLoginMethod {
 	org.ow2.proactive.resourcemanager.authentication.RMLDAPLoginModule required ;
 };
+
+RMPAMLoginMethod {
+	org.ow2.proactive.resourcemanager.authentication.RMPAMLoginModule required serviceName="proactive-jpam";
+};
+

--- a/config/authentication/jaas.config
+++ b/config/authentication/jaas.config
@@ -8,6 +8,10 @@ SchedulerLDAPLoginMethod {
 	org.ow2.proactive.scheduler.authentication.SchedulerLDAPLoginModule required ;
 };
 
+SchedulerPAMLoginMethod {
+	org.ow2.proactive.scheduler.authentication.SchedulerPAMLoginModule required serviceName="proactive-jpam";
+};
+
 RMFileLoginMethod {
 	org.ow2.proactive.resourcemanager.authentication.RMFileLoginModule required ;
 };
@@ -15,3 +19,8 @@ RMFileLoginMethod {
 RMLDAPLoginMethod {
 	org.ow2.proactive.resourcemanager.authentication.RMLDAPLoginModule required ;
 };
+
+RMPAMLoginMethod {
+	org.ow2.proactive.resourcemanager.authentication.RMPAMLoginModule required serviceName="proactive-jpam";
+};
+

--- a/config/authentication/proactive-jpam
+++ b/config/authentication/proactive-jpam
@@ -1,0 +1,46 @@
+#####################################################################
+# Pam Service Configuration for Unix Authentication 
+# Author: Greg Luck
+# Version: $Id: proactive-jpam,v 1.1 2016/09/28 11:49:40 fviale Exp $
+#
+# Requirements
+# ============
+# This configuration file is specific to Linux, although it should work on most Unixes.
+#
+# Instructions
+# ============
+# 1. Place this file in /etc/pam.d
+# 2. Uncomment one of the Module configurations below
+# 3. change /etc/shadow to be readable by the user.
+#
+# Format of pam.d files
+# =====================
+#
+# The first column is the facility. Possible values are:
+# account - account management
+# auth - authentication management
+# password - password  management
+# session - session session management.
+#
+# The second column is the control flag,  which is how the result of the operation is to
+# be interpreted. Possible values are:
+#
+# required - If the module succeeds, the rest of the chain is executed, and the request is granted unless some other module fails. If the module fails, the rest of the chain is also executed, but the request is ultimately denied.
+# requisite - If the module succeeds, the rest of the chain is executed, and the request is granted unless some other module fails. If the module fails, the chain is immediately terminated and the request is denied.
+# sufficient - If the module succeeds and no earlier module in the chain has failed, the chain is immediately terminated and the request is granted. If the module fails, the module is ignored and the rest of the chain is executed.
+#
+# The third column is the path to the module to be used for the chain.
+#
+# The fourth column is optional. It is for any options to be passed to the module.
+#
+######################################################################
+
+# Unix PAM Module
+# ===============
+#
+# Requirements: Requires /etc/shadow be made readable by the user executing java
+#
+auth       required   /lib64/security/pam_unix_auth.so
+account    required   /lib64/security/pam_unix_acct.so
+password   required   /lib64/security/pam_unix_passwd.so
+session    required   /lib64/security/pam_unix_session.so

--- a/config/rm/settings.ini
+++ b/config/rm/settings.ini
@@ -133,6 +133,7 @@ pa.rm.defaultgroupfilename=config/authentication/group.cfg
 #It can be one of the following values :
 #	- "RMFileLoginMethod" to use file login and group management
 #	- "RMLDAPLoginMethod" to use LDAP login management
+#	- "RMPAMLoginMethod" to use PAM login management
 pa.rm.authentication.loginMethod=RMFileLoginMethod
 
 # Path to the rm credentials file for authentication

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -219,6 +219,7 @@ pa.scheduler.core.defaultgroupfilename=config/authentication/group.cfg
 # It can be one of the following values:
 #	- "SchedulerFileLoginMethod" to use file login and group management
 #	- "SchedulerLDAPLoginMethod" to use LDAP login management
+#	- "SchedulerPAMLoginMethod" to use PAM login management
 pa.scheduler.core.authentication.loginMethod=SchedulerFileLoginMethod
 
 #-------------------------------------------------------

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMPAMLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMPAMLoginModule.java
@@ -1,0 +1,90 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$PROACTIVE_INITIAL_DEV$$
+ */
+package org.ow2.proactive.resourcemanager.authentication;
+
+import org.apache.log4j.Logger;
+import org.ow2.proactive.authentication.PAMLoginModule;
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
+
+import java.io.File;
+
+
+/**
+ * File login module implementation for resource manager. Extracts "login" and "group" files names from
+ * resource manager configuration and uses them to authenticate users.
+ */
+public class RMPAMLoginModule extends PAMLoginModule {
+
+    /**
+     * Returns login file name from resource manager configuration file
+     */
+    @Override
+    protected String getLoginFileName() {
+
+        String loginFile = PAResourceManagerProperties.RM_LOGIN_FILE.getValueAsString();
+        //test that login file path is an absolute path or not
+        if (!(new File(loginFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            loginFile = PAResourceManagerProperties.RM_HOME.getValueAsString() + File.separator + loginFile;
+        }
+
+        return loginFile;
+    }
+
+    /**
+     * Returns group file name from resource manager configuration file
+     */
+    @Override
+    protected String getGroupFileName() {
+        String groupFile = PAResourceManagerProperties.RM_GROUP_FILE.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(groupFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            groupFile = PAResourceManagerProperties.RM_HOME.getValueAsString() + File.separator + groupFile;
+        }
+
+        return groupFile;
+    }
+
+    /**
+     * Returns logger used for authentication
+     */
+    public Logger getLogger() {
+        return Logger.getLogger(RMPAMLoginModule.class);
+    }
+
+}

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerPAMLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerPAMLoginModule.java
@@ -1,0 +1,95 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$PROACTIVE_INITIAL_DEV$$
+ */
+package org.ow2.proactive.scheduler.authentication;
+
+import org.apache.log4j.Logger;
+import org.ow2.proactive.authentication.PAMLoginModule;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+
+import java.io.File;
+
+
+/**
+ * File login module implementation for scheduler. Extracts "login" and "group" files names from
+ * scheduler configuration and uses them to authenticate users.
+ */
+public class SchedulerPAMLoginModule extends PAMLoginModule {
+
+    /**
+     * Returns login file name from scheduler configuration file
+     *
+     * @return login file name from scheduler configuration file
+     */
+    @Override
+    protected String getLoginFileName() {
+        String loginFile = PASchedulerProperties.SCHEDULER_LOGIN_FILENAME.getValueAsString();
+        //test that login file path is an absolute path or not
+        if (!(new File(loginFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            loginFile = PASchedulerProperties.SCHEDULER_HOME.getValueAsString() + File.separator + loginFile;
+        }
+
+        return loginFile;
+    }
+
+    /**
+     * Returns group file name from scheduler configuration file
+     *
+     * @return group file name from scheduler configuration file
+     */
+    @Override
+    protected String getGroupFileName() {
+        String groupFile = PASchedulerProperties.SCHEDULER_GROUP_FILENAME.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(groupFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            groupFile = PASchedulerProperties.SCHEDULER_HOME.getValueAsString() + File.separator + groupFile;
+        }
+
+        return groupFile;
+    }
+
+    /**
+     * Returns logger used for authentication
+     *
+     * @return logger used for authentication
+     */
+    public Logger getLogger() {
+        return Logger.getLogger(SchedulerPAMLoginModule.class);
+    }
+
+}

--- a/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -6,11 +6,11 @@
 ##
 ##############################################################################
 
-# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
-DEFAULT_JVM_OPTS=${defaultJvmOpts}
-
 APP_NAME="${applicationName}"
 APP_BASE_NAME=`basename "\$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+DEFAULT_JVM_OPTS=${defaultJvmOpts}
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
@@ -64,6 +64,8 @@ SAVED="`pwd`"
 cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >&-
 APP_HOME="`pwd -P`"
 cd "\$SAVED" >&-
+
+DEFAULT_JVM_OPTS="\$DEFAULT_JVM_OPTS -Djava.library.path=\$APP_HOME/dist/lib"
 
 CLASSPATH=$classpath
 


### PR DESCRIPTION
- created a PAMLoginModule which inherits FileLoginModule and authenticates users with PAM if the file authentication didn't work. Group membership is still provided in the group.cfg file

- updated gradle builds to include jpam dependency (both the jar and the native libjpam.so)

- updated unixStartScript.txt to set the java.library.path of the scheduler to dist/lib which contains libjpam.so (absolute path must be provided)

- provide a proactive-jpam configuration which must be installed in /etc/pam.d

- updated the install.sh script to automate PAMLoginModule configuration when installing a scheduler in production

- cosmetic changes in FileLoginModule for error messages.