### PR TITLE
gracefullTaskTerminationRunAsMe

### DIFF
--- a/dist/scripts/processbuilder/linux/command_step.sh
+++ b/dist/scripts/processbuilder/linux/command_step.sh
@@ -19,6 +19,9 @@ OSPL_E_CAUSE="CAUSE";
 OSLP_PACKAGE="org.objectweb.proactive.extensions.processbuilder.exception."
 #---------------
 
+
+trap "echo trapped signal" SIGTERM
+
 token=$1
 
 # temp file

--- a/dist/scripts/processbuilder/linux/kill_process_tree.sh
+++ b/dist/scripts/processbuilder/linux/kill_process_tree.sh
@@ -4,9 +4,43 @@
 # pattern. Any process which does not belong the current user will be ingored.
 
 LOGIN=$(whoami)
+
+parentPid=`ps -o ppid= -p $$`
+
+######## SEND SIGTERM
 for ppid in `pgrep -u $LOGIN -f $1`;
 do
-  if [ $ppid -ne $$ ]
+  if [ $ppid -ne $$ -a $ppid -ne $parentPid ]
+  then
+    for pid in `pstree -p $ppid | grep -o -E [0-9]+`
+    do
+      kill -15 $pid > /dev/null 2>&1
+    done
+  fi
+done
+
+
+
+###### WAIT FOR PROCESSES TO BE STOPPED
+# Iterate in seconds
+for iteration in $(seq 1 $2)
+do
+    if [ `pgrep -u $LOGIN -f $1 -c` -eq "2" ] # command_step.sh executes kill_process.tree.sh, so two processes
+    # means nothing else than the killing procedure is running
+    then
+        break # Processes don't exist -> so don't wait
+    fi
+    echo "Sleep a second: $iteration"
+    sleep 1s # Sleep one seconds, because timeout is expressed in seconds
+done
+
+
+
+
+##### SEND SIGKILL AFTER TIMEOUT HIT
+for ppid in `pgrep -u $LOGIN -f $1`;
+do
+  if [ $ppid -ne $$ -a $ppid -ne $parentPid ]
   then
     for pid in `pstree -p $ppid | grep -o -E [0-9]+`
     do

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
@@ -163,6 +163,7 @@ public class RMNodeStarter {
     protected static int NB_OF_RECONNECTION_ATTEMPTS = 2 * 5; // so 5 minutes by default
 
     public final static String SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME = "proactive.node.task.cleanup.time";
+    public final static String SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME_PROACTIVE_PROGRAMMING = "proactive.process.builder.cleanup.time.seconds";
     /** Name of the java property to set the number of attempts performed to add a node to the resource manager */
     public final static String NB_OF_RECONNECTION_ATTEMPTS_PROP_NAME = "proactive.node.reconnection.attempts";
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/WallTimer.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/WallTimer.java
@@ -37,6 +37,8 @@ package org.ow2.proactive.scheduler.task.utils;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.ow2.proactive.scheduler.task.utils.task.termination.TaskKiller;
+
 
 public class WallTimer {
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetter.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetter.java
@@ -1,0 +1,79 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2017 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s): ActiveEon Team - http://www.activeeon.com
+ *
+ *  * $$ACTIVEEON_CONTRIBUTOR$$
+ */
+package org.ow2.proactive.scheduler.task.utils.task.termination;
+
+import org.apache.log4j.Logger;
+import org.ow2.proactive.resourcemanager.utils.RMNodeStarter;
+
+public class CleanupTimeoutGetter {
+
+    private static final Logger LOGGER = Logger.getLogger(CleanupTimeoutGetter.class);
+
+    private static final long CLEANUP_TIME_DEFAULT_SECONDS = 10;
+
+    public long getCleanupTimeSeconds() {
+        try {
+            String cleanupTimeString = System.getProperty(RMNodeStarter.SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME);
+            writePropertyDebugMessageIfEnabled(cleanupTimeString);
+            if (cleanupTimeString != null) {
+                System.setProperty(RMNodeStarter.
+                                SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME_PROACTIVE_PROGRAMMING,
+                        cleanupTimeString);
+                return Long.parseLong(cleanupTimeString);
+            } else {
+                writeDefaultPropertyUsedDebugMessageIfEnabled();
+                return CLEANUP_TIME_DEFAULT_SECONDS;
+            }
+        } catch (NumberFormatException e) {
+            LOGGER.warn("proactive.task.cleanup.time: "
+                    + System.getProperty(RMNodeStarter.SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME)
+                    + " is not parsable to long, fallback to default value. Error : "
+                    + e.getMessage());
+            return CLEANUP_TIME_DEFAULT_SECONDS;
+        }
+    }
+
+    private void writeDefaultPropertyUsedDebugMessageIfEnabled() {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Cleanup timeout default value used: " + CLEANUP_TIME_DEFAULT_SECONDS);
+        }
+    }
+
+    private void writePropertyDebugMessageIfEnabled(String cleanupTimeString) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Cleanup timeout retrieved from property: " + cleanupTimeString);
+        }
+    }
+}

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetterDoubleValue.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetterDoubleValue.java
@@ -1,0 +1,44 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2017 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s): ActiveEon Team - http://www.activeeon.com
+ *
+ *  * $$ACTIVEEON_CONTRIBUTOR$$
+ */
+package org.ow2.proactive.scheduler.task.utils.task.termination;
+
+
+public class CleanupTimeoutGetterDoubleValue extends CleanupTimeoutGetter {
+
+    @Override
+    public long getCleanupTimeSeconds() {
+        return super.getCleanupTimeSeconds() * 2;
+    }
+}

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/utils/TaskKillerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/utils/TaskKillerTest.java
@@ -3,9 +3,13 @@ package org.ow2.proactive.scheduler.task.utils;
 import static java.lang.Thread.sleep;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 import org.ow2.proactive.resourcemanager.utils.RMNodeStarter;
+import org.ow2.proactive.scheduler.task.utils.task.termination.CleanupTimeoutGetter;
+import org.ow2.proactive.scheduler.task.utils.task.termination.TaskKiller;
 
 public class TaskKillerTest {
 
@@ -16,8 +20,10 @@ public class TaskKillerTest {
         KilledThread testThreadToBeInterrupted = new KilledThread();
         testThreadToBeInterrupted.start();
 
-        System.setProperty(this.taskKillerCleanupTimePropertyName, "5");
-        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted);
+        CleanupTimeoutGetter cleanupTimeoutGetterMock = mock(CleanupTimeoutGetter.class);
+        doReturn(5L).when(cleanupTimeoutGetterMock).getCleanupTimeSeconds();
+
+        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted, cleanupTimeoutGetterMock);
 
         assertThat("Task Killer must not interrupt thread before kill() is called",
                 testThreadToBeInterrupted.isInterruptedOnce, is(false));
@@ -44,43 +50,14 @@ public class TaskKillerTest {
     }
 
     @Test
-    public void testThatTaskKillerInterruptsThreadWithDefaultTimeoutWhenPropertyIsSetToGarbage() {
-        KilledThread testThreadToBeInterrupted = new KilledThread();
-        testThreadToBeInterrupted.start();
-
-        System.setProperty(this.taskKillerCleanupTimePropertyName, "A34Gf");
-        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted);
-
-        assertThat("Task Killer must not interrupt thread before kill() is called",
-                testThreadToBeInterrupted.isInterruptedOnce, is(false));
-        assertThat("Task Killer must not interrupt thread before kill() is called",
-                testThreadToBeInterrupted.isInterruptedMoreThanOnce, is(false));
-
-        startKilling(taskKiller);
-        // Wait a second for killing thread to start
-        waitOrFailTest(1000);
-
-        assertThat("Task Killer must interrupt once if kill() is called and then wait for the timeout which is set to 10 seconds.",
-                testThreadToBeInterrupted.isInterruptedOnce, is(true));
-        assertThat("Task Killer must only interrupt once (not twice) after kill() is called and then wait for the timeout which is set to 10 seconds.",
-                testThreadToBeInterrupted.isInterruptedMoreThanOnce, is(false));
-
-        // Wait 10 seconds for killing timeout to be exceeded
-        waitOrFailTest(10000);
-
-        assertThat("Task Killer must have interrupted at least twice after timeout has passed",
-                testThreadToBeInterrupted.isInterruptedMoreThanOnce, is(true));
-
-        // Cleanup - remove system property
-        System.clearProperty(this.taskKillerCleanupTimePropertyName);
-    }
-
-    @Test
     public void testThatTaskKillerInterruptsThreadThenWaitsUntilInterruptingAgainWithoutSystemPropertySet() {
         KilledThread testThreadToBeInterrupted = new KilledThread();
         testThreadToBeInterrupted.start();
 
-        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted);
+        CleanupTimeoutGetter cleanupTimeoutGetterMock = mock(CleanupTimeoutGetter.class);
+        doReturn(10L).when(cleanupTimeoutGetterMock).getCleanupTimeSeconds();
+
+        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted, cleanupTimeoutGetterMock);
 
         assertThat("Task Killer must not interrupt thread before kill() is called",
                 testThreadToBeInterrupted.isInterruptedOnce, is(false));
@@ -108,8 +85,10 @@ public class TaskKillerTest {
         KilledThread testThreadToBeInterrupted = new KilledThread();
         testThreadToBeInterrupted.start();
 
-        System.setProperty(this.taskKillerCleanupTimePropertyName, "0");
-        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted);
+        CleanupTimeoutGetter cleanupTimeoutGetterMock = mock(CleanupTimeoutGetter.class);
+        doReturn(0L).when(cleanupTimeoutGetterMock).getCleanupTimeSeconds();
+
+        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted, cleanupTimeoutGetterMock);
 
         assertThat("Task Killer must not interrupt thread before kill() is called",
                 testThreadToBeInterrupted.isInterruptedOnce, is(false));
@@ -134,8 +113,10 @@ public class TaskKillerTest {
         KilledThread testThreadToBeInterrupted = new KilledThread();
         testThreadToBeInterrupted.start();
 
-        System.setProperty(this.taskKillerCleanupTimePropertyName, "-20");
-        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted);
+        CleanupTimeoutGetter cleanupTimeoutGetterMock = mock(CleanupTimeoutGetter.class);
+        doReturn(-20L).when(cleanupTimeoutGetterMock).getCleanupTimeSeconds();
+
+        TaskKiller taskKiller = new TaskKiller(testThreadToBeInterrupted, cleanupTimeoutGetterMock);
 
         assertThat("Task Killer must not interrupt thread before kill() is called",
                 testThreadToBeInterrupted.isInterruptedOnce, is(false));

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetterDoubleValueTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetterDoubleValueTest.java
@@ -1,0 +1,22 @@
+package org.ow2.proactive.scheduler.task.utils.task.termination;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+
+import org.junit.Test;
+
+
+public class CleanupTimeoutGetterDoubleValueTest {
+
+    private static final long CLEANUP_TIME_DEFAULT_SECONDS = 10;
+
+    @Test
+    public void testThatDefaultTimeoutIsReturnedDoubled() {
+        CleanupTimeoutGetter cleanupTimeoutGetter =
+                new CleanupTimeoutGetterDoubleValue();
+        assertThat(cleanupTimeoutGetter.getCleanupTimeSeconds(), is(CLEANUP_TIME_DEFAULT_SECONDS*2));
+    }
+}

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetterTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/utils/task/termination/CleanupTimeoutGetterTest.java
@@ -1,0 +1,43 @@
+package org.ow2.proactive.scheduler.task.utils.task.termination;
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+
+import org.junit.Test;
+import org.ow2.proactive.resourcemanager.utils.RMNodeStarter;
+
+public class CleanupTimeoutGetterTest {
+
+    private static final long CLEANUP_TIME_DEFAULT_SECONDS = 10;
+    private static final String CLEANUP_TIME_PROPERTY_NAME = RMNodeStarter.SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME;
+
+    @Test
+    public void testThatDefaultTimeoutIsReturnedIfNoPropertyIsSet() {
+        testThatReturnedTimeoutIs(CLEANUP_TIME_DEFAULT_SECONDS);
+    }
+
+    @Test
+    public void testThatDefaultTimeoutIsReturnedIfPropertyIsSetToGarbage() {
+        System.setProperty(CLEANUP_TIME_PROPERTY_NAME, "bahasd3342");
+        testThatReturnedTimeoutIs(CLEANUP_TIME_DEFAULT_SECONDS);
+        System.clearProperty(CLEANUP_TIME_PROPERTY_NAME);
+    }
+
+    @Test
+    public void testThatCorrectValueIsReturnedIfProperyIsSet() {
+        System.setProperty(CLEANUP_TIME_PROPERTY_NAME, "15");
+        testThatReturnedTimeoutIs(15L);
+        System.clearProperty(CLEANUP_TIME_PROPERTY_NAME);
+    }
+
+    private void testThatReturnedTimeoutIs(long expectedTimeout) {
+        CleanupTimeoutGetter cleanupTimeoutGetter =
+                new CleanupTimeoutGetter();
+        assertThat(cleanupTimeoutGetter.getCleanupTimeSeconds(), is(expectedTimeout));
+    }
+
+}


### PR DESCRIPTION
Graceful task termination for run as me

Problem:
- command_step.sh is interrupted and kills its sup-process
- kill_process_tree.sh did kill the whole process tree without interrupt
- The graceful task termination is set through a java property, which is given at the start of the node.
- The run as me mode, has its own Process implementation

Solution:
- command_step.sh traps SIGTERM and ignores it
- kill_process_tree.sh sigterms the whole process tree except itself and its parent processes then waits a graceful task termination timeout. Then it kills the the whole process tree with SIGKILL. Furthermore, the kill_process_tree.sh waits half of the graceful task termination timeout. Otherwise the TaskKiller will interrupt the killing process and killing the process tree is not guaranteed.
- Introduction of a graceful termination timeout getter, which retrieves the timeout or returns the default timeout of 10seconds
- To synchronize with the programming implementation a property synchronizer was introduced. It is executed each time the timeout is retrieved