### PR TITLE
Implement test suite for RunAsMe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ plugins {
     id "org.sonarqube" version "1.2"
 }
 
+def isWindows = System.properties['os.name'].toLowerCase().contains('windows')
+
 def custom ={ "$rootDir/gradle/${it}.gradle"}
 
 apply plugin: 'java'
@@ -171,6 +173,19 @@ ext.schedulingFunctionalTestConfiguration = {
     systemProperties << ['java.security.policy': file("$rootDir/config/security.java.policy-server").absolutePath]
     systemProperties << ['file.encoding': 'UTF-8']
 
+    if (project.hasProperty('runasme.user')) {
+        systemProperties << ['runasme.user': project.property('runasme.user')]
+    }
+    if (project.hasProperty('runasme.pwd')) {
+        systemProperties << ['runasme.pwd': project.property('runasme.pwd')]
+    }
+    if (project.hasProperty('runasme.key.path')) {
+        systemProperties << ['runasme.key.path': project.property('runasme.key.path')]
+    }
+    if (project.hasProperty('runasme.shared.dir')) {
+        systemProperties << ['runasme.shared.dir': project.property('runasme.shared.dir')]
+    }
+
     testLogging {
         exceptionFormat = 'full'
     }
@@ -178,8 +193,40 @@ ext.schedulingFunctionalTestConfiguration = {
         logger.lifecycle("Running: " + descriptor)
     }
 
+    def createRunAsMeUser = {
+        if (project.hasProperty('runasme.user') && project.hasProperty('runasme.pwd')) {
+            def extension = isWindows ? ".bat" : ""
+            def pb = new java.lang.ProcessBuilder()
+            pb.inheritIO()
+            pb.command(new File(project.rootDir.getAbsoluteFile(), "tools/proactive-users" + extension).getAbsolutePath(), "-C", "-l", project.property('runasme.user'), "-p", project.property('runasme.pwd'), "-g", "user")
+            def process = pb.start()
+            process.waitFor();
+        }
+    }
+
+    def copySchedulingToSharedDirOnWindows = {
+        if (System.properties['os.name'].toLowerCase().contains('windows') && project.hasProperty('runasme.shared.dir')) {
+            project.copy {
+                from project.rootDir
+                into project.property('runasme.shared.dir')
+                include "dist/lib/*"
+                include "dist/script/**"
+                include "config/**"
+            }
+        }
+    }
+
     def clean = {
         println project.nativeLibsDir
+
+        if (project.hasProperty('runasme.user')) {
+            def extension = isWindows ? ".bat" : ""
+            def pb = new java.lang.ProcessBuilder()
+            pb.inheritIO()
+            pb.command(new File(project.rootDir.getAbsoluteFile(), "tools/proactive-users" + extension).getAbsolutePath(), "-D", "-l", project.property('runasme.user'))
+            def process = pb.start()
+            process.waitFor();
+        }
 
         project.javaexec {
             main = "org.ow2.tests.ProcessCleaner"
@@ -189,7 +236,10 @@ ext.schedulingFunctionalTestConfiguration = {
     }
 
     finalizedBy project.task(project.name + '-clean', { doLast clean })
-    doFirst clean
+    dependsOn project.task(project.name + '-beforetests') << {
+        clean(); createRunAsMeUser(); copySchedulingToSharedDirOnWindows()
+    }
+
 }
 
 dependencies {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -34,13 +34,8 @@
  */
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.base.Strings;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.ow2.proactive.resourcemanager.utils.OneJar;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
@@ -50,7 +45,14 @@ import org.ow2.proactive.scheduler.task.context.TaskContextVariableExtractor;
 import org.ow2.proactive.scheduler.task.executors.forked.env.command.JavaPrefixCommandExtractor;
 import org.ow2.proactive.scripting.ForkEnvironmentScriptResult;
 import org.ow2.proactive.scripting.ScriptResult;
-import com.google.common.base.Strings;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 
 public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
     private final static String javaHomePostfixJavaExecutable = File.separatorChar + "bin" + File.separatorChar + "java";
@@ -131,9 +133,13 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
 
     private StringBuilder getStandardClassPathEntries(Map<String, Serializable> variables) throws IOException {
         StringBuilder classpathEntries = new StringBuilder();
-        Serializable schedulerHomeSerializable = variables.get("PA_SCHEDULER_HOME");
-        if (schedulerHomeSerializable != null) {
-            File paHome = new File((String) schedulerHomeSerializable).getCanonicalFile();
+        String schedulerHome;
+        schedulerHome = System.getProperty(CentralPAPropertyRepository.PA_HOME.getName());
+        if (schedulerHome == null) {
+            schedulerHome = (String) variables.get("PA_SCHEDULER_HOME");
+        }
+        if (schedulerHome != null) {
+            File paHome = new File(schedulerHome).getCanonicalFile();
             File distLib = new File(paHome, "dist/lib").getCanonicalFile();
             if (distLib.exists()) {
                 File addons = new File(paHome, "addons").getCanonicalFile();

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/ForkerUtils.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/ForkerUtils.java
@@ -79,7 +79,7 @@ public final class ForkerUtils {
         }
     }
 
-    private enum ForkMethod {
+    public enum ForkMethod {
         NONE("none"), PWD("pwd"), KEY("key");
         private String value;
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMe.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMe.java
@@ -1,0 +1,53 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests.runasme;
+
+import functionaltests.utils.SchedulerFunctionalTestWithCustomConfigAndRestart;
+
+import static org.junit.Assume.assumeNotNull;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 05/01/2017
+ */
+public class TestRunAsMe extends SchedulerFunctionalTestWithCustomConfigAndRestart {
+
+    public static final String RUNASME_USERNAME_PROPNAME = "runasme.user";
+
+    public static final String RUNASME_PASSWORD_PROPNAME = "runasme.pwd";
+
+    protected static String username;
+
+    protected static String password;
+
+    protected static void setupUser() {
+        username = System.getProperty(RUNASME_USERNAME_PROPNAME);
+        assumeNotNull(username);
+        password = System.getProperty(RUNASME_PASSWORD_PROPNAME);
+        assumeNotNull(password);
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxKey.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxKey.java
@@ -1,0 +1,114 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package functionaltests.runasme;
+
+import functionaltests.dataspaces.TestCacheSpaceCleaning;
+import functionaltests.utils.RMTHelper;
+import functionaltests.utils.SchedulerTHelper;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.objectweb.proactive.utils.OperatingSystem;
+import org.ow2.proactive.resourcemanager.RMFactory;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.task.utils.ForkerUtils;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+
+/**
+ * Tests RunAsMe feature on linux configured with ssh keys impersonation
+ *
+ * @author ActiveEon Team
+ * @since 05/01/2017
+ */
+public class TestRunAsMeLinuxKey extends TestRunAsMe {
+
+    static URL jobDescriptor = TestCacheSpaceCleaning.class.getResource("/functionaltests/descriptors/Job_RunAsMe_Linux.xml");
+
+    public static final String RUNASME_KEY_PATH_PROPNAME = "runasme.key.path";
+
+    protected static byte[] key;
+
+    @BeforeClass
+    public static void startDedicatedScheduler() throws Exception {
+        assumeTrue(OperatingSystem.getOperatingSystem() == OperatingSystem.unix);
+
+        setupUser();
+
+        String keyPath = System.getProperty(RUNASME_KEY_PATH_PROPNAME);
+        assumeNotNull(keyPath);
+
+        key = IOUtils.toByteArray(new File(keyPath).toURI());
+
+        RMFactory.setOsJavaProperty();
+        // start an empty scheduler and add a node source with modified properties
+        schedulerHelper = new SchedulerTHelper(true, true);
+        List<String> arguments = new ArrayList<>();
+        arguments.addAll(RMTHelper.setup.getJvmParametersAsList());
+        arguments.add("-D" + ForkerUtils.FORK_METHOD_KEY + "=" + ForkerUtils.ForkMethod.KEY.toString());
+
+        schedulerHelper.createNodeSource("RunAsMeNSKey", 5, arguments);
+    }
+
+    @Test
+    public void testRunAsMe() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, key);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler,
+                                                        JobFactory.getFactory()
+                                                                  .createJob(new File(jobDescriptor.toURI()).getAbsolutePath()),
+                                                        false,
+                                                        true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxNone.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxNone.java
@@ -1,0 +1,103 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package functionaltests.runasme;
+
+import functionaltests.dataspaces.TestCacheSpaceCleaning;
+import functionaltests.utils.RMTHelper;
+import functionaltests.utils.SchedulerTHelper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.objectweb.proactive.utils.OperatingSystem;
+import org.ow2.proactive.resourcemanager.RMFactory;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.task.utils.ForkerUtils;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assume.assumeTrue;
+
+
+/**
+ * Tests RunAsMe feature on linux configured with sudo impersonation
+ *
+ * @author ActiveEon Team
+ * @since 05/01/2017
+ */
+public class TestRunAsMeLinuxNone extends TestRunAsMe {
+
+    static URL jobDescriptor = TestCacheSpaceCleaning.class.getResource("/functionaltests/descriptors/Job_RunAsMe_Linux.xml");
+
+    @BeforeClass
+    public static void startDedicatedScheduler() throws Exception {
+        assumeTrue(OperatingSystem.getOperatingSystem() == OperatingSystem.unix);
+
+        setupUser();
+
+        RMFactory.setOsJavaProperty();
+        // start an empty scheduler and add a node source with modified properties
+        schedulerHelper = new SchedulerTHelper(true, true);
+        List<String> arguments = new ArrayList<>();
+        arguments.addAll(RMTHelper.setup.getJvmParametersAsList());
+        arguments.add("-D" + ForkerUtils.FORK_METHOD_KEY + "=" + ForkerUtils.ForkMethod.NONE.toString());
+
+        schedulerHelper.createNodeSource("RunAsMeNSNone", 5, arguments);
+    }
+
+    @Test
+    public void testRunAsMe() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler,
+                                                        JobFactory.getFactory()
+                                                                  .createJob(new File(jobDescriptor.toURI()).getAbsolutePath()),
+                                                        false,
+                                                        true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxPwd.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxPwd.java
@@ -1,0 +1,103 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package functionaltests.runasme;
+
+import functionaltests.dataspaces.TestCacheSpaceCleaning;
+import functionaltests.utils.RMTHelper;
+import functionaltests.utils.SchedulerTHelper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.objectweb.proactive.utils.OperatingSystem;
+import org.ow2.proactive.resourcemanager.RMFactory;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.task.utils.ForkerUtils;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assume.assumeTrue;
+
+
+/**
+ * Tests RunAsMe feature on linux configured with su impersonation
+ *
+ * @author ActiveEon Team
+ * @since 05/01/2017
+ */
+public class TestRunAsMeLinuxPwd extends TestRunAsMe {
+
+    static URL jobDescriptor = TestCacheSpaceCleaning.class.getResource("/functionaltests/descriptors/Job_RunAsMe_Linux.xml");
+
+    @BeforeClass
+    public static void startDedicatedScheduler() throws Exception {
+        assumeTrue(OperatingSystem.getOperatingSystem() == OperatingSystem.unix);
+
+        setupUser();
+
+        RMFactory.setOsJavaProperty();
+        // start an empty scheduler and add a node source with modified properties
+        schedulerHelper = new SchedulerTHelper(true, true);
+        List<String> arguments = new ArrayList<>();
+        arguments.addAll(RMTHelper.setup.getJvmParametersAsList());
+        arguments.add("-D" + ForkerUtils.FORK_METHOD_KEY + "=" + ForkerUtils.ForkMethod.PWD.toString());
+
+        schedulerHelper.createNodeSource("RunAsMeNSPwd", 5, arguments);
+    }
+
+    @Test
+    public void testRunAsMe() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler,
+                                                        JobFactory.getFactory()
+                                                                  .createJob(new File(jobDescriptor.toURI()).getAbsolutePath()),
+                                                        false,
+                                                        true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeWindows.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeWindows.java
@@ -1,0 +1,125 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests.runasme;
+
+import functionaltests.dataspaces.TestCacheSpaceCleaning;
+import functionaltests.utils.RMTHelper;
+import functionaltests.utils.SchedulerTHelper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
+import org.objectweb.proactive.utils.OperatingSystem;
+import org.ow2.proactive.resourcemanager.RMFactory;
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.ow2.proactive.scheduler.task.utils.ForkerUtils;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+
+/**
+ * Tests RunAsMe feature on windows
+ *
+ * @author ActiveEon Team
+ * @since 05/01/2017
+ */
+public class TestRunAsMeWindows extends TestRunAsMe {
+
+    public static final String RUNASME_SHARED_DIR_PROPNAME = "runasme.shared.dir";
+
+    protected static String sharedDirectory;
+
+    static URL jobDescriptor = TestCacheSpaceCleaning.class.getResource("/functionaltests/descriptors/Job_RunAsMe_Windows.xml");
+
+    @BeforeClass
+    public static void startDedicatedScheduler() throws Exception {
+        assumeTrue(OperatingSystem.getOperatingSystem() == OperatingSystem.windows);
+
+        setupUser();
+
+        sharedDirectory = System.getProperty(RUNASME_SHARED_DIR_PROPNAME);
+        assumeNotNull(sharedDirectory);
+
+        RMFactory.setOsJavaProperty();
+        // start an empty scheduler and add a node source with modified properties
+        schedulerHelper = new SchedulerTHelper(true, true);
+        List<String> arguments = new ArrayList<>();
+        // change the proactive home directory to the shared directory, proactive libs are copied before the test to this folder
+        // this ensures that the forked jvm will be able to access the proactive jars
+        arguments.addAll(setProActiveHomeInJVMParametersList(RMTHelper.setup.getJvmParametersAsList()));
+        arguments.add("-D" + ForkerUtils.FORK_METHOD_KEY + "=" + ForkerUtils.ForkMethod.PWD.toString());
+        arguments.add("-Djava.io.tmpdir=" + sharedDirectory);
+        arguments.add("-Dpa.logs.home=" + sharedDirectory);
+
+        schedulerHelper.createNodeSource("RunAsMeNS", 5, arguments);
+    }
+
+    private static List<String> setProActiveHomeInJVMParametersList(List<String> jvmParameters) {
+        List<String> newJVMParameters = new ArrayList<>(jvmParameters.size());
+        for (String parameter : jvmParameters) {
+            if (parameter.contains(CentralPAPropertyRepository.PA_HOME.getName())) {
+                newJVMParameters.add(CentralPAPropertyRepository.PA_HOME.getCmdLine() + sharedDirectory);
+            } else if (parameter.contains(PASchedulerProperties.SCHEDULER_HOME.getKey())) {
+                newJVMParameters.add(PASchedulerProperties.SCHEDULER_HOME.getCmdLine() + sharedDirectory);
+            } else if (parameter.contains(PAResourceManagerProperties.RM_HOME.getKey())) {
+                newJVMParameters.add(PAResourceManagerProperties.RM_HOME.getCmdLine() + sharedDirectory);
+            } else {
+                newJVMParameters.add(parameter);
+            }
+        }
+        return newJVMParameters;
+    }
+
+    @Test
+    public void testRunAsMe() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler,
+                                                        JobFactory.getFactory()
+                                                                  .createJob(new File(jobDescriptor.toURI()).getAbsolutePath()),
+                                                        false,
+                                                        true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerFunctionalTestWithCustomConfigAndRestart.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerFunctionalTestWithCustomConfigAndRestart.java
@@ -51,7 +51,9 @@ public class SchedulerFunctionalTestWithCustomConfigAndRestart extends Scheduler
 
     @AfterClass
     public static void cleanupScheduler() throws Exception {
-        schedulerHelper.log("Kill Scheduler after test.");
-        schedulerHelper.killScheduler();
+        if (schedulerHelper != null) {
+            schedulerHelper.log("Kill Scheduler after test.");
+            schedulerHelper.killScheduler();
+        }
     }
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTestUser.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTestUser.java
@@ -56,6 +56,8 @@ public class SchedulerTestUser {
     private String connectedUserName = null;
     private String connectedUserPassword = null;
 
+    private byte[] connectedUserKey = null;
+
     private static SchedulerTestUser instance = null;
 
     private SchedulerMonitorsHandler monitorsHandler;
@@ -78,13 +80,19 @@ public class SchedulerTestUser {
         return user.username.equals(connectedUserName);
     }
 
+    public boolean is(String username, String password) {
+        return username.equals(connectedUserName) && password.equals(connectedUserPassword);
+    }
+
     /**
      * Connects the singleton using the given user
      */
-    public boolean connect(TestUsers user, String schedulerUrl) throws LoginException,
+    public boolean connect(String username, String password, byte[] key, String schedulerUrl)
+            throws LoginException,
             KeyException, ActiveObjectCreationException, NodeException, SchedulerException {
-        this.connectedUserName = user.username;
-        this.connectedUserPassword = user.password;
+        this.connectedUserName = username;
+        this.connectedUserPassword = password;
+        this.connectedUserKey = key;
 
         disconnectFromScheduler();
 
@@ -95,7 +103,8 @@ public class SchedulerTestUser {
         SchedulerTHelper.log("Connecting user " + connectedUserName + " to the Scheduler at url " + schedulerUrl);
         CredData connectedUserCreds =
                 new CredData(CredData.parseLogin(connectedUserName), CredData.parseDomain(connectedUserName),
-                        connectedUserPassword);
+                                                 connectedUserPassword,
+                                                 connectedUserKey);
 
         schedulerProxy.init(schedulerUrl, connectedUserCreds);
 
@@ -114,6 +123,14 @@ public class SchedulerTestUser {
         SchedulerState state = schedulerProxy.addEventListener(eventReceiver, true, true);
         monitorsHandler.init(state);
         return true;
+    }
+
+    /**
+     * Connects the singleton using the given user
+     */
+    public boolean connect(TestUsers user, String schedulerUrl)
+            throws LoginException, KeyException, ActiveObjectCreationException, NodeException, SchedulerException {
+        return connect(user.username, user.password, null, schedulerUrl);
     }
 
     public void schedulerIsRestarted() {

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_RunAsMe_Linux.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_RunAsMe_Linux.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.7"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.7 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.7/schedulerjob.xsd"
+        name="RunAsMeJob"
+        priority="normal"
+        onTaskError="continueJobExecution"
+        maxNumberOfExecution="2"
+>
+    <taskFlow>
+        <task name="Split">
+            <description>
+                <![CDATA[ This task defines some input, here strings to be processed. ]]>
+            </description>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+            <controlFlow>
+                <replicate>
+                    <script>
+                        <code language="groovy">
+                            <![CDATA[
+runs=10
+]]>
+                        </code>
+                    </script>
+                </replicate>
+            </controlFlow>
+        </task>
+        <task name="RunAsMeTask"
+              maxNumberOfExecution="1"
+
+
+              runAsMe="true">
+            <description>
+                <![CDATA[ This task will be replicated according to the 'runs' value specified in the replication script.                The replication index is used in each task's instance to select the input. ]]>
+            </description>
+            <depends>
+                <task ref="Split"/>
+            </depends>
+            <scriptExecutable>
+                <script>
+                    <code language="bash">
+                        <![CDATA[
+echo $USER
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+        <task name="Merge">
+            <description>
+                <![CDATA[ As a merge operation, we simply print the results from previous tasks. ]]>
+            </description>
+            <depends>
+                <task ref="RunAsMeTask"/>
+            </depends>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+println results
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+    </taskFlow>
+</job>

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_RunAsMe_Windows.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_RunAsMe_Windows.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.7"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.7 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.7/schedulerjob.xsd"
+        name="RunAsMeJob"
+        priority="normal"
+        onTaskError="continueJobExecution"
+        maxNumberOfExecution="2"
+>
+    <taskFlow>
+        <task name="Split">
+            <description>
+                <![CDATA[ This task defines some input, here strings to be processed. ]]>
+            </description>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+            <controlFlow>
+                <replicate>
+                    <script>
+                        <code language="groovy">
+                            <![CDATA[
+runs=10
+]]>
+                        </code>
+                    </script>
+                </replicate>
+            </controlFlow>
+        </task>
+        <task name="RunAsMeTask"
+              maxNumberOfExecution="1"
+
+
+              runAsMe="true">
+            <description>
+                <![CDATA[ This task will be replicated according to the 'runs' value specified in the replication script.                The replication index is used in each task's instance to select the input. ]]>
+            </description>
+            <depends>
+                <task ref="Split"/>
+            </depends>
+            <scriptExecutable>
+                <script>
+                    <code language="cmd">
+                        <![CDATA[
+echo %USERNAME%
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+        <task name="Merge">
+            <description>
+                <![CDATA[ As a merge operation, we simply print the results from previous tasks. ]]>
+            </description>
+            <depends>
+                <task ref="RunAsMeTask"/>
+            </depends>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+println results
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+    </taskFlow>
+</job>


### PR DESCRIPTION
- implemented RunAsMe tests for Linux and Windows in functionaltests/runasme package
- improved SchedulerTHelper and SchedulerTestUser to allow the connection of a specific user to the scheduler, allow as well providing a ssh key.
 - ForkedJvmTaskExecutionCommandCreator : use proactive.home variable when provided to build the forked command classpath (it was necessary for runasme tests on windows)
 - build.gradle : added all project properties related to runasme, create runasme user in the scheduler before launching tests, copy scheduling dist/config folders to a shared directory on windows to avoid permission denied error when starting the forked jvm under a different account.