### PR TITLE
Fix #264 Support for Scilab 5.5 and more

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/executable/JavaExecutable.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/executable/JavaExecutable.java
@@ -89,8 +89,9 @@ public abstract class JavaExecutable {
         setVariables(propagatedVariables);
         // update arguments
         updateVariables(arguments, getVariables());
-        init(arguments);
+
         initDataSpaces(sc);
+        init(arguments);
     }
 
     /**


### PR DESCRIPTION
The overriden init() method in ScilabExecutable calls initLocalspace() that requires its localspace attribute (defined in the mother class JavaExecutable) to be already defined. Therefore, we must call initDataspaces() before.