### PR TITLE
Update pnp heartbeat period

### DIFF
--- a/config/network/node.ini
+++ b/config/network/node.ini
@@ -6,12 +6,16 @@ proactive.communication.protocol=pnp
 
 ### PNP protocol configuration
 #proactive.pnp.port=1100
-proactive.pnp.default_heartbeat=30000
+proactive.pnp.default_heartbeat=10000
+proactive.pnp.heartbeat_factor=3
+proactive.pnp.heartbeat_window=5
 proactive.pnp.idle_timeout=60000
 
 ### PNPS protocol configuration
 #proactive.pnps.authenticate=false
-proactive.pnps.default_heartbeat=30000
+proactive.pnps.default_heartbeat=10000
+proactive.pnps.heartbeat_factor=3
+proactive.pnps.heartbeat_window=5
 proactive.pnps.idle_timeout=60000
 #proactive.pnps.keystore=/path/to/keystore.jks
 #proactive.pnps.keystore.password=your-password

--- a/config/network/server.ini
+++ b/config/network/server.ini
@@ -7,12 +7,16 @@ proactive.communication.protocol=pnp
 
 ### PNP protocol configuration
 proactive.pnp.port=64738
-proactive.pnp.default_heartbeat=30000
+proactive.pnp.default_heartbeat=10000
+proactive.pnp.heartbeat_factor=3
+proactive.pnp.heartbeat_window=5
 proactive.pnp.idle_timeout=60000
 
 ### PNPS protocol configuration
 #proactive.pnps.authenticate=false
-proactive.pnps.default_heartbeat=30000
+proactive.pnps.default_heartbeat=10000
+proactive.pnps.heartbeat_factor=3
+proactive.pnps.heartbeat_window=5
 proactive.pnps.idle_timeout=60000
 #proactive.pnps.keystore=/path/to/keystore.jks
 #proactive.pnps.keystore.password=your-password


### PR DESCRIPTION
- Because of the new adaptative timeout mechanism, it is necessary to change the default pnp heartbeat period configured in the scheduler