### PR TITLE
Update the jline version

### DIFF
--- a/rest/rest-cli/build.gradle
+++ b/rest/rest-cli/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile 'com.eclipsesource.minimal-json:minimal-json:0.9.4'
     compile 'commons-cli:commons-cli:1.3.1'
     compile 'commons-io:commons-io:2.5'
-    compile 'jline:jline:2.11'
+    compile 'jline:jline:2.14.2'
 
     compile 'org.apache.httpcomponents:httpmime:4.5.2'
 

--- a/rest/rest-client/build.gradle
+++ b/rest/rest-client/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java-library-distribution'
 dependencies {
     compile 'commons-cli:commons-cli:1.3.1'
     compile 'commons-io:commons-io:2.5'
-    compile 'jline:jline:2.11'
+    compile 'jline:jline:2.14.2'
 
     compile 'org.apache.httpcomponents:httpclient:4.5.2'
     compile 'org.apache.httpcomponents:httpmime:4.5.2'


### PR DESCRIPTION
This fixes the problem of having JLine not detecting properly the underlying terminal mode, as a result, some character keys can be altered and not function anymore (e.g the backspace key). This also fixes #2466 