### PR TITLE
refactorRunAsMeBashScriptsUSeTokenVariable

### DIFF
--- a/dist/scripts/processbuilder/linux/kill_process_tree.sh
+++ b/dist/scripts/processbuilder/linux/kill_process_tree.sh
@@ -5,46 +5,35 @@
 
 LOGIN=$(whoami)
 
-parentPid=`ps -o ppid= -p $$`
-
 ######## SEND SIGTERM
-for ppid in `pgrep -u $LOGIN -f $1`;
+for ppid in `pgrep -u $LOGIN -f $PROCESS_KILL_TOKEN`;
 do
-  if [ $ppid -ne $$ -a $ppid -ne $parentPid ]
-  then
-    for pid in `pstree -p $ppid | grep -o -E [0-9]+`
-    do
-      kill -15 $pid > /dev/null 2>&1
-    done
-  fi
+  for pid in `pstree -p $ppid | grep -o -E [0-9]+`
+  do
+    kill -15 $pid > /dev/null 2>&1
+  done
 done
-
 
 
 ###### WAIT FOR PROCESSES TO BE STOPPED
 # Iterate in seconds
-for iteration in $(seq 1 $2)
+for iteration in $(seq 1 $1)
 do
-    if [ `pgrep -u $LOGIN -f $1 -c` -eq "2" ] # command_step.sh executes kill_process.tree.sh, so two processes
+    if [ `pgrep -u $LOGIN -f $PROCESS_KILL_TOKEN -c` -eq "0" ]
     # means nothing else than the killing procedure is running
     then
         break # Processes don't exist -> so don't wait
     fi
-    echo "Sleep a second: $iteration"
     sleep 1s # Sleep one seconds, because timeout is expressed in seconds
 done
 
 
-
-
 ##### SEND SIGKILL AFTER TIMEOUT HIT
-for ppid in `pgrep -u $LOGIN -f $1`;
+for ppid in `pgrep -u $LOGIN -f $PROCESS_KILL_TOKEN`;
 do
-  if [ $ppid -ne $$ -a $ppid -ne $parentPid ]
-  then
-    for pid in `pstree -p $ppid | grep -o -E [0-9]+`
-    do
-      kill -9 $pid > /dev/null 2>&1
-    done
-  fi
+  for pid in `pstree -p $ppid | grep -o -E [0-9]+`
+  do
+      echo "Send SIGKILL to $pid"
+    kill -9 $pid > /dev/null 2>&1
+  done
 done


### PR DESCRIPTION
Receive kill token via variable, when killing a run as me task

Problem:
- Code complexity was high, because the kill_process_tree.sh script was filtering it's own process id and it's parent process id, the command_step.sh from the list of processes.

Solution:
- Receive the kill token through variables. So the kill_process_tree.sh script doesn't need to filter itself, because it is not visible in the list of processes to kill.