### PR TITLE
useBashScriptEngineWhichSendsSigtermInNonForkedMode

### DIFF
--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -24,6 +24,6 @@ dependencies {
     runtime 'org.python:jython-standalone:2.7.0'
 
     runtime 'org.codehaus.groovy:groovy-all:2.4.6'
-    runtime 'jsr223:jsr223-nativeshell:0.4.1'
+    runtime 'jsr223:jsr223-nativeshell:0.4.2'
     runtime 'jsr223:jsr223-docker-compose:0.2.1'
 }


### PR DESCRIPTION
Use new version of bash script engine

Problem:
- Bash script engine does not send a SIGTERM when in non forked mode and a task is killed

Solution:
- Use new version of script engine which has that fixed
