### PR TITLE
Add variable recursive late bindings for task generic information

### DIFF
--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestJobLogsTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestJobLogsTest.java
@@ -108,7 +108,7 @@ public class SchedulerStateRestJobLogsTest {
     @Test
     public void job_full_logs_not_finished() throws Exception {
         InternalTaskFlowJob jobState = new InternalTaskFlowJob();
-        jobState.addTask(new InternalScriptTask());
+        jobState.addTask(new InternalScriptTask(jobState));
         when(mockScheduler.getJobState("123")).thenReturn(jobState);
 
         InputStream fullLogs = restScheduler.jobFullLogs(validSessionId, "123", validSessionId);
@@ -119,7 +119,7 @@ public class SchedulerStateRestJobLogsTest {
     @Test
     public void job_full_logs_finished() throws Exception {
         InternalTaskFlowJob jobState = new InternalTaskFlowJob();
-        InternalScriptTask task = new InternalScriptTask();
+        InternalScriptTask task = new InternalScriptTask(jobState);
         task.setPreciousLogs(true);
         jobState.addTask(task);
 
@@ -161,7 +161,7 @@ public class SchedulerStateRestJobLogsTest {
     }
 
     private static void addTask(InternalTaskFlowJob jobState, long finishedTime, long id) {
-        InternalScriptTask task = new InternalScriptTask();
+        InternalScriptTask task = new InternalScriptTask(jobState);
         task.setPreciousLogs(true);
         task.setFinishedTime(finishedTime);
         jobState.addTask(task);

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
@@ -36,11 +36,8 @@
  */
 package org.ow2.proactive.scheduler.common.job;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.io.Serializable;
+import java.util.*;
 
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
@@ -53,6 +50,7 @@ import org.ow2.proactive.scheduler.common.util.Pagination;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
+import org.ow2.proactive.scheduler.task.SchedulerVars;
 
 
 /**
@@ -476,5 +474,26 @@ public abstract class JobState extends Job implements Comparable<JobState> {
     public String toString() {
         return getClass().getSimpleName() + "[" + getId() + "]";
     }
-    
+
+    /**
+     * Returns job generic information, where job variables, PA_JOB_ID, PA_JOB_NAME and PA_USER were replaced
+     */
+    public Map<String, String> getRuntimeGenericInformation() {
+        if (genericInformation == null) {
+            // task is not yet properly initialized
+            return new HashMap<>(0);
+        }
+
+        Map<String, Serializable> replacements = new HashMap<>();
+        JobId jobId = getJobInfo().getJobId();
+        if (jobId != null) {
+            replacements.put(SchedulerVars.PA_JOB_ID.toString(), jobId.toString());
+            replacements.put(SchedulerVars.PA_JOB_NAME.toString(), jobId.getReadableName());
+            replacements.put(SchedulerVars.PA_USER.toString(), getOwner());
+        }
+        if (variables != null) {
+            replacements.putAll(variables);
+        }
+        return applyReplacementsOnGenericInformation(genericInformation, replacements);
+    }
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
@@ -36,17 +36,17 @@
  */
 package org.ow2.proactive.scheduler.common.task;
 
+import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.scheduler.common.task.util.IntegerWrapper;
+import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-
-import org.objectweb.proactive.annotation.PublicAPI;
-import org.ow2.proactive.scheduler.common.task.util.IntegerWrapper;
 
 
 /**
@@ -206,21 +206,8 @@ public abstract class CommonAttribute implements Serializable {
 
     }
 
-    protected Map<String, String> applyReplacementsOnGenericInformation(Map<String, String> replacements) {
-        Map<String, String> replacedGenericInformation = new HashMap<String, String>();
-        for (Entry<String, String> e : this.genericInformation.entrySet()) {
-            String key = e.getKey();
-            String value = e.getValue();
-
-            for (Entry<String, String> replacement : replacements.entrySet()) {
-                String javaStyleProperty = replacement.getKey();
-                String envStyleProperty = "$" + javaStyleProperty.toUpperCase().replace('.', '_');
-                value = value.replace(envStyleProperty, replacement.getValue());
-            }
-
-            replacedGenericInformation.put(key, value);
-        }
-        return replacedGenericInformation;
+    protected static Map<String, String> applyReplacementsOnGenericInformation(Map<String, String> genericInformation, Map<String, Serializable> variables) {
+        return VariableSubstitutor.filterAndUpdate(genericInformation, variables);
     }
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
@@ -730,16 +730,6 @@ public abstract class Task extends CommonAttribute {
         }
         return taskVariables;
     }
-    
-    public Map<String, Serializable> getSerializableVariables(){
-        Map<String, Serializable> taskVariables = new HashMap<>();
-        for (TaskVariable variable: getVariables().values()){
-            if (!variable.isJobInherited()){
-                taskVariables.put(variable.getName(), variable.getValue());
-            }
-        }
-        return taskVariables;
-    }
 
     @Override
     public String toString() {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
@@ -36,7 +36,6 @@
  */
 package org.ow2.proactive.scheduler.common.task;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/VariableSubstitutor.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/VariableSubstitutor.java
@@ -36,11 +36,11 @@
  */
 package org.ow2.proactive.scheduler.common.util;
 
+import org.ow2.proactive.scripting.Script;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.ow2.proactive.scripting.Script;
 
 
 /**
@@ -89,11 +89,20 @@ public class VariableSubstitutor {
         }
 
         String output = input;
-        for (Map.Entry<String, String> replacement : buildSubstitutes(variables).entrySet()) {
-            if (replacement.getValue() != null) {
-                output = output.replace(replacement.getKey(), replacement.getValue());
+        Map<String, String> substitutes = buildSubstitutes(variables);
+        boolean anyReplacement;
+        int depthCount = 0;
+        do {
+            anyReplacement = false;
+            depthCount++;
+            for (Map.Entry<String, String> replacement : substitutes.entrySet()) {
+                if (replacement.getValue() != null) {
+                    String newOutput = output.replace(replacement.getKey(), replacement.getValue());
+                    anyReplacement = anyReplacement || !newOutput.equals(output);
+                    output = newOutput;
+                }
             }
-        }
+        } while (anyReplacement && depthCount < 5);
 
         return output;
     }
@@ -130,6 +139,7 @@ public class VariableSubstitutor {
                     String value = variable.getValue().toString();
 
                     replacements.put("$" + key, value);
+                    replacements.put("$" + key.toUpperCase().replace(".", "_"), value);
                     replacements.put("${" + key + "}", value);
                 }
             }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/VariableSubstitutor.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/VariableSubstitutor.java
@@ -51,6 +51,10 @@ import java.util.Map;
  */
 public class VariableSubstitutor {
 
+    // Maximum depth allowed in recursive variable replacements to avoid infinite loops.
+    // This is not configurable as it should cover all use cases.
+    public static final int MAXIMUM_DEPTH = 5;
+
     // non-instantiable
     private VariableSubstitutor() {
     }
@@ -90,7 +94,21 @@ public class VariableSubstitutor {
 
         String output = input;
         Map<String, String> substitutes = buildSubstitutes(variables);
+        output = replaceRecursively(output, substitutes);
+
+        return output;
+    }
+
+    /**
+     * Replace the given string with a list of substitutions recursively. Recursion will be limited to MAXIMUM_DEPTH.
+     *
+     * @param value       string used to apply replacement
+     * @param substitutes map of substitutions
+     * @return a new string where all replacements were performed
+     */
+    private static String replaceRecursively(final String value, Map<String, String> substitutes) {
         boolean anyReplacement;
+        String output = value;
         int depthCount = 0;
         do {
             anyReplacement = false;
@@ -102,8 +120,7 @@ public class VariableSubstitutor {
                     output = newOutput;
                 }
             }
-        } while (anyReplacement && depthCount < 5);
-
+        } while (anyReplacement && depthCount < MAXIMUM_DEPTH);
         return output;
     }
 

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/util/VariablesUtilTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/util/VariablesUtilTest.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.junit.Test;
 
 import static java.util.Collections.singletonMap;
@@ -14,13 +16,35 @@ import static org.ow2.proactive.scheduler.common.util.VariableSubstitutor.filter
 
 public class VariablesUtilTest {
 
-    private static final String testString = "A${foo}C";
+    private static final String testString = "A${foo.bar}C";
+    private static final String testStringRecursive = "A_${foo.${suffix}}_C";
+    private static final String testStringRecursive2 = "A_${myvar}_C";
+    private static final String testStringRecursive3 = "A${expand}";
+    private static final String testStringAlias1 = "A$FOO_BARC";
 
     @Test
     public void testFilterAndUpdateWithVariableMap() {
-        Map<String, String> variables = singletonMap("foo", "B");
-        String updated = filterAndUpdate(testString, variables);
-        assertEquals("ABC", updated);
+        Map<String, String> variables = singletonMap("foo.bar", "B");
+        String updated1 = filterAndUpdate(testString, variables);
+        String updated2 = filterAndUpdate(testStringAlias1, variables);
+        assertEquals("ABC", updated1);
+        assertEquals("ABC", updated2);
+    }
+
+    @Test
+    public void testFilterAndUpdateWithRecursiveDefinition() {
+        Map<String, String> variables = ImmutableMap.<String, String>builder().put("suffix", "bar").put("foo.bar", "B").put("myvar", "${foo.${suffix}}").build();
+        String updated1 = filterAndUpdate(testStringRecursive, variables);
+        String updated2 = filterAndUpdate(testStringRecursive2, variables);
+        assertEquals("A_B_C", updated1);
+        assertEquals("A_B_C", updated2);
+    }
+
+    @Test(timeout = 3000)
+    public void testFilterAndUpdateInfiniteRecursion() {
+        Map<String, String> variables = ImmutableMap.<String, String>builder().put("expand", "A${expand}").build();
+        String updated1 = filterAndUpdate(testStringRecursive3, variables);
+        assertEquals("AAAAAA${expand}", updated1);
     }
 
     @Test
@@ -39,6 +63,8 @@ public class VariablesUtilTest {
         }
         String updated = VariableSubstitutor.filterAndUpdate("A${bar}C", variables);
         assertEquals("ABC", updated);
+        String updated2 = VariableSubstitutor.filterAndUpdate("A$BARC", variables);
+        assertEquals("ABC", updated2);
         assertEquals("B", variables.get("bar"));
     }
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreator.java
@@ -34,6 +34,7 @@
  */
 package org.ow2.proactive.scheduler.task.executors;
 
+import org.apache.commons.io.FileUtils;
 import org.objectweb.proactive.extensions.processbuilder.OSProcessBuilder;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.task.context.TaskContext;
@@ -61,7 +62,7 @@ public class ForkedProcessBuilderCreator implements Serializable {
      * @param outputSink        Standard output sink.
      * @param errorSink         Error sink.
      * @param workingDir        The working directory to execute the process in.
-     * @return Returns a process builder, ready to excute.
+     * @return Returns a process builder, ready to execute.
      * @throws Exception
      */
     public OSProcessBuilder createForkedProcessBuilder(TaskContext context, File serializedContext,
@@ -122,6 +123,9 @@ public class ForkedProcessBuilderCreator implements Serializable {
     private OSProcessBuilder getOsProcessBuilder(TaskContext context, File workingDir,
             String nativeScriptPath) throws IOException, IllegalAccessException, KeyException {
         OSProcessBuilder processBuilder;
+        if (!workingDir.exists()) {
+            FileUtils.forceMkdir(workingDir);
+        }
         if (context.isRunAsUser()) {
             ForkerUtils.setSharedPermissions(workingDir, true);
             processBuilder = ForkerUtils.getOSProcessBuilderFactory(nativeScriptPath).getBuilder(

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/ForkerUtils.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/ForkerUtils.java
@@ -168,10 +168,13 @@ public final class ForkerUtils {
     }
 
     public static void setSharedPermissions(File file, boolean setExecutable) {
-        file.setReadable(true, false);
-        file.setWritable(true, false);
+        if (!file.setReadable(true, false))
+            logger.warn("Failed to set read permission on : " + file);
+        if (!file.setWritable(true, false))
+            logger.warn("Failed to set write permission on : " + file);
         if (setExecutable) {
-            file.setExecutable(true, false);
+            if (!file.setExecutable(true, false))
+                logger.warn("Failed to set executable permission on : " + file);
         }
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -50,9 +50,6 @@ import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobType;
-import org.ow2.proactive.scheduler.common.task.TaskId;
-import org.ow2.proactive.scheduler.common.task.TaskResult;
-import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
 import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
@@ -64,11 +61,9 @@ import org.ow2.proactive.scheduler.descriptor.JobDescriptor;
 import org.ow2.proactive.scheduler.descriptor.TaskDescriptor;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.policy.Policy;
-import org.ow2.proactive.scheduler.task.SchedulerVars;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
 import org.ow2.proactive.scheduler.task.containers.ExecutableContainer;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
-import org.ow2.proactive.scheduler.task.utils.VariablesMap;
 import org.ow2.proactive.scheduler.util.JobLogger;
 import org.ow2.proactive.scheduler.util.TaskLogger;
 import org.ow2.proactive.scripting.SelectionScript;
@@ -399,16 +394,19 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
 
         EligibleTaskDescriptor etd = tasksToSchedule.getFirst();
         InternalJob currentJob = jobMap.get(etd.getJobId()).getInternal();
-        InternalTask internalTask = currentJob.getIHMTasks().get(etd.getTaskId());
+        InternalTask internalTask0 = currentJob.getIHMTasks().get(etd.getTaskId());
 
         try {
+            updateVariablesForTasksToSchedule(jobMap, tasksToSchedule);
+
             TopologyDescriptor descriptor = null;
             boolean bestEffort = true;
-            if (internalTask.isParallel()) {
-                descriptor = internalTask.getParallelEnvironment().getTopologyDescriptor();
+
+            if (internalTask0.isParallel()) {
+                descriptor = internalTask0.getParallelEnvironment().getTopologyDescriptor();
                 bestEffort = false;
                 if (descriptor == null) {
-                    logger.debug("Topology is not defined for the task " + internalTask.getName());
+                    logger.debug("Topology is not defined for the task " + internalTask0.getName());
                 }
             }
             if (descriptor == null) {
@@ -421,15 +419,15 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 criteria.setTopology(descriptor);
                 // resolve script variables (if any) in the list of selection
                 // scripts and then set it as the selection criteria.
-                criteria.setScripts(resolveScriptVariables(internalTask.getSelectionScripts(), 
-                        internalTask.getVariablesOverriden(currentJob)));
-                criteria.setBlackList(internalTask.getNodeExclusion());
+                criteria.setScripts(resolveScriptVariables(internalTask0.getSelectionScripts(),
+                        internalTask0.getRuntimeVariables()));
+                criteria.setBlackList(internalTask0.getNodeExclusion());
                 criteria.setBestEffort(bestEffort);
                 criteria.setAcceptableNodesUrls(freeResources);
-                criteria.setBindings(createBindingsForSelectionScripts(currentJob, etd, internalTask));
+                criteria.setBindings(createBindingsForSelectionScripts(currentJob, etd, internalTask0));
 
-                if (internalTask.getGenericInformation().containsKey(SchedulerConstants.NODE_ACCESS_TOKEN)) {
-                    criteria.setNodeAccessToken(internalTask.getGenericInformation().get(
+                if (internalTask0.getRuntimeGenericInformation().containsKey(SchedulerConstants.NODE_ACCESS_TOKEN)) {
+                    criteria.setNodeAccessToken(internalTask0.getRuntimeGenericInformation().get(
                             SchedulerConstants.NODE_ACCESS_TOKEN));
                 }
 
@@ -454,8 +452,8 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
             return nodeSet;
 
         } catch (IOException | ClassNotFoundException e) {
-            logger.warn("Failed to deserialize previous task variables before selection for task " + internalTask.getId().toString(), e);
-            schedulingService.simulateJobStartAndCancelIt(tasksToSchedule, "Failed to deserialize previous task variables before selection for task " + internalTask.getId().toString());
+            logger.warn("Failed to deserialize previous task variables before selection for task " + internalTask0.getId().toString(), e);
+            schedulingService.simulateJobStartAndCancelIt(tasksToSchedule, "Failed to deserialize previous task variables before selection for task " + internalTask0.getId().toString());
             return null;
         } catch (RMProxyCreationException e) {
             logger.warn("Failed to create User RM Proxy", e);
@@ -468,51 +466,28 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
         }
     }
 
+    private void updateVariablesForTasksToSchedule(Map<JobId, JobDescriptor> jobMap, LinkedList<EligibleTaskDescriptor> tasksToSchedule) throws IOException, ClassNotFoundException {
+        for (EligibleTaskDescriptor taskDescriptor : tasksToSchedule) {
+            InternalJob associatedJob = jobMap.get(taskDescriptor.getJobId()).getInternal();
+            InternalTask internalTask = associatedJob.getIHMTasks().get(taskDescriptor.getTaskId());
+            internalTask.updateVariables(schedulingService);
+        }
+    }
+
     /**
      * Create bindings which will be used by selection scripts for the given tasks
      */
     private Map<String, Serializable> createBindingsForSelectionScripts(InternalJob job, EligibleTaskDescriptor etd, InternalTask task) throws IOException, ClassNotFoundException {
         Map<String, Serializable> bindings = new HashMap<>();
-        VariablesMap variables = new VariablesMap();
-        variables.setScopeMap(task.getSerializableVariables());
+        Map<String, Serializable> variables = new HashMap<>();
         Map<String, Serializable> genericInfo = new HashMap<>();
 
+        variables.putAll(task.getRuntimeVariables());
 
-        int resultSize = etd.getParents().size();
-        if (job.getType() == JobType.TASKSFLOW) {
-            // retrieve from the database the previous task results if available
-            if ((resultSize > 0) && task.handleResultsArguments()) {
-                List<TaskId> parentIds = new ArrayList<>(resultSize);
-                for (int i = 0; i < resultSize; i++) {
-                    parentIds.add(etd.getParents().get(i).getTaskId());
-                }
-                Map<TaskId, TaskResult> taskResults = schedulingService.getInfrastructure().getDBManager()
-                        .loadTasksResults(
-                                job.getId(), parentIds);
-                for (TaskResult taskResult : taskResults.values()) {
-                    if (taskResult.getPropagatedVariables() != null) {
-                        variables.getInheritedMap().putAll(SerializationUtil.deserializeVariableMap(taskResult.getPropagatedVariables()));
-                    }
-                }
-            } else {
-                // otherwise use the default job variables
-                variables.getInheritedMap().putAll(job.getVariables());
-            }
-        }
-
-        // update the variable bindings values for this task
-        variables.getInheritedMap().put(SchedulerVars.PA_JOB_ID.toString(), job.getId().value());
-        variables.getInheritedMap().put(SchedulerVars.PA_JOB_NAME.toString(), job.getName());
-        variables.getInheritedMap().put(SchedulerVars.PA_TASK_ID.toString(), task.getId().value());
-        variables.getInheritedMap().put(SchedulerVars.PA_TASK_NAME.toString(), task.getName());
-        variables.getInheritedMap().put(SchedulerVars.PA_USER.toString(), job.getOwner());
-
-        genericInfo.putAll(job.getGenericInformation());
+        genericInfo.putAll(job.getRuntimeGenericInformation());
 
         if (job.getType() == JobType.TASKSFLOW) {
-            variables.getInheritedMap().put(SchedulerVars.PA_TASK_ITERATION.toString(), task.getIterationIndex());
-            variables.getInheritedMap().put(SchedulerVars.PA_TASK_REPLICATION.toString(), task.getReplicationIndex());
-            genericInfo.putAll(task.getGenericInformation());
+            genericInfo.putAll(task.getRuntimeGenericInformation());
         }
 
         bindings.put(SchedulerConstants.VARIABLES_BINDING_NAME, (Serializable) variables);
@@ -556,7 +531,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
             try {
 
                 // create launcher
-                launcher = task.createLauncher(job, node);
+                launcher = task.createLauncher(node);
 
                 activeObjectCreationRetryTimeNumber = ACTIVEOBJECT_CREATION_RETRY_TIME_NUMBER;
 
@@ -619,7 +594,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
      * Replace selection script variables with values specified in the map.
      */
     private List<SelectionScript> resolveScriptVariables(List<SelectionScript> selectionScripts,
-            Map<String, String> variables) {
+                                                         Map<String, Serializable> variables) {
         if (selectionScripts == null) {
             return null;
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -424,7 +424,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 criteria.setBlackList(internalTask0.getNodeExclusion());
                 criteria.setBestEffort(bestEffort);
                 criteria.setAcceptableNodesUrls(freeResources);
-                criteria.setBindings(createBindingsForSelectionScripts(currentJob, etd, internalTask0));
+                criteria.setBindings(createBindingsForSelectionScripts(currentJob, internalTask0));
 
                 if (internalTask0.getRuntimeGenericInformation().containsKey(SchedulerConstants.NODE_ACCESS_TOKEN)) {
                     criteria.setNodeAccessToken(internalTask0.getRuntimeGenericInformation().get(
@@ -466,7 +466,10 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
         }
     }
 
-    private void updateVariablesForTasksToSchedule(Map<JobId, JobDescriptor> jobMap, LinkedList<EligibleTaskDescriptor> tasksToSchedule) throws IOException, ClassNotFoundException {
+    /**
+     * Update all variables for the given scheduled tasks
+     */
+    private void updateVariablesForTasksToSchedule(Map<JobId, JobDescriptor> jobMap, LinkedList<EligibleTaskDescriptor> tasksToSchedule) {
         for (EligibleTaskDescriptor taskDescriptor : tasksToSchedule) {
             InternalJob associatedJob = jobMap.get(taskDescriptor.getJobId()).getInternal();
             InternalTask internalTask = associatedJob.getIHMTasks().get(taskDescriptor.getTaskId());
@@ -477,7 +480,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
     /**
      * Create bindings which will be used by selection scripts for the given tasks
      */
-    private Map<String, Serializable> createBindingsForSelectionScripts(InternalJob job, EligibleTaskDescriptor etd, InternalTask task) throws IOException, ClassNotFoundException {
+    private Map<String, Serializable> createBindingsForSelectionScripts(InternalJob job, InternalTask task) throws IOException, ClassNotFoundException {
         Map<String, Serializable> bindings = new HashMap<>();
         Map<String, Serializable> variables = new HashMap<>();
         Map<String, Serializable> genericInfo = new HashMap<>();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparator.java
@@ -111,8 +111,7 @@ public class SchedulingTaskComparator {
         // checked before
 
         //add the 6 tests to the returned value
-        return false;
-        //return sameSsHash && sameNodeEx && sameOwner && samePriority && !isParallel && !selectionScriptUseVariables && !requireNodeWithTokern;
+        return sameSsHash && sameNodeEx && sameOwner && samePriority && !isParallel && !selectionScriptUseVariables && !requireNodeWithTokern;
     }
 
     private boolean doesSelectionScriptsUseVariables(InternalTask task) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparator.java
@@ -102,16 +102,17 @@ public class SchedulingTaskComparator {
 
         boolean selectionScriptUseVariables = (doesSelectionScriptsUseVariables(task) || doesSelectionScriptsUseVariables(tcomp.task));
 
-        boolean requireNodeWithTokern = task.getGenericInformation().containsKey(
+        boolean requireNodeWithTokern = task.getRuntimeGenericInformation().containsKey(
                 SchedulerConstants.NODE_ACCESS_TOKEN) ||
-            tcomp.task.getGenericInformation().containsKey(SchedulerConstants.NODE_ACCESS_TOKEN);
+                tcomp.task.getRuntimeGenericInformation().containsKey(SchedulerConstants.NODE_ACCESS_TOKEN);
 
         // if topology is specified for any of task => not equal
         // for now topology is allowed only for parallel tasks which is
         // checked before
 
         //add the 6 tests to the returned value
-        return sameSsHash && sameNodeEx && sameOwner && samePriority && !isParallel && !selectionScriptUseVariables && !requireNodeWithTokern;
+        return false;
+        //return sameSsHash && sameNodeEx && sameOwner && samePriority && !isParallel && !selectionScriptUseVariables && !requireNodeWithTokern;
     }
 
     private boolean doesSelectionScriptsUseVariables(InternalTask task) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
@@ -121,8 +121,7 @@ final class TerminationData {
             Map<String, String> genericInformation = new HashMap<>();
             VariablesMap variables = null;
             if (taskToTerminate.internalJob != null) {
-                genericInformation = taskData.getTask().getGenericInformationOverridden(
-                        taskToTerminate.internalJob);
+                genericInformation = taskData.getTask().getRuntimeGenericInformation();
             }
             try {
                 variables = getStringSerializableMap(service, taskToTerminate);
@@ -177,7 +176,7 @@ final class TerminationData {
         TaskResultImpl taskResult = taskToTerminate.taskResult;
         InternalJob internalJob = taskToTerminate.internalJob;
 
-        variablesMap.setScopeMap(taskData.getTask().getSerializableVariables());
+        variablesMap.setScopeMap(taskData.getTask().getRuntimeVariables());
         
         if (!taskToTerminate.normalTermination || taskResult == null) {
             List<InternalTask> iDependences = taskData.getTask().getIDependences();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
@@ -176,7 +176,7 @@ final class TerminationData {
         TaskResultImpl taskResult = taskToTerminate.taskResult;
         InternalJob internalJob = taskToTerminate.internalJob;
 
-        variablesMap.setScopeMap(taskData.getTask().getRuntimeVariables());
+        variablesMap.setScopeMap(taskData.getTask().getScopeVariables());
         
         if (!taskToTerminate.normalTermination || taskResult == null) {
             List<InternalTask> iDependences = taskData.getTask().getIDependences();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -233,7 +233,7 @@ public class JobData implements Serializable {
         jobRuntimeData.setOutputSpace(job.getOutputSpace());
         jobRuntimeData.setGlobalSpace(job.getGlobalSpace());
         jobRuntimeData.setUserSpace(job.getUserSpace());
-        jobRuntimeData.setGenericInformation(job.getRuntimeGenericInformation(false));
+        jobRuntimeData.setGenericInformation(job.getGenericInformation());
         jobRuntimeData.setVariables(job.getVariables());
         jobRuntimeData.setStatus(job.getStatus());
         jobRuntimeData.setOwner(job.getOwner());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -233,7 +233,7 @@ public class JobData implements Serializable {
         jobRuntimeData.setOutputSpace(job.getOutputSpace());
         jobRuntimeData.setGlobalSpace(job.getGlobalSpace());
         jobRuntimeData.setUserSpace(job.getUserSpace());
-        jobRuntimeData.setGenericInformation(job.getGenericInformation(false));
+        jobRuntimeData.setGenericInformation(job.getRuntimeGenericInformation(false));
         jobRuntimeData.setVariables(job.getVariables());
         jobRuntimeData.setStatus(job.getStatus());
         jobRuntimeData.setOwner(job.getOwner());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -471,7 +471,7 @@ public class TaskData {
         taskData.setNumberOfExecutionOnFailureLeft(
                 PASchedulerProperties.NUMBER_OF_EXECUTION_ON_FAILURE.getValueAsInt());
         taskData.setNumberOfExecutionLeft(task.getMaxNumberOfExecution());
-        taskData.setGenericInformation(task.getGenericInformation(false));
+        taskData.setGenericInformation(task.getGenericInformation());
         taskData.setVariables(new HashMap<String, TaskDataVariable>());
         for (Map.Entry<String, TaskVariable> entry: task.getVariables().entrySet())
             taskData.getVariables().put(entry.getKey(), getTaskDataVariable(entry.getValue()));
@@ -599,9 +599,9 @@ public class TaskData {
         InternalTask internalTask;
 
         if (taskType.equals(SCRIPT_TASK)) {
-            internalTask = new InternalScriptTask();
+            internalTask = new InternalScriptTask(internalJob);
         } else if (taskType.equals(FORKED_SCRIPT_TASK)) {
-            internalTask = new InternalForkedScriptTask();
+            internalTask = new InternalForkedScriptTask(internalJob);
         } else {
             throw new IllegalStateException("Unexpected stored task type: " + taskType);
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdater.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdater.java
@@ -51,7 +51,7 @@ public class StartAtUpdater {
 
     private boolean resetJobGenericInformation(InternalJob job, String startAt) {
 
-        Map<String, String> genericInformation = job.getRuntimeGenericInformation(true);
+        Map<String, String> genericInformation = job.getRuntimeGenericInformation();
 
         if (isValidStartAt(genericInformation, startAt)) {
             genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdater.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdater.java
@@ -51,7 +51,7 @@ public class StartAtUpdater {
 
     private boolean resetJobGenericInformation(InternalJob job, String startAt) {
 
-        Map<String, String> genericInformation = job.getGenericInformation(true);
+        Map<String, String> genericInformation = job.getRuntimeGenericInformation(true);
 
         if (isValidStartAt(genericInformation, startAt)) {
             genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -36,20 +36,7 @@
  */
 package org.ow2.proactive.scheduler.job;
 
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
-import javax.xml.bind.annotation.XmlTransient;
-
+import it.sauronsoftware.cron4j.Predictor;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.extensions.dataspaces.core.naming.NamingService;
 import org.ow2.proactive.authentication.crypto.Credentials;
@@ -84,7 +71,11 @@ import org.ow2.proactive.scheduler.task.TaskInfoImpl;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 
-import it.sauronsoftware.cron4j.Predictor;
+import javax.xml.bind.annotation.XmlTransient;
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.Map.Entry;
 
 
 /**
@@ -239,7 +230,6 @@ public abstract class InternalJob extends JobState {
      *         not.
      */
     public boolean addTask(InternalTask task) {
-        task.setJobId(getId());
 
         int taskId = tasks.size();
         task.setId(TaskIdImpl.createTaskId(getId(), task.getName(), taskId));
@@ -1248,19 +1238,19 @@ public abstract class InternalJob extends JobState {
      * $PA_TASK_ID, $PA_TASK_ITERATION $PA_TASK_REPLICATION by it's actual value
      *
      */
-    public Map<String, String> getGenericInformation() {
+    public Map<String, String> getRuntimeGenericInformation() {
         if (genericInformation == null) {
             // task is not yet properly initialized
             return new HashMap<>(0);
         }
 
-        Map<String, String> replacements = new HashMap<>();
+        Map<String, Serializable> replacements = new HashMap<>();
         JobId jobId = jobInfo.getJobId();
         if (jobId != null) {
             replacements.put(SchedulerVars.PA_JOB_ID.toString(), jobId.toString());
             replacements.put(SchedulerVars.PA_JOB_NAME.toString(), jobId.getReadableName());
         }
-        return applyReplacementsOnGenericInformation(replacements);
+        return applyReplacementsOnGenericInformation(genericInformation, replacements);
     }
 
     /**
@@ -1272,9 +1262,9 @@ public abstract class InternalJob extends JobState {
      *            information
      *
      */
-    public Map<String, String> getGenericInformation(boolean replaceVariables) {
+    public Map<String, String> getRuntimeGenericInformation(boolean replaceVariables) {
         if (replaceVariables) {
-            return this.getGenericInformation();
+            return this.getRuntimeGenericInformation();
         } else {
             return super.getGenericInformation();
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -65,14 +65,12 @@ import org.ow2.proactive.scheduler.descriptor.TaskDescriptor;
 import org.ow2.proactive.scheduler.job.termination.handlers.TerminateIfTaskHandler;
 import org.ow2.proactive.scheduler.job.termination.handlers.TerminateLoopHandler;
 import org.ow2.proactive.scheduler.job.termination.handlers.TerminateReplicateTaskHandler;
-import org.ow2.proactive.scheduler.task.SchedulerVars;
 import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.TaskInfoImpl;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 
 import javax.xml.bind.annotation.XmlTransient;
-import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.Map.Entry;
@@ -1229,44 +1227,6 @@ public abstract class InternalJob extends JobState {
             return task;
         } else {
             throw new UnknownTaskException("'" + taskId + "' does not exist in this job.");
-        }
-    }
-
-    /**
-     *
-     * Return generic info replacing $PA_JOB_NAME, $PA_JOB_ID, $PA_TASK_NAME,
-     * $PA_TASK_ID, $PA_TASK_ITERATION $PA_TASK_REPLICATION by it's actual value
-     *
-     */
-    public Map<String, String> getRuntimeGenericInformation() {
-        if (genericInformation == null) {
-            // task is not yet properly initialized
-            return new HashMap<>(0);
-        }
-
-        Map<String, Serializable> replacements = new HashMap<>();
-        JobId jobId = jobInfo.getJobId();
-        if (jobId != null) {
-            replacements.put(SchedulerVars.PA_JOB_ID.toString(), jobId.toString());
-            replacements.put(SchedulerVars.PA_JOB_NAME.toString(), jobId.getReadableName());
-        }
-        return applyReplacementsOnGenericInformation(genericInformation, replacements);
-    }
-
-    /**
-     *
-     * Gets the task generic information.
-     * 
-     * @param replaceVariables
-     *            - if set to true method replaces variables in the generic
-     *            information
-     *
-     */
-    public Map<String, String> getRuntimeGenericInformation(boolean replaceVariables) {
-        if (replaceVariables) {
-            return this.getRuntimeGenericInformation();
-        } else {
-            return super.getGenericInformation();
         }
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
@@ -117,9 +117,9 @@ public class ExtendedSchedulerPolicy extends DefaultPolicy {
      * defined job level.
      */
     private String getStartAtValue(JobDescriptor jobDesc, EligibleTaskDescriptor taskDesc) {
-        String startAt = taskDesc.getInternal().getGenericInformation().get(GENERIC_INFORMATION_KEY_START_AT);
+        String startAt = taskDesc.getInternal().getRuntimeGenericInformation().get(GENERIC_INFORMATION_KEY_START_AT);
         if (startAt == null) {
-            startAt = jobDesc.getInternal().getGenericInformation().get(GENERIC_INFORMATION_KEY_START_AT);
+            startAt = jobDesc.getInternal().getRuntimeGenericInformation().get(GENERIC_INFORMATION_KEY_START_AT);
         }
         return startAt;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ram/RamSchedulingPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ram/RamSchedulingPolicy.java
@@ -34,7 +34,7 @@ public class RamSchedulingPolicy extends ExtendedSchedulerPolicy {
 
         logger.debug("Analysing task: " + task.getInternal().getName());
 
-        String allocRam = task.getInternal().getGenericInformation().get(RAM_VARIABLE_NAME);
+        String allocRam = task.getInternal().getRuntimeGenericInformation().get(RAM_VARIABLE_NAME);
 
         if (allocRam != null) {
             return canRunTaskOnNode(selectedNodes, task, Double.parseDouble(allocRam));

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalForkedScriptTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalForkedScriptTask.java
@@ -55,7 +55,8 @@ public class InternalForkedScriptTask extends InternalScriptTask {
     /**
      * ProActive empty constructor.
      */
-    public InternalForkedScriptTask() {
+    public InternalForkedScriptTask(InternalJob internalJob) {
+        super(internalJob);
     }
 
     /**
@@ -63,7 +64,8 @@ public class InternalForkedScriptTask extends InternalScriptTask {
      *
      * @param execContainer the Native Executable Container
      */
-    public InternalForkedScriptTask(ExecutableContainer execContainer) {
+    public InternalForkedScriptTask(ExecutableContainer execContainer, InternalJob internalJob) {
+        super(internalJob);
         this.executableContainer = execContainer;
     }
 
@@ -71,11 +73,11 @@ public class InternalForkedScriptTask extends InternalScriptTask {
      * {@inheritDoc}
      */
     @Override
-    public TaskLauncher createLauncher(InternalJob job, Node node) throws ActiveObjectCreationException,
+    public TaskLauncher createLauncher(Node node) throws ActiveObjectCreationException,
             NodeException {
         logger.info(getTaskInfo().getTaskId(), "creating forked task launcher");
         TaskLauncher launcher = (TaskLauncher) PAActiveObject.newActive(TaskLauncher.class.getName(),
-                new Object[] { getDefaultTaskLauncherInitializer(job),
+                new Object[]{getDefaultTaskLauncherInitializer(),
                         new ProActiveForkedTaskLauncherFactory() }, node);
         // wait until the task launcher is active
         launcher.isActivated();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalScriptTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalScriptTask.java
@@ -57,15 +57,18 @@ public class InternalScriptTask extends InternalTask {
     /**
      * ProActive empty constructor.
      */
-    public InternalScriptTask() {
+    public InternalScriptTask(InternalJob internalJob) {
+        super(internalJob);
     }
 
     /**
      * Create a new script task descriptor with the given command line.
      *
      * @param execContainer the Native Executable Container
+     * @param internalJob
      */
-    public InternalScriptTask(ExecutableContainer execContainer) {
+    public InternalScriptTask(ExecutableContainer execContainer, InternalJob internalJob) {
+        super(internalJob);
         this.executableContainer = execContainer;
     }
 
@@ -73,11 +76,11 @@ public class InternalScriptTask extends InternalTask {
      * {@inheritDoc}
      */
     @Override
-    public TaskLauncher createLauncher(InternalJob job, Node node) throws ActiveObjectCreationException,
+    public TaskLauncher createLauncher(Node node) throws ActiveObjectCreationException,
             NodeException {
         logger.info(getTaskInfo().getTaskId(), "creating non forked task launcher");
         TaskLauncher launcher = (TaskLauncher) PAActiveObject.newActive(TaskLauncher.class.getName(),
-                new Object[] { getDefaultTaskLauncherInitializer(job), new ProActiveNonForkedTaskLauncherFactory()}, node);
+                new Object[]{getDefaultTaskLauncherInitializer(), new ProActiveNonForkedTaskLauncherFactory()}, node);
         // wait until the task launcher is active
         launcher.isActivated();
         setExecuterInformation(new ExecuterInformation(launcher, node));

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -37,9 +37,12 @@
 package org.ow2.proactive.scheduler.task.internal;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -55,17 +58,14 @@ import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.core.util.converter.ProActiveMakeDeepCopy;
 import org.ow2.proactive.scheduler.common.exception.ExecutableCreationException;
-import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
-import org.ow2.proactive.scheduler.common.task.Task;
-import org.ow2.proactive.scheduler.common.task.TaskId;
-import org.ow2.proactive.scheduler.common.task.TaskInfo;
-import org.ow2.proactive.scheduler.common.task.TaskState;
-import org.ow2.proactive.scheduler.common.task.TaskStatus;
+import org.ow2.proactive.scheduler.common.job.JobType;
+import org.ow2.proactive.scheduler.common.task.*;
 import org.ow2.proactive.scheduler.common.task.flow.FlowAction;
 import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.ow2.proactive.scheduler.common.task.flow.FlowBlock;
+import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
+import org.ow2.proactive.scheduler.core.SchedulingService;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.task.SchedulerVars;
@@ -101,6 +101,9 @@ public abstract class InternalTask extends TaskState {
 
     @XmlTransient
     private static transient long lastAuthorizedFolderLoadingTime = 0;
+
+    @XmlTransient
+    protected transient InternalJob internalJob;
 
     /** Parents list: null if no dependency */
     @XmlTransient
@@ -148,6 +151,13 @@ public abstract class InternalTask extends TaskState {
 
     private transient InternalTask replicatedFrom;
 
+    @XmlTransient
+    private transient Map<String, Serializable> updatedVariables;
+
+    protected InternalTask(InternalJob internalJob) {
+        this.internalJob = internalJob;
+    }
+
     void setReplicatedFrom(InternalTask replicatedFrom) {
         this.replicatedFrom = replicatedFrom;
     }
@@ -193,6 +203,8 @@ public abstract class InternalTask extends TaskState {
         } catch (Throwable t) {
             throw new ExecutableCreationException("Failed to serialize task", t);
         }
+
+        replicatedTask.internalJob = internalJob;
 
         // ideps contain references to other InternalTasks, it needs to be removed.
         // anyway, dependencies for the new task will not be the same as the original
@@ -484,10 +496,9 @@ public abstract class InternalTask extends TaskState {
      * Create the launcher for this taskDescriptor.
      *
      * @param node the node on which to create the launcher.
-     * @param job the job on which to create the launcher.
      * @return the created launcher as an activeObject.
      */
-    public abstract TaskLauncher createLauncher(InternalJob job, Node node)
+    public abstract TaskLauncher createLauncher(Node node)
             throws ActiveObjectCreationException, NodeException;
 
     /**
@@ -555,6 +566,7 @@ public abstract class InternalTask extends TaskState {
                     "' but was '" + taskInfo.getTaskId() + "'");
         }
         this.taskInfo = (TaskInfoImpl) taskInfo;
+        this.taskInfo.setJobId(internalJob.getId());
     }
 
     /**
@@ -636,15 +648,6 @@ public abstract class InternalTask extends TaskState {
         if (finishedTime > 0) {
             taskInfo.setProgress(100);
         }
-    }
-
-    /**
-     * To set the jobId
-     *
-     * @param id the jobId to set
-     */
-    public void setJobId(JobId id) {
-        taskInfo.setJobId(id);
     }
 
     /**
@@ -1098,10 +1101,10 @@ public abstract class InternalTask extends TaskState {
      *
      * @return the default created task launcher initializer
      */
-    protected TaskLauncherInitializer getDefaultTaskLauncherInitializer(InternalJob job) {
+    protected TaskLauncherInitializer getDefaultTaskLauncherInitializer() {
         TaskLauncherInitializer tli = new TaskLauncherInitializer();
         tli.setTaskId(getId());
-        tli.setJobOwner(job.getJobInfo().getJobOwner());
+        tli.setJobOwner(internalJob.getJobInfo().getJobOwner());
         tli.setSchedulerRestUrl(PASchedulerProperties.SCHEDULER_REST_URL.getValueAsStringOrNull());
         tli.setPreScript(getPreScript());
         tli.setPostScript(getPostScript());
@@ -1109,11 +1112,11 @@ public abstract class InternalTask extends TaskState {
         tli.setTaskInputFiles(getInputFilesList());
         tli.setTaskOutputFiles(getOutputFilesList());
         tli.setNamingService(
-                job.getTaskDataSpaceApplications().get(getId().longValue()).getNamingServiceStub());
+                internalJob.getTaskDataSpaceApplications().get(getId().longValue()).getNamingServiceStub());
         tli.setIterationIndex(getIterationIndex());
         tli.setReplicationIndex(getReplicationIndex());
 
-        Map<String, String> gInfo = getGenericInformationOverridden(job);
+        Map<String, String> gInfo = getRuntimeGenericInformation();
         tli.setGenericInformation(gInfo);
 
         ForkEnvironment environment = getForkEnvironment();
@@ -1128,23 +1131,13 @@ public abstract class InternalTask extends TaskState {
             tli.setWalltime(wallTime);
         }
         tli.setPreciousLogs(isPreciousLogs());
-        tli.setVariables(job.getVariables());
+        tli.setVariables(internalJob.getVariables());
         tli.setTaskVariables(getVariables());
 
         tli.setPingPeriod(PASchedulerProperties.SCHEDULER_NODE_PING_FREQUENCY.getValueAsInt());
         tli.setPingAttempts(PASchedulerProperties.SCHEDULER_NODE_PING_ATTEMPTS.getValueAsInt());
 
         return tli;
-    }
-
-    /**
-     * @return the generic information of the job overridden eventually by the task's generic info
-     */
-    public Map<String, String> getGenericInformationOverridden(InternalJob job) {
-        HashMap<String, String> gInfo = new HashMap<>();
-        gInfo.putAll(job.getGenericInformation());
-        gInfo.putAll(getGenericInformation());
-        return gInfo;
     }
 
     /**
@@ -1162,47 +1155,81 @@ public abstract class InternalTask extends TaskState {
         return false;
     }
 
+    public synchronized void updateVariables(SchedulingService schedulingService) throws IOException, ClassNotFoundException {
+        if (updatedVariables == null) {
+            updatedVariables = new LinkedHashMap<>();
+            updatedVariables.putAll(internalJob.getVariables());
+            for (TaskVariable variable : variables.values()) {
+                if (!variable.isJobInherited()) {
+                    updatedVariables.put(variable.getName(), variable.getValue());
+                }
+            }
+
+            if (ideps != null) {
+                List<TaskId> parentIds = new ArrayList<>(ideps.size());
+                for (InternalTask parentTask : ideps) {
+                    parentIds.add(parentTask.getId());
+                }
+                if (parentIds.size() > 0) {
+                    Map<TaskId, TaskResult> taskResults = schedulingService.getInfrastructure().getDBManager()
+                            .loadTasksResults(
+                                    internalJob.getId(), parentIds);
+                    for (TaskResult taskResult : taskResults.values()) {
+                        if (taskResult.getPropagatedVariables() != null) {
+                            updatedVariables.putAll(SerializationUtil.deserializeVariableMap(taskResult.getPropagatedVariables()));
+                        }
+                    }
+                }
+            }
+
+            updatedVariables.put(SchedulerVars.PA_JOB_ID.toString(), internalJob.getId().value());
+            updatedVariables.put(SchedulerVars.PA_JOB_NAME.toString(), internalJob.getName());
+            if (getId() != null) {
+                updatedVariables.put(SchedulerVars.PA_TASK_ID.toString(), getId().value());
+                updatedVariables.put(SchedulerVars.PA_TASK_NAME.toString(), getName());
+            }
+            updatedVariables.put(SchedulerVars.PA_USER.toString(), internalJob.getOwner());
+
+            if (internalJob.getType() == JobType.TASKSFLOW) {
+                updatedVariables.put(SchedulerVars.PA_TASK_ITERATION.toString(), getIterationIndex());
+                updatedVariables.put(SchedulerVars.PA_TASK_REPLICATION.toString(), getReplicationIndex());
+            }
+        }
+    }
+
+
+    public synchronized Map<String, Serializable> getRuntimeVariables() {
+        if (updatedVariables == null) {
+            return new HashMap<>();
+        } else {
+            return updatedVariables;
+        }
+    }
+
     /**
      *
      * Return generic info replacing $PA_JOB_NAME, $PA_JOB_ID, $PA_TASK_NAME, $PA_TASK_ID, $PA_TASK_ITERATION
      * $PA_TASK_REPLICATION by it's actual value
      *
      */
-    public Map<String, String> getGenericInformation() {
+    public synchronized Map<String, String> getRuntimeGenericInformation() {
 
-        if (taskInfo == null || genericInformation == null) {
+        if (taskInfo == null) {
             // task is not yet properly initialized
             return new HashMap<>();
         }
 
-        Map<String, String> replacements = new HashMap<>();
-        JobId jobId = taskInfo.getJobId();
-        if (jobId != null) {
-            replacements.put(SchedulerVars.PA_JOB_ID.toString(), jobId.toString());
-            replacements.put(SchedulerVars.PA_JOB_NAME.toString(), jobId.getReadableName());
+        HashMap<String, String> gInfo = new HashMap<>();
+        Map<String, String> jobGenericInfo = internalJob.getRuntimeGenericInformation();
+        if (jobGenericInfo != null) {
+            gInfo.putAll(jobGenericInfo);
         }
-        TaskId taskId = taskInfo.getTaskId();
-        if (taskId != null) {
-            replacements.put(SchedulerVars.PA_TASK_ID.toString(), taskId.toString());
-            replacements.put(SchedulerVars.PA_TASK_NAME.toString(), taskId.getReadableName());
-        }
-        replacements.put(SchedulerVars.PA_TASK_ITERATION.toString(), String.valueOf(iteration));
-        replacements.put(SchedulerVars.PA_TASK_REPLICATION.toString(), String.valueOf(replication));
 
-        return applyReplacementsOnGenericInformation(replacements);
-    }
-
-    /**
-     *
-     * Gets the task generic information.
-     * @param replaceVariables - if set to true method replaces variables in the generic information
-     *
-     */
-    public Map<String, String> getGenericInformation(boolean replaceVariables) {
-        if (replaceVariables) {
-            return this.getGenericInformation();
-        } else {
-            return super.getGenericInformation();
+        if (genericInformation != null) {
+            Map<String, String> updatedTaskGenericInfo = applyReplacementsOnGenericInformation(genericInformation, getRuntimeVariables());
+            gInfo.putAll(updatedTaskGenericInfo);
         }
+
+        return gInfo;
     }
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TagTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TagTest.java
@@ -45,10 +45,13 @@ import java.util.ArrayList;
 import org.junit.Before;
 import org.junit.Test;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
+import org.ow2.proactive.scheduler.common.job.JobPriority;
+import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.common.task.flow.FlowAction;
 import org.ow2.proactive.scheduler.common.task.flow.FlowBlock;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scheduler.core.SchedulerStateUpdate;
+import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.job.InternalTaskFlowJob;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.internal.ExecuterInformation;
@@ -81,10 +84,11 @@ public class TagTest extends ProActiveTest{
     }
 
 
+    private InternalScriptTask createTask(String name, InternalTask[] dependences, FlowBlock block, String matchingBlock) {
 
-    private InternalScriptTask createTask(String name, InternalTask[] dependences, FlowBlock block, String matchingBlock)
-             {
-        InternalScriptTask result = new InternalScriptTask();
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        InternalScriptTask result = new InternalScriptTask(job);
         result.setName(name);
 
         if(dependences != null && dependences.length > 0){

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TagTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TagTest.java
@@ -86,8 +86,6 @@ public class TagTest extends ProActiveTest{
 
     private InternalScriptTask createTask(String name, InternalTask[] dependences, FlowBlock block, String matchingBlock) {
 
-        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
-                "description");
         InternalScriptTask result = new InternalScriptTask(job);
         result.setName(name);
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestDynamicGenericInfo.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestDynamicGenericInfo.java
@@ -1,0 +1,61 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s): ActiveEon Team - http://www.activeeon.com
+ *
+ * ################################################################
+ * $$ACTIVEEON_CONTRIBUTOR$$
+ */
+package functionaltests.scripts;
+
+import functionaltests.utils.SchedulerFunctionalTestNoRestart;
+import org.junit.Test;
+import org.ow2.proactive.scheduler.common.exception.JobCreationException;
+
+import java.io.File;
+
+
+/**
+ * Tests used to check that {@code forkEnvironment} element is allowed
+ * in {@code task} element for Jobs Schema in version 3.3 but not longer
+ * in {@code javaExecutable} element.
+ */
+public class TestDynamicGenericInfo extends SchedulerFunctionalTestNoRestart {
+
+
+    @Test
+    public void testDynamicGenericInfo() throws Exception {
+        schedulerHelper.testJobSubmission(new File(TestDynamicGenericInfo.class.getResource(
+                "/functionaltests/descriptors/Job_DynamicGenericInfo.xml").toURI()).getAbsolutePath());
+    }
+
+}
+

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestGenericInformation.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestGenericInformation.java
@@ -126,7 +126,7 @@ public class TestGenericInformation extends SchedulerFunctionalTestNoRestart {
 
         for (String key : expected.keySet()) {
             Assert.assertEquals("Wrong value for " + key, expected.get(key), jobState
-                    .getGenericInformation().get(key));
+                    .getRuntimeGenericInformation().get(key));
             System.out.println(key + " is " + expected.get(key) + " - good");
         }
     }
@@ -143,7 +143,7 @@ public class TestGenericInformation extends SchedulerFunctionalTestNoRestart {
 
         for (String key : expected.keySet()) {
             Assert.assertEquals("Wrong value for " + key, expected.get(key), taskState
-                    .getGenericInformation().get(key));
+                    .getRuntimeGenericInformation().get(key));
             System.out.println(key + " is " + expected.get(key) + " - good");
         }
     }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/LiveJobsTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/LiveJobsTest.java
@@ -138,7 +138,7 @@ public class LiveJobsTest {
         job.setId(id);
         
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         internalTask.setStatus(TaskStatus.IN_ERROR);
         
@@ -176,7 +176,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         internalTask.setStatus(TaskStatus.PAUSED);
         tasksList.add(internalTask);
@@ -193,7 +193,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         internalTask.setStatus(TaskStatus.PENDING);
         tasksList.add(internalTask);
@@ -210,7 +210,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         tasksList.add(internalTask);
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
@@ -225,7 +225,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         tasksList.add(internalTask);
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
@@ -239,7 +239,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         tasksList.add(internalTask);
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
@@ -253,7 +253,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         tasksList.add(internalTask);
         job.setTasks(tasksList);
@@ -269,7 +269,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         tasksList.add(internalTask);
         job.setTasks(tasksList);
@@ -286,7 +286,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         internalTask.setStatus(TaskStatus.RUNNING);
         tasksList.add(internalTask);
@@ -305,7 +305,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalScriptTask internalTask = new InternalScriptTask();
+        InternalScriptTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         internalTask.setStatus(TaskStatus.RUNNING);
         internalTask.setMaxNumberOfExecution(5);
@@ -338,7 +338,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalScriptTask internalTask = new InternalScriptTask();
+        InternalScriptTask internalTask = new InternalScriptTask(job);
         internalTask.setName("task-name");
         internalTask.setStatus(TaskStatus.RUNNING);
         internalTask.setMaxNumberOfExecution(5);
@@ -365,7 +365,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         TaskId taskId = TaskIdImpl.createTaskId(id, "task-name", 777L);
         internalTask.setId(taskId);
         internalTask.setName("task-name");
@@ -386,7 +386,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         TaskId taskId = TaskIdImpl.createTaskId(id, "task-name", 0L);
         internalTask.setId(taskId);
         internalTask.setName("task-name");
@@ -424,7 +424,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         TaskId taskId = TaskIdImpl.createTaskId(id, "task-name", 0L);
         internalTask.setId(taskId);
         internalTask.setName("task-name");
@@ -460,7 +460,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         TaskId taskId = TaskIdImpl.createTaskId(id, "task-name", 0L);
         internalTask.setId(taskId);
         internalTask.setName("task-name");
@@ -471,7 +471,7 @@ public class LiveJobsTest {
 
         internalTask.setOnTaskError(OnTaskError.PAUSE_JOB);
 
-        InternalTask internalTask2 = new InternalScriptTask();
+        InternalTask internalTask2 = new InternalScriptTask(job);
         TaskId taskId2 = TaskIdImpl.createTaskId(id, "task-name2", 1L);
         internalTask2.setId(taskId2);
         internalTask2.setName("task-name2");
@@ -511,7 +511,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         TaskId taskId = TaskIdImpl.createTaskId(id, "task-name", 0L);
         internalTask.setId(taskId);
         internalTask.setName("task-name");
@@ -546,7 +546,7 @@ public class LiveJobsTest {
         JobId id = new JobIdImpl(666L, "test-name");
         job.setId(id);
         List<InternalTask> tasksList = new ArrayList<>();
-        InternalTask internalTask = new InternalScriptTask();
+        InternalTask internalTask = new InternalScriptTask(job);
         TaskId taskId = TaskIdImpl.createTaskId(id, "task-name", 0L);
         internalTask.setId(taskId);
         internalTask.setName("task-name");

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/OnErrorPolicyInterpreterTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/OnErrorPolicyInterpreterTest.java
@@ -4,12 +4,15 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
+import org.mockito.Mock;
 import org.objectweb.proactive.ActiveObjectCreationException;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeException;
+import org.ow2.proactive.scheduler.common.job.JobPriority;
 import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.job.InternalJob;
+import org.ow2.proactive.scheduler.job.InternalTaskFlowJob;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 
@@ -223,7 +226,9 @@ public class OnErrorPolicyInterpreterTest {
     }
 
     private InternalTask createTask() {
-        InternalTask task = new InternalTask() {
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        InternalTask task = new InternalTask(job) {
 
             @Override
             public boolean handleResultsArguments() {
@@ -232,7 +237,7 @@ public class OnErrorPolicyInterpreterTest {
             }
 
             @Override
-            public TaskLauncher createLauncher(InternalJob job, Node node)
+            public TaskLauncher createLauncher(Node node)
                     throws ActiveObjectCreationException, NodeException {
                 // TODO Auto-generated method stub
                 return null;

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingServiceTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingServiceTest.java
@@ -5,10 +5,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.ow2.proactive.scheduler.common.SchedulerEvent;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobPriority;
+import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.core.db.RecoveredSchedulerState;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.core.rmproxies.RMProxiesManager;
 import org.ow2.proactive.scheduler.job.InternalJob;
+import org.ow2.proactive.scheduler.job.InternalTaskFlowJob;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.policy.DefaultPolicy;
 import org.ow2.proactive.scheduler.task.internal.InternalScriptTask;
@@ -248,15 +252,19 @@ public class SchedulingServiceTest {
 
     @Test
     public void testCannotRestartTaskOnNodeFailure() {
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
         schedulingService.status = schedulingService.status.KILLED;
-        InternalTask task = new InternalScriptTask();
+        InternalTask task = new InternalScriptTask(job);
         schedulingService.restartTaskOnNodeFailure(task);
         Mockito.verify(infrastructure, Mockito.times(0)).getInternalOperationsThreadPool();
     }
 
     @Test
     public void testRestartTaskOnNodeFailure() {
-        InternalTask task = new InternalScriptTask();
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        InternalTask task = new InternalScriptTask(job);
         ExecutorService executorService = Mockito.mock(ExecutorService.class);
         Mockito.when(infrastructure.getInternalOperationsThreadPool()).thenReturn(executorService);
         schedulingService.restartTaskOnNodeFailure(task);

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparatorTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingTaskComparatorTest.java
@@ -91,10 +91,10 @@ public class SchedulingTaskComparatorTest {
 
     @Test
     public void testAnyRequiresNodeWithToken() throws Exception {
-        Mockito.when(task1.getGenericInformation()).thenReturn(ImmutableMap.of(SchedulerConstants.NODE_ACCESS_TOKEN, "token"));
+        Mockito.when(task1.getRuntimeGenericInformation()).thenReturn(ImmutableMap.of(SchedulerConstants.NODE_ACCESS_TOKEN, "token"));
         Assert.assertFalse((new SchedulingTaskComparator(task1, job1)).equals(new SchedulingTaskComparator(task2, job2)));
-        Mockito.when(task2.getGenericInformation()).thenReturn(null);
-        Mockito.when(task2.getGenericInformation()).thenReturn(ImmutableMap.of(SchedulerConstants.NODE_ACCESS_TOKEN, "token"));
+        Mockito.when(task2.getRuntimeGenericInformation()).thenReturn(null);
+        Mockito.when(task2.getRuntimeGenericInformation()).thenReturn(ImmutableMap.of(SchedulerConstants.NODE_ACCESS_TOKEN, "token"));
         Assert.assertFalse((new SchedulingTaskComparator(task1, job1)).equals(new SchedulingTaskComparator(task2, job2)));
     }
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/TerminationDataTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/TerminationDataTest.java
@@ -9,11 +9,15 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobPriority;
+import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
 import org.ow2.proactive.scheduler.core.rmproxies.RMProxiesManager;
 import org.ow2.proactive.scheduler.core.rmproxies.RMProxy;
 import org.ow2.proactive.scheduler.core.rmproxies.RMProxyCreationException;
+import org.ow2.proactive.scheduler.job.InternalJob;
+import org.ow2.proactive.scheduler.job.InternalTaskFlowJob;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
@@ -68,9 +72,11 @@ public class TerminationDataTest {
 	@Test
 	public void testAddTaskData(){
 		assertThat(terminationData.isEmpty(), is(true));
-		JobId jobId = new JobIdImpl(666, "readableName");
-		InternalTask internalTask = new InternalScriptTask();
-		TaskId taskId = TaskIdImpl.createTaskId(jobId, "task-name", 777L);
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        JobId jobId = new JobIdImpl(666, "readableName");
+        InternalTask internalTask = new InternalScriptTask(job);
+        TaskId taskId = TaskIdImpl.createTaskId(jobId, "task-name", 777L);
 		internalTask.setId(taskId);
 		internalTask.setName("task-name");
 		internalTask.setStatus(TaskStatus.RUNNING);
@@ -101,9 +107,11 @@ public class TerminationDataTest {
 	
 	@Test
 	public void testHandleTerminationForTaskNotNormalTermination() throws IOException, ClassNotFoundException {
-		JobId jobId = new JobIdImpl(666, "readableName");
-		InternalTask internalTask = new InternalScriptTask();
-		TaskId taskId = TaskIdImpl.createTaskId(jobId, "task-name", 777L);
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        JobId jobId = new JobIdImpl(666, "readableName");
+        InternalTask internalTask = new InternalScriptTask(job);
+        TaskId taskId = TaskIdImpl.createTaskId(jobId, "task-name", 777L);
 		internalTask.setId(taskId);
 		internalTask.setName("task-name");
 		internalTask.setStatus(TaskStatus.RUNNING);
@@ -117,9 +125,11 @@ public class TerminationDataTest {
 	
 	@Test
 	public void testHandleTerminationForTaskNormalTermination() throws RMProxyCreationException, IOException, ClassNotFoundException {
-		JobId jobId = new JobIdImpl(666, "readableName");
-		InternalTask internalTask = new InternalScriptTask();
-		TaskId taskId = TaskIdImpl.createTaskId(jobId, "task-name", 777L);
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        JobId jobId = new JobIdImpl(666, "readableName");
+        InternalTask internalTask = new InternalScriptTask(job);
+        TaskId taskId = TaskIdImpl.createTaskId(jobId, "task-name", 777L);
 		internalTask.setId(taskId);
 		internalTask.setName("task-name");
 		internalTask.setStatus(TaskStatus.RUNNING);

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/RecoveredSchedulerStateTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/RecoveredSchedulerStateTest.java
@@ -61,7 +61,7 @@ public class RecoveredSchedulerStateTest {
         InternalTaskFlowJob job =
                 new InternalTaskFlowJob("MyJob", JobPriority.HIGH, OnTaskError.CANCEL_JOB, "Description");
 
-        InternalScriptTask internalScriptTask = new InternalScriptTask();
+        InternalScriptTask internalScriptTask = new InternalScriptTask(job);
 
         job.addTasks(ImmutableList.<InternalTask>of(internalScriptTask));
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobAttributes.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobAttributes.java
@@ -66,8 +66,8 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         Assert.assertEquals("input", jobData.getInputSpace());
         Assert.assertEquals("output", jobData.getOutputSpace());
         Assert.assertEquals(JobPriority.HIGHEST, jobData.getPriority());
-        Assert.assertNotNull(jobData.getRuntimeGenericInformation());
-        Assert.assertTrue(jobData.getRuntimeGenericInformation().isEmpty());
+        Assert.assertNotNull(jobData.getGenericInformation());
+        Assert.assertTrue(jobData.getGenericInformation().isEmpty());
     }
 
     @Test
@@ -80,17 +80,17 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         genericInfo = new HashMap<>();
         job.setGenericInformation(genericInfo);
         jobData = defaultSubmitJobAndLoadInternal(false, job);
-        Assert.assertNotNull(jobData.getRuntimeGenericInformation());
-        Assert.assertTrue(jobData.getRuntimeGenericInformation().isEmpty());
+        Assert.assertNotNull(jobData.getGenericInformation());
+        Assert.assertTrue(jobData.getGenericInformation().isEmpty());
 
         genericInfo = new HashMap<>();
         genericInfo.put("p1", "v1");
         genericInfo.put("p2", "v2");
         job.setGenericInformation(genericInfo);
         jobData = defaultSubmitJobAndLoadInternal(false, job);
-        Assert.assertEquals(2, jobData.getRuntimeGenericInformation().size());
-        Assert.assertEquals("v1", jobData.getRuntimeGenericInformation().get("p1"));
-        Assert.assertEquals("v2", jobData.getRuntimeGenericInformation().get("p2"));
+        Assert.assertEquals(2, jobData.getGenericInformation().size());
+        Assert.assertEquals("v1", jobData.getGenericInformation().get("p1"));
+        Assert.assertEquals("v2", jobData.getGenericInformation().get("p2"));
 
         StringBuilder longString = new StringBuilder();
         for (int i = 0; i < 100; i++) {
@@ -100,8 +100,8 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         genericInfo.put("longProperty", longString.toString());
         job.setGenericInformation(genericInfo);
         jobData = defaultSubmitJobAndLoadInternal(false, job);
-        Assert.assertEquals(1, jobData.getRuntimeGenericInformation().size());
-        Assert.assertEquals(longString.toString(), jobData.getRuntimeGenericInformation().get("longProperty"));
+        Assert.assertEquals(1, jobData.getGenericInformation().size());
+        Assert.assertEquals(longString.toString(), jobData.getGenericInformation().get("longProperty"));
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobAttributes.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobAttributes.java
@@ -66,8 +66,8 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         Assert.assertEquals("input", jobData.getInputSpace());
         Assert.assertEquals("output", jobData.getOutputSpace());
         Assert.assertEquals(JobPriority.HIGHEST, jobData.getPriority());
-        Assert.assertNotNull(jobData.getGenericInformation());
-        Assert.assertTrue(jobData.getGenericInformation().isEmpty());
+        Assert.assertNotNull(jobData.getRuntimeGenericInformation());
+        Assert.assertTrue(jobData.getRuntimeGenericInformation().isEmpty());
     }
 
     @Test
@@ -80,17 +80,17 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         genericInfo = new HashMap<>();
         job.setGenericInformation(genericInfo);
         jobData = defaultSubmitJobAndLoadInternal(false, job);
-        Assert.assertNotNull(jobData.getGenericInformation());
-        Assert.assertTrue(jobData.getGenericInformation().isEmpty());
+        Assert.assertNotNull(jobData.getRuntimeGenericInformation());
+        Assert.assertTrue(jobData.getRuntimeGenericInformation().isEmpty());
 
         genericInfo = new HashMap<>();
         genericInfo.put("p1", "v1");
         genericInfo.put("p2", "v2");
         job.setGenericInformation(genericInfo);
         jobData = defaultSubmitJobAndLoadInternal(false, job);
-        Assert.assertEquals(2, jobData.getGenericInformation().size());
-        Assert.assertEquals("v1", jobData.getGenericInformation().get("p1"));
-        Assert.assertEquals("v2", jobData.getGenericInformation().get("p2"));
+        Assert.assertEquals(2, jobData.getRuntimeGenericInformation().size());
+        Assert.assertEquals("v1", jobData.getRuntimeGenericInformation().get("p1"));
+        Assert.assertEquals("v2", jobData.getRuntimeGenericInformation().get("p2"));
 
         StringBuilder longString = new StringBuilder();
         for (int i = 0; i < 100; i++) {
@@ -100,8 +100,8 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         genericInfo.put("longProperty", longString.toString());
         job.setGenericInformation(genericInfo);
         jobData = defaultSubmitJobAndLoadInternal(false, job);
-        Assert.assertEquals(1, jobData.getGenericInformation().size());
-        Assert.assertEquals(longString.toString(), jobData.getGenericInformation().get("longProperty"));
+        Assert.assertEquals(1, jobData.getRuntimeGenericInformation().size());
+        Assert.assertEquals(longString.toString(), jobData.getRuntimeGenericInformation().get("longProperty"));
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestTaskAttributes.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestTaskAttributes.java
@@ -193,17 +193,17 @@ public class TestTaskAttributes extends BaseSchedulerDBTest {
         task.setGenericInformation(genericInfo);
         taskData = saveSingleTask(task).getTask(task.getName());
 
-        Assert.assertNotNull(taskData.getRuntimeGenericInformation());
-        Assert.assertTrue(taskData.getRuntimeGenericInformation().isEmpty());
+        Assert.assertNotNull(taskData.getGenericInformation());
+        Assert.assertTrue(taskData.getGenericInformation().isEmpty());
 
         genericInfo = new HashMap<>();
         genericInfo.put("p1", "v1");
         genericInfo.put("p2", "v2");
         task.setGenericInformation(genericInfo);
         taskData = saveSingleTask(task).getTask(task.getName());
-        Assert.assertEquals(2, taskData.getRuntimeGenericInformation().size());
-        Assert.assertEquals("v1", taskData.getRuntimeGenericInformation().get("p1"));
-        Assert.assertEquals("v2", taskData.getRuntimeGenericInformation().get("p2"));
+        Assert.assertEquals(2, taskData.getGenericInformation().size());
+        Assert.assertEquals("v1", taskData.getGenericInformation().get("p1"));
+        Assert.assertEquals("v2", taskData.getGenericInformation().get("p2"));
 
         StringBuilder longString = new StringBuilder();
         for (int i = 0; i < 100; i++) {
@@ -213,8 +213,8 @@ public class TestTaskAttributes extends BaseSchedulerDBTest {
         genericInfo.put("longProperty", longString.toString());
         task.setGenericInformation(genericInfo);
         taskData = saveSingleTask(task).getTask(task.getName());
-        Assert.assertEquals(1, taskData.getRuntimeGenericInformation().size());
-        Assert.assertEquals(longString.toString(), taskData.getRuntimeGenericInformation().get("longProperty"));
+        Assert.assertEquals(1, taskData.getGenericInformation().size());
+        Assert.assertEquals(longString.toString(), taskData.getGenericInformation().get("longProperty"));
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestTaskAttributes.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestTaskAttributes.java
@@ -193,17 +193,17 @@ public class TestTaskAttributes extends BaseSchedulerDBTest {
         task.setGenericInformation(genericInfo);
         taskData = saveSingleTask(task).getTask(task.getName());
 
-        Assert.assertNotNull(taskData.getGenericInformation());
-        Assert.assertTrue(taskData.getGenericInformation().isEmpty());
+        Assert.assertNotNull(taskData.getRuntimeGenericInformation());
+        Assert.assertTrue(taskData.getRuntimeGenericInformation().isEmpty());
 
         genericInfo = new HashMap<>();
         genericInfo.put("p1", "v1");
         genericInfo.put("p2", "v2");
         task.setGenericInformation(genericInfo);
         taskData = saveSingleTask(task).getTask(task.getName());
-        Assert.assertEquals(2, taskData.getGenericInformation().size());
-        Assert.assertEquals("v1", taskData.getGenericInformation().get("p1"));
-        Assert.assertEquals("v2", taskData.getGenericInformation().get("p2"));
+        Assert.assertEquals(2, taskData.getRuntimeGenericInformation().size());
+        Assert.assertEquals("v1", taskData.getRuntimeGenericInformation().get("p1"));
+        Assert.assertEquals("v2", taskData.getRuntimeGenericInformation().get("p2"));
 
         StringBuilder longString = new StringBuilder();
         for (int i = 0; i < 100; i++) {
@@ -213,8 +213,8 @@ public class TestTaskAttributes extends BaseSchedulerDBTest {
         genericInfo.put("longProperty", longString.toString());
         task.setGenericInformation(genericInfo);
         taskData = saveSingleTask(task).getTask(task.getName());
-        Assert.assertEquals(1, taskData.getGenericInformation().size());
-        Assert.assertEquals(longString.toString(), taskData.getGenericInformation().get("longProperty"));
+        Assert.assertEquals(1, taskData.getRuntimeGenericInformation().size());
+        Assert.assertEquals(longString.toString(), taskData.getRuntimeGenericInformation().get("longProperty"));
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
@@ -62,7 +62,7 @@ public class StartAtUpdaterTest {
         Map<String, String> genericInformation = Maps.newHashMap();
 
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
-        when(internalJob.getGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAt, dbManager), is(false));
 
@@ -80,7 +80,7 @@ public class StartAtUpdaterTest {
 
         when(internalJob.getITasks()).thenReturn(internalTasks);
         Map<String, String> genericInformation = Maps.newHashMap();
-        when(internalJob.getGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAt, dbManager), is(true));
 
@@ -101,7 +101,7 @@ public class StartAtUpdaterTest {
         when(internalJob.getITasks()).thenReturn(internalTasks);
         Map<String, String> genericInformation = Maps.newHashMap();
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
-        when(internalJob.getGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAtUpdate, dbManager), is(true));
 
@@ -120,7 +120,7 @@ public class StartAtUpdaterTest {
         when(internalJob.getITasks()).thenReturn(internalTasks);
         Map<String, String> genericInformation = Maps.newHashMap();
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
-        when(internalJob.getGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAtUpdate, dbManager), is(false));
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
@@ -62,7 +62,7 @@ public class StartAtUpdaterTest {
         Map<String, String> genericInformation = Maps.newHashMap();
 
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
-        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation()).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAt, dbManager), is(false));
 
@@ -80,7 +80,7 @@ public class StartAtUpdaterTest {
 
         when(internalJob.getITasks()).thenReturn(internalTasks);
         Map<String, String> genericInformation = Maps.newHashMap();
-        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation()).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAt, dbManager), is(true));
 
@@ -101,7 +101,7 @@ public class StartAtUpdaterTest {
         when(internalJob.getITasks()).thenReturn(internalTasks);
         Map<String, String> genericInformation = Maps.newHashMap();
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
-        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation()).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAtUpdate, dbManager), is(true));
 
@@ -120,7 +120,7 @@ public class StartAtUpdaterTest {
         when(internalJob.getITasks()).thenReturn(internalTasks);
         Map<String, String> genericInformation = Maps.newHashMap();
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
-        when(internalJob.getRuntimeGenericInformation(true)).thenReturn(genericInformation);
+        when(internalJob.getRuntimeGenericInformation()).thenReturn(genericInformation);
 
         assertThat(startAtUpdater.updateStartAt(internalJob, startAtUpdate, dbManager), is(false));
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/job/termination/handlers/TerminateLoopHandlerTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/job/termination/handlers/TerminateLoopHandlerTest.java
@@ -12,13 +12,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.ow2.proactive.scheduler.common.job.JobPriority;
+import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.flow.FlowAction;
 import org.ow2.proactive.scheduler.core.SchedulerStateUpdate;
-import org.ow2.proactive.scheduler.job.ChangedTasksInfo;
-import org.ow2.proactive.scheduler.job.InternalJob;
-import org.ow2.proactive.scheduler.job.JobIdImpl;
-import org.ow2.proactive.scheduler.job.JobInfoImpl;
+import org.ow2.proactive.scheduler.job.*;
 import org.ow2.proactive.scheduler.task.TaskIdImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalScriptTask;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
@@ -81,9 +80,9 @@ public class TerminateLoopHandlerTest {
 				.thenReturn(true);
 		boolean result = terminateLoopHandler.terminateLoopTask(action, initiator, changesInfo, frontend);
 		assertThat(result, is(true));
-		Map<String, String> genericInformation = newTasks.values().iterator().next().getGenericInformation();
-		assertThat(genericInformation.containsKey(InternalJob.GENERIC_INFO_START_AT_KEY), is(true));
-		assertThat(newTasks.values().iterator().next().getScheduledTime(),
+        Map<String, String> genericInformation = newTasks.values().iterator().next().getRuntimeGenericInformation();
+        assertThat(genericInformation.containsKey(InternalJob.GENERIC_INFO_START_AT_KEY), is(true));
+        assertThat(newTasks.values().iterator().next().getScheduledTime(),
 				is(ISO8601DateUtil.toDate(genericInformation.get(InternalJob.GENERIC_INFO_START_AT_KEY)).getTime()));
 	}
 
@@ -95,9 +94,11 @@ public class TerminateLoopHandlerTest {
 	}
 
 	private InternalTask generateInternalTask() {
-		InternalTask internalTask = new InternalScriptTask();
-		internalTask.setId(TaskIdImpl.createTaskId(new JobIdImpl(666L, "JobName"), "readableName", 555L));
-		return internalTask;
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        InternalTask internalTask = new InternalScriptTask(job);
+        internalTask.setId(TaskIdImpl.createTaskId(new JobIdImpl(666L, "JobName"), "readableName", 555L));
+        return internalTask;
 
 	}
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/DefaultPolicyTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/DefaultPolicyTest.java
@@ -76,7 +76,7 @@ public class DefaultPolicyTest {
         InternalTaskFlowJob taskFlowJob = new InternalTaskFlowJob("test", jobPriority, OnTaskError.CANCEL_JOB, "");
         taskFlowJob.setId(JobIdImpl.makeJobId(Integer.toString(jobId++)));
         ArrayList<InternalTask> tasks = new ArrayList<>();
-        tasks.add(new InternalScriptTask());
+        tasks.add(new InternalScriptTask(taskFlowJob));
         taskFlowJob.addTasks(tasks);
         return new JobDescriptorImpl(taskFlowJob);
     }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicyTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicyTest.java
@@ -43,6 +43,7 @@ import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptor;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptor;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptorImpl;
+import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.job.InternalTaskFlowJob;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalScriptTask;
@@ -188,7 +189,7 @@ public class ExtendedSchedulerPolicyTest {
     }
 
     private String startAtValue(EligibleTaskDescriptor taskDesc) {
-        return taskDesc.getInternal().getGenericInformation().get(GENERIC_INFO_START_AT_KEY);
+        return taskDesc.getInternal().getRuntimeGenericInformation().get(GENERIC_INFO_START_AT_KEY);
     }
 
     private EligibleTaskDescriptor first(List<EligibleTaskDescriptor> taskDescList) {
@@ -214,7 +215,9 @@ public class ExtendedSchedulerPolicyTest {
     }
 
     private InternalScriptTask createTask(String taskStartAt) {
-        InternalScriptTask task1 = new InternalScriptTask();
+        InternalJob job = new InternalTaskFlowJob("test-name", JobPriority.NORMAL, OnTaskError.CANCEL_JOB,
+                "description");
+        InternalScriptTask task1 = new InternalScriptTask(job);
         if (taskStartAt != null) {
             task1.addGenericInformation("START_AT", taskStartAt);
         }

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_DynamicGenericInfo.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_DynamicGenericInfo.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.7"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.7 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.7/schedulerjob.xsd"
+        name="Job_DynamicGenericInfo"
+        priority="normal"
+        onTaskError="continueJobExecution"
+        maxNumberOfExecution="2"
+>
+    <taskFlow>
+        <task name="Split">
+            <description>
+                <![CDATA[ This task defines some input, here strings to be processed. ]]>
+            </description>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+for (int i = 0; i < 4 ; i++) {
+  variables.put("VAR_" + i, "VALUE_" + i)
+}
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+            <controlFlow>
+                <replicate>
+                    <script>
+                        <code language="groovy">
+                            <![CDATA[
+runs=4
+]]>
+                        </code>
+                    </script>
+                </replicate>
+            </controlFlow>
+        </task>
+        <task name="Process">
+            <description>
+                <![CDATA[ This task will be replicated according to the 'runs' value specified in the replication script.                The replication index is used in each task's instance to select the input. ]]>
+            </description>
+            <genericInformation>
+                <info name="GINFO" value="${VAR_${PA_TASK_REPLICATION}}"/>
+            </genericInformation>
+            <depends>
+                <task ref="Split"/>
+            </depends>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+index = variables.get("PA_TASK_REPLICATION");
+if (!genericInformation.get("GINFO").equals("VALUE_" + index)) {
+  throw new RuntimeException("Expected GINFO=" + "VALUE_" + index + " but received GINFO=" + genericInformation.get("GINFO"))
+}
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+        <task name="Merge">
+            <description>
+                <![CDATA[ As a merge operation, we simply print the results from previous tasks. ]]>
+            </description>
+            <depends>
+                <task ref="Process"/>
+            </depends>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+println results
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+    </taskFlow>
+</job>


### PR DESCRIPTION
Add variable recursive late bindings for task generic information
Before this change, variable patterns used in generic info were static and did not use propagated variable values.

In order to allow late binding on generic info, InternalTask keeps a map of up-to-date variables. SchedulingMethodImpl class updates this map the first time it tries to schedule a given task.

To allow recursive binding where the name of the variable used is built by another variable, the VariableSubstitutor was updated.

Additionally
- refactored InternalTask to hold a transient reference to InternalJob (simplification of APIs)
- allow recursive late bindings for variable themselves
- added a unit test for recursive replacements
- added a functional test which verifies late bindings for generic info