### PR TITLE
IncreaseFunctionalTestTimeouts

### DIFF
--- a/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
@@ -44,7 +44,7 @@ public class AbstractFunctCmdTest extends AbstractRestFuncTestCase{
         File jobFile = new File(this.getClass().getResource("config/" + filename).toURI());
         WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler);
         JobId id = submitter.submit(jobFile, new HashMap<String, String>());
-        waitJobState(id, waitForStatus, 100000);
+        waitJobState(id, waitForStatus, 500000);
         return id;
     }
 

--- a/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
@@ -70,12 +70,18 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        System.out.println(Thread.currentThread().getStackTrace());
+        System.out.println("Initialize Test Class: "+RestSchedulerTagTest.class.toString());
         init();
+        System.out.println("Finished Initialize Test Class: "+RestSchedulerTagTest.class.toString());
+
     }
 
     @Before
     public void setUp() throws Exception {
+        System.out.println("Setup test case." + Thread.currentThread().getStackTrace());
         if (jobId == null) {
+            System.out.println("Setup - no jobId found: Remove all jobs from scheduler");
             scheduler = RestFuncTHelper.getScheduler();
             SchedulerState state = scheduler.getState();
             List<JobState> jobStates = new ArrayList<>();
@@ -87,18 +93,20 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
                 scheduler.killJob(jobId);
                 scheduler.removeJob(jobId);
             }
-
+            System.out.println("Scheduler was cleaned.");
+            System.out.println("Submit job for test cases.");
             //submit a job with a loop and out and err outputs
             System.out.println("submit a job with loop, out and err outputs");
             jobId = submitJob("flow_loop_out.xml");
         }
+        System.out.println("Finished setup test case.");
     }
 
     private JobId submitJob(String filename) throws Exception {
         File jobFile = new File(this.getClass().getResource("config/" + filename).toURI());
         WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler);
         JobId id = submitter.submit(jobFile, new HashMap<String, String>());
-        waitJobState(id, JobStatus.FINISHED, 100000);
+        waitJobState(id, JobStatus.FINISHED, 500000);
         return id;
     }
 

--- a/rest/rest-smartproxy/src/test/java/functionaltests/RestSmartProxyTest.java
+++ b/rest/rest-smartproxy/src/test/java/functionaltests/RestSmartProxyTest.java
@@ -93,7 +93,7 @@ public final class RestSmartProxyTest extends AbstractRestFuncTestCase {
 
     private static final long ONE_SECOND = TimeUnit.SECONDS.toMillis(1);
 
-    private static final long TEN_MINUTES = 36000; // in milliseconds
+    private static final long TEN_MINUTES = 600000; // in milliseconds
 
     protected static int NB_TASKS = 4;
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TaskProActiveDataspacesIntegrationTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TaskProActiveDataspacesIntegrationTest.java
@@ -57,7 +57,7 @@ public class TaskProActiveDataspacesIntegrationTest {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(120);
+    public Timeout globalTimeout = Timeout.seconds(600);
 
     private Process schedulerDataspaceProcess;
 


### PR DESCRIPTION
Increase Functional Test Timeouts

Problem:
- Windows Server 2012 Jenkins Slaves take 1m:51s to execute the flow_loop_out.xml
- The timeout is set to 100 seconds 1m:30s
- try.activeeon.com takes 1m:27s, so the timeout might be too tight
- The RestSmartProxyTest have the TEN_MINUTES (in miliseconds) set to 36000

Solution:
- Increase the timeout to 500 seconds (factor 5)
- The RestSmartProxyTest TEN_MINUTES (in miliseconds) set to 600000
