### PR TITLE
Refactor RestartMode

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/RestartMode.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/RestartMode.java
@@ -42,6 +42,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.objectweb.proactive.annotation.PublicAPI;
+import com.google.common.annotations.VisibleForTesting;
 
 
 /**
@@ -60,6 +61,7 @@ public class RestartMode implements java.io.Serializable {
      * The task will be restarted according to its possible resources.
      */
     public static final RestartMode ANYWHERE = new RestartMode(1, "Anywhere");
+
     /**
      * The task will be restarted on an other node.
      */
@@ -70,23 +72,25 @@ public class RestartMode implements java.io.Serializable {
 
     @XmlAttribute
     private String description;
-    
-    public RestartMode(){}
+
+    public RestartMode() {}
 
     /**
      * Implicit constructor of a restart mode.
      *
      * @param description the name of the restart mode.
      */
-    private RestartMode(int index, String description) {
+    @VisibleForTesting
+    protected RestartMode(int index, String description) {
         this.index = index;
         this.description = description;
     }
 
     /**
-     * Return the RestartMode  corresponding to the given sMode String.
+     * Return the RestartMode corresponding to the given {@code description}.
      *
      * @param description a string representing the restart mode.
+     *
      * @return the RestartMode.
      */
     public static RestartMode getMode(String description) {
@@ -97,26 +101,48 @@ public class RestartMode implements java.io.Serializable {
         }
     }
 
-    /**
-     * @see java.lang.Enum#toString()
-     */
-    @Override
-    public String toString() {
+    public static RestartMode getMode(int restartModeId) {
+        switch (restartModeId) {
+            case 1:
+                return RestartMode.ANYWHERE;
+            case 2:
+                return RestartMode.ELSEWHERE;
+            default:
+                throw new IllegalArgumentException("Unknown restart mode: " + restartModeId);
+        }
+    }
+
+    public String getDescription() {
         return description;
     }
 
-    /**
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
+    public int getIndex() {
+        return index;
+    }
+
     @Override
-    public boolean equals(Object obj) {
-        try {
-            return index == ((RestartMode) obj).index;
-        } catch (ClassCastException e) {
-            return false;
-        } catch (NullPointerException e) {
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
+
+        RestartMode that = (RestartMode) o;
+
+        return index == that.index;
+    }
+
+    @Override
+    public int hashCode() {
+        return index;
+    }
+
+    @Override
+    public String toString() {
+        return description;
     }
 
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/RestartModeTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/RestartModeTest.java
@@ -1,0 +1,137 @@
+package org.ow2.proactive.scheduler.common.task;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.ow2.proactive.scheduler.common.task.RestartMode.ANYWHERE;
+import static org.ow2.proactive.scheduler.common.task.RestartMode.ELSEWHERE;
+import static org.ow2.proactive.scheduler.common.task.RestartMode.getMode;
+
+/**
+ * @author ActiveEon Team
+ */
+public class RestartModeTest {
+
+    @Test
+    public void testConstructor() {
+        RestartMode restartMode = new RestartMode(7, "restartMode");
+        assertThat(restartMode.getIndex()).isEqualTo(7);
+        assertThat(restartMode.getDescription()).isEqualTo("restartMode");
+    }
+
+    @Test
+    public void testGetModeUsingDescriptionAnywhere1() {
+        assertThat(getMode("Anywhere")).isEqualTo(ANYWHERE);
+    }
+
+    @Test
+    public void testGetModeUsingDescriptionAnywhere2() {
+        assertThat(getMode("AnYwHeRe")).isEqualTo(ANYWHERE);
+    }
+
+    @Test
+    public void testGetModeUsingDescriptionElsewhere1() {
+        assertThat(getMode("Elsewhere")).isEqualTo(ELSEWHERE);
+    }
+
+    @Test
+    public void testGetModeUsingDescriptionElsewhere2() {
+        assertThat(getMode("ElSeWhErE")).isEqualTo(ELSEWHERE);
+    }
+
+    @Test
+    public void testGetModeUsingDescriptionAnyInput1() {
+        assertThat(getMode("any")).isEqualTo(ANYWHERE);
+    }
+
+    @Test
+    public void testGetModeUsingDescriptionAnyInput2() {
+        assertThat(getMode("")).isEqualTo(ANYWHERE);
+    }
+
+    @Test
+    public void testGetModeUsingIdAnywhere1() {
+        assertThat(getMode(1)).isEqualTo(ANYWHERE);
+    }
+
+    @Test
+    public void testGetModeUsingIdElsewhere1() {
+        assertThat(getMode(2)).isEqualTo(ELSEWHERE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetModeUsingInvalidId1() {
+        getMode(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetModeUsingInvalidId2() {
+        getMode(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetModeUsingInvalidId3() {
+        getMode(3);
+    }
+
+    @Test
+    public void testGetDescriptionForAnywhereOption() {
+        assertThat(ANYWHERE.getDescription()).isEqualTo("Anywhere");
+    }
+
+    @Test
+    public void testGetDescriptionForElsewhereOption() {
+        assertThat(ELSEWHERE.getDescription()).isEqualTo("Elsewhere");
+    }
+
+    @Test
+    public void testGetIndexForAnywhereOption() {
+        assertThat(ANYWHERE.getIndex()).isEqualTo(1);
+    }
+
+    @Test
+    public void testGetIndexForElsewhereOption() {
+        assertThat(ELSEWHERE.getIndex()).isEqualTo(2);
+    }
+
+    @Test
+    public void testToStringAnywhereOption() {
+        assertThat(ANYWHERE.toString()).isEqualTo(ANYWHERE.getDescription());
+    }
+
+    @Test
+    public void testToStringElsewhereOption() {
+        assertThat(ELSEWHERE.toString()).isEqualTo(ELSEWHERE.getDescription());
+    }
+
+    @Test
+    public void testHashCodeAnywhereOption() {
+        assertThat(ANYWHERE.hashCode()).isEqualTo(ANYWHERE.getIndex());
+    }
+
+    @Test
+    public void testHashCodeElsewhereOption() {
+        assertThat(ELSEWHERE.hashCode()).isEqualTo(ELSEWHERE.getIndex());
+    }
+
+    @Test
+    public void testEquality1() {
+        assertThat(ANYWHERE.equals(ANYWHERE)).isTrue();
+    }
+
+    @Test
+    public void testEquality2() throws Exception {
+        assertThat(ANYWHERE.equals(ELSEWHERE)).isFalse();
+    }
+
+    @Test
+    public void testEquality3() throws Exception {
+        assertThat(ANYWHERE.equals(ELSEWHERE)).isFalse();
+    }
+
+    @Test
+    public void testEquality4() throws Exception {
+        assertThat(ANYWHERE.equals(null)).isFalse();
+    }
+
+}

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -1086,24 +1086,11 @@ public class TaskData {
 
     @Transient
     RestartMode getRestartMode() {
-        switch (restartModeId) {
-            case 1:
-                return RestartMode.ANYWHERE;
-            case 2:
-                return RestartMode.ELSEWHERE;
-            default:
-                throw new IllegalStateException("Invalid restartModeId: " + restartModeId);
-        }
+        return RestartMode.getMode(restartModeId);
     }
 
     void setRestartMode(RestartMode restartMode) {
-        if (restartMode.equals(RestartMode.ANYWHERE)) {
-            restartModeId = 1;
-        } else if (restartMode.equals(RestartMode.ELSEWHERE)) {
-            restartModeId = 2;
-        } else {
-            throw new IllegalArgumentException("Invalid restart mode: " + restartMode);
-        }
+        restartModeId = restartMode.getIndex();
     }
 
     @Transient


### PR DESCRIPTION
The purpose is to keep the existing behaviour but to provide accessors to index
and description fields. It is a requirement for the new Scheduling API.

Equals method has been rewritten to prevent usage of exceptions which are costly.
However, the semantic of the method is still the same. Since equals was defined,
the missing hashcode method has also been added.