### PR TITLE
Fix TagCommandsFunctTest

### DIFF
--- a/rest/rest-cli/src/test/java/functionaltests/TagCommandsFunctTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/TagCommandsFunctTest.java
@@ -7,26 +7,32 @@ import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
 
-/**
- * Created by Sandrine on 18/09/2015.
- */
 public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
 
     private static JobId jobId = null;
 
+    /**
+     * Very large jobId, very probably not existent, in this test env.
+     */
+    private static long NOT_EXISTENT_JOBID = 234454567;
 
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        System.out.println("Init class: " + TagCommandsFunctTest.class);
         init();
+        System.out.println("Finished init class: " + TagCommandsFunctTest.class);
     }
 
     @Before
     public void setUp() throws Exception {
+        System.out.println("Setup test case for class: " + TagCommandsFunctTest.class);
         synchronized (TagCommandsFunctTest.class) {
+            System.out.println("Synchronized");
             super.setUp();
             if (jobId == null) {
+                System.out.println("JobId was null");
                 cleanScheduler();
 
                 //submit a job with a loop and out and err outputs
@@ -35,12 +41,13 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
                 System.out.println("Job " + jobId + " finished");
             }
         }
+        System.out.println("Finished setup test case");
     }
 
 
     @Test
     public void testListJobTaskIds() throws Exception {
-        typeLine("listtasks(1)");
+        typeLine("listtasks(+" + jobId.longValue() + ")");
 
         runCli();
 
@@ -61,7 +68,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListJobTaskIdsWithTag() throws Exception {
-        typeLine("listtasks(1, 'LOOP-T2-1')");
+        typeLine("listtasks(" + jobId.longValue() + ", 'LOOP-T2-1')");
 
         runCli();
 
@@ -82,7 +89,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListJobTaskIdsWithUnknownTag() throws Exception {
-        typeLine("listtasks(1, 'unknownTag')");
+        typeLine("listtasks(" + jobId.longValue() + ", 'unknownTag')");
 
         runCli();
 
@@ -103,7 +110,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListJobTaskIdsUnknownJob() throws Exception {
-        typeLine("listtasks(2, 'unknownTag')");
+        typeLine("listtasks(" + NOT_EXISTENT_JOBID + ", 'unknownTag')");
 
         runCli();
 
@@ -124,7 +131,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListTaskStates() throws Exception {
-        typeLine("taskstates(1)");
+        typeLine("taskstates(" + jobId.longValue() + ")");
 
         runCli();
 
@@ -145,7 +152,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListTaskStateWithTag() throws Exception {
-        typeLine("taskstates(1, 'LOOP-T2-1')");
+        typeLine("taskstates(" + jobId.longValue() + ", 'LOOP-T2-1')");
 
         runCli();
 
@@ -166,7 +173,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListTaskStatesWithUnknownTag() throws Exception {
-        typeLine("taskstates(1, 'unknownTag')");
+        typeLine("taskstates(" + jobId.longValue() + ", 'unknownTag')");
 
         runCli();
 
@@ -187,7 +194,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListTaskStatesUnknownJob() throws Exception {
-        typeLine("taskstates(2, 'unknownTag')");
+        typeLine("taskstates(" + NOT_EXISTENT_JOBID + ", 'unknownTag')");
 
         runCli();
 
@@ -207,10 +214,9 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
     }
 
 
-
     @Test
     public void testJobOutput() throws Exception {
-        typeLine("joboutput(1)");
+        typeLine("joboutput(" + jobId.longValue() + ")");
 
         runCli();
 
@@ -229,7 +235,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testJobOutputWithTag() throws Exception {
-        typeLine("joboutput(1, 'LOOP-T2-1')");
+        typeLine("joboutput(" + jobId.longValue() + ", 'LOOP-T2-1')");
 
         runCli();
 
@@ -248,7 +254,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testJobOutputWithUnknownTag() throws Exception {
-        typeLine("joboutput(1, 'unknownTag')");
+        typeLine("joboutput(" + jobId.longValue() + ", 'unknownTag')");
 
         runCli();
 
@@ -264,7 +270,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListJobOutputUnknownJob() throws Exception {
-        typeLine("joboutput(2, 'unknownTag')");
+        typeLine("joboutput(" + NOT_EXISTENT_JOBID + ", 'unknownTag')");
 
         runCli();
 
@@ -278,7 +284,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testJobResult() throws Exception {
-        typeLine("jobresult(1)");
+        typeLine("jobresult(" + jobId.longValue() + ")");
 
         runCli();
 
@@ -299,7 +305,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testJobResultWithTag() throws Exception {
-        typeLine("jobresult(1, 'LOOP-T2-1')");
+        typeLine("jobresult(" + jobId.longValue() + ", 'LOOP-T2-1')");
 
         runCli();
 
@@ -320,7 +326,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testJobResultWithUnknownTag() throws Exception {
-        typeLine("jobresult(1, 'unknownTag')");
+        typeLine("jobresult(" + jobId.longValue() + ", 'unknownTag')");
 
         runCli();
 
@@ -341,7 +347,7 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
 
     @Test
     public void testListJobResultUnknownJob() throws Exception {
-        typeLine("jobresult(2, 'unknownTag')");
+        typeLine("jobresult(" + NOT_EXISTENT_JOBID + ", 'unknownTag')");
 
         runCli();
 

--- a/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
@@ -66,7 +66,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     private static Scheduler scheduler;
 
-    private static JobId jobId = null;
+    private static JobId submittedJobId = null;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -74,8 +74,8 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
     }
 
     @Before
-    public void setUp() throws Exception {
-        if (jobId == null) {
+    public void submitWorkflowWhichIsUSedByAllTestCasesOnce() throws Exception {
+        if (submittedJobId == null) {
             scheduler = RestFuncTHelper.getScheduler();
             SchedulerState state = scheduler.getState();
             List<JobState> jobStates = new ArrayList<>();
@@ -87,10 +87,9 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
                 scheduler.killJob(jobId);
                 scheduler.removeJob(jobId);
             }
-
             //submit a job with a loop and out and err outputs
             System.out.println("submit a job with loop, out and err outputs");
-            jobId = submitJob("flow_loop_out.xml");
+            submittedJobId = submitJob("flow_loop_out.xml");
         }
     }
 
@@ -113,7 +112,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskIdsByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1");
         JSONObject jsonObject = toJsonObject(response);
         JSONArray taskIds = (JSONArray) jsonObject.get("list");
 
@@ -127,7 +126,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskIdsByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag");
         JSONObject jsonObject = toJsonObject(response);
 
         System.out.println(jsonObject.toJSONString());
@@ -136,7 +135,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskStatesByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/taskstates/LOOP-T2-1");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/taskstates/LOOP-T2-1");
         JSONObject jsonObject = toJsonObject(response);
 
         System.out.println(jsonObject.toJSONString());
@@ -145,7 +144,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskStatesByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/taskstates/unknownTag");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/taskstates/unknownTag");
         JSONObject jsonObject = toJsonObject(response);
 
         System.out.println(jsonObject.toJSONString());
@@ -154,7 +153,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskLogAllByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1/result/log/all");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1/result/log/all");
         String responseContent = getContent(response);
 
         System.out.println(responseContent);
@@ -166,7 +165,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskLogAllByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag/result/log/all");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag/result/log/all");
         String responseContent = getContent(response);
 
         assertEquals("", responseContent);
@@ -174,7 +173,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskLogErrByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1/result/log/err");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1/result/log/err");
         String responseContent = getContent(response);
 
         System.out.println(responseContent);
@@ -184,7 +183,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskLogErrByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag/result/log/err");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag/result/log/err");
         String responseContent = getContent(response);
 
         assertEquals("", responseContent);
@@ -192,7 +191,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskLogOutByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1/result/log/out");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1/result/log/out");
         String responseContent = getContent(response);
 
         System.out.println(responseContent);
@@ -203,7 +202,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskLogOutByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag/result/log/all");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag/result/log/all");
         String responseContent = getContent(response);
 
         assertEquals("", responseContent);
@@ -211,17 +210,17 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskLogServerByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1/log/server");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1/log/server");
         String responseContent = getContent(response);
 
-        for (TaskState state : scheduler.getJobState(jobId).getTasksByTag("LOOP-T2-1")) {
+        for (TaskState state : scheduler.getJobState(submittedJobId).getTasksByTag("LOOP-T2-1")) {
             assertTrue(responseContent.contains("Task " + state.getId() + " logs"));
         }
     }
 
     @Test
     public void testTaskLogSeverByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag/log/server");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag/log/server");
         String responseContent = getContent(response);
 
         assertTrue(!responseContent.contains("TaskLogger"));
@@ -230,7 +229,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
     //FIXME
     @Test
     public void testTaskResultByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1/result");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1/result");
         JSONArray jsonArray = toJsonArray(response);
 
         System.out.println(jsonArray.toJSONString());
@@ -251,7 +250,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskResultByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag/result");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag/result");
         JSONArray jsonArray = toJsonArray(response);
 
         System.out.println(jsonArray.toJSONString());
@@ -260,7 +259,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskResultValueByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1/result/value");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1/result/value");
         JSONObject jsonObject = toJsonObject(response);
 
         System.out.println(jsonObject.toJSONString());
@@ -274,7 +273,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskResultValueByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag/result/value");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag/result/value");
         JSONObject jsonObject = toJsonObject(response);
 
         System.out.println(jsonObject.toJSONString());
@@ -283,7 +282,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskResultSerializedvalueByTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/LOOP-T2-1/result/serializedvalue");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/LOOP-T2-1/result/serializedvalue");
         JSONObject jsonObject = toJsonObject(response);
 
         System.out.println(jsonObject.toJSONString());
@@ -297,7 +296,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testTaskResultSerializedvalueByUnknownTag() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tag/unknownTag/result/serializedvalue");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tag/unknownTag/result/serializedvalue");
         JSONObject jsonObject = toJsonObject(response);
 
         System.out.println(jsonObject.toJSONString());
@@ -306,7 +305,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testJobTags() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tags");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tags");
         JSONArray jsonArray = toJsonArray(response);
 
         System.out.println(jsonArray.toJSONString());
@@ -321,7 +320,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testJobTagsPrefix() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tags/startsWith/LOOP");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tags/startsWith/LOOP");
         JSONArray jsonArray = toJsonArray(response);
 
         System.out.println(jsonArray.toJSONString());
@@ -334,7 +333,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @Test
     public void testJobTagsBadPrefix() throws Exception {
-        HttpResponse response = sendRequest("jobs/" + jobId + "/tasks/tags/startsWith/blabla");
+        HttpResponse response = sendRequest("jobs/" + submittedJobId + "/tasks/tags/startsWith/blabla");
         JSONArray jsonArray = toJsonArray(response);
 
         System.out.println(jsonArray.toJSONString());


### PR DESCRIPTION
Fix TagCommandsFunctTest

What was the problem:
- Database had data inside (failing tests, failed cleanup,....)
- Test submitted job. JobId was 10, because preceding tests did also submit jobs.
- Test had hardcoded jobId = 1, which didn't exists (job removed) or was a different job.

What is the solution:
- Using the jobId from the submitted job in test cases
- Defining a large number, as a jobId which doesn't exists. Before it was jobId = 2.

Also the verbosity of the test cases was increased, by adding more system.out.println().