### PR TITLE
Start HSQLDB in server mode

### DIFF
--- a/config/hsqldb-server.properties
+++ b/config/hsqldb-server.properties
@@ -1,0 +1,18 @@
+# This files contains properties that are used when starting
+# ProActive Workflows and Scheduling with the default embedded
+# database, namely HSQLDB, in server mode.
+
+server.catalogs.option_line=create=true;hsqldb.tx=mvcc;hsqldb.applog=0;hsqldb.sqllog=0;hsqldb.write_delay=false
+
+# See HSQLDB configuration (table 14.1) for a description of
+# the following properties:
+# http://hsqldb.org/doc/guide/listeners-chapt.html
+
+server.address=localhost
+server.daemon=false
+server.no_system_exit=true
+server.port=9001
+server.remote_open=false
+server.silent=true
+server.tls=false
+server.trace=false

--- a/config/log/server.properties
+++ b/config/log/server.properties
@@ -29,6 +29,7 @@ log4j.logger.proactive.pamr.router=INFO
 
 # silence third party libraries
 log4j.logger.com.mchange=WARN
+log4j.logger.hsqldb.db=WARN
 log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.hibernate=WARN
 log4j.logger.java.sql.DatabaseMetaData=WARN

--- a/config/rm/database.properties
+++ b/config/rm/database.properties
@@ -3,7 +3,7 @@
 # the URL (hibernate.connection.url), and don't forget the dialect (hibernate.dialect)
 
 hibernate.connection.driver_class=org.hsqldb.jdbc.JDBCDriver
-hibernate.connection.url=jdbc:hsqldb:file:${pa.rm.home}/data/db/rm/rm;create=true;hsqldb.tx=mvcc;hsqldb.applog=1;hsqldb.sqllog=0;hsqldb.write_delay=false
+hibernate.connection.url=jdbc:hsqldb:hsql://localhost:9001/rm
 hibernate.dialect=org.hibernate.dialect.HSQLDialect
 
 # Username and password

--- a/config/scheduler/database.properties
+++ b/config/scheduler/database.properties
@@ -3,7 +3,7 @@
 # the URL (hibernate.connection.url), and don't forget the dialect (hibernate.dialect)
 
 hibernate.connection.driver_class=org.hsqldb.jdbc.JDBCDriver
-hibernate.connection.url=jdbc:hsqldb:file:${pa.scheduler.home}/data/db/scheduler/scheduler;create=true;hsqldb.tx=mvcc;hsqldb.applog=1;hsqldb.sqllog=0;hsqldb.write_delay=false
+hibernate.connection.url=jdbc:hsqldb:hsql://localhost:9001/scheduler
 hibernate.dialect=org.hibernate.dialect.HSQLDialect
 
 # Username and password

--- a/rm/rm-server/build.gradle
+++ b/rm/rm-server/build.gradle
@@ -24,7 +24,16 @@ dependencies {
 
     testCompile 'org.apache.sshd:sshd-core:0.14.0'
 
-    runtime 'org.hsqldb:hsqldb:2.3.4'
+    // The version used is a custom one that includes a fix for the silent option:
+    // https://sourceforge.net/p/hsqldb/bugs/1456/
+    //
+    // The source code used to generate this version is available at:
+    //   https://github.com/activeeon/hsqldb/commits/master
+    //
+    // This version can be replaced by an official one once the fix about the
+    // previous issue is released
+    runtime 'org.hsqldb:hsqldb:r5658-f2e27a7'
+
     runtime "org.objectweb.proactive:programming-extension-pnp:${programmingVersion}"
     runtime "org.objectweb.proactive:programming-extension-pnpssl:${programmingVersion}"
 }

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -36,7 +36,15 @@ dependencies {
     testCompile project(':rm:rm-policy:rm-policy-scheduler')
     testCompile project(':scheduler:scheduler-examples')
 
-    runtime 'org.hsqldb:hsqldb:2.3.4'
+    // The version used is a custom one that includes a fix for the silent option:
+    // https://sourceforge.net/p/hsqldb/bugs/1456/
+    //
+    // The source code used to generate this version is available at:
+    //   https://github.com/activeeon/hsqldb/commits/master
+    //
+    // This version can be replaced by an official one once the fix about the
+    // previous issue is released
+    runtime 'org.hsqldb:hsqldb:r5658-f2e27a7'
 
     runtime "org.objectweb.proactive:programming-extension-pnp:${programmingVersion}"
     runtime "org.objectweb.proactive:programming-extension-pnpssl:${programmingVersion}"

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile project(':rm:rm-server')
     compile project(':rm:rm-client')
 
+    testCompile "com.google.jimfs:jimfs:1.1"
     testCompile "org.objectweb.proactive:programming-extension-pnp:${programmingVersion}"
     testCompile "org.objectweb.proactive:programming-extension-pnpssl:${programmingVersion}"
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/HsqldbServer.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/HsqldbServer.java
@@ -1,0 +1,290 @@
+/*
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package org.ow2.proactive.scheduler.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.log4j.Logger;
+import org.hsqldb.Server;
+import org.hsqldb.persist.HsqlProperties;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.AbstractIdleService;
+
+
+/**
+ * This class encapsulates the logic to create an HSQLDB instance in server mode.
+ * <p>
+ * The server manages catalogs. Each catalog depicts an isolated database.
+ * <p>
+ * When HSQLDB is started in server mode, multiple clients can connect to it 
+ * at the same time, which is not the case with the file or in-memory mode.
+ *
+ * @author ActiveEon Team
+ */
+public class HsqldbServer extends AbstractIdleService {
+
+    private static final Logger logger = Logger.getLogger(HsqldbServer.class);
+
+    /**
+     * Hibernate properties.
+     */
+
+    protected static final String PROP_HIBERNATE_CONNECTION_URL = "hibernate.connection.url";
+
+    protected static final String PROP_HIBERNATE_CONNECTION_USERNAME = "hibernate.connection.username";
+
+    @SuppressWarnings("squid:S2068")
+    protected static final String PROP_HIBERNATE_CONNECTION_PASSWORD = "hibernate.connection.password";
+
+    /*
+     * HSQLDB properties.
+     */
+
+    protected static final String HSQLDB_DOCUMENTATION_URL = "http://hsqldb.org/doc/guide/dbproperties-chapt.html";
+
+    // custom property used by tests to be able to pass catalog location in Hibernate configuration file
+    protected static final String PROP_HSQLDB_PREFIX_CATALOG_PATH = "catalog.path";
+
+    protected static final String PROP_HSQLDB_PREFIX_DBNAME = "server.dbname";
+
+    protected static final String PROP_HSQLDB_PREFIX_SERVER_DATABASE = "server.database";
+
+    // this property is not a common HSQLDB property but a custom one to configure catalog options
+    protected static final String PROP_HSQLDB_SERVER_CATALOGS_OPTION_LINE = "server.catalogs.option_line";
+
+    /*
+     * Instance variables.
+     */
+
+    private int catalogIndex;
+
+    private final String catalogOptionLine;
+
+    private final HsqlProperties hsqlProperties;
+
+    private Server server;
+
+    /**
+     * Creates a new instance of HSQLDB server.
+     */
+    HsqldbServer() {
+        catalogOptionLine = "";
+        hsqlProperties = new HsqlProperties();
+    }
+
+    /**
+     * Creates a new instance of HSQLDB server.
+     *
+     * @param configuration the path to the HSQLDB server properties file.
+     *
+     * @throws IOException if an error occurs while reading the configuration file.
+     */
+    public HsqldbServer(Path configuration) throws IOException {
+
+        Properties hsqldbServerProperties = loadProperties(configuration);
+
+        catalogOptionLine = hsqldbServerProperties.getProperty(PROP_HSQLDB_SERVER_CATALOGS_OPTION_LINE);
+        hsqldbServerProperties.remove(PROP_HSQLDB_SERVER_CATALOGS_OPTION_LINE);
+
+        hsqlProperties = new HsqlProperties(hsqldbServerProperties);
+    }
+
+    public void addCatalog(Path defaultLocation, Path hibernateConfiguration) throws IOException {
+        Properties hibernateProperties = loadProperties(hibernateConfiguration);
+
+        String connectionUrl = hibernateProperties.getProperty(PROP_HIBERNATE_CONNECTION_URL);
+
+        String catalogLocation = identifyCatalogLocationFromConnectionUrl(connectionUrl);
+        String catalogName = identifyCatalogNameFromConnectionUrl(connectionUrl);
+        String catalogPassword = hibernateProperties.getProperty(PROP_HIBERNATE_CONNECTION_PASSWORD);
+        String catalogUsername = hibernateProperties.getProperty(PROP_HIBERNATE_CONNECTION_USERNAME);
+
+        Path catalogPath;
+        if (catalogLocation == null) {
+            // Catalog path references a file.
+            // Double resolve is used to get a dedicated folder with the catalog name.
+            catalogPath = defaultLocation.resolve(catalogName).resolve(catalogName);
+        } else {
+            catalogPath = Paths.get(catalogLocation);
+        }
+
+        addCatalog(catalogPath, catalogName, catalogUsername, catalogPassword);
+    }
+
+    public void addCatalog(Path catalogLocation, String catalogName, String catalogUsername,
+            String catalogPassword) {
+
+        if (state() != State.NEW) {
+            throw new IllegalStateException("Catalogs configuration must be done before starting the server");
+        }
+
+        String catalogIndexAsString = Integer.toString(catalogIndex);
+
+        // See documentation, Table 14.1:
+        // http://hsqldb.org/doc/guide/listeners-chapt.html
+        hsqlProperties.setProperty(PROP_HSQLDB_PREFIX_SERVER_DATABASE + "." + catalogIndexAsString,
+                createCatalogOptions(catalogLocation, catalogOptionLine, catalogUsername, catalogPassword));
+        hsqlProperties.setProperty(PROP_HSQLDB_PREFIX_DBNAME + "." + catalogIndexAsString, catalogName);
+
+        catalogIndex++;
+    }
+
+    @VisibleForTesting
+    String createCatalogOptions(Path catalogPath, String catalogOptionLine, String catalogUsername,
+            String catalogPassword) {
+        return "file:" + catalogPath.toString() + ";user=" + catalogUsername + ";password=" +
+            catalogPassword + ";" + catalogOptionLine;
+    }
+
+    // See HSQLDB documentation, table 13.4 (Server Database URL) for input examples
+    // http://hsqldb.org/doc/guide/dbproperties-chapt.html#dpc_db_props_url
+    @VisibleForTesting
+    String identifyCatalogNameFromConnectionUrl(String connectionUrl) {
+        String[] chunks = connectionUrl.split(":");
+
+        if (chunks.length != 4 && chunks.length != 5) {
+            throw new IllegalArgumentException("Invalid connection URL: " + connectionUrl +
+                ". Please look at the HSQLDB documentation: " + HSQLDB_DOCUMENTATION_URL);
+        }
+
+        // discard connection options
+        chunks = chunks[chunks.length - 1].split(";");
+        // split to identify catalog name
+        chunks = chunks[0].split("/");
+
+        return chunks[chunks.length - 1];
+    }
+
+    @VisibleForTesting
+    String identifyCatalogLocationFromConnectionUrl(String connectionUrl) {
+        String[] chunks = connectionUrl.split(";");
+
+        for (String chunk : chunks) {
+            String[] split = chunk.split("=");
+
+            if (split.length == 1) {
+                continue;
+            }
+
+            String key = split[0];
+            String value = split[1];
+
+            if (PROP_HSQLDB_PREFIX_CATALOG_PATH.equals(key)) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    @VisibleForTesting
+    HsqlProperties getHsqlProperties() {
+        return hsqlProperties;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        server = new Server();
+        server.setProperties(hsqlProperties);
+        server.setErrWriter(null);
+        server.setLogWriter(null);
+        server.start();
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        server.stop();
+    }
+
+    public static boolean isServerModeRequired(Path hibernateConfiguration, Path... others)
+            throws IOException {
+
+        List<Path> hibernateConfigurations = ImmutableList.<Path> builder().add(hibernateConfiguration)
+                .add(others).build();
+
+        boolean result = false;
+
+        for (Path config : hibernateConfigurations) {
+            Properties hibernateProperties = loadProperties(config);
+            result |= isServerConnectionConfigured(hibernateProperties);
+        }
+
+        return result;
+    }
+
+    /**
+     * Check if the server connection for HSQLDB is set for the given set of properties.
+     *
+     * @param hibernateProperties the properties to look at for checking configuration.
+     * @return a boolean that says if starting HSQLDB in server mode is required.
+     */
+    @VisibleForTesting
+    static boolean isServerConnectionConfigured(Properties hibernateProperties) {
+        String dbConnectionUrl = hibernateProperties.getProperty(PROP_HIBERNATE_CONNECTION_URL);
+
+        if (dbConnectionUrl == null) {
+            return false;
+        } else if (dbConnectionUrl.startsWith("jdbc:hsqldb:hsql")) {
+            return true;
+        } else if (dbConnectionUrl.startsWith("jdbc:hsqldb:")) {
+            String message = "Non server database URL detected. HSQLDB must be configured in server mode to " +
+                "work smoothly with ProActive Workflows and Scheduling. Please look at HSQLDB documentation: " +
+                HSQLDB_DOCUMENTATION_URL;
+            logger.warn(message);
+            return false;
+        } else {
+            return false;
+        }
+    }
+
+    private static Properties loadProperties(Path configuration) throws IOException {
+        Properties dbProperties = new Properties();
+
+        try (InputStream stream = Files.newInputStream(configuration)) {
+            dbProperties.load(stream);
+        }
+
+        return dbProperties;
+    }
+
+}

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerHsqldbStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerHsqldbStarter.java
@@ -1,0 +1,126 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package org.ow2.proactive.scheduler.util;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+
+import com.google.common.annotations.VisibleForTesting;
+
+
+/**
+ * Manage the startup of an HSQLDB server configured for ProActive Workflows and Scheduling.
+ *
+ * @author ActiveEon Team
+ * @see HsqldbServer
+ */
+public class SchedulerHsqldbStarter {
+
+    private final String schedulerHome = PASchedulerProperties.SCHEDULER_HOME.getValueAsString();
+
+    private final HsqldbServer hsqldbServer;
+
+    private Path hibernateRmConfiguration;
+
+    private Path hibernateSchedulerConfiguration;
+
+    public SchedulerHsqldbStarter() throws IOException {
+        this.hsqldbServer = createHsqldbServer();
+        configureCatalogs(hsqldbServer, schedulerHome);
+    }
+
+    @VisibleForTesting
+    SchedulerHsqldbStarter(HsqldbServer hsqldbServer) throws IOException {
+        this.hsqldbServer = hsqldbServer;
+        configureCatalogs(hsqldbServer, schedulerHome);
+    }
+
+    private HsqldbServer createHsqldbServer() throws IOException {
+        return new HsqldbServer(Paths.get(schedulerHome, "config", "hsqldb-server.properties"));
+    }
+
+    @VisibleForTesting
+    void configureCatalogs(HsqldbServer server, String schedulerHome) throws IOException {
+        String databaseFileName = "database.properties";
+        String schedulerConfigurationFolderName = "config";
+
+        Path schedulerDbPath = Paths.get(schedulerHome, "data", "db");
+
+        hibernateRmConfiguration = Paths.get(schedulerHome, schedulerConfigurationFolderName, "rm",
+                databaseFileName);
+        hibernateSchedulerConfiguration = Paths.get(schedulerHome, schedulerConfigurationFolderName,
+                "scheduler", databaseFileName);
+
+        server.addCatalog(schedulerDbPath, hibernateRmConfiguration);
+        server.addCatalog(schedulerDbPath, hibernateSchedulerConfiguration);
+    }
+
+    public boolean isServerModeRequired() throws IOException {
+        return HsqldbServer.isServerModeRequired(hibernateRmConfiguration, hibernateSchedulerConfiguration);
+    }
+
+    public void startIfNeeded() throws IOException {
+        if (isServerModeRequired()) {
+            start();
+        }
+    }
+
+    @VisibleForTesting
+    void start() {
+        hsqldbServer.startAsync();
+        hsqldbServer.awaitRunning();
+    }
+
+    public void stop() {
+        if (isRunning()) {
+            stopImmediately();
+        }
+    }
+
+    @VisibleForTesting
+    boolean isRunning() {
+        return hsqldbServer.isRunning();
+    }
+
+    @VisibleForTesting
+    void stopImmediately() {
+        hsqldbServer.stopAsync();
+        hsqldbServer.awaitTerminated();
+    }
+
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerStartForFunctionalTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerStartForFunctionalTest.java
@@ -50,6 +50,7 @@ import org.ow2.proactive.scheduler.SchedulerFactory;
 import org.ow2.proactive.scheduler.common.SchedulerConnection;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.task.utils.ForkerUtils;
+import org.ow2.proactive.scheduler.util.SchedulerHsqldbStarter;
 
 import java.io.Serializable;
 import java.net.URI;
@@ -105,6 +106,8 @@ public class SchedulerStartForFunctionalTest implements Serializable {
         PASchedulerProperties.updateProperties(schedPropPath);
 
         RMFactory.setOsJavaProperty();
+
+        new SchedulerHsqldbStarter().startIfNeeded();
 
         new Thread() {
             public void run() {

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/HsqldbServerTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/HsqldbServerTest.java
@@ -1,0 +1,302 @@
+package org.ow2.proactive.scheduler.util;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+
+
+/**
+ * Tests associated to {@link HsqldbServer}.
+ *
+ * @author ActiveEon Team
+ */
+public class HsqldbServerTest {
+
+    @Test
+    public void testAddCatalog() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        Properties properties = hsqldbServer.getHsqlProperties().getProperties();
+
+        assertThat(properties).hasSize(0);
+
+        hsqldbServer.addCatalog(Paths.get("a"), "b", "c", "d");
+
+        properties = hsqldbServer.getHsqlProperties().getProperties();
+
+        assertThat(properties).hasSize(2);
+        assertThat(properties).containsEntry(HsqldbServer.PROP_HSQLDB_PREFIX_DBNAME + ".0", "b");
+        assertThat(properties).containsEntry(HsqldbServer.PROP_HSQLDB_PREFIX_SERVER_DATABASE + ".0",
+                "file:a;user=c;password=d;");
+    }
+
+    @Test
+    public void testAddCatalogProperties() throws IOException {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        Properties properties = hsqldbServer.getHsqlProperties().getProperties();
+
+        assertThat(properties).hasSize(0);
+
+        String username = "username";
+        String password = "password";
+
+        Path hibernateConfiguration = createHibernateConfiguration(ImmutableMap.of(
+                HsqldbServer.PROP_HIBERNATE_CONNECTION_URL, "jdbc:hsqldb:hsql://localhost:9001/scheduler",
+                HsqldbServer.PROP_HIBERNATE_CONNECTION_USERNAME, username,
+                HsqldbServer.PROP_HIBERNATE_CONNECTION_PASSWORD, password));
+
+        Path defaultLocation = Paths.get("/default/location");
+
+        hsqldbServer.addCatalog(defaultLocation, hibernateConfiguration);
+
+        properties = hsqldbServer.getHsqlProperties().getProperties();
+
+        assertThat(properties).hasSize(2);
+        assertThat(properties).containsEntry(HsqldbServer.PROP_HSQLDB_PREFIX_DBNAME + ".0", "scheduler");
+        assertThat(properties).containsEntry(HsqldbServer.PROP_HSQLDB_PREFIX_SERVER_DATABASE + ".0",
+                "file:" + defaultLocation.resolve("scheduler").resolve("scheduler").toString() + ";user=" +
+                    username + ";password=" + password + ";");
+
+        Path dbPath = Paths.get("build", "RM_DB");
+
+        hibernateConfiguration = createHibernateConfiguration(
+                ImmutableMap.of(HsqldbServer.PROP_HIBERNATE_CONNECTION_URL,
+                        "jdbc:hsqldb:hsql://localhost:9001/rm;catalog.path=" + dbPath,
+                        HsqldbServer.PROP_HIBERNATE_CONNECTION_USERNAME, username,
+                        HsqldbServer.PROP_HIBERNATE_CONNECTION_PASSWORD, password));
+
+        hsqldbServer.addCatalog(defaultLocation, hibernateConfiguration);
+
+        assertThat(properties).hasSize(4);
+        assertThat(properties).containsEntry(HsqldbServer.PROP_HSQLDB_PREFIX_DBNAME + ".1", "rm");
+        assertThat(properties).containsEntry(HsqldbServer.PROP_HSQLDB_PREFIX_SERVER_DATABASE + ".1",
+                "file:" + dbPath + ";user=" + username + ";password=" + password + ";");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddCatalogNotAllowedAfterStartup() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+        hsqldbServer.startAsync();
+        hsqldbServer.addCatalog(Paths.get("a"), "b", "c", "d");
+    }
+
+    @Test
+    public void testCreateCatalogOptions() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        Path catalogPath = Paths.get("/a/b/c/d/e");
+        String catalogOptionLine = "option1=alpha;option2=beta;option3=gamma";
+        String catalogUsername = "username";
+        String catalogPassword = "password";
+
+        String optionsLine = hsqldbServer.createCatalogOptions(catalogPath, catalogOptionLine,
+                catalogUsername, catalogPassword);
+
+        assertThat(optionsLine).isEqualTo("file:" + catalogPath +
+            ";user=username;password=password;option1=alpha;option2=beta;option3=gamma");
+    }
+
+    @Test
+    public void testIdentifyCatalogNameFromConnectionUrl1() {
+        HsqldbServer server = new HsqldbServer();
+
+        String catalogName = server
+                .identifyCatalogNameFromConnectionUrl("jdbc:hsqldb:hsql://localhost:9001/scheduler");
+
+        assertThat(catalogName).isEqualTo("scheduler");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIdentifyCatalogNameFromConnectionUrl2() {
+        HsqldbServer server = new HsqldbServer();
+        server.identifyCatalogNameFromConnectionUrl("");
+    }
+
+    @Test
+    public void testIdentifyCatalogNameFromConnectionUrl3() {
+        HsqldbServer server = new HsqldbServer();
+
+        String catalogName = server.identifyCatalogNameFromConnectionUrl(
+                "jdbc:hsqldb:file:build/TEST_SCHEDULER_DB;create=true;hsqldb.tx=mvcc;hsqldb.write_delay=false");
+
+        assertThat(catalogName).isEqualTo("TEST_SCHEDULER_DB");
+    }
+
+    @Test
+    public void testIdentifyCatalogNameFromConnectionUrl4() {
+        HsqldbServer server = new HsqldbServer();
+
+        String catalogName = server.identifyCatalogNameFromConnectionUrl(
+                "jdbc:hsqldb:file:test;create=true;hsqldb.tx=mvcc;hsqldb.write_delay=false");
+
+        assertThat(catalogName).isEqualTo("test");
+    }
+
+    @Test
+    public void testIdentifyCatalogLocationFromConnectionUrl1() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        String catalogLocation = hsqldbServer.identifyCatalogLocationFromConnectionUrl(
+                "jdbc:hsqldb:hsql://localhost:9001/rm;catalog.path=build/TEST_RM_DB");
+
+        assertThat(catalogLocation).isEqualTo("build/TEST_RM_DB");
+    }
+
+    @Test
+    public void testIdentifyCatalogLocationFromConnectionUrl2() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        String catalogLocation = hsqldbServer.identifyCatalogLocationFromConnectionUrl(
+                "jdbc:hsqldb:hsql://localhost:9001/rm;catalog.path=build/TEST_RM_DB;");
+
+        assertThat(catalogLocation).isEqualTo("build/TEST_RM_DB");
+    }
+
+    @Test
+    public void testIdentifyCatalogLocationFromConnectionUrl3() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        String catalogLocation = hsqldbServer.identifyCatalogLocationFromConnectionUrl(
+                "jdbc:hsqldb:hsql://localhost:9001/rm;option1=alpha;option2=beta;" +
+                    "option3=gamma;catalog.path=build/TEST_RM_DB;option4=delta;option5=epsilon");
+
+        assertThat(catalogLocation).isEqualTo("build/TEST_RM_DB");
+    }
+
+    @Test
+    public void testIdentifyCatalogLocationFromConnectionUrl4() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        String catalogLocation = hsqldbServer
+                .identifyCatalogLocationFromConnectionUrl(";==jdbbuil;;d/TEST_;=RM_DB;");
+
+        assertThat(catalogLocation).isNull();
+    }
+
+    @Test
+    public void testIdentifyCatalogLocationFromConnectionUrl5() {
+        HsqldbServer hsqldbServer = new HsqldbServer();
+
+        String catalogLocation = hsqldbServer
+                .identifyCatalogLocationFromConnectionUrl("jdbbuild/TEST_RM_DB;");
+
+        assertThat(catalogLocation).isNull();
+    }
+
+    @Test
+    public void testIsServerModeRequired() throws Exception {
+        Path hibernateConfiguration = createHibernateConfiguration(of(
+                HsqldbServer.PROP_HIBERNATE_CONNECTION_URL, "jdbc:hsqldb:hsql://localhost:9001/scheduler"));
+
+        assertThat(HsqldbServer.isServerModeRequired(hibernateConfiguration)).isTrue();
+    }
+
+    @Test
+    public void testIsServerModeRequiredMultipleConfigurationFiles() throws Exception {
+        Path hibernateConfiguration1 = createHibernateConfiguration(
+                of(HsqldbServer.PROP_HIBERNATE_CONNECTION_URL, "jdbc:mysql://localhost:3306/scheduler"));
+
+        Path hibernateConfiguration2 = createHibernateConfiguration(of(
+                HsqldbServer.PROP_HIBERNATE_CONNECTION_URL, "jdbc:hsqldb:hsql://localhost:9001/scheduler"));
+
+        Path hibernateConfiguration3 = createHibernateConfiguration(ImmutableMap.<String, String> of());
+
+        assertThat(HsqldbServer.isServerModeRequired(hibernateConfiguration1, hibernateConfiguration2,
+                hibernateConfiguration3)).isTrue();
+    }
+
+    @Test
+    public void testIsServerModeNotRequiredSinceEmptyFile() throws Exception {
+        Path hibernateConfiguration = createHibernateConfiguration(ImmutableMap.<String, String> of());
+
+        assertThat(HsqldbServer.isServerModeRequired(hibernateConfiguration)).isFalse();
+    }
+
+    @Test
+    public void testIsServerModeNotRequiredSincePropertyNotFound() throws Exception {
+        Path hibernateConfiguration = createHibernateConfiguration(ImmutableMap.of("a", "b", "c", "d"));
+
+        assertThat(HsqldbServer.isServerModeRequired(hibernateConfiguration)).isFalse();
+    }
+
+    @Test
+    public void testIsServerModeNotRequiredMultipleConfigurationFiles() throws Exception {
+        Path hibernateConfiguration1 = createHibernateConfiguration(ImmutableMap.<String, String> of());
+
+        Path hibernateConfiguration2 = createHibernateConfiguration(
+                of(HsqldbServer.PROP_HIBERNATE_CONNECTION_URL, "42"));
+
+        Path hibernateConfiguration3 = createHibernateConfiguration(
+                of(HsqldbServer.PROP_HIBERNATE_CONNECTION_URL, "jdbc:mysql://localhost:3306/scheduler"));
+
+        assertThat(HsqldbServer.isServerModeRequired(hibernateConfiguration1, hibernateConfiguration2,
+                hibernateConfiguration3)).isFalse();
+    }
+
+    private Path createHibernateConfiguration(ImmutableMap<String, String> props) throws IOException {
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+
+        Path config = fs.getPath(UUID.randomUUID().toString() + ".properties");
+
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        for (Map.Entry<String, String> prop : props.entrySet()) {
+            builder.add(prop.getKey() + '=' + escapeWindowsPath(prop.getValue()));
+        }
+
+        Files.write(config, builder.build(), StandardCharsets.UTF_8);
+
+        return config;
+    }
+
+    private String escapeWindowsPath(String path) {
+        return path.replace("\\", "\\\\");
+    }
+
+    @Test
+    public void testIsServerConnectionConfiguredTrue() throws Exception {
+        Properties properties = newProperties(of(HsqldbServer.PROP_HIBERNATE_CONNECTION_URL,
+                "jdbc:hsqldb:hsql://localhost:9001/scheduler"));
+
+        assertThat(HsqldbServer.isServerConnectionConfigured(properties)).isTrue();
+    }
+
+    @Test
+    public void testIsServerConnectionConfiguredFalse() throws Exception {
+        Properties properties = newProperties(
+                of("unknownProperty", "jdbc:hsqldb:hsql://localhost:9001/scheduler"));
+
+        assertThat(HsqldbServer.isServerConnectionConfigured(properties)).isFalse();
+    }
+
+    @Test
+    public void testIsServerConnectionConfiguredFalseWithWarning() throws Exception {
+        Properties properties = newProperties(of(HsqldbServer.PROP_HIBERNATE_CONNECTION_URL,
+                "jdbc:hsqldb:file:${pa.rm.home}/data/db/rm/rm;create=true;hsqldb.tx=mvcc;hsqldb.applog=1"));
+
+        assertThat(HsqldbServer.isServerConnectionConfigured(properties)).isFalse();
+    }
+
+    private Properties newProperties(ImmutableMap<String, String> props) {
+        Properties properties = new Properties();
+        properties.putAll(props);
+        return properties;
+    }
+
+}

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/SchedulerHsqldbStarterTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/SchedulerHsqldbStarterTest.java
@@ -1,0 +1,85 @@
+package org.ow2.proactive.scheduler.util;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+
+/**
+ * @author ActiveEon Team
+ * 
+ * @see SchedulerHsqldbStarter
+ */
+public class SchedulerHsqldbStarterTest {
+
+    private HsqldbServer hsqldbServerMock;
+
+    private SchedulerHsqldbStarter schedulerHsqldbStarter;
+
+    @Before
+    public void setUp() throws IOException {
+        hsqldbServerMock = Mockito.mock(HsqldbServer.class);
+        schedulerHsqldbStarter = new SchedulerHsqldbStarter(hsqldbServerMock);
+        schedulerHsqldbStarter = Mockito.spy(schedulerHsqldbStarter);
+    }
+
+    @Test
+    public void testConfigureCatalogs() throws Exception {
+        verify(hsqldbServerMock, times(2)).addCatalog(Mockito.<Path> any(), Mockito.<Path> any());
+
+        schedulerHsqldbStarter.configureCatalogs(hsqldbServerMock, "/scheduler/home/");
+
+        verify(hsqldbServerMock, times(4)).addCatalog(Mockito.<Path> any(), Mockito.<Path> any());
+    }
+
+    @Test
+    public void testStartNotRequired() throws Exception {
+        doReturn(false).when(schedulerHsqldbStarter).isServerModeRequired();
+
+        schedulerHsqldbStarter.startIfNeeded();
+
+        verify(schedulerHsqldbStarter).isServerModeRequired();
+        verify(hsqldbServerMock, times(0)).startUp();
+    }
+
+    @Test
+    public void testStartRequired() throws Exception {
+        doReturn(true).when(schedulerHsqldbStarter).isServerModeRequired();
+        doNothing().when(schedulerHsqldbStarter).start();
+
+        schedulerHsqldbStarter.startIfNeeded();
+
+        verify(schedulerHsqldbStarter).isServerModeRequired();
+        verify(schedulerHsqldbStarter).start();
+    }
+
+    @Test
+    public void testStopRequired() throws Exception {
+        doReturn(true).when(schedulerHsqldbStarter).isRunning();
+        doNothing().when(schedulerHsqldbStarter).stopImmediately();
+
+        schedulerHsqldbStarter.stop();
+
+        verify(schedulerHsqldbStarter).isRunning();
+        verify(schedulerHsqldbStarter).stopImmediately();
+    }
+
+    @Test
+    public void testStopNotRequired() throws Exception {
+        doReturn(false).when(schedulerHsqldbStarter).isRunning();
+
+        schedulerHsqldbStarter.stop();
+
+        verify(schedulerHsqldbStarter).isRunning();
+        verify(schedulerHsqldbStarter, times(0)).stopImmediately();
+    }
+
+}


### PR DESCRIPTION
The purpose of this change is to allow multiple clients to connect to the database used by the Scheduler and Resource Manager. It is a requirement for having more than one API or client linking directly with the database.

This change is also interesting for debugging purposes.