### PR TITLE
Add model to JobVariables

### DIFF
--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
@@ -37,6 +37,21 @@
 
 package org.ow2.proactive_grid_cloud_portal.scheduler;
 
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -51,18 +66,6 @@ import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStoreTestUtils;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobIdData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
-
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.PathSegment;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
 
 public class SchedulerRestWorkflowFromCatalogExecutionTest extends RestTestServer {
 
@@ -140,7 +143,7 @@ public class SchedulerRestWorkflowFromCatalogExecutionTest extends RestTestServe
         verify(scheduler).submit(argumentCaptor.capture());
         Job interceptedJob = argumentCaptor.getValue();
         Assert.assertEquals(1, interceptedJob.getVariables().size());
-        Assert.assertEquals("defaultvalue", interceptedJob.getVariables().get("var1"));
+        Assert.assertEquals("defaultvalue", interceptedJob.getVariables().get("var1").getValue());
 
         Assert.assertEquals(88L, response.getId());
         Assert.assertEquals("job", response.getReadableName());
@@ -160,7 +163,7 @@ public class SchedulerRestWorkflowFromCatalogExecutionTest extends RestTestServe
         Job interceptedJob = argumentCaptor.getValue();
 
         Assert.assertEquals(1, interceptedJob.getVariables().size());
-        Assert.assertEquals("value1", interceptedJob.getVariables().get("var1"));
+        Assert.assertEquals("value1", interceptedJob.getVariables().get("var1").getValue());
 
         Assert.assertEquals(99L, response.getId());
         Assert.assertEquals("job", response.getReadableName());

--- a/rest/rest-smartproxy/src/test/java/functionaltests/RestSmartProxyTest.java
+++ b/rest/rest-smartproxy/src/test/java/functionaltests/RestSmartProxyTest.java
@@ -36,7 +36,22 @@
  */
 package functionaltests;
 
-import com.google.common.base.Throwables;
+import static com.google.common.truth.Truth.assertThat;
+import static functionaltests.RestFuncTHelper.getRestServerUrl;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.After;
 import org.junit.Assert;
@@ -45,6 +60,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.ow2.proactive.authentication.ConnectionInfo;
 import org.ow2.proactive.scheduler.common.NotificationData;
 import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
@@ -66,27 +82,13 @@ import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
-import org.ow2.proactive.authentication.ConnectionInfo;
 import org.ow2.proactive.scheduler.smartproxy.common.SchedulerEventListenerExtended;
 import org.ow2.proactive.scripting.InvalidScriptException;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
 import org.ow2.proactive_grid_cloud_portal.smartproxy.RestSmartProxyImpl;
 
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-
-import static com.google.common.truth.Truth.assertThat;
-import static functionaltests.RestFuncTHelper.getRestServerUrl;
+import com.google.common.base.Throwables;
 
 
 public final class RestSmartProxyTest extends AbstractRestFuncTestCase {
@@ -263,7 +265,7 @@ public final class RestSmartProxyTest extends AbstractRestFuncTestCase {
 
         Thread.sleep(ONE_SECOND);
 
-        while (!jobState.isFinished()) {
+        while (jobState.getStatus().isJobAlive()) {
             jobState = restSmartProxy.getJobState(jobIdAsString);
             Thread.sleep(ONE_SECOND);
         }

--- a/scheduler/scheduler-api/build.gradle
+++ b/scheduler/scheduler-api/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 apply plugin: 'trang'
 task convertSchemas
-['3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', 'dev'].each { schemaVersion ->
+['3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', 'dev'].each { schemaVersion ->
     task("convertSchemasXsd-$schemaVersion", type: org.hsudbrock.tranggradleplugin.TrangTask) {
         sourceDirectory = project.file("src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/${schemaVersion}")
         targetDirectory = sourceDirectory

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
@@ -36,6 +36,7 @@
  */
 package org.ow2.proactive.scheduler.common.job;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -84,7 +85,7 @@ public abstract class Job extends CommonAttribute {
     protected String userSpace = null;
 
     /** A map to holds job descriptor variables */
-    protected ConcurrentHashMap<String, String> variables = new ConcurrentHashMap<>();
+    protected ConcurrentHashMap<String, JobVariable> variables = new ConcurrentHashMap<>();
 
     /** ProActive Empty Constructor */
     public Job() {
@@ -243,8 +244,19 @@ public abstract class Job extends CommonAttribute {
      * 
      * @param variables the variables map
      */
-    public void setVariables(Map<String, String> variables) {
+    public void setVariables(Map<String, JobVariable> variables) {
+        verifyVariableMap(variables);
         this.variables = new ConcurrentHashMap<>(variables);
+    }
+
+    public static void verifyVariableMap(Map<String, ? extends JobVariable> variables) {
+        for (Map.Entry<String, ? extends JobVariable> entry : variables.entrySet()) {
+            if (!entry.getKey().equals(entry.getValue().getName())) {
+                throw new IllegalArgumentException("Variables map entry key (" + entry.getKey() +
+                                                   ") is different from variable name (" + entry.getValue().getName() +
+                                                   ")");
+            }
+        }
     }
 
     /**
@@ -252,8 +264,21 @@ public abstract class Job extends CommonAttribute {
      * 
      * @return a variable map
      */
-    public Map<String, String> getVariables() {
+    public Map<String, JobVariable> getVariables() {
         return this.variables;
+    }
+
+    /**
+     * Returns a map containing the variable names and their values.
+     *
+     * @return a variable map
+     */
+    public Map<String, String> getVariablesAsReplacementMap() {
+        HashMap<String, String> replacementVariables = new HashMap<>(variables.size());
+        for (JobVariable variable : variables.values()) {
+            replacementVariables.put(variable.getName(), variable.getValue());
+        }
+        return replacementVariables;
     }
 
     @Override

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobVariable.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobVariable.java
@@ -34,10 +34,9 @@
  * ################################################################
  * $$PROACTIVE_INITIAL_DEV$$
  */
-package org.ow2.proactive.scheduler.common.task;
+package org.ow2.proactive.scheduler.common.job;
 
 import org.objectweb.proactive.annotation.PublicAPI;
-import org.ow2.proactive.scheduler.common.job.JobVariable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -48,66 +47,88 @@ import java.io.Serializable;
  * 
  * 
  * @author The ProActive Team
- * @since ProActive Scheduling 7.20
+ * @since ProActive Scheduling 7.24
  */
 @PublicAPI
 @XmlAccessorType(XmlAccessType.FIELD)
-public class TaskVariable extends JobVariable implements Serializable {
+public class JobVariable implements Serializable {
 
-    private boolean jobInherited;
+    private String name;
 
-    public TaskVariable() {
+    private String value;
+
+    private String model;
+
+    public JobVariable() {
         //Empty constructor
     }
 
-    public TaskVariable(String name, String value, String model, boolean isJobInherited) {
-        super(name, value, model);
-        this.jobInherited = isJobInherited;
+    public JobVariable(String name, String value) {
+        this(name, value, null);
     }
 
-    public boolean isJobInherited() {
-        return jobInherited;
+    public JobVariable(String name, String value, String model) {
+        this.name = name;
+        this.value = value;
+        this.model = model;
     }
 
-    public void setJobInherited(boolean inherited) {
-        this.jobInherited = inherited;
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
     }
 
     @Override
-    public boolean equals(Object object){
-        if (this == object){
+    public boolean equals(Object object) {
+        if (this == object) {
             return true;
         }
-        if (object == null){
+        if (object == null) {
             return false;
-        }        
-        if (getClass() != object.getClass()){
+        }
+        if (getClass() != object.getClass()) {
             return false;
         }
 
-        TaskVariable taskVariable = (TaskVariable) object;
-        if (jobInherited != taskVariable.isJobInherited()){
-            return false;
-        }
-        if (getName() == null) {
-            if (taskVariable.getName() != null) {
+        JobVariable jobVariable = (JobVariable) object;
+        if (name == null) {
+            if (jobVariable.name != null) {
                 return false;
             }
-        } else if (!getName().equals(taskVariable.getName())) {
+        } else if (!name.equals(jobVariable.name)) {
             return false;
         }
-        if (getValue() == null) {
-            if (taskVariable.getValue() != null) {
+        if (value == null) {
+            if (jobVariable.value != null) {
                 return false;
             }
-        } else if (!getValue().equals(taskVariable.getValue())) {
+        } else if (!value.equals(jobVariable.value)) {
             return false;
         }
-        if (getModel() == null) {
-            if (taskVariable.getModel() != null) {
+        if (model == null) {
+            if (jobVariable.model != null) {
                 return false;
             }
-        } else if (!getModel().equals(taskVariable.getModel())) {
+        } else if (!model.equals(jobVariable.model)) {
             return false;
         }
         return true;
@@ -117,17 +138,15 @@ public class TaskVariable extends JobVariable implements Serializable {
     public int hashCode() {
         final int primeNumber = 31;
         int result = 1;
-        result = primeNumber * result + (jobInherited ? 3 : 5);
-        result = primeNumber * result + ((getName() == null) ? 0 : getName().hashCode());
-        result = primeNumber * result + ((getValue() == null) ? 0 : getValue().hashCode());
-        result = primeNumber * result + ((getModel() == null) ? 0 : getModel().hashCode());
+        result = primeNumber * result + ((name == null) ? 0 : name.hashCode());
+        result = primeNumber * result + ((value == null) ? 0 : value.hashCode());
+        result = primeNumber * result + ((model == null) ? 0 : model.hashCode());
         return result;
     }
 
     @Override
     public String toString() {
-        return "TaskVariable{" + "name='" + getName() + '\'' + ", value='" + getValue() + '\'' + ", model='" +
-               getModel() + '\'' + ", jobInherited=" + jobInherited + '}';
+        return "JobVariable{" + "name='" + name + '\'' + ", value='" + value + '\'' + ", model='" + model + '\'' + '}';
     }
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
@@ -61,6 +61,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
@@ -208,7 +209,7 @@ public class Job2XMLTransformer {
 
         // <ref name="variables"/>
         if (job.getVariables() != null && !job.getVariables().isEmpty()) {
-            Element variablesE = createVariablesElement(doc, job.getVariables());
+            Element variablesE = createJobVariablesElement(doc, job.getVariables());
             rootJob.appendChild(variablesE);
         }
 
@@ -277,17 +278,21 @@ public class Job2XMLTransformer {
     }
 
     /*
-     * Creates the variables element
+     * Creates the job variables element
      */
-    private Element createVariablesElement(Document doc, Map<String, String> variables) {
-        if (variables == null) {
+    private Element createJobVariablesElement(Document doc, Map<String, JobVariable> jobVariables) {
+        if (jobVariables == null) {
             return null;
         }
         Element variablesE = doc.createElementNS(Schemas.SCHEMA_LATEST.getNamespace(), XMLTags.VARIABLES.getXMLName());
-        for (String name : variables.keySet()) {
+        for (String name : jobVariables.keySet()) {
             Element variableE = createElement(doc, XMLTags.VARIABLE.getXMLName(), null, new Attribute(
-                    XMLAttributes.COMMON_NAME.getXMLName(), name), new Attribute(XMLAttributes.COMMON_VALUE
-                    .getXMLName(), variables.get(name)));
+                                                            XMLAttributes.VARIABLE_NAME.getXMLName(),
+                                                            name),
+                                              new Attribute(XMLAttributes.VARIABLE_VALUE.getXMLName(),
+                                                            jobVariables.get(name).getValue()),
+                                              new Attribute(XMLAttributes.VARIABLE_MODEL.getXMLName(),
+                                                            jobVariables.get(name).getModel()));
             variablesE.appendChild(variableE);
         }
         return variablesE;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Schemas.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Schemas.java
@@ -64,12 +64,15 @@ public enum Schemas {
     SCHEMA_3_7(
             "/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.7/schedulerjob.rng",
             "urn:proactive:jobdescriptor:3.7"),
+    SCHEMA_3_8(
+            "/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.8/schedulerjob.rng",
+            "urn:proactive:jobdescriptor:3.8"),
     SCHEMA_DEV(
             "/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng",
             "urn:proactive:jobdescriptor:dev"),
 
     // should contain a reference to the last one declared, see #validate
-    SCHEMA_LATEST(SCHEMA_3_7.location, SCHEMA_3_7.namespace);
+    SCHEMA_LATEST(SCHEMA_3_8.location, SCHEMA_3_8.namespace);
 
     private String location;
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -48,6 +48,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -65,9 +66,10 @@ import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
 import org.ow2.proactive.scheduler.common.job.JobType;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
-import org.ow2.proactive.scheduler.common.job.factories.spi.JobValidatorService;
 import org.ow2.proactive.scheduler.common.job.factories.spi.JobValidatorRegistry;
+import org.ow2.proactive.scheduler.common.job.factories.spi.JobValidatorService;
 import org.ow2.proactive.scheduler.common.task.CommonAttribute;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
@@ -141,11 +143,11 @@ public class StaxJobFactory extends JobFactory {
     }
 
     @Override
-    public Job createJob(String filePath, Map<String, String> updatedVariables) throws JobCreationException {
+    public Job createJob(String filePath, Map<String, String> replacementVariables) throws JobCreationException {
         try {
             // Check if the file exist
             File file = new File(filePath);
-            return createJob(file, updatedVariables);
+            return createJob(file, replacementVariables);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -159,11 +161,11 @@ public class StaxJobFactory extends JobFactory {
     }
 
     @Override
-    public Job createJob(URI filePath, Map<String, String> updatedVariables) throws JobCreationException {
+    public Job createJob(URI filePath, Map<String, String> replacementVariables) throws JobCreationException {
         try {
             //Check if the file exist
             File file = new File(filePath);
-            return createJob(file, updatedVariables);
+            return createJob(file, replacementVariables);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -171,7 +173,7 @@ public class StaxJobFactory extends JobFactory {
         }
     }
 
-    private Job createJob(File file, Map<String, String> updatedVariables) throws JobCreationException {
+    private Job createJob(File file, Map<String, String> replacementVariables) throws JobCreationException {
         try {
             //Check if the file exist
             if (!file.exists()) {
@@ -193,7 +195,7 @@ public class StaxJobFactory extends JobFactory {
             //Dependencies
             Map<String, ArrayList<String>> dependencies = new HashMap<>();
             //Create the job starting at the first cursor position of the XML Stream reader
-            Job job = createJob(xmlsr, updatedVariables, dependencies);
+            Job job = createJob(xmlsr, replacementVariables, dependencies);
             //Close the stream
             xmlsr.close();
             //make dependencies
@@ -266,7 +268,8 @@ public class StaxJobFactory extends JobFactory {
      *
      * @throws JobCreationException if an error occurred during job creation process.
      */
-    private Job createJob(XMLStreamReader cursorRoot, Map<String, String> updatedVariables, Map<String, ArrayList<String>> dependencies)
+    private Job createJob(XMLStreamReader cursorRoot, Map<String, String> replacementVariables,
+            Map<String, ArrayList<String>> dependencies)
             throws JobCreationException {
 
         String current = null;
@@ -280,19 +283,15 @@ public class StaxJobFactory extends JobFactory {
                     current = cursorRoot.getLocalName();
                     if (XMLTags.JOB.matches(current)) {
                         //first tag of the job.
-                        job = createAndFillJob(cursorRoot, updatedVariables);
+                        job = createAndFillJob(cursorRoot, replacementVariables);
                     } else if (XMLTags.TASK.matches(current)) {
                         //once here, the job instance has been created
                         fillJobWithTasks(cursorRoot, job, dependencies);
                     }
                 }
             }
-            //as the job attributes are declared before variable evaluation,
-            //replace variables in this attributes after job creation (after variables evaluation)
             if (job != null){
-                job.setName(replace(job.getName(), job.getVariables()));
-                job.setProjectName(replace(job.getProjectName(), job.getVariables()));
-                resolveCleaningScripts((TaskFlowJob) job, job.getVariables());
+                resolveCleaningScripts((TaskFlowJob) job, job.getVariablesAsReplacementMap());
             }
             return job;
         } catch (JobCreationException jce) {
@@ -310,11 +309,11 @@ public class StaxJobFactory extends JobFactory {
      * the first tag that define the real type of job.
      *
      * @param cursorJob          the streamReader with the cursor on the job element.
-     * @param updatedVariableMap map of variables which has precedence over those that defined
+     * @param replacementVariables map of variables which has precedence over those that defined
      *                           in Job descriptor
      * @throws JobCreationException if an exception occurs during job creation.
      */
-    private Job createAndFillJob(XMLStreamReader cursorJob, Map<String, String> updatedVariableMap)
+    private Job createAndFillJob(XMLStreamReader cursorJob, Map<String, String> replacementVariables)
             throws JobCreationException {
         //create a job that will just temporary store the common properties of the job
         Job commonPropertiesHolder = new Job() {
@@ -329,29 +328,17 @@ public class StaxJobFactory extends JobFactory {
                 throw new RuntimeException("Not Available!");
             }
         };
-        //parse job attributes and fill the temporary one
+        // parse job attributes and fill the temporary one
+
+        // all attributes in the job element are saved and will be handled after the job variables are parsed.
+        // This is to allow variable replacements on these attributes
+        Map<String, String> delayedJobAttributes = new HashMap<>();
         int attrLen = cursorJob.getAttributeCount();
         int i = 0;
         for (; i < attrLen; i++) {
             String attributeName = cursorJob.getAttributeLocalName(i);
             String attributeValue = cursorJob.getAttributeValue(i);
-
-            if (XMLAttributes.COMMON_NAME.matches(attributeName)) {
-                commonPropertiesHolder.setName(attributeValue);
-            } else if (XMLAttributes.JOB_PRIORITY.matches(attributeName)) {
-                commonPropertiesHolder.setPriority(JobPriority.findPriority(replace(attributeValue, commonPropertiesHolder.getVariables())));
-            } else if (XMLAttributes.COMMON_CANCEL_JOB_ON_ERROR.matches(attributeName)) {
-                handleCancelJobOnErrorAttribute(commonPropertiesHolder, attributeValue);
-            } else if (XMLAttributes.COMMON_RESTART_TASK_ON_ERROR.matches(attributeName)) {
-                commonPropertiesHolder.setRestartTaskOnError(RestartMode.getMode(replace(attributeValue, commonPropertiesHolder.getVariables())));
-            } else if (XMLAttributes.COMMON_ON_TASK_ERROR.matches(attributeName)) {
-                commonPropertiesHolder.setOnTaskError(OnTaskError.getInstance(replace(attributeValue, commonPropertiesHolder.getVariables())));
-            } else if (XMLAttributes.COMMON_MAX_NUMBER_OF_EXECUTION.matches(attributeName)) {
-                commonPropertiesHolder.setMaxNumberOfExecution(Integer.parseInt(replace(attributeValue, commonPropertiesHolder.getVariables())));
-            } else if (XMLAttributes.JOB_PROJECT_NAME.matches(attributeName)) {
-                //don't replace() here it is done at the end of the job
-                commonPropertiesHolder.setProjectName(attributeValue);
-            }
+            delayedJobAttributes.put(attributeName, attributeValue);
         }
         //parse job elements and fill the temporary one
         Job job = commonPropertiesHolder;
@@ -364,29 +351,35 @@ public class StaxJobFactory extends JobFactory {
                     case XMLEvent.START_ELEMENT:
                         String current = cursorJob.getLocalName();
                         if (XMLTags.VARIABLES.matches(current)) {
-                            if (updatedVariableMap != null && !updatedVariableMap.isEmpty()) {
-                                commonPropertiesHolder.getVariables().putAll(updatedVariableMap);
-                            }
-                            commonPropertiesHolder.getVariables().putAll(createVariables(cursorJob, commonPropertiesHolder.getVariables()));
-                            if (updatedVariableMap != null && !updatedVariableMap.isEmpty()) {
-                                commonPropertiesHolder.getVariables().putAll(updatedVariableMap);
-                            }
+
+                            // create job variables using the replacement map provided at job submission
+                            // the final value of the variable can either be overwritten by a value of the replacement map or
+                            // use in a pattern such value
+                            commonPropertiesHolder.getVariables()
+                                                  .putAll(createJobVariables(cursorJob, replacementVariables));
+
                         } else if (XMLTags.COMMON_GENERIC_INFORMATION.matches(current)) {
-                            commonPropertiesHolder.setGenericInformation(getGenericInformation(cursorJob, commonPropertiesHolder.getVariables()));
+                            commonPropertiesHolder.setGenericInformation(getGenericInformation(cursorJob,
+                                                                                               commonPropertiesHolder.getVariablesAsReplacementMap()));
                         } else if (XMLTags.JOB_CLASSPATHES.matches(current)) {
                             logger.warn("Element " + XMLTags.JOB_CLASSPATHES.getXMLName() +
                                 " is no longer supported. Please define a " +
                                 XMLTags.FORK_ENVIRONMENT.getXMLName() + " per task if needed.");
                         } else if (XMLTags.COMMON_DESCRIPTION.matches(current)) {
-                            commonPropertiesHolder.setDescription(getDescription(cursorJob, commonPropertiesHolder.getVariables()));
+                            commonPropertiesHolder.setDescription(getDescription(cursorJob,
+                                                                                 commonPropertiesHolder.getVariablesAsReplacementMap()));
                         } else if (XMLTags.DS_INPUT_SPACE.matches(current)) {
-                            commonPropertiesHolder.setInputSpace(getIOSpace(cursorJob, commonPropertiesHolder.getVariables()));
+                            commonPropertiesHolder.setInputSpace(getIOSpace(cursorJob,
+                                                                            commonPropertiesHolder.getVariablesAsReplacementMap()));
                         } else if (XMLTags.DS_OUTPUT_SPACE.matches(current)) {
-                            commonPropertiesHolder.setOutputSpace(getIOSpace(cursorJob, commonPropertiesHolder.getVariables()));
+                            commonPropertiesHolder.setOutputSpace(getIOSpace(cursorJob,
+                                                                             commonPropertiesHolder.getVariablesAsReplacementMap()));
                         } else if (XMLTags.DS_GLOBAL_SPACE.matches(current)) {
-                            commonPropertiesHolder.setGlobalSpace(getIOSpace(cursorJob, commonPropertiesHolder.getVariables()));
+                            commonPropertiesHolder.setGlobalSpace(getIOSpace(cursorJob,
+                                                                             commonPropertiesHolder.getVariablesAsReplacementMap()));
                         } else if (XMLTags.DS_USER_SPACE.matches(current)) {
-                            commonPropertiesHolder.setUserSpace(getIOSpace(cursorJob, commonPropertiesHolder.getVariables()));
+                            commonPropertiesHolder.setUserSpace(getIOSpace(cursorJob,
+                                                                           commonPropertiesHolder.getVariablesAsReplacementMap()));
                         } else if (XMLTags.TASK_FLOW.matches(current)) {
                             job = new TaskFlowJob();
                             shouldContinue = false;
@@ -394,6 +387,9 @@ public class StaxJobFactory extends JobFactory {
                         break;
                 }
             }
+
+            handleJobAttributes(commonPropertiesHolder, delayedJobAttributes);
+
             //if this point is reached, fill the real job using the temporary one
             if (job != commonPropertiesHolder){
                 job.setDescription(commonPropertiesHolder.getDescription());
@@ -421,6 +417,38 @@ public class StaxJobFactory extends JobFactory {
             }
             throw new JobCreationException(cursorJob.getLocalName(), temporaryAttribute, e);
         }
+
+    }
+
+    private void handleJobAttributes(Job commonPropertiesHolder, Map<String, String> delayedJobAttributes)
+            throws JobCreationException {
+        for (Map.Entry<String, String> delayedAttribute : delayedJobAttributes.entrySet()) {
+            String attributeName = delayedAttribute.getKey();
+            String attributeValue = delayedAttribute.getValue();
+            if (XMLAttributes.COMMON_NAME.matches(attributeName)) {
+                commonPropertiesHolder.setName(replace(attributeValue,
+                                                       commonPropertiesHolder.getVariablesAsReplacementMap()));
+            } else if (XMLAttributes.JOB_PRIORITY.matches(attributeName)) {
+                commonPropertiesHolder.setPriority(JobPriority.findPriority(replace(attributeValue,
+                                                                                    commonPropertiesHolder.getVariablesAsReplacementMap())));
+            } else if (XMLAttributes.COMMON_CANCEL_JOB_ON_ERROR.matches(attributeName)) {
+                handleCancelJobOnErrorAttribute(commonPropertiesHolder,
+                                                replace(attributeValue,
+                                                        commonPropertiesHolder.getVariablesAsReplacementMap()));
+            } else if (XMLAttributes.COMMON_RESTART_TASK_ON_ERROR.matches(attributeName)) {
+                commonPropertiesHolder.setRestartTaskOnError(RestartMode.getMode(replace(attributeValue,
+                                                                                         commonPropertiesHolder.getVariablesAsReplacementMap())));
+            } else if (XMLAttributes.COMMON_ON_TASK_ERROR.matches(attributeName)) {
+                commonPropertiesHolder.setOnTaskError(OnTaskError.getInstance(replace(attributeValue,
+                                                                                      commonPropertiesHolder.getVariablesAsReplacementMap())));
+            } else if (XMLAttributes.COMMON_MAX_NUMBER_OF_EXECUTION.matches(attributeName)) {
+                commonPropertiesHolder.setMaxNumberOfExecution(Integer.parseInt(replace(attributeValue,
+                                                                                        commonPropertiesHolder.getVariablesAsReplacementMap())));
+            } else if (XMLAttributes.JOB_PROJECT_NAME.matches(attributeName)) {
+                commonPropertiesHolder.setProjectName(replace(attributeValue,
+                                                              commonPropertiesHolder.getVariablesAsReplacementMap()));
+            }
+        }
     }
 
     private void handleCancelJobOnErrorAttribute(CommonAttribute commonPropertiesHolder,
@@ -440,12 +468,14 @@ public class StaxJobFactory extends JobFactory {
      * Leave the method with the cursor at the end of 'ELEMENT_VARIABLES' tag
      *
      * @param cursorVariables the streamReader with the cursor on the 'ELEMENT_VARIABLES' tag.
+     * @param replacementVariables variables which have precedence over the one defined in the job
      * @return the map in which the variables were added.
      * @throws JobCreationException
      */
-     private Map<String, String> createVariables(XMLStreamReader cursorVariables, Map<String, String> variables) 
+    private Map<String, JobVariable> createJobVariables(XMLStreamReader cursorVariables,
+            Map<String, String> replacementVariables)
              throws JobCreationException {
-        Map<String, String> variablesMap = new HashMap<>();
+        HashMap<String, JobVariable> variablesMap = new LinkedHashMap<>();
         try {
             int eventType;
             while (cursorVariables.hasNext()) {
@@ -453,17 +483,17 @@ public class StaxJobFactory extends JobFactory {
                 switch (eventType) {
                     case XMLEvent.START_ELEMENT:
                         if (XMLTags.VARIABLE.matches(cursorVariables.getLocalName())) {
-                            Map<String, String> attributesAsMap = getAttributesAsMap(cursorVariables, variables);
+                            Map<String, String> attributesAsMap = getAttributesAsMap(cursorVariables, null);
 
                             String name = attributesAsMap.get(XMLAttributes.VARIABLE_NAME.getXMLName());
                             String value = attributesAsMap.get(XMLAttributes.VARIABLE_VALUE.getXMLName());
-
-                            variablesMap.put(name, value);
+                            String model = attributesAsMap.get(XMLAttributes.VARIABLE_MODEL.getXMLName());
+                            variablesMap.put(name, new JobVariable(name, value, model));
                         }
                         break;
                     case XMLEvent.END_ELEMENT:
                         if (XMLTags.VARIABLES.matches(cursorVariables.getLocalName())) {
-                            return variablesMap;
+                            return replaceVariablesInJobVariablesMap(variablesMap, replacementVariables);
                         }
                         break;
                 }
@@ -478,10 +508,48 @@ public class StaxJobFactory extends JobFactory {
             }
             throw new JobCreationException(cursorVariables.getLocalName(), attrtmp, e);
         }
+
         return variablesMap;
     }
 
-     /**
+    protected Map<String, JobVariable> replaceVariablesInJobVariablesMap(Map<String, JobVariable> variablesMap,
+            Map<String, String> replacementVariables) throws JobCreationException {
+
+        HashMap<String, String> updatedReplacementVariables = new HashMap<>();
+        HashMap<String, JobVariable> updatedVariablesMap = new HashMap<>(variablesMap);
+
+        // replacements will include at first variables defined in the job
+        for (JobVariable variable : updatedVariablesMap.values()) {
+            updatedReplacementVariables.put(variable.getName(), variable.getValue());
+        }
+        if (replacementVariables != null) {
+            // overwritten by variables used at job submission
+            updatedReplacementVariables.putAll(replacementVariables);
+        }
+
+        for (Map.Entry<String, String> replacementVariable : updatedReplacementVariables.entrySet()) {
+            if (updatedVariablesMap.containsKey(replacementVariable.getKey())) {
+                // if the variable is already defined in the job, overwrite its value by the replacement variable,
+                // eventually using other variables as pattern replacements
+                JobVariable jobVariable = updatedVariablesMap.get(replacementVariable.getKey());
+                jobVariable.setValue(replace(replacementVariable.getValue(), updatedReplacementVariables));
+                if (jobVariable.getModel() != null) {
+                    // model of an existing variable can use other variables as pattern replacements
+                    jobVariable.setModel(replace(jobVariable.getModel(), updatedReplacementVariables));
+                }
+            } else {
+                // if the variable is not defined in the job, create a new job variable with an empty model
+                updatedVariablesMap.put(replacementVariable.getKey(),
+                                        new JobVariable(replacementVariable.getKey(),
+                                                        replace(replacementVariable.getValue(),
+                                                                updatedReplacementVariables),
+                                                        null));
+            }
+        }
+        return updatedVariablesMap;
+    }
+
+    /**
       * Create a map of variables from XML variables.
       * Leave the method with the cursor at the end of 'ELEMENT_VARIABLES' tag
       *
@@ -523,13 +591,14 @@ public class StaxJobFactory extends JobFactory {
          return variablesMap;
      }
 
-    private Map<String, String> getAttributesAsMap(XMLStreamReader cursorVariables, Map<String, String> variables)
+    private Map<String, String> getAttributesAsMap(XMLStreamReader cursorVariables,
+            Map<String, String> replacementVariables)
             throws JobCreationException {
         final ImmutableMap.Builder<String, String> result = ImmutableMap.builder();
 
         for (int i = 0; i < cursorVariables.getAttributeCount(); i++) {
             result.put(cursorVariables.getAttributeLocalName(i),
-                    replace(cursorVariables.getAttributeValue(i), variables));
+                       replace(cursorVariables.getAttributeValue(i), replacementVariables));
         }
 
         return result.build();
@@ -1579,6 +1648,7 @@ public class StaxJobFactory extends JobFactory {
             logger.debug("name: " + job.getName());
             logger.debug("description: " + job.getDescription());
             logger.debug("projectName: " + job.getProjectName());
+            logger.debug("variables: " + job.getVariables());
             logger.debug("priority: " + job.getPriority());
             logger.debug("onTaskError: " + job.getOnTaskErrorProperty().getValue().toString());
             logger.debug("restartTaskOnError: " + job.getRestartTaskOnError());
@@ -1686,11 +1756,11 @@ public class StaxJobFactory extends JobFactory {
         }
     }
 
-    private static void resolveCleaningScripts(TaskFlowJob job, Map<String, String> variables) {
+    private static void resolveCleaningScripts(TaskFlowJob job, Map<String, String> replacementVariables) {
         for (Task task : job.getTasks()) {
             Script<?> cScript = task.getCleaningScript();
             if (cScript != null) {
-                filterAndUpdate(cScript, variables);
+                filterAndUpdate(cScript, replacementVariables);
             }
         }
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
@@ -28,13 +28,12 @@ package org.ow2.proactive.scheduler.common.job.factories.spi.model;
 import java.io.File;
 
 import org.ow2.proactive.scheduler.common.exception.JobValidationException;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.spi.JobValidatorService;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.validator.ModelValidator;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskVariable;
-
-import com.google.common.base.Strings;
 
 
 /**
@@ -53,21 +52,25 @@ public class DefaultModelJobValidatorServiceProvider implements JobValidatorServ
 
     @Override
     public void validateJob(TaskFlowJob job) throws JobValidationException {
+        for (JobVariable jobVariable : job.getVariables().values()) {
+            checkVariableFormat(null, jobVariable);
+        }
         for (Task task : job.getTasks()) {
-            for (TaskVariable variable : task.getVariables().values()) {
-                checkVariableFormat(task, variable);
+            for (TaskVariable taskVariable : task.getVariables().values()) {
+                checkVariableFormat(task, taskVariable);
             }
         }
     }
 
-    protected void checkVariableFormat(Task task, TaskVariable variable) throws JobValidationException {
-        if (!Strings.isNullOrEmpty(variable.getModel())) {
+    protected void checkVariableFormat(Task task, JobVariable variable) throws JobValidationException {
+        if (variable.getModel() != null && !variable.getModel().trim().isEmpty()) {
             String model = variable.getModel().trim();
 
             try {
                 new ModelValidator(model).validate(variable.getValue());
             } catch (Exception e) {
-                throw new JobValidationException("Task '" + task.getName() + "': Variable '" + variable.getName() +
+                throw new JobValidationException((task != null ? "Task '" + task.getName() + "': " : "") +
+                                                 "Variable '" + variable.getName() +
                                                  "': Model " + variable.getModel() + ": " + e.getMessage(), e);
             }
         }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
@@ -36,7 +36,17 @@
  */
 package org.ow2.proactive.scheduler.common.task;
 
-import com.google.common.base.Joiner;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
@@ -51,15 +61,7 @@ import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.scripting.SelectionScript;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import com.google.common.base.Joiner;
 
 
 /**
@@ -698,18 +700,8 @@ public abstract class Task extends CommonAttribute {
      * @param variables the variables map
      */
     public void setVariables(Map<String, TaskVariable> variables) {
-        verifyVariableMap(variables);
+        Job.verifyVariableMap(variables);
         this.variables = new ConcurrentHashMap<>(variables);
-    }
-
-    private void verifyVariableMap(Map<String, TaskVariable> variables) {
-        for (Map.Entry<String, TaskVariable> entry : variables.entrySet()) {
-            if (!entry.getKey().equals(entry.getValue().getName())) {
-                throw new IllegalArgumentException("Variables map entry key (" + entry.getKey() +
-                                                   ") is different from task variable name (" +
-                                                   entry.getValue().getName() + ")");
-            }
-        }
     }
 
     /**
@@ -729,7 +721,7 @@ public abstract class Task extends CommonAttribute {
     public Map<String, String> getVariablesOverriden(Job job) {
         Map<String, String> taskVariables = new HashMap<>();
         if (job != null){
-            taskVariables.putAll(job.getVariables());
+            taskVariables.putAll(job.getVariablesAsReplacementMap());
         }
         for (TaskVariable variable: getVariables().values()){
             if (!variable.isJobInherited()){

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.5/schedulerjob.xsd
@@ -1,1288 +1,1225 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-           targetNamespace="urn:proactive:jobdescriptor:3.5" xmlns:jd="urn:proactive:jobdescriptor:3.5"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <xs:import namespace="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="xsi.xsd"/>
-    <xs:element name="job">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:proactive:jobdescriptor:3.5" xmlns:jd="urn:proactive:jobdescriptor:3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <xs:import namespace="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="xsi.xsd"/>
+  <xs:element name="job">
+    <xs:annotation>
+      <xs:documentation>Definition of a job for the scheduler </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="jd:variables"/>
+        <xs:group minOccurs="0" ref="jd:jobDescription"/>
+        <xs:element minOccurs="0" ref="jd:genericInformation"/>
+        <xs:element minOccurs="0" ref="jd:inputSpace"/>
+        <xs:element minOccurs="0" ref="jd:outputSpace"/>
+        <xs:element minOccurs="0" ref="jd:globalSpace"/>
+        <xs:element minOccurs="0" ref="jd:userSpace"/>
+        <xs:element ref="jd:taskFlow"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="jd:jobName"/>
+      <xs:attribute name="priority">
         <xs:annotation>
-            <xs:documentation>Definition of a job for the scheduler</xs:documentation>
+          <xs:documentation>Priority of the job</xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element minOccurs="0" ref="jd:variables"/>
-                <xs:group minOccurs="0" ref="jd:jobDescription"/>
-                <xs:element minOccurs="0" ref="jd:genericInformation"/>
-                <xs:element minOccurs="0" ref="jd:inputSpace"/>
-                <xs:element minOccurs="0" ref="jd:outputSpace"/>
-                <xs:element minOccurs="0" ref="jd:globalSpace"/>
-                <xs:element minOccurs="0" ref="jd:userSpace"/>
-                <xs:element ref="jd:taskFlow"/>
-            </xs:sequence>
-            <xs:attributeGroup ref="jd:jobName"/>
-            <xs:attribute name="priority">
-                <xs:annotation>
-                    <xs:documentation>Priority of the job</xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:union memberTypes="jd:jobPriority jd:variableRefType"/>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="onTaskError">
-                <xs:annotation>
-                    <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and
-                        continue job execution are possible settings. The onTaskError behavior is triggered on task
-                        failure, not node failure. (default=continue job execution)
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="restartTaskOnError">
-                <xs:annotation>
-                    <xs:documentation>For each task, where does the task restart if an error occurred ?
-                        (default=anywhere)
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="maxNumberOfExecution">
-                <xs:annotation>
-                    <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="projectName" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>Name of the project related to this job. It is also used in the policy to group
-                        some jobs together
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute ref="xsi:schemaLocation"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="jobName">
-        <xs:attribute name="name" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>Identification of this job</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="variables">
+        <xs:simpleType>
+          <xs:union memberTypes="jd:jobPriority jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="onTaskError">
         <xs:annotation>
-            <xs:documentation>Definition of variables which can be reused throughout this descriptor</xs:documentation>
+          <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue job execution are possible settings. The onTaskError behavior is triggered on task failure, not node failure. (default=continue job execution)</xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:group maxOccurs="unbounded" ref="jd:variable"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:group name="variable">
-        <xs:sequence>
-            <xs:element name="variable">
-                <xs:annotation>
-                    <xs:documentation>Definition of one variable, the variable can be reused (even in another following
-                        variable definition) by using the syntax ${name_of_variable}
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attributeGroup ref="jd:variableName"/>
-                    <xs:attributeGroup ref="jd:variableValue"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:attributeGroup name="variableName">
-        <xs:attribute name="name" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>Name of a variable</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="variableValue">
-        <xs:attribute name="value" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>The patterns ${variable_name} will be replaced by this value</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="priority">
-        <xs:attribute name="priority" use="required">
-            <xs:annotation>
-                <xs:documentation>Priority of the job</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="jd:jobPriority jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="onTaskError_j">
-        <xs:attribute name="onTaskError" use="required">
-            <xs:annotation>
-                <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue
-                    job execution are possible settings. The onTaskError behavior is triggered on task failure, not node
-                    failure. (default=continue job execution)
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="restartTaskOnError_j">
-        <xs:attribute name="restartTaskOnError" use="required">
-            <xs:annotation>
-                <xs:documentation>For each task, where does the task restart if an error occurred ? (default=anywhere)
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="numberOfExecution_j">
-        <xs:attribute name="maxNumberOfExecution" use="required">
-            <xs:annotation>
-                <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="pathElement">
+        <xs:simpleType>
+          <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="restartTaskOnError">
         <xs:annotation>
-            <xs:documentation>Path element (one pathElement for each classpath entry)</xs:documentation>
+          <xs:documentation>For each task, where does the task restart if an error occurred ? (default=anywhere)</xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="path" use="required" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="genericInformation">
+        <xs:simpleType>
+          <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="maxNumberOfExecution">
         <xs:annotation>
-            <xs:documentation>Definition of any information you would like to get in the policy</xs:documentation>
+          <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element maxOccurs="unbounded" ref="jd:info"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="info">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="projectName" type="xs:string">
         <xs:annotation>
-            <xs:documentation>Information that you can get in the policy through the job content</xs:documentation>
+          <xs:documentation>Name of the project related to this job. It is also used in the policy to group some jobs together</xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:attributeGroup ref="jd:infoName"/>
-            <xs:attributeGroup ref="jd:infoValue"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="infoName">
-        <xs:attribute name="name" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>Name of the information variable</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="infoValue">
-        <xs:attribute name="value" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>Value of the information variable</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="projectName">
-        <xs:attribute name="projectName" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>Name of the project related to this job. It is also used in the policy to group some
-                    jobs together
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:group name="jobDescription">
-        <xs:sequence>
-            <xs:element name="description" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>Textual description of this job</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:element name="taskFlow">
-        <xs:annotation>
-            <xs:documentation>A job composed of a flow of tasks with or without dependencies</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:group maxOccurs="unbounded" ref="jd:task"/>
-        </xs:complexType>
-    </xs:element>
-    <!-- +++++++++++++ task -->
-    <xs:group name="task">
-        <xs:sequence>
-            <xs:element name="task">
-                <xs:annotation>
-                    <xs:documentation>A task is the smallest computation unit for the scheduler</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:group minOccurs="0" ref="jd:taskDescription"/>
-                        <xs:element minOccurs="0" ref="jd:genericInformation"/>
-                        <xs:element minOccurs="0" ref="jd:depends"/>
-                        <xs:element minOccurs="0" ref="jd:inputFiles"/>
-                        <xs:element minOccurs="0" ref="jd:parallel"/>
-                        <xs:element minOccurs="0" ref="jd:selection"/>
-                        <xs:element minOccurs="0" ref="jd:forkEnvironment"/>
-                        <xs:element minOccurs="0" ref="jd:pre"/>
-                        <xs:element ref="jd:executable"/>
-                        <xs:element minOccurs="0" ref="jd:controlFlow"/>
-                        <xs:element minOccurs="0" ref="jd:post"/>
-                        <xs:element minOccurs="0" ref="jd:cleaning"/>
-                        <xs:element minOccurs="0" ref="jd:outputFiles"/>
-                    </xs:sequence>
-                    <xs:attributeGroup ref="jd:taskName"/>
-                    <xs:attribute name="numberOfNodes">
-                        <xs:annotation>
-                            <xs:documentation>number of cores needed for the task (identifier)</xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="xs:positiveInteger jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="onTaskError">
-                        <xs:annotation>
-                            <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job
-                                and continue job execution are possible settings. The onTaskError behavior is triggered
-                                on task failure, not node failure. (default=continue job execution)
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="restartTaskOnError" type="jd:restartTaskType">
-                        <xs:annotation>
-                            <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="maxNumberOfExecution">
-                        <xs:annotation>
-                            <xs:documentation>Maximum number of execution for this task</xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="runAsMe">
-                        <xs:annotation>
-                            <xs:documentation>Do we run this task under the job owner user identity</xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="xs:boolean jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="walltime">
-                        <xs:annotation>
-                            <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss'
-                                OR 'mm:ss' OR 'hh:mm:ss')
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="preciousResult">
-                        <xs:annotation>
-                            <xs:documentation>Do we keep the result among the job results</xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="xs:boolean jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="preciousLogs">
-                        <xs:annotation>
-                            <xs:documentation>Do we keep the logs as file on USERSPACE</xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="xs:boolean jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="resultPreviewClass">
-                        <xs:annotation>
-                            <xs:documentation>A class implementing the ResultPreview interface which can be used to
-                                display the result of this task
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
-                        </xs:simpleType>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:attributeGroup name="taskName">
-        <xs:attribute name="name" use="required" type="xs:ID">
-            <xs:annotation>
-                <xs:documentation>Identification of this task (identifier)</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="nodesNumber_t">
-        <xs:attribute name="numberOfNodes" use="required">
-            <xs:annotation>
-                <xs:documentation>number of cores needed for the task (identifier)</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:positiveInteger jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:group name="taskDescription">
-        <xs:sequence>
-            <xs:element name="description" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>Textual description of this task</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:attributeGroup name="walltime">
-        <xs:attribute name="walltime" use="required">
-            <xs:annotation>
-                <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss'
-                    OR 'hh:mm:ss')
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="onTaskError_t">
-        <xs:attribute name="onTaskError" use="required">
-            <xs:annotation>
-                <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue
-                    job execution are possible settings. The onTaskError behavior is triggered on task failure, not node
-                    failure. (default=continue job execution)
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="restartTaskOnError_t">
-        <xs:attribute name="restartTaskOnError" use="required" type="jd:restartTaskType">
-            <xs:annotation>
-                <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="numberOfExecution_t">
-        <xs:attribute name="maxNumberOfExecution" use="required">
-            <xs:annotation>
-                <xs:documentation>Maximum number of execution for this task</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="preciousResult">
-        <xs:attribute name="preciousResult" use="required">
-            <xs:annotation>
-                <xs:documentation>Do we keep the result among the job results</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:boolean jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="preciousLogs">
-        <xs:attribute name="preciousLogs" use="required">
-            <xs:annotation>
-                <xs:documentation>Do we keep the logs as file on USERSPACE</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:boolean jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="resultPreviewClass">
-        <xs:attribute name="resultPreviewClass" use="required">
-            <xs:annotation>
-                <xs:documentation>A class implementing the ResultPreview interface which can be used to display the
-                    result of this task
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="depends">
-        <xs:annotation>
-            <xs:documentation>A list of dependencies for this task</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:group maxOccurs="unbounded" ref="jd:dependsTask"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:group name="dependsTask">
-        <xs:sequence>
-            <xs:element name="task">
-                <xs:annotation>
-                    <xs:documentation>A task from which this task depends</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="ref" use="required" type="xs:IDREF"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:element name="parallel">
-        <xs:annotation>
-            <xs:documentation>An information related parallel task including nodes number and topology
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element minOccurs="0" ref="jd:topology"/>
-            </xs:sequence>
-            <xs:attributeGroup ref="jd:nodesNumber_t"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="topology">
-        <xs:annotation>
-            <xs:documentation>A topology descriptor of the parallel task</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:choice>
-                <xs:element ref="jd:arbitrary"/>
-                <xs:element ref="jd:bestProximity"/>
-                <xs:element ref="jd:thresholdProximity"/>
-                <xs:element ref="jd:singleHost"/>
-                <xs:element ref="jd:singleHostExclusive"/>
-                <xs:element ref="jd:multipleHostsExclusive"/>
-                <xs:element ref="jd:differentHostsExclusive"/>
-            </xs:choice>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="selection">
-        <xs:annotation>
-            <xs:documentation>A script used to select resources that can handle the task</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:group maxOccurs="unbounded" ref="jd:selectionScript"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="controlFlow">
-        <xs:annotation>
-            <xs:documentation>Flow control : block declaration, flow action</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:choice minOccurs="0">
-                <xs:element ref="jd:if"/>
-                <xs:element ref="jd:replicate"/>
-                <xs:element ref="jd:loop"/>
-            </xs:choice>
-            <xs:attribute name="block" type="jd:blockAttr">
-                <xs:annotation>
-                    <xs:documentation>block declaration</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-        </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="block">
-        <xs:attribute name="block" use="required" type="jd:blockAttr">
-            <xs:annotation>
-                <xs:documentation>block declaration</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="pre" type="jd:simpleScript">
-        <xs:annotation>
-            <xs:documentation>A script launched before the task execution in the task node</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="post" type="jd:simpleScript">
-        <xs:annotation>
-            <xs:documentation>A script launched after the task execution in the task node</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="cleaning" type="jd:simpleScript">
-        <xs:annotation>
-            <xs:documentation>A script launched by the Resource Manager after the task or post script</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:attributeGroup name="runAsMe">
-        <xs:attribute name="runAsMe" use="required">
-            <xs:annotation>
-                <xs:documentation>Do we run this task under the job owner user identity</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:boolean jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <!-- +++++++++++++ scripts -->
-    <xs:complexType name="simpleScript">
-        <xs:sequence>
-            <xs:element name="script">
-                <xs:annotation>
-                    <xs:documentation>Definition of a standard script</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:choice>
-                        <xs:element ref="jd:code"/>
-                        <xs:element ref="jd:file"/>
-                    </xs:choice>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
+      </xs:attribute>
+      <xs:attribute ref="xsi:schemaLocation"/>
     </xs:complexType>
-    <xs:group name="selectionScript">
-        <xs:sequence>
-            <xs:element name="script">
-                <xs:annotation>
-                    <xs:documentation>Definition of a specific script which is used for resource selection
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:choice>
-                        <xs:element ref="jd:code"/>
-                        <xs:element ref="jd:file"/>
-                    </xs:choice>
-                    <xs:attribute name="type" type="jd:scriptTypeT">
-                        <xs:annotation>
-                            <xs:documentation>Type of script for the infrastructure manager (default to dynamic)
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:attributeGroup name="scriptType">
-        <xs:attribute name="type" use="required" type="jd:scriptTypeT">
-            <xs:annotation>
-                <xs:documentation>Type of script for the infrastructure manager (default to dynamic)</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="code">
-        <xs:annotation>
-            <xs:documentation>Definition of a script by writing directly the code inside the descriptor
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType mixed="true">
-            <xs:attribute name="language" use="required" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="file">
-        <xs:annotation>
-            <xs:documentation>Definition of a script by loading a file</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:group minOccurs="0" ref="jd:fileScriptArguments"/>
-            <xs:attribute name="path">
-                <xs:annotation>
-                    <xs:documentation>File path to script definition</xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="url">
-                <xs:annotation>
-                    <xs:documentation>Remote script definition, reachable at the given url</xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
-                </xs:simpleType>
-            </xs:attribute>
-        </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="path">
-        <xs:attribute name="path" use="required">
-            <xs:annotation>
-                <xs:documentation>File path to script definition</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="url">
-        <xs:attribute name="url" use="required">
-            <xs:annotation>
-                <xs:documentation>Remote script definition, reachable at the given url</xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:group name="fileScriptArguments">
-        <xs:sequence>
-            <xs:element name="arguments">
-                <xs:annotation>
-                    <xs:documentation>A list of arguments of this script</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:group maxOccurs="unbounded" ref="jd:fileScriptArgument"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:group name="fileScriptArgument">
-        <xs:sequence>
-            <xs:element name="argument">
-                <xs:annotation>
-                    <xs:documentation>An argument of this script</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="value" use="required" type="xs:string"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <!-- +++++++++++++ Topology -->
-    <xs:element name="arbitrary">
-        <xs:annotation>
-            <xs:documentation>arbitrary topology</xs:documentation>
-        </xs:annotation>
-        <xs:complexType/>
-    </xs:element>
-    <xs:element name="bestProximity">
-        <xs:annotation>
-            <xs:documentation>best nodes proximity</xs:documentation>
-        </xs:annotation>
-        <xs:complexType/>
-    </xs:element>
-    <xs:element name="thresholdProximity">
-        <xs:annotation>
-            <xs:documentation>threshold nodes proximity</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attributeGroup ref="jd:threshold"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="singleHost">
-        <xs:annotation>
-            <xs:documentation>nodes on single host</xs:documentation>
-        </xs:annotation>
-        <xs:complexType/>
-    </xs:element>
-    <xs:element name="singleHostExclusive">
-        <xs:annotation>
-            <xs:documentation>nodes on single host exclusively</xs:documentation>
-        </xs:annotation>
-        <xs:complexType/>
-    </xs:element>
-    <xs:element name="multipleHostsExclusive">
-        <xs:annotation>
-            <xs:documentation>nodes on multiple hosts exclusively</xs:documentation>
-        </xs:annotation>
-        <xs:complexType/>
-    </xs:element>
-    <xs:element name="differentHostsExclusive">
-        <xs:annotation>
-            <xs:documentation>nodes on single host exclusively</xs:documentation>
-        </xs:annotation>
-        <xs:complexType/>
-    </xs:element>
-    <xs:attributeGroup name="threshold">
-        <xs:attribute name="threshold" use="required" type="xs:nonNegativeInteger">
-            <xs:annotation>
-                <xs:documentation>threshold value</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <!-- +++++++++++++ executables -->
-    <xs:element name="executable" abstract="true"/>
-    <xs:element name="nativeExecutable" substitutionGroup="jd:executable" type="jd:staticCommand">
-        <xs:annotation>
-            <xs:documentation>A native command call, it can be statically described or generated by a script
-            </xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:complexType name="staticCommand">
-        <xs:sequence>
-            <xs:element ref="jd:staticCommand"/>
-        </xs:sequence>
+  </xs:element>
+  <xs:attributeGroup name="jobName">
+    <xs:attribute name="name" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Identification of this job</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="variables">
+    <xs:annotation>
+      <xs:documentation>Definition of variables which can be reused throughout this descriptor</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="jd:variable"/>
     </xs:complexType>
-    <xs:element name="staticCommand">
+  </xs:element>
+  <xs:group name="variable">
+    <xs:sequence>
+      <xs:element name="variable">
         <xs:annotation>
-            <xs:documentation>A native command statically defined in the descriptor</xs:documentation>
+          <xs:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:group minOccurs="0" ref="jd:commandArguments"/>
-            <xs:attribute name="value" use="required" type="xs:string"/>
+          <xs:attributeGroup ref="jd:variableName"/>
+          <xs:attributeGroup ref="jd:variableValue"/>
         </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="workingDir_t">
-        <xs:attribute name="workingDir" use="required" type="xs:string">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="variableName">
+    <xs:attribute name="name" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of a variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="variableValue">
+    <xs:attribute name="value" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The patterns ${variable_name} will be replaced by this value</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="priority">
+    <xs:attribute name="priority" use="required">
+      <xs:annotation>
+        <xs:documentation>Priority of the job</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:jobPriority jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="onTaskError_j">
+    <xs:attribute name="onTaskError" use="required">
+      <xs:annotation>
+        <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue job execution are possible settings. The onTaskError behavior is triggered on task failure, not node failure. (default=continue job execution)</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="restartTaskOnError_j">
+    <xs:attribute name="restartTaskOnError" use="required">
+      <xs:annotation>
+        <xs:documentation>For each task, where does the task restart if an error occurred ? (default=anywhere)</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="numberOfExecution_j">
+    <xs:attribute name="maxNumberOfExecution" use="required">
+      <xs:annotation>
+        <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="pathElement">
+    <xs:annotation>
+      <xs:documentation>Path element (one pathElement for each classpath entry)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="genericInformation">
+    <xs:annotation>
+      <xs:documentation>Definition of any information you would like to get in the policy</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:info"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="info">
+    <xs:annotation>
+      <xs:documentation>Information that you can get in the policy through the job content</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:infoName"/>
+      <xs:attributeGroup ref="jd:infoValue"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="infoName">
+    <xs:attribute name="name" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of the information variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="infoValue">
+    <xs:attribute name="value" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Value of the information variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="projectName">
+    <xs:attribute name="projectName" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of the project related to this job. It is also used in the policy to group some jobs together</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:group name="jobDescription">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Textual description of this job </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="taskFlow">
+    <xs:annotation>
+      <xs:documentation>A job composed of a flow of tasks with or without dependencies </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="jd:task"/>
+    </xs:complexType>
+  </xs:element>
+  <!-- +++++++++++++ task -->
+  <xs:group name="task">
+    <xs:sequence>
+      <xs:element name="task">
+        <xs:annotation>
+          <xs:documentation>A task is the smallest computation unit for the scheduler </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group minOccurs="0" ref="jd:taskDescription"/>
+            <xs:element minOccurs="0" ref="jd:genericInformation"/>
+            <xs:element minOccurs="0" ref="jd:depends"/>
+            <xs:element minOccurs="0" ref="jd:inputFiles"/>
+            <xs:element minOccurs="0" ref="jd:parallel"/>
+            <xs:element minOccurs="0" ref="jd:selection"/>
+            <xs:element minOccurs="0" ref="jd:forkEnvironment"/>
+            <xs:element minOccurs="0" ref="jd:pre"/>
+            <xs:element ref="jd:executable"/>
+            <xs:element minOccurs="0" ref="jd:controlFlow"/>
+            <xs:element minOccurs="0" ref="jd:post"/>
+            <xs:element minOccurs="0" ref="jd:cleaning"/>
+            <xs:element minOccurs="0" ref="jd:outputFiles"/>
+          </xs:sequence>
+          <xs:attributeGroup ref="jd:taskName"/>
+          <xs:attribute name="numberOfNodes">
             <xs:annotation>
-                <xs:documentation>working dir for native command to execute (ie launching dir, pwd...)
-                </xs:documentation>
+              <xs:documentation>number of cores needed for the task (identifier)</xs:documentation>
             </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:group name="commandArguments">
-        <xs:sequence>
-            <xs:element name="arguments">
-                <xs:annotation>
-                    <xs:documentation>List of arguments to the native command (they will be appended at the end of the
-                        command)
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:group maxOccurs="unbounded" ref="jd:commandArgument"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:group name="commandArgument">
-        <xs:sequence>
-            <xs:element name="argument">
-                <xs:complexType>
-                    <xs:attribute name="value" use="required" type="xs:string"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:element name="javaExecutable" substitutionGroup="jd:executable">
-        <xs:annotation>
-            <xs:documentation>A Java class implementing the Executable interface</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element minOccurs="0" ref="jd:parameters"/>
-            </xs:sequence>
-            <xs:attributeGroup ref="jd:class"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="class">
-        <xs:attribute name="class" use="required">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:positiveInteger jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="onTaskError">
             <xs:annotation>
-                <xs:documentation>The fully qualified class name</xs:documentation>
+              <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue job execution are possible settings. The onTaskError behavior is triggered on task failure, not node failure. (default=continue job execution)</xs:documentation>
             </xs:annotation>
             <xs:simpleType>
-                <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
+              <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
             </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="forkEnvironment">
-        <xs:annotation>
-            <xs:documentation>Fork environment if needed</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element minOccurs="0" ref="jd:SystemEnvironment"/>
-                <xs:element minOccurs="0" ref="jd:jvmArgs"/>
-                <xs:element minOccurs="0" ref="jd:additionalClasspath"/>
-                <xs:element minOccurs="0" ref="jd:envScript"/>
-            </xs:sequence>
-            <xs:attribute name="workingDir" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>working dir for native command to execute (ie launching dir, pwd...)
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="javaHome">
-                <xs:annotation>
-                    <xs:documentation>Path to installed java directory, to this path '/bin/java' will be added, if
-                        attribute does not exist only 'java' command will be called
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
-                </xs:simpleType>
-            </xs:attribute>
-        </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="javaHome">
-        <xs:attribute name="javaHome" use="required">
+          </xs:attribute>
+          <xs:attribute name="restartTaskOnError" type="jd:restartTaskType">
             <xs:annotation>
-                <xs:documentation>Path to installed java directory, to this path '/bin/java' will be added, if attribute
-                    does not exist only 'java' command will be called
-                </xs:documentation>
+              <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
             </xs:annotation>
-            <xs:simpleType>
-                <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="SystemEnvironment">
-        <xs:annotation>
-            <xs:documentation>a list of sysProp</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:group maxOccurs="unbounded" ref="jd:sysProp"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:group name="sysProp">
-        <xs:sequence>
-            <xs:element name="variable">
-                <xs:annotation>
-                    <xs:documentation>A parameter in the form of key/value pair</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="name" use="required" type="xs:string"/>
-                    <xs:attribute name="value" use="required" type="xs:string"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:element name="jvmArgs">
-        <xs:annotation>
-            <xs:documentation>A list of java properties or options</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element maxOccurs="unbounded" ref="jd:jvmArg"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="jvmArg">
-        <xs:annotation>
-            <xs:documentation>A list of java properties or options</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="value" use="required" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="additionalClasspath">
-        <xs:annotation>
-            <xs:documentation>classpath entries to add to the new java process</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element maxOccurs="unbounded" ref="jd:pathElement"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="envScript" type="jd:simpleScript">
-        <xs:annotation>
-            <xs:documentation>environment script to execute for setting forked process environment</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="parameters">
-        <xs:annotation>
-            <xs:documentation>A list of parameters that will be given to the Java task through the init method
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element maxOccurs="unbounded" ref="jd:parameter"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="parameter">
-        <xs:annotation>
-            <xs:documentation>A parameter in the form of key/value pair</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="name" use="required" type="xs:string"/>
-            <xs:attribute name="value" use="required" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="scriptExecutable" substitutionGroup="jd:executable" type="jd:simpleScript">
-        <xs:annotation>
-            <xs:documentation>A script to be executed as a task</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <!-- +++++++++++++ DataSpaces -->
-    <xs:element name="inputSpace">
-        <xs:annotation>
-            <xs:documentation>INPUT space for the job, this setting overrides the default input space provided by the
-                scheduler. It is typically used to store input files for a single job.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attributeGroup ref="jd:url"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="outputSpace">
-        <xs:annotation>
-            <xs:documentation>OUTPUT space for the job, this setting overrides the default output space provided by the
-                scheduler. It is typically used to store output files for a single job.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attributeGroup ref="jd:url"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="globalSpace">
-        <xs:annotation>
-            <xs:documentation>GLOBAL space for the job, this setting overrides the default global space provided by the
-                scheduler. It is typically used to store files shared by all users.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attributeGroup ref="jd:url"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="userSpace">
-        <xs:annotation>
-            <xs:documentation>USER space for the job, this setting overrides the default user space provided by the
-                scheduler. It is typically used to store files that a user needs across multiple jobs.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attributeGroup ref="jd:url"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="inputFiles">
-        <xs:annotation>
-            <xs:documentation>selection of input files that will be accessible for the application and copied from
-                INPUT/OUTPUT to local system
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:group maxOccurs="unbounded" ref="jd:infiles_"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:group name="infiles_">
-        <xs:sequence>
-            <xs:element name="files">
-                <xs:annotation>
-                    <xs:documentation>description of input files with include, exclude and an access mode
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attributeGroup ref="jd:includes_"/>
-                    <xs:attribute name="excludes" type="jd:inexcludePattern">
-                        <xs:annotation>
-                            <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT
-                                or OUTPUT spaces
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attributeGroup ref="jd:inaccessMode_"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:attributeGroup name="inaccessMode_">
-        <xs:attribute name="accessMode" use="required" type="jd:inaccessModeType">
+          </xs:attribute>
+          <xs:attribute name="maxNumberOfExecution">
             <xs:annotation>
-                <xs:documentation>type of access on the selected files</xs:documentation>
+              <xs:documentation>Maximum number of execution for this task</xs:documentation>
             </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="outputFiles">
+            <xs:simpleType>
+              <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="runAsMe">
+            <xs:annotation>
+              <xs:documentation>Do we run this task under the job owner user identity</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="walltime">
+            <xs:annotation>
+              <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="preciousResult">
+            <xs:annotation>
+              <xs:documentation>Do we keep the result among the job results  </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="preciousLogs">
+            <xs:annotation>
+              <xs:documentation>Do we keep the logs as file on USERSPACE</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="resultPreviewClass">
+            <xs:annotation>
+              <xs:documentation>A class implementing the ResultPreview interface which can be used to display the result of this task</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="taskName">
+    <xs:attribute name="name" use="required" type="xs:ID">
+      <xs:annotation>
+        <xs:documentation>Identification of this task (identifier) </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="nodesNumber_t">
+    <xs:attribute name="numberOfNodes" use="required">
+      <xs:annotation>
+        <xs:documentation>number of cores needed for the task (identifier)</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:positiveInteger jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:group name="taskDescription">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string">
         <xs:annotation>
-            <xs:documentation>selection of output files that will be copied from LOCALSPACE to OUTPUT</xs:documentation>
+          <xs:documentation>Textual description of this task</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="walltime">
+    <xs:attribute name="walltime" use="required">
+      <xs:annotation>
+        <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="onTaskError_t">
+    <xs:attribute name="onTaskError" use="required">
+      <xs:annotation>
+        <xs:documentation>Defines the base task error behavior. Cancel job, suspend task, pause job and continue job execution are possible settings. The onTaskError behavior is triggered on task failure, not node failure. (default=continue job execution)</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:onErrorTaskType jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="restartTaskOnError_t">
+    <xs:attribute name="restartTaskOnError" use="required" type="jd:restartTaskType">
+      <xs:annotation>
+        <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="numberOfExecution_t">
+    <xs:attribute name="maxNumberOfExecution" use="required">
+      <xs:annotation>
+        <xs:documentation>Maximum number of execution for this task</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:nonNegativeInteger jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="preciousResult">
+    <xs:attribute name="preciousResult" use="required">
+      <xs:annotation>
+        <xs:documentation>Do we keep the result among the job results  </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="preciousLogs">
+    <xs:attribute name="preciousLogs" use="required">
+      <xs:annotation>
+        <xs:documentation>Do we keep the logs as file on USERSPACE</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="resultPreviewClass">
+    <xs:attribute name="resultPreviewClass" use="required">
+      <xs:annotation>
+        <xs:documentation>A class implementing the ResultPreview interface which can be used to display the result of this task</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="depends">
+    <xs:annotation>
+      <xs:documentation>A list of dependencies for this task </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="jd:dependsTask"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="dependsTask">
+    <xs:sequence>
+      <xs:element name="task">
+        <xs:annotation>
+          <xs:documentation>A task from which this task depends </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:group maxOccurs="unbounded" ref="jd:outfiles_"/>
+          <xs:attribute name="ref" use="required" type="xs:IDREF"/>
         </xs:complexType>
-    </xs:element>
-    <xs:group name="outfiles_">
-        <xs:sequence>
-            <xs:element name="files">
-                <xs:annotation>
-                    <xs:documentation>description of output files with include, exclude and an access mode
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attributeGroup ref="jd:includes_"/>
-                    <xs:attribute name="excludes" type="jd:inexcludePattern">
-                        <xs:annotation>
-                            <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT
-                                or OUTPUT spaces
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attributeGroup ref="jd:outaccessMode_"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    <xs:attributeGroup name="outaccessMode_">
-        <xs:attribute name="accessMode" use="required" type="jd:outaccessModeType">
-            <xs:annotation>
-                <xs:documentation>type of access on the selected files</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="includes_">
-        <xs:attribute name="includes" use="required" type="jd:inexcludePattern">
-            <xs:annotation>
-                <xs:documentation>Pattern of the files to include, relative to INPUT or OUTPUT spaces</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="excludes_">
-        <xs:attribute name="excludes" use="required" type="jd:inexcludePattern">
-            <xs:annotation>
-                <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT or OUTPUT
-                    spaces
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <!-- +++++++++++++ Control flow -->
-    <xs:element name="if">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="parallel">
+    <xs:annotation>
+      <xs:documentation>An information related parallel task including nodes number and topology</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="jd:topology"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="jd:nodesNumber_t"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="topology">
+    <xs:annotation>
+      <xs:documentation>A topology descriptor of the parallel task</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="jd:arbitrary"/>
+        <xs:element ref="jd:bestProximity"/>
+        <xs:element ref="jd:thresholdProximity"/>
+        <xs:element ref="jd:singleHost"/>
+        <xs:element ref="jd:singleHostExclusive"/>
+        <xs:element ref="jd:multipleHostsExclusive"/>
+        <xs:element ref="jd:differentHostsExclusive"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="selection">
+    <xs:annotation>
+      <xs:documentation>A script used to select resources that can handle the task </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="jd:selectionScript"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="controlFlow">
+    <xs:annotation>
+      <xs:documentation>Flow control : block declaration, flow action</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="jd:if"/>
+        <xs:element ref="jd:replicate"/>
+        <xs:element ref="jd:loop"/>
+      </xs:choice>
+      <xs:attribute name="block" type="jd:blockAttr">
         <xs:annotation>
-            <xs:documentation>branching Control flow action</xs:documentation>
+          <xs:documentation>block declaration</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="block">
+    <xs:attribute name="block" use="required" type="jd:blockAttr">
+      <xs:annotation>
+        <xs:documentation>block declaration</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="pre" type="jd:simpleScript">
+    <xs:annotation>
+      <xs:documentation>A script launched before the task execution in the task node</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="post" type="jd:simpleScript">
+    <xs:annotation>
+      <xs:documentation>A script launched after the task execution in the task node</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="cleaning" type="jd:simpleScript">
+    <xs:annotation>
+      <xs:documentation>A script launched by the Resource Manager after the task or post script</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:attributeGroup name="runAsMe">
+    <xs:attribute name="runAsMe" use="required">
+      <xs:annotation>
+        <xs:documentation>Do we run this task under the job owner user identity</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:boolean jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <!-- +++++++++++++ scripts -->
+  <xs:complexType name="simpleScript">
+    <xs:sequence>
+      <xs:element name="script">
+        <xs:annotation>
+          <xs:documentation>Definition of a standard script</xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="jd:simpleScript">
-                    <xs:attributeGroup ref="jd:target"/>
-                    <xs:attributeGroup ref="jd:targetElse"/>
-                    <xs:attribute name="continuation" type="xs:string">
-                        <xs:annotation>
-                            <xs:documentation>branching else target</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
+          <xs:choice>
+            <xs:element ref="jd:code"/>
+            <xs:element ref="jd:file"/>
+          </xs:choice>
         </xs:complexType>
-    </xs:element>
-    <xs:attributeGroup name="target">
-        <xs:attribute name="target" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>branching if target</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="targetElse">
-        <xs:attribute name="else" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>branching else target</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="targetContinuation">
-        <xs:attribute name="continuation" use="required" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>branching else target</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    <xs:element name="loop">
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:group name="selectionScript">
+    <xs:sequence>
+      <xs:element name="script">
         <xs:annotation>
-            <xs:documentation>looping control flow action</xs:documentation>
+          <xs:documentation>Definition of a specific script which is used for resource selection </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="jd:simpleScript">
-                    <xs:attributeGroup ref="jd:target"/>
-                </xs:extension>
-            </xs:complexContent>
+          <xs:choice>
+            <xs:element ref="jd:code"/>
+            <xs:element ref="jd:file"/>
+          </xs:choice>
+          <xs:attribute name="type" type="jd:scriptTypeT">
+            <xs:annotation>
+              <xs:documentation>Type of script for the infrastructure manager (default to dynamic)  </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:complexType>
-    </xs:element>
-    <xs:element name="replicate" type="jd:simpleScript">
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="scriptType">
+    <xs:attribute name="type" use="required" type="jd:scriptTypeT">
+      <xs:annotation>
+        <xs:documentation>Type of script for the infrastructure manager (default to dynamic)  </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="code">
+    <xs:annotation>
+      <xs:documentation>Definition of a script by writing directly the code inside the descriptor </xs:documentation>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:attribute name="language" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="file">
+    <xs:annotation>
+      <xs:documentation>Definition of a script by loading a file </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group minOccurs="0" ref="jd:fileScriptArguments"/>
+      <xs:attribute name="path">
         <xs:annotation>
-            <xs:documentation>replicate control flow action</xs:documentation>
+          <xs:documentation>File path to script definition  </xs:documentation>
         </xs:annotation>
-    </xs:element>
-    <!-- +++++++++++++ User define types -->
-    <xs:simpleType name="jobPriority">
-        <xs:union memberTypes="jd:variableRefType">
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="highest"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="high"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="normal"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="low"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="lowest"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <xs:simpleType name="restartTaskType">
-        <xs:union memberTypes="jd:variableRefType">
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="anywhere"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="elsewhere"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <xs:simpleType name="onErrorTaskType">
-        <xs:union memberTypes="jd:variableRefType">
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="cancelJob"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="suspendTask"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="pauseJob"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="continueJobExecution"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="none"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <xs:simpleType name="inaccessModeType">
-        <xs:union memberTypes="jd:variableRefType">
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="transferFromInputSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="transferFromOutputSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="transferFromGlobalSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="transferFromUserSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="cacheFromInputSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="cacheFromOutputSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="cacheFromGlobalSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="cacheFromUserSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="none"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <xs:simpleType name="outaccessModeType">
-        <xs:union memberTypes="jd:variableRefType">
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="transferToOutputSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="transferToGlobalSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="transferToUserSpace"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="none"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <xs:simpleType name="classPattern">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="walltimePattern">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="variableRefType">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="$\{[A-Za-z0-9._]+\}"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="inexcludePattern">
-        <xs:restriction base="xs:string">
-            <xs:pattern value=".+(,.+)*"/>
-        </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="controlFlowAction">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="url">
+        <xs:annotation>
+          <xs:documentation>Remote script definition, reachable at the given url </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="path">
+    <xs:attribute name="path" use="required">
+      <xs:annotation>
+        <xs:documentation>File path to script definition  </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="url">
+    <xs:attribute name="url" use="required">
+      <xs:annotation>
+        <xs:documentation>Remote script definition, reachable at the given url </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:group name="fileScriptArguments">
+    <xs:sequence>
+      <xs:element name="arguments">
+        <xs:annotation>
+          <xs:documentation>A list of arguments of this script </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="jd:fileScriptArgument"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="fileScriptArgument">
+    <xs:sequence>
+      <xs:element name="argument">
+        <xs:annotation>
+          <xs:documentation>An argument of this script  </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="value" use="required" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <!-- +++++++++++++ Topology -->
+  <xs:element name="arbitrary">
+    <xs:annotation>
+      <xs:documentation>arbitrary topology</xs:documentation>
+    </xs:annotation>
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="bestProximity">
+    <xs:annotation>
+      <xs:documentation>best nodes proximity</xs:documentation>
+    </xs:annotation>
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="thresholdProximity">
+    <xs:annotation>
+      <xs:documentation>threshold nodes proximity</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:threshold"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="singleHost">
+    <xs:annotation>
+      <xs:documentation>nodes on single host</xs:documentation>
+    </xs:annotation>
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="singleHostExclusive">
+    <xs:annotation>
+      <xs:documentation>nodes on single host exclusively</xs:documentation>
+    </xs:annotation>
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="multipleHostsExclusive">
+    <xs:annotation>
+      <xs:documentation>nodes on multiple hosts exclusively</xs:documentation>
+    </xs:annotation>
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="differentHostsExclusive">
+    <xs:annotation>
+      <xs:documentation>nodes on single host exclusively</xs:documentation>
+    </xs:annotation>
+    <xs:complexType/>
+  </xs:element>
+  <xs:attributeGroup name="threshold">
+    <xs:attribute name="threshold" use="required" type="xs:nonNegativeInteger">
+      <xs:annotation>
+        <xs:documentation>threshold value</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <!-- +++++++++++++ executables -->
+  <xs:element name="executable" abstract="true"/>
+  <xs:element name="nativeExecutable" substitutionGroup="jd:executable" type="jd:staticCommand">
+    <xs:annotation>
+      <xs:documentation>A native command call, it can be statically described or generated by a script </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="staticCommand">
+    <xs:sequence>
+      <xs:element ref="jd:staticCommand"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="staticCommand">
+    <xs:annotation>
+      <xs:documentation>A native command statically defined in the descriptor </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group minOccurs="0" ref="jd:commandArguments"/>
+      <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="workingDir_t">
+    <xs:attribute name="workingDir" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>working dir for native command to execute (ie launching dir, pwd...)</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:group name="commandArguments">
+    <xs:sequence>
+      <xs:element name="arguments">
+        <xs:annotation>
+          <xs:documentation>List of arguments to the native command (they will be appended at the end of the command) </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:group maxOccurs="unbounded" ref="jd:commandArgument"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="commandArgument">
+    <xs:sequence>
+      <xs:element name="argument">
+        <xs:complexType>
+          <xs:attribute name="value" use="required" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="javaExecutable" substitutionGroup="jd:executable">
+    <xs:annotation>
+      <xs:documentation>A Java class implementing the Executable interface</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="jd:parameters"/>
+      </xs:sequence>
+      <xs:attributeGroup ref="jd:class"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="class">
+    <xs:attribute name="class" use="required">
+      <xs:annotation>
+        <xs:documentation>The fully qualified class name </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:classPattern jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="forkEnvironment">
+    <xs:annotation>
+      <xs:documentation>Fork environment if needed</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="jd:SystemEnvironment"/>
+        <xs:element minOccurs="0" ref="jd:jvmArgs"/>
+        <xs:element minOccurs="0" ref="jd:additionalClasspath"/>
+        <xs:element minOccurs="0" ref="jd:envScript"/>
+      </xs:sequence>
+      <xs:attribute name="workingDir" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>working dir for native command to execute (ie launching dir, pwd...)</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="javaHome">
+        <xs:annotation>
+          <xs:documentation>Path to installed java directory, to this path '/bin/java' will be added, if attribute does not exist only 'java' command will be called</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="javaHome">
+    <xs:attribute name="javaHome" use="required">
+      <xs:annotation>
+        <xs:documentation>Path to installed java directory, to this path '/bin/java' will be added, if attribute does not exist only 'java' command will be called</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:anyURI jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="SystemEnvironment">
+    <xs:annotation>
+      <xs:documentation>a list of sysProp</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="jd:sysProp"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="sysProp">
+    <xs:sequence>
+      <xs:element name="variable">
+        <xs:annotation>
+          <xs:documentation>A parameter in the form of key/value pair</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" use="required" type="xs:string"/>
+          <xs:attribute name="value" use="required" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="jvmArgs">
+    <xs:annotation>
+      <xs:documentation>A list of java properties or options</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:jvmArg"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="jvmArg">
+    <xs:annotation>
+      <xs:documentation>A list of java properties or options</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="additionalClasspath">
+    <xs:annotation>
+      <xs:documentation>classpath entries to add to the new java process</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:pathElement"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="envScript" type="jd:simpleScript">
+    <xs:annotation>
+      <xs:documentation>environment script to execute for setting forked process environment</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="parameters">
+    <xs:annotation>
+      <xs:documentation>A list of parameters that will be given to the Java task through the init method </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:parameter"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="parameter">
+    <xs:annotation>
+      <xs:documentation>A parameter in the form of key/value pair </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="scriptExecutable" substitutionGroup="jd:executable" type="jd:simpleScript">
+    <xs:annotation>
+      <xs:documentation>A script to be executed as a task</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- +++++++++++++ DataSpaces -->
+  <xs:element name="inputSpace">
+    <xs:annotation>
+      <xs:documentation>INPUT space for the job, this setting overrides the default input space provided by the scheduler. It is typically used to store input files for a single job.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:url"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="outputSpace">
+    <xs:annotation>
+      <xs:documentation>OUTPUT space for the job, this setting overrides the default output space provided by the scheduler. It is typically used to store output files for a single job.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:url"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="globalSpace">
+    <xs:annotation>
+      <xs:documentation>GLOBAL space for the job, this setting overrides the default global space provided by the scheduler. It is typically used to store files shared by all users.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:url"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="userSpace">
+    <xs:annotation>
+      <xs:documentation>USER space for the job, this setting overrides the default user space provided by the scheduler. It is typically used to store files that a user needs across multiple jobs.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:url"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inputFiles">
+    <xs:annotation>
+      <xs:documentation>selection of input files that will be accessible for the application and copied from INPUT/OUTPUT to local system</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="jd:infiles_"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="infiles_">
+    <xs:sequence>
+      <xs:element name="files">
+        <xs:annotation>
+          <xs:documentation>description of input files with include, exclude and an access mode</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attributeGroup ref="jd:includes_"/>
+          <xs:attribute name="excludes" type="jd:inexcludePattern">
+            <xs:annotation>
+              <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT or OUTPUT spaces</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attributeGroup ref="jd:inaccessMode_"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="inaccessMode_">
+    <xs:attribute name="accessMode" use="required" type="jd:inaccessModeType">
+      <xs:annotation>
+        <xs:documentation>type of access on the selected files</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="outputFiles">
+    <xs:annotation>
+      <xs:documentation>selection of output files that will be copied from LOCALSPACE to OUTPUT</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:group maxOccurs="unbounded" ref="jd:outfiles_"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="outfiles_">
+    <xs:sequence>
+      <xs:element name="files">
+        <xs:annotation>
+          <xs:documentation>description of output files with include, exclude and an access mode</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attributeGroup ref="jd:includes_"/>
+          <xs:attribute name="excludes" type="jd:inexcludePattern">
+            <xs:annotation>
+              <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT or OUTPUT spaces</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attributeGroup ref="jd:outaccessMode_"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="outaccessMode_">
+    <xs:attribute name="accessMode" use="required" type="jd:outaccessModeType">
+      <xs:annotation>
+        <xs:documentation>type of access on the selected files</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="includes_">
+    <xs:attribute name="includes" use="required" type="jd:inexcludePattern">
+      <xs:annotation>
+        <xs:documentation>Pattern of the files to include, relative to INPUT or OUTPUT spaces</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="excludes_">
+    <xs:attribute name="excludes" use="required" type="jd:inexcludePattern">
+      <xs:annotation>
+        <xs:documentation>Pattern of the files to exclude among the included one, relative to INPUT or OUTPUT spaces</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <!-- +++++++++++++ Control flow -->
+  <xs:element name="if">
+    <xs:annotation>
+      <xs:documentation>branching Control flow action</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="jd:simpleScript">
+          <xs:attributeGroup ref="jd:target"/>
+          <xs:attributeGroup ref="jd:targetElse"/>
+          <xs:attribute name="continuation" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>branching else target</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="target">
+    <xs:attribute name="target" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>branching if target</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="targetElse">
+    <xs:attribute name="else" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>branching else target</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="targetContinuation">
+    <xs:attribute name="continuation" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>branching else target</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="loop">
+    <xs:annotation>
+      <xs:documentation>looping control flow action</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="jd:simpleScript">
+          <xs:attributeGroup ref="jd:target"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="replicate" type="jd:simpleScript">
+    <xs:annotation>
+      <xs:documentation>replicate control flow action</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- +++++++++++++ User define types -->
+  <xs:simpleType name="jobPriority">
+    <xs:union memberTypes="jd:variableRefType">
+      <xs:simpleType>
         <xs:restriction base="xs:token">
-            <xs:enumeration value="goto"/>
-            <xs:enumeration value="replicate"/>
-            <xs:enumeration value="continue"/>
+          <xs:enumeration value="highest"/>
         </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="blockAttr">
+      </xs:simpleType>
+      <xs:simpleType>
         <xs:restriction base="xs:token">
-            <xs:enumeration value="start"/>
-            <xs:enumeration value="end"/>
-            <xs:enumeration value="none"/>
+          <xs:enumeration value="high"/>
         </xs:restriction>
-    </xs:simpleType>
-    <xs:simpleType name="scriptTypeT">
-        <xs:union memberTypes="jd:variableRefType">
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="dynamic"/>
-                </xs:restriction>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:token">
-                    <xs:enumeration value="static"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <xs:simpleType name="propertyAppendChar">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="."/>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="normal"/>
         </xs:restriction>
-    </xs:simpleType>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="low"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="lowest"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="restartTaskType">
+    <xs:union memberTypes="jd:variableRefType">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="anywhere"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="elsewhere"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="onErrorTaskType">
+    <xs:union memberTypes="jd:variableRefType">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cancelJob"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="suspendTask"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="pauseJob"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="continueJobExecution"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="none"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="inaccessModeType">
+    <xs:union memberTypes="jd:variableRefType">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="transferFromInputSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="transferFromOutputSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="transferFromGlobalSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="transferFromUserSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromInputSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromOutputSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromGlobalSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="cacheFromUserSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="none"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="outaccessModeType">
+    <xs:union memberTypes="jd:variableRefType">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="transferToOutputSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="transferToGlobalSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="transferToUserSpace"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="none"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="classPattern">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="walltimePattern">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="variableRefType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="$\{[A-Za-z0-9._]+\}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="inexcludePattern">
+    <xs:restriction base="xs:string">
+      <xs:pattern value=".+(,.+)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="controlFlowAction">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="goto"/>
+      <xs:enumeration value="replicate"/>
+      <xs:enumeration value="continue"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="blockAttr">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="start"/>
+      <xs:enumeration value="end"/>
+      <xs:enumeration value="none"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="scriptTypeT">
+    <xs:union memberTypes="jd:variableRefType">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="dynamic"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="static"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="propertyAppendChar">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="."/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.8/schedulerjob.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.8/schedulerjob.rnc
@@ -1,5 +1,5 @@
-default namespace = "urn:proactive:jobdescriptor:dev"
-namespace jd = "urn:proactive:jobdescriptor:dev"
+default namespace = "urn:proactive:jobdescriptor:3.8"
+namespace jd = "urn:proactive:jobdescriptor:3.8"
 namespace xsi = "http://www.w3.org/2001/XMLSchema-instance"
 namespace doc = "http://relaxng.org/ns/compatibility/annotations/1.0"
 start = job

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.8/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.8/schedulerjob.rng
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar ns="urn:proactive:jobdescriptor:3.5" xmlns:doc="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:jd="urn:proactive:jobdescriptor:3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar ns="urn:proactive:jobdescriptor:3.8" xmlns:doc="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:jd="urn:proactive:jobdescriptor:3.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <start>
     <ref name="job"/>
   </start>
@@ -70,6 +70,9 @@
       <doc:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</doc:documentation>
       <ref name="variableName"/>
       <ref name="variableValue"/>
+      <optional>
+        <ref name="variableModel"/>
+      </optional>
     </element>
   </define>
   <define name="variableName">
@@ -81,6 +84,12 @@
   <define name="variableValue">
     <attribute name="value">
       <doc:documentation>The patterns ${variable_name} will be replaced by this value</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="variableModel">
+    <attribute name="model">
+      <doc:documentation>Model definition of the variable</doc:documentation>
       <data type="string"/>
     </attribute>
   </define>
@@ -211,6 +220,9 @@
         <ref name="taskDescription"/>
       </optional>
       <optional>
+        <ref name="taskVariables"/>
+      </optional>
+      <optional>
         <ref name="genericInformation"/>
       </optional>
       <optional>
@@ -250,6 +262,47 @@
     <attribute name="name">
       <doc:documentation>Identification of this task (identifier) </doc:documentation>
       <data type="ID"/>
+    </attribute>
+  </define>
+  <define name="taskVariables">
+    <element name="variables">
+      <doc:documentation>Definition of variables which can be used throughout the task</doc:documentation>
+      <oneOrMore>
+        <ref name="taskVariable"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="taskVariable">
+    <element name="variable">
+      <doc:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</doc:documentation>
+      <ref name="taskVariableName"/>
+      <ref name="taskVariableValue"/>
+      <ref name="taskVariableInheritance"/>
+      <ref name="taskVariableModel"/>
+    </element>
+  </define>
+  <define name="taskVariableName">
+    <attribute name="name">
+      <doc:documentation>Name of a variable</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="taskVariableValue">
+    <attribute name="value">
+      <doc:documentation>The patterns ${variable_name} will be replaced by this value</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="taskVariableInheritance">
+    <attribute name="inherited">
+      <doc:documentation>States whether variable value is inherited from parents</doc:documentation>
+      <data type="boolean"/>
+    </attribute>
+  </define>
+  <define name="taskVariableModel">
+    <attribute name="model">
+      <doc:documentation>Variable type</doc:documentation>
+      <data type="string"/>
     </attribute>
   </define>
   <define name="nodesNumber_t">

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.8/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.8/schedulerjob.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:proactive:jobdescriptor:dev" xmlns:jd="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:proactive:jobdescriptor:3.8" xmlns:jd="urn:proactive:jobdescriptor:3.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <xs:import namespace="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="xsi.xsd"/>
   <xs:element name="job">
     <xs:annotation>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
@@ -70,6 +70,9 @@
       <doc:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</doc:documentation>
       <ref name="variableName"/>
       <ref name="variableValue"/>
+      <optional>
+        <ref name="variableModel"/>
+      </optional>
     </element>
   </define>
   <define name="variableName">
@@ -81,6 +84,12 @@
   <define name="variableValue">
     <attribute name="value">
       <doc:documentation>The patterns ${variable_name} will be replaced by this value</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="variableModel">
+    <attribute name="model">
+      <doc:documentation>Model definition of the variable</doc:documentation>
       <data type="string"/>
     </attribute>
   </define>

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
@@ -36,13 +36,17 @@
  */
 package org.ow2.proactive.scheduler.common.job.factories;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
@@ -55,11 +59,8 @@ import org.ow2.proactive.scheduler.common.task.RestartMode;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
-import org.junit.Assert;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import com.google.common.collect.ImmutableMap;
 
 
 /**
@@ -90,27 +91,27 @@ public class TestJobFactory {
         TaskFlowJob tfJob = getJob(jobTaskFlowDescriptor, impl, scriptFolder);
 
         //Check job properties
-        assertEquals(tfJob.getDescription(), "No paquit in its HostName.");
-        assertEquals(tfJob.getName(), "Job_TaskFlow");
-        assertEquals(tfJob.getProjectName(), "My_project");
-        assertEquals(tfJob.getPriority(), JobPriority.NORMAL);
+        assertEquals("No paquit in its HostName.", tfJob.getDescription());
+        assertEquals("Job_TaskFlow", tfJob.getName());
+        assertEquals("My_project", tfJob.getProjectName());
+        assertEquals(JobPriority.HIGH, tfJob.getPriority());
         assertEquals(OnTaskError.CANCEL_JOB, tfJob.getOnTaskErrorProperty().getValue());
-        assertEquals(tfJob.getMaxNumberOfExecution(), 2);
-        assertEquals(tfJob.getRestartTaskOnError(), RestartMode.ELSEWHERE);
-        assertEquals(tfJob.getType(), JobType.TASKSFLOW);
-        assertEquals(tfJob.getTasks().size(), 4);
+        assertEquals(2, tfJob.getMaxNumberOfExecution());
+        assertEquals(RestartMode.ELSEWHERE, tfJob.getRestartTaskOnError());
+        assertEquals(JobType.TASKSFLOW, tfJob.getType());
+        assertEquals(4, tfJob.getTasks().size());
         assertEquals("input/space", tfJob.getInputSpace());
         assertEquals("output/space", tfJob.getOutputSpace());
 
         //Check task 1 properties
         Task task1 = tfJob.getTask("task1");
 
-        assertEquals(task1.getName(), "task1");
+        assertEquals("task1", task1.getName());
         assertEquals(OnTaskError.NONE, task1.getOnTaskErrorProperty().getValue()); // The job factory overwrites the task settings with the job settings if they are set to none.
-        assertEquals(task1.isPreciousResult(), false);
-        assertEquals(task1.getRestartTaskOnError(), RestartMode.ANYWHERE);
-        assertEquals(task1.getMaxNumberOfExecution(), 1);
-        assertEquals(task1.getDescription(), "Parallel Tasks - Task 1");
+        assertEquals(false, task1.isPreciousResult());
+        assertEquals(RestartMode.ANYWHERE, task1.getRestartTaskOnError());
+        assertEquals(1, task1.getMaxNumberOfExecution());
+        assertEquals("Parallel Tasks - Task 1", task1.getDescription());
         assertEquals(2, task1.getSelectionScripts().size());
         assertEquals(false, task1.getSelectionScripts().get(0).isDynamic());
         Assert.assertTrue(task1.getSelectionScripts().get(0).getScript() != null);
@@ -126,41 +127,41 @@ public class TestJobFactory {
         assertNull(task1.getPostScript().getParameters());
         Assert.assertTrue(task1.getCleaningScript().getScript().contains("Beginning of clean script"));
         assertNull(task1.getCleaningScript().getParameters());
-        assertEquals(task1.getDependencesList(), null);
-        assertEquals(task1.getNumberOfNodesNeeded(), 1);
-        assertEquals(task1.getWallTime(), 12 * 1000);
-        assertEquals(task1.isWallTimeSet(), true);
-        assertEquals(task1.getGenericInformation().size(), 0);
+        assertEquals(null, task1.getDependencesList());
+        assertEquals(1, task1.getNumberOfNodesNeeded());
+        assertEquals(12 * 1000, task1.getWallTime());
+        assertEquals(true, task1.isWallTimeSet());
+        assertEquals(0, task1.getGenericInformation().size());
         assertNull(task1.getInputFilesList());
         assertNull(task1.getOutputFilesList());
-        assertEquals(((JavaTask) task1).getArgument("sleepTime"), "1");
-        assertEquals(((JavaTask) task1).getArgument("number"), "1");
-        assertEquals(((JavaTask) task1).getExecutableClassName(), "org.ow2.proactive.scheduler.examples.WaitAndPrint");
-        assertEquals(((JavaTask) task1).isFork(), true);
-        assertEquals(task1.getForkEnvironment(), null);
+        assertEquals("1", ((JavaTask) task1).getArgument("sleepTime"));
+        assertEquals("1", ((JavaTask) task1).getArgument("number"));
+        assertEquals("org.ow2.proactive.scheduler.examples.WaitAndPrint", ((JavaTask) task1).getExecutableClassName());
+        assertEquals(true, ((JavaTask) task1).isFork());
+        assertEquals(null, task1.getForkEnvironment());
 
         //Check task 2 properties
         Task task2 = tfJob.getTask("task2");
-        assertEquals(task2.getName(), "task2");
+        assertEquals("task2", task2.getName());
         assertEquals(OnTaskError.NONE, task2.getOnTaskErrorProperty().getValue());
         //the following commented check fails, it is what we expect, because replacement is done in the internal factory.
         //it avoids complex changes during user job creation process.
         //this property is tested in the TestDatabaseCRUD
         //Assert.assertEquals(tfJob.getTask("task2").isCancelJobOnError(),true);
-        assertEquals(task2.isPreciousResult(), false);
-        assertEquals(task2.getRestartTaskOnError(), RestartMode.ELSEWHERE);
-        assertEquals(task2.getMaxNumberOfExecution(), 2);
-        assertEquals(task2.getDescription(), "Parallel Tasks - Task 2");
-        assertEquals(task2.getSelectionScripts(), null);
+        assertEquals(false, task2.isPreciousResult());
+        assertEquals(RestartMode.ELSEWHERE, task2.getRestartTaskOnError());
+        assertEquals(2, task2.getMaxNumberOfExecution());
+        assertEquals("Parallel Tasks - Task 2", task2.getDescription());
+        assertEquals(null, task2.getSelectionScripts());
         Assert.assertTrue(task2.getPreScript().getScript().contains(
                 "Beginning of Pre-Script"));
-        assertEquals(task2.getPostScript(), null);
-        assertEquals(task2.getCleaningScript(), null);
-        assertEquals(task2.getDependencesList(), null);
-        assertEquals(task2.getNumberOfNodesNeeded(), 1);
-        assertEquals(task2.getWallTime(), 0);
-        assertEquals(task2.isWallTimeSet(), false);
-        assertEquals(task2.getGenericInformation().size(), 0);
+        assertEquals(null, task2.getPostScript());
+        assertEquals(null, task2.getCleaningScript());
+        assertEquals(null, task2.getDependencesList());
+        assertEquals(1, task2.getNumberOfNodesNeeded());
+        assertEquals(0, task2.getWallTime());
+        assertEquals(false, task2.isWallTimeSet());
+        assertEquals(0, task2.getGenericInformation().size());
         Assert.assertTrue(task2.getInputFilesList().get(0).getInputFiles()
                 .getIncludes().contains("tata*"));
         Assert.assertTrue(task2.getInputFilesList().get(0).getInputFiles()
@@ -185,18 +186,16 @@ public class TestJobFactory {
                 .getExcludes().contains("titi*3.txt"));
         assertEquals(OutputAccessMode.TransferToOutputSpace,
           task2.getOutputFilesList().get(1).getMode());
-        assertEquals(((JavaTask) task2).getArgument("sleepTime"), "12");
-        assertEquals(((JavaTask) task2).getArgument("number"), "21");
-        assertEquals(((JavaTask) task2).getArgument("test"), "/bin/java/jdk1.5");
-        assertEquals(((JavaTask) task2).getExecutableClassName(),
-          "org.ow2.proactive.scheduler.examples.WaitAndPrint");
-        assertEquals(((JavaTask) task2).isFork(), true);
-        assertEquals(task2.isWallTimeSet(), false);
-        assertEquals(task2.getForkEnvironment().getJavaHome(), "/bin/java/jdk1.5");
-        assertEquals(task2.getForkEnvironment().getWorkingDir(), "/bin/java/jdk1.5/toto");
-        assertEquals(task2.getForkEnvironment().getJVMArguments().get(0), "-dparam=12");
-        assertEquals(task2.getForkEnvironment().getJVMArguments().get(1),
-          "-djhome=/bin/java/jdk1.5");
+        assertEquals("12", ((JavaTask) task2).getArgument("sleepTime"));
+        assertEquals("21", ((JavaTask) task2).getArgument("number"));
+        assertEquals("/bin/java/jdk1.5", ((JavaTask) task2).getArgument("test"));
+        assertEquals("org.ow2.proactive.scheduler.examples.WaitAndPrint", ((JavaTask) task2).getExecutableClassName());
+        assertEquals(true, ((JavaTask) task2).isFork());
+        assertEquals(false, task2.isWallTimeSet());
+        assertEquals("/bin/java/jdk1.5", task2.getForkEnvironment().getJavaHome());
+        assertEquals("/bin/java/jdk1.5/toto", task2.getForkEnvironment().getWorkingDir());
+        assertEquals("-dparam=12", task2.getForkEnvironment().getJVMArguments().get(0));
+        assertEquals("-djhome=/bin/java/jdk1.5", task2.getForkEnvironment().getJVMArguments().get(1));
         Map<String, String> props = task2.getForkEnvironment()
                 .getSystemEnvironment();
         assertEquals(2, props.size());
@@ -216,14 +215,14 @@ public class TestJobFactory {
 
         //Check task 3 properties
         Task task3 = tfJob.getTask("task3");
-        assertEquals(task3.getName(), "task3");
+        assertEquals("task3", task3.getName());
         assertEquals(OnTaskError.NONE, task3.getOnTaskErrorProperty().getValue());
         //the following commented check fails, it is what we expect, because replacement is done in the
         // internal factory.
         //it avoids complex changes during user job creation process.
         //this property is tested in the TestDatabaseCRUD
         //Assert.assertEquals(tfJob.getTask("task3").isCancelJobOnError(),true);
-        assertEquals(task3.isPreciousResult(), false);
+        assertEquals(false, task3.isPreciousResult());
         //the following commented check fails, it is what we expect, because replacement is done in the
         // internal factory.
         //it avoids complex changes during user job creation process.
@@ -233,19 +232,19 @@ public class TestJobFactory {
         //it avoids complex changes during user job creation process.
         //this property is tested in the TestDatabaseCRUD
         //Assert.assertEquals(tfJob.getTask("task3").getMaxNumberOfExecution(),2);
-        assertEquals(task3.getDescription(), "Dependent Tasks - Task 3");
-        assertEquals(task3.getSelectionScripts(), null);
-        assertEquals(task3.getPreScript(), null);
+        assertEquals("Dependent Tasks - Task 3", task3.getDescription());
+        assertEquals(null, task3.getSelectionScripts());
+        assertEquals(null, task3.getPreScript());
         Assert.assertTrue(task3.getPostScript().getScript().contains(
                 "Unsetting system property user.property1"));
-        assertEquals(task3.getPostScript().getParameters(), null);
-        assertEquals(task3.getCleaningScript(), null);
-        assertEquals(task3.getDependencesList().size(), 2);
-        assertEquals(task3.getDependencesList().get(0).getName(), "task1");
-        assertEquals(task3.getDependencesList().get(1).getName(), "task2");
-        assertEquals(task3.getWallTime(), 10 * 60 * 1000 + 53 * 1000);
-        assertEquals(task3.isWallTimeSet(), true);
-        assertEquals(task3.getGenericInformation().size(), 0);
+        assertNull(task3.getPostScript().getParameters());
+        assertEquals(null, task3.getCleaningScript());
+        assertEquals(2, task3.getDependencesList().size());
+        assertEquals("task1", task3.getDependencesList().get(0).getName());
+        assertEquals("task2", task3.getDependencesList().get(1).getName());
+        assertEquals(10 * 60 * 1000 + 53 * 1000, task3.getWallTime());
+        assertEquals(true, task3.isWallTimeSet());
+        assertEquals(0, task3.getGenericInformation().size());
         assertEquals(1, task3.getInputFilesList().size());
         Assert.assertTrue(task3.getInputFilesList().get(0).getInputFiles()
                 .getIncludes().contains("tata*"));
@@ -253,32 +252,32 @@ public class TestJobFactory {
                 task3.getInputFilesList().get(0).getInputFiles().getExcludes().isEmpty());
         assertEquals(InputAccessMode.none, task3.getInputFilesList().get(0).getMode());
         assertNull(task3.getOutputFilesList());
-        assertEquals(((NativeTask) task3).getCommandLine().length, 5);
-        assertEquals(((NativeTask) task3).getCommandLine()[1], "1");
-        assertEquals(((NativeTask) task3).getCommandLine()[2], "2 2");
-        assertEquals(((NativeTask) task3).getCommandLine()[3], "3");
-        assertEquals(((NativeTask) task3).getCommandLine()[4], "12");
+        assertEquals(5, ((NativeTask) task3).getCommandLine().length);
+        assertEquals("1", ((NativeTask) task3).getCommandLine()[1]);
+        assertEquals("2 2", ((NativeTask) task3).getCommandLine()[2]);
+        assertEquals("3", ((NativeTask) task3).getCommandLine()[3]);
+        assertEquals("12", ((NativeTask) task3).getCommandLine()[4]);
         assertNull(((NativeTask) task3).getWorkingDir());
-        assertEquals(task3.getNumberOfNodesNeeded(), 3);
+        assertEquals(3, task3.getNumberOfNodesNeeded());
 
         //Check task 4 properties
         Task task4 = tfJob.getTask("task4");
-        assertEquals(task4.getName(), "task4");
+        assertEquals("task4", task4.getName());
         assertEquals(OnTaskError.CANCEL_JOB, task4.getOnTaskErrorProperty().getValue());
-        assertEquals(task4.isPreciousResult(), true);
-        assertEquals(task4.getRestartTaskOnError(), RestartMode.ANYWHERE);
-        assertEquals(task4.getMaxNumberOfExecution(), 3);
-        assertEquals(task4.getDescription(), null);
-        assertEquals(task4.getSelectionScripts(), null);
-        assertEquals(task4.getPreScript(), null);
-        assertEquals(task4.getPostScript(), null);
-        assertEquals(task4.getCleaningScript(), null);
-        assertEquals(task4.getDependencesList().size(), 1);
-        assertEquals(task4.getDependencesList().get(0).getName(), "task3");
-        assertEquals(task4.getWallTime(), 0);
-        assertEquals(task4.isWallTimeSet(), false);
-        assertEquals(task4.getGenericInformation().get("n11"), "v11");
-        assertEquals(task4.getGenericInformation().get("n22"), "v22");
+        assertEquals(true, task4.isPreciousResult());
+        assertEquals(RestartMode.ANYWHERE, task4.getRestartTaskOnError());
+        assertEquals(3, task4.getMaxNumberOfExecution());
+        assertEquals(null, task4.getDescription());
+        assertEquals(null, task4.getSelectionScripts());
+        assertEquals(null, task4.getPreScript());
+        assertEquals(null, task4.getPostScript());
+        assertEquals(null, task4.getCleaningScript());
+        assertEquals(1, task4.getDependencesList().size());
+        assertEquals("task3", task4.getDependencesList().get(0).getName());
+        assertEquals(0, task4.getWallTime());
+        assertEquals(false, task4.isWallTimeSet());
+        assertEquals("v11", task4.getGenericInformation().get("n11"));
+        assertEquals("v22", task4.getGenericInformation().get("n22"));
         assertNull(task4.getInputFilesList());
         assertEquals(5, task4.getOutputFilesList().size());
         Assert.assertTrue(task4.getOutputFilesList().get(0).getOutputFiles()
@@ -308,37 +307,37 @@ public class TestJobFactory {
           task4.getOutputFilesList().get(3).getMode());
         assertEquals(OutputAccessMode.none, task4.getOutputFilesList().get(4).getMode());
         assertEquals(null, ((NativeTask) task4).getWorkingDir());
-        assertEquals(task4.getNumberOfNodesNeeded(), 10);
+        assertEquals(10, task4.getNumberOfNodesNeeded());
 
         log("Test Job MULTI_NODES");
         TaskFlowJob mnJob = getJob(jobMultiNodesDescriptor, impl, scriptFolder);
         //Check job properties
-        assertEquals(mnJob.getDescription(), "No description");
-        assertEquals(mnJob.getName(), "job_multiNodes");
-        assertEquals(mnJob.getPriority(), JobPriority.LOW);
-        assertEquals(mnJob.getOnTaskErrorProperty().getValue(), OnTaskError.NONE);
-        assertEquals(mnJob.getMaxNumberOfExecution(), 1);
-        assertEquals(mnJob.getRestartTaskOnError(), RestartMode.ANYWHERE);
-        assertEquals(mnJob.getType(), JobType.TASKSFLOW);
-        assertEquals(mnJob.getGenericInformation().get("n1"), "v1");
-        assertEquals(mnJob.getGenericInformation().get("n2"), "v2");
+        assertEquals("No description", mnJob.getDescription());
+        assertEquals("job_multiNodes", mnJob.getName());
+        assertEquals(JobPriority.LOW, mnJob.getPriority());
+        assertEquals(OnTaskError.NONE, mnJob.getOnTaskErrorProperty().getValue());
+        assertEquals(1, mnJob.getMaxNumberOfExecution());
+        assertEquals(RestartMode.ANYWHERE, mnJob.getRestartTaskOnError());
+        assertEquals(JobType.TASKSFLOW, mnJob.getType());
+        assertEquals("v1", mnJob.getGenericInformation().get("n1"));
+        assertEquals("v2", mnJob.getGenericInformation().get("n2"));
         //Check task properties
         JavaTask jt = (JavaTask) mnJob.getTask("Controller");
-        assertEquals(jt.getArgument("numberToFind"), "100");
-        assertEquals(jt.getOnTaskErrorProperty().getValue(), OnTaskError.NONE);
-        assertEquals(jt.getCleaningScript(), null);
-        assertEquals(jt.getDependencesList(), null);
-        assertEquals(jt.getDescription(), "Will control the workers in order to find the prime number");
-        assertEquals(jt.getExecutableClassName(), "org.ow2.proactive.scheduler.examples.MultiNodeExample");
-        assertEquals(jt.getGenericInformation().get("n11"), "v11");
-        assertEquals(jt.getGenericInformation().get("n22"), "v22");
-        assertEquals(jt.getMaxNumberOfExecution(), 1);
-        assertEquals(jt.getName(), "Controller");
-        assertEquals(jt.getNumberOfNodesNeeded(), 3);
-        assertEquals(jt.getPreScript(), null);
-        assertEquals(jt.getPostScript(), null);
-        assertEquals(jt.getRestartTaskOnError(), RestartMode.ANYWHERE);
-        assertEquals(jt.getSelectionScripts(), null);
+        assertEquals("100", jt.getArgument("numberToFind"));
+        assertEquals(OnTaskError.NONE, jt.getOnTaskErrorProperty().getValue());
+        assertEquals(null, jt.getCleaningScript());
+        assertEquals(null, jt.getDependencesList());
+        assertEquals("Will control the workers in order to find the prime number", jt.getDescription());
+        assertEquals("org.ow2.proactive.scheduler.examples.MultiNodeExample", jt.getExecutableClassName());
+        assertEquals("v11", jt.getGenericInformation().get("n11"));
+        assertEquals("v22", jt.getGenericInformation().get("n22"));
+        assertEquals(1, jt.getMaxNumberOfExecution());
+        assertEquals("Controller", jt.getName());
+        assertEquals(3, jt.getNumberOfNodesNeeded());
+        assertEquals(null, jt.getPreScript());
+        assertEquals(null, jt.getPostScript());
+        assertEquals(RestartMode.ANYWHERE, jt.getRestartTaskOnError());
+        assertEquals(null, jt.getSelectionScripts());
         Assert.assertTrue(jt.isPreciousResult());
 
         log("Test generated task name");
@@ -369,7 +368,13 @@ public class TestJobFactory {
     private TaskFlowJob getJob(URL jobDesc, String jobFacImpl, String scriptFolder) throws JobCreationException,
             URISyntaxException {
         return ScriptUpdateUtil.resolveScripts((TaskFlowJob) JobFactory.getFactory(jobFacImpl).createJob(
-          new File(jobDesc.toURI()).getAbsolutePath(), Collections.singletonMap("scripts.folder", scriptFolder)));
+                                                                                                         new File(jobDesc.toURI()).getAbsolutePath(),
+                                                                                                         ImmutableMap.of("scripts.folder",
+                                                                                                                         scriptFolder,
+                                                                                                                         "priority",
+                                                                                                                         "high",
+                                                                                                                         "nb.execution",
+                                                                                                                         "2")));
     }
 
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProviderTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProviderTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.ow2.proactive.scheduler.common.exception.JobValidationException;
 import org.ow2.proactive.scheduler.common.exception.UserException;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.factory.BooleanParserValidator;
 import org.ow2.proactive.scheduler.common.task.ScriptTask;
@@ -48,37 +49,60 @@ public class DefaultModelJobValidatorServiceProviderTest {
     }
 
     @Test
-    public void testValidateJobWithModelOK() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithModelVariable("true", BooleanParserValidator.BOOLEAN_TYPE));
+    public void testValidateJobWithJobModelVariableOK() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithJobModelVariable("true", BooleanParserValidator.BOOLEAN_TYPE));
     }
 
     @Test(expected = JobValidationException.class)
-    public void testValidateJobWithModelKO() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithModelVariable("blabla", BooleanParserValidator.BOOLEAN_TYPE));
+    public void testValidateJobWithJobModelVariableKO() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithJobModelVariable("blabla", BooleanParserValidator.BOOLEAN_TYPE));
     }
 
     @Test
-    public void testValidateJobEmptyModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithModelVariable("blabla", ""));
+    public void testValidateJobWithJobModelVariableEmptyModel() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithJobModelVariable("blabla", "  "));
     }
 
     @Test
-    public void testValidateJobUnknownModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithModelVariable("blabla", "UNKNOWN"));
+    public void testValidateJobWithJobModelVariableUnknownModel() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithJobModelVariable("blabla", "UNKNOWN"));
     }
 
-    private TaskFlowJob createJobWithModelVariable(String value, String model) throws UserException {
+    @Test
+    public void testValidateJobWithTaskModelVariableOK() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithTaskModelVariable("true", BooleanParserValidator.BOOLEAN_TYPE));
+    }
+
+    @Test(expected = JobValidationException.class)
+    public void testValidateJobWithTaskModelVariableKO() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithTaskModelVariable("blabla", BooleanParserValidator.BOOLEAN_TYPE));
+    }
+
+    @Test
+    public void testValidateJobWithTaskModelVariableEmptyModel() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithTaskModelVariable("blabla", "  "));
+    }
+
+    @Test
+    public void testValidateJobWithTaskModelVariableUnknownModel() throws UserException, JobValidationException {
+        factory.validateJob(createJobWithTaskModelVariable("blabla", "UNKNOWN"));
+    }
+
+    private TaskFlowJob createJobWithJobModelVariable(String value, String model) throws UserException {
         TaskFlowJob job = new TaskFlowJob();
-        Task task = createTaskWithModelVariable(value, model);
-        job.addTask(task);
+        JobVariable jobVariable = new JobVariable("VAR", value, model);
+        job.setVariables(Collections.singletonMap(jobVariable.getName(), jobVariable));
         return job;
     }
 
-    private Task createTaskWithModelVariable(String value, String model) {
+    private TaskFlowJob createJobWithTaskModelVariable(String value, String model) throws UserException {
+        TaskFlowJob job = new TaskFlowJob();
         TaskVariable variable = new TaskVariable("VAR", value, model, false);
         Task task = new ScriptTask();
         task.setName("ModelTask");
         task.setVariables(Collections.singletonMap(variable.getName(), variable));
-        return task;
+        job.addTask(task);
+        return job;
     }
+
 }

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/Job_TaskFlow.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/Job_TaskFlow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <job xmlns="urn:proactive:jobdescriptor:3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="urn:proactive:jobdescriptor:3.2 ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.2/schedulerjob.xsd"
-	name="${jobName}" cancelJobOnError="true" maxNumberOfExecution="2" projectName="${PROJECT}" restartTaskOnError="elsewhere">
+	name="${jobName}" cancelJobOnError="true" maxNumberOfExecution="${NB_EXECUTION}" projectName="${PROJECT}" restartTaskOnError="elsewhere" priority="${PRIORITY}">
 	<!-- ${jobName} is set as JVM parameter in the TestJobFactory -->
 	<variables>
 		<!-- Relative path is from Scheduler root directory for the tests -->
@@ -10,6 +10,8 @@
 		<variable name="EXCLUSION_STRING" value="paquit"/>
 		<variable name="JAVA_HOME" value="/bin/java/jdk1.5"/>
 		<variable name="PROJECT" value="My_project"/>
+		<variable name="PRIORITY" value="${priority}"/>
+		<variable name="NB_EXECUTION" value="${nb.execution}"/>
 	</variables>
 	<description>No ${EXCLUSION_STRING} in its HostName.</description>
 	<inputSpace url="input/space"/>

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_variable_xml_element.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_attr_def_variable_xml_element.xml
@@ -3,8 +3,8 @@
 	 xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
 	 name="${job_name}" onTaskError="continueJobExecution" priority="normal">
 	<variables>
-		<variable name="name1" value="value1" />
-		<variable value="value2" name="name2" />
+		<variable name="name1" value="value1" model="model1"/>
+		<variable value="value2" model="model2" name="name2"/>
 	</variables>
 	<description>Test</description>
 	<taskFlow>

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -296,11 +296,11 @@ public class TaskLauncher implements InitActive {
 
     private Map<String, Serializable> fileSelectorsFilters(TaskContext taskContext, TaskResult taskResult)
             throws Exception {
-        return taskContextVariableExtractor.extractTaskVariables(taskContext, taskResult);
+        return taskContextVariableExtractor.extractVariables(taskContext, taskResult, true);
     }
 
     private Map<String, Serializable> fileSelectorsFilters(TaskContext taskContext) throws Exception {
-        return taskContextVariableExtractor.extractTaskVariables(taskContext);
+        return taskContextVariableExtractor.extractVariables(taskContext, true);
     }
 
     private void copyTaskLogsToUserSpace(File taskLogFile, TaskDataspaces dataspaces) {
@@ -323,7 +323,8 @@ public class TaskLauncher implements InitActive {
             String workingDirPath = taskContext.getInitializer().getForkEnvironment().getWorkingDir();
             if (workingDirPath != null) {
                 workingDirPath = VariableSubstitutor.filterAndUpdate(workingDirPath,
-                        taskContextVariableExtractor.extractTaskVariables(taskContext));
+                                                                     taskContextVariableExtractor.extractVariables(taskContext,
+                                                                                                                   true));
                 workingDir = new File(workingDirPath);
             }
         }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherInitializer.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherInitializer.java
@@ -36,8 +36,15 @@
  */
 package org.ow2.proactive.scheduler.task;
 
-import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.objectweb.proactive.extensions.dataspaces.core.naming.NamingService;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskVariable;
@@ -47,12 +54,7 @@ import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
 import org.ow2.proactive.scripting.Script;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.google.common.collect.ImmutableMap;
 
 
 /**
@@ -95,7 +97,7 @@ public class TaskLauncherInitializer implements Serializable {
     private NamingService namingService;
     private boolean preciousLogs;
 
-    private ImmutableMap<String, String> variables;
+    private ImmutableMap<String, JobVariable> variables;
 
     private ImmutableMap<String, TaskVariable> taskVariables = ImmutableMap.of();
     private int pingPeriod;
@@ -322,11 +324,11 @@ public class TaskLauncherInitializer implements Serializable {
         this.preciousLogs = preciousLogs;
     }
 
-    public void setVariables(Map<String, String> variables) {
+    public void setJobVariables(Map<String, JobVariable> variables) {
         this.variables = ImmutableMap.copyOf(variables);
     }
 
-    public ImmutableMap<String, String> getVariables() {
+    public ImmutableMap<String, JobVariable> getJobVariables() {
         return this.variables;
     }
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkEnvironmentScriptExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkEnvironmentScriptExecutor.java
@@ -34,6 +34,11 @@
  */
 package org.ow2.proactive.scheduler.task.executors;
 
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+
 import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive.scheduler.rest.ds.IDataSpaceClient;
 import org.ow2.proactive.scheduler.task.client.SchedulerNodeClient;
@@ -45,11 +50,6 @@ import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.scripting.ScriptHandler;
 import org.ow2.proactive.scripting.ScriptLoader;
 import org.ow2.proactive.scripting.ScriptResult;
-
-import java.io.PrintStream;
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.Map;
 
 public class ForkEnvironmentScriptExecutor implements Serializable {
     private final ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();
@@ -69,7 +69,7 @@ public class ForkEnvironmentScriptExecutor implements Serializable {
             PrintStream errorSink) throws Exception {
 
         VariablesMap variables = new VariablesMap();
-        variables.setInheritedMap(taskContextVariableExtractor.extractTaskVariables(context));
+        variables.setInheritedMap(taskContextVariableExtractor.extractVariables(context, false));
         variables.setScopeMap(taskContextVariableExtractor.extractScopeVariables(context));
         Map<String, String> thirdPartyCredentials = forkedTaskVariablesManager.extractThirdPartyCredentials(
                 context);

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
@@ -34,7 +34,19 @@
  */
 package org.ow2.proactive.scheduler.task.executors;
 
-import com.google.common.base.Stopwatch;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.io.FileUtils;
 import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive.scheduler.common.task.flow.FlowAction;
@@ -55,11 +67,7 @@ import org.ow2.proactive.scripting.ScriptLoader;
 import org.ow2.proactive.scripting.ScriptResult;
 import org.ow2.proactive.utils.PAProperties;
 
-import java.io.*;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import com.google.common.base.Stopwatch;
 
 
 /**
@@ -128,8 +136,7 @@ public class InProcessTaskExecutor implements TaskExecutor {
         try {
             nodesFile = writeNodesFile(taskContext);
             VariablesMap variables = new VariablesMap();
-            variables.setInheritedMap(taskContextVariableExtractor.extractTaskVariables(
-                    taskContext, nodesFile));
+            variables.setInheritedMap(taskContextVariableExtractor.extractVariables(taskContext, nodesFile, false));
             variables.setScopeMap(taskContextVariableExtractor.extractScopeVariables(
                     taskContext));
             Map<String, String> resultMetadata = new HashMap<>();

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -34,7 +34,13 @@
  */
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
-import com.google.common.base.Strings;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.ow2.proactive.resourcemanager.utils.OneJar;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
@@ -46,12 +52,7 @@ import org.ow2.proactive.scheduler.task.executors.forked.env.command.JavaPrefixC
 import org.ow2.proactive.scripting.ForkEnvironmentScriptResult;
 import org.ow2.proactive.scripting.ScriptResult;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import com.google.common.base.Strings;
 
 
 public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
@@ -77,7 +78,7 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
         if (taskContext == null) {
             return new ArrayList<>(0);
         }
-        Map<String, Serializable> variables = taskContextVariableExtractor.extractTaskVariables(taskContext);
+        Map<String, Serializable> variables = taskContextVariableExtractor.extractVariables(taskContext, true);
         String javaHome = System.getProperty("java.home");
         ArrayList<String> jvmArguments = new ArrayList<>(1);
 

--- a/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorTest.java
+++ b/scheduler/scheduler-node/src/test/java/functionaltests/ForkedTaskExecutorTest.java
@@ -1,11 +1,27 @@
 package functionaltests;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
-import org.junit.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.InputStreamReader;
+import java.security.KeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
@@ -22,12 +38,8 @@ import org.ow2.proactive.scheduler.task.utils.Decrypter;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
 
-import java.io.File;
-import java.io.InputStreamReader;
-import java.security.*;
-import java.util.Collections;
-
-import static org.junit.Assert.*;
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
 
 /**
  * The ForkedTaskExecutorTest executes several scenarios on the ForkedTaskExecutor
@@ -191,7 +203,7 @@ public class ForkedTaskExecutorTest {
 
         TaskLauncherInitializer initializer = new TaskLauncherInitializer();
         initializer.setTaskId((TaskIdImpl.createTaskId(JobIdImpl.makeJobId("1000"), "job", 1000L)));
-        initializer.setVariables(Collections.singletonMap("aVar", "aValue"));
+        initializer.setJobVariables(Collections.singletonMap("aVar", new JobVariable("aVar", "aValue")));
 
         ForkEnvironment forkEnvironment = new ForkEnvironment();
         forkEnvironment.addSystemEnvironmentVariable("envVar", "$aVar");

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
@@ -1,6 +1,24 @@
 package org.ow2.proactive.scheduler.task;
 
-import com.google.common.collect.ImmutableMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.ow2.proactive.scheduler.task.TaskAssertions.assertTaskResultOk;
+
+import java.io.Serializable;
+import java.security.KeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -10,6 +28,7 @@ import org.objectweb.proactive.core.runtime.VMInformation;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
@@ -25,20 +44,7 @@ import org.ow2.proactive.scripting.TaskScript;
 import org.ow2.proactive.utils.ClasspathUtils;
 import org.ow2.proactive.utils.NodeSet;
 
-import java.io.Serializable;
-import java.security.KeyException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.ow2.proactive.scheduler.task.TaskAssertions.assertTaskResultOk;
+import com.google.common.collect.ImmutableMap;
 
 
 public class InProcessTaskExecutorTest {
@@ -170,7 +176,7 @@ public class InProcessTaskExecutorTest {
         initializer.setPostScript(
                 new SimpleScript("print(variables.get('var')); variables.put('var', 'post')", "groovy"));
         initializer.setTaskId(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L));
-        initializer.setVariables(Collections.singletonMap("var", "value"));
+        initializer.setJobVariables(Collections.singletonMap("var", new JobVariable("var", "value")));
 
         TaskResultImpl result = new InProcessTaskExecutor().execute(new TaskContext(
                         new ScriptExecutableContainer(new TaskScript(new SimpleScript(

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherDataSpacesTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherDataSpacesTest.java
@@ -1,12 +1,23 @@
 package org.ow2.proactive.scheduler.task;
 
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.ow2.proactive.scheduler.task.TaskAssertions.assertTaskResultOk;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
 import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
@@ -18,15 +29,6 @@ import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
-import static org.junit.Assert.*;
-import static org.ow2.proactive.scheduler.task.TaskAssertions.assertTaskResultOk;
 
 
 public class TaskLauncherDataSpacesTest {
@@ -89,7 +91,7 @@ public class TaskLauncherDataSpacesTest {
 
         TaskLauncherInitializer initializer = new TaskLauncherInitializer();
         initializer.setTaskId(TaskIdImpl.createTaskId(JobIdImpl.makeJobId("1000"), "job", 1000L));
-        initializer.setVariables(singletonMap("aVar", "foo"));
+        initializer.setJobVariables(singletonMap("aVar", new JobVariable("aVar", "foo")));
         initializer.setTaskInputFiles(singletonList(
           new InputSelector(new FileSelector("input_${aVar}_${aResultVar}.txt"),
             InputAccessMode.TransferFromInputSpace)));

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
@@ -1,7 +1,22 @@
 package org.ow2.proactive.scheduler.task;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -10,6 +25,7 @@ import org.objectweb.proactive.extensions.dataspaces.core.naming.NamingService;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -22,16 +38,8 @@ import org.ow2.proactive.scheduler.task.data.TaskDataspaces;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
 
-import java.io.InputStreamReader;
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.List;
-
-import static java.util.Collections.singletonMap;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
 
 
 public class TaskLauncherTest {
@@ -149,7 +157,7 @@ public class TaskLauncherTest {
                 new TaskScript(new SimpleScript(pwdCommand(), "native")));
 
         TaskLauncherInitializer initializer = new TaskLauncherInitializer();
-        initializer.setVariables(singletonMap("folder", tempFolder));
+        initializer.setJobVariables(singletonMap("folder", new JobVariable("folder", tempFolder)));
         initializer.setForkEnvironment(new ForkEnvironment("$folder"));
 
         initializer.setTaskId(TaskIdImpl.createTaskId(JobIdImpl.makeJobId("1000"), "job", 1000L));

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
@@ -1,11 +1,17 @@
 package org.ow2.proactive.scheduler.task.context;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Test;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.common.task.TaskVariable;
 import org.ow2.proactive.scheduler.common.util.Object2ByteConverter;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.task.SchedulerVars;
@@ -15,10 +21,6 @@ import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TaskContextVariableExtractorTest {
     private String jobNameValue = "TestJobName";
@@ -32,6 +34,10 @@ public class TaskContextVariableExtractorTest {
     private String testVariable1Key = "TestVariable1";
     private String testVariable1Value = "valueForTest1";
 
+    private String testVariable2Key = "TestVariable2";
+
+    private String testVariable2Value = "valueForTest2";
+
     private String taskResultPropagatedVariables1Key = "TaskResultVariable1";
     private String taskResultPropagatedVariables1Value = "TaksResultValue1";
 
@@ -42,7 +48,7 @@ public class TaskContextVariableExtractorTest {
         ScriptExecutableContainer scriptContainer = new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript(
                         "print('hello'); result='hello'", "javascript")));
-        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
+        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariables();
 
         Map<String, byte[]> taskResultVariables = new HashMap<>();
         // The task result variables are expected to be converted to byte streams.
@@ -57,7 +63,7 @@ public class TaskContextVariableExtractorTest {
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, taskResultArray,
                 new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
-        new TaskContextVariableExtractor().extractTaskVariables(taskContext, (TaskResult) null);
+        new TaskContextVariableExtractor().extractVariables(taskContext, (TaskResult) null, true);
 
     }
 
@@ -65,7 +71,9 @@ public class TaskContextVariableExtractorTest {
     public void testExtractThrowsNullPointerExceptionIfTaskContextIsNull() throws Exception {
 
         Map<String, Serializable> contextVariables
-                = new TaskContextVariableExtractor().extractTaskVariables(null, (TaskResult) null);
+                                                   = new TaskContextVariableExtractor().extractVariables(null,
+                                                                                                         (TaskResult) null,
+                                                                                                         true);
     }
 
     @Test
@@ -73,7 +81,7 @@ public class TaskContextVariableExtractorTest {
         ScriptExecutableContainer scriptContainer = new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript(
                         "print('hello'); result='hello'", "javascript")));
-        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
+        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariables();
 
         Map<String, byte[]> taskResultVariables = new HashMap<>();
         // The task result variables are expected to be converted to byte streams.
@@ -90,7 +98,9 @@ public class TaskContextVariableExtractorTest {
 
 
         Map<String, Serializable> contextVariables
-                = new TaskContextVariableExtractor().extractTaskVariables(taskContext, (TaskResult) null);
+                                                   = new TaskContextVariableExtractor().extractVariables(taskContext,
+                                                                                                         (TaskResult) null,
+                                                                                                         true);
 
         assertThat((String) contextVariables.get(taskResultPropagatedVariables1Key),
                 is(taskResultPropagatedVariables1Value));
@@ -101,7 +111,7 @@ public class TaskContextVariableExtractorTest {
         ScriptExecutableContainer scriptContainer = new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript(
                         "print('hello'); result='hello'", "javascript")));
-        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
+        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariables();
 
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
@@ -117,7 +127,9 @@ public class TaskContextVariableExtractorTest {
         taskResult.setPropagatedVariables(taskResultVariables);
 
         Map<String, Serializable> contextVariables
-                = new TaskContextVariableExtractor().extractTaskVariables(taskContext, taskResult);
+                                                   = new TaskContextVariableExtractor().extractVariables(taskContext,
+                                                                                                         taskResult,
+                                                                                                         true);
 
         assertThat((String) contextVariables.get(taskResultPropagatedVariables1Key),
                 is(taskResultPropagatedVariables1Value));
@@ -128,12 +140,14 @@ public class TaskContextVariableExtractorTest {
         ScriptExecutableContainer scriptContainer = new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript(
                         "print('hello'); result='hello'", "javascript")));
-        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
+        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariables();
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
                 new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
         Map<String, Serializable> contextVariables
-                = new TaskContextVariableExtractor().extractTaskVariables(taskContext, nodesfileContent);
+                                                   = new TaskContextVariableExtractor().extractVariables(taskContext,
+                                                                                                         nodesfileContent,
+                                                                                                         false);
 
         assertThat("Nodes number must be equal to number of other nodes + 1 (for the own node).",
                 (int) contextVariables.get(SchedulerVars.PA_NODESNUMBER.toString()),
@@ -151,23 +165,28 @@ public class TaskContextVariableExtractorTest {
         ScriptExecutableContainer scriptContainer = new ScriptExecutableContainer(
                 new TaskScript(new SimpleScript(
                         "print('hello'); result='hello'", "javascript")));
-        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariable();
+        TaskLauncherInitializer taskLauncherInitializer = getTaskLauncherInitializerWithWorkflowVariables();
 
         TaskContext taskContext = new TaskContext(scriptContainer, taskLauncherInitializer, null,
                 new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
         Map<String, Serializable> contextVariables
-                = new TaskContextVariableExtractor().extractTaskVariables(taskContext);
+                                                   = new TaskContextVariableExtractor().extractVariables(taskContext,
+                                                                                                         true);
 
         assertThat((String) contextVariables.get(testVariable1Key), is(testVariable1Value));
+        assertThat((String) contextVariables.get(testVariable2Key), is(testVariable2Value));
     }
 
-    private TaskLauncherInitializer getTaskLauncherInitializerWithWorkflowVariable() {
+    private TaskLauncherInitializer getTaskLauncherInitializerWithWorkflowVariables() {
         // Create and setup task launcher initializer
         TaskLauncherInitializer taskLauncherInitializer = createTaskLauncherInitializer();
-        Map<String, String> variablesToPut = new HashMap<>();
-        variablesToPut.put(testVariable1Key, testVariable1Value);
-        taskLauncherInitializer.setVariables(variablesToPut);
+        Map<String, JobVariable> variablesToPut = new HashMap<>();
+        variablesToPut.put(testVariable1Key, new JobVariable(testVariable1Key, testVariable1Value));
+        taskLauncherInitializer.setJobVariables(variablesToPut);
+        Map<String, TaskVariable> variablesToPut2 = new HashMap<>();
+        variablesToPut2.put(testVariable2Key, new TaskVariable(testVariable2Key, testVariable2Value, null, false));
+        taskLauncherInitializer.setTaskVariables(variablesToPut2);
         return taskLauncherInitializer;
     }
 
@@ -180,7 +199,8 @@ public class TaskContextVariableExtractorTest {
                 new NodeDataSpacesURIs(null, null, null, null, null, null), null, null);
 
         Map<String, Serializable> contextVariables
-                = new TaskContextVariableExtractor().extractTaskVariables(taskContext);
+                                                   = new TaskContextVariableExtractor().extractVariables(taskContext,
+                                                                                                         true);
 
         validateExtractedVariablesFromTaskLauncherInitializer(contextVariables);
     }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreatorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreatorTest.java
@@ -1,11 +1,24 @@
 package org.ow2.proactive.scheduler.task.executors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.extensions.processbuilder.OSProcessBuilder;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
@@ -21,18 +34,6 @@ import org.ow2.proactive.scripting.InvalidScriptException;
 import org.ow2.proactive.scripting.ScriptResult;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-
-import java.io.PrintStream;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 
 public class ForkedProcessBuilderCreatorTest {
     @Rule
@@ -162,9 +163,9 @@ public class ForkedProcessBuilderCreatorTest {
         // Create and setup task launcher initializer
         TaskLauncherInitializer taskLauncherInitializer = createTaskLauncherInitializer();
         taskLauncherInitializer.setForkEnvironment(createForkEnvironment());
-        Map<String, String> variablesToPut = new HashMap<>();
-        variablesToPut.put(testVariable1Key, testVariable1Value);
-        taskLauncherInitializer.setVariables(variablesToPut);
+        Map<String, JobVariable> variablesToPut = new HashMap<>();
+        variablesToPut.put(testVariable1Key, new JobVariable(testVariable1Key, testVariable1Value));
+        taskLauncherInitializer.setJobVariables(variablesToPut);
         return taskLauncherInitializer;
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreatorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreatorTest.java
@@ -1,7 +1,20 @@
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 import org.objectweb.proactive.core.node.NodeException;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
@@ -15,18 +28,6 @@ import org.ow2.proactive.scripting.InvalidScriptException;
 import org.ow2.proactive.scripting.ScriptResult;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
-
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 
 public class ForkedJvmTaskExecutionCommandCreatorTest {
     private String jobNameValue = "TestJobName";
@@ -198,9 +199,9 @@ public class ForkedJvmTaskExecutionCommandCreatorTest {
     private TaskLauncherInitializer getTaskLauncherInitializerWithWorkflowVariableAndForkEnvironment() {
         // Create and setup task launcher initializer
         TaskLauncherInitializer taskLauncherInitializer = createTaskLauncherInitializer();
-        Map<String, String> variablesToPut = new HashMap<>();
-        variablesToPut.put(testVariable1Key, testVariable1Value);
-        taskLauncherInitializer.setVariables(variablesToPut);
+        Map<String, JobVariable> variablesToPut = new HashMap<>();
+        variablesToPut.put(testVariable1Key, new JobVariable(testVariable1Key, testVariable1Value));
+        taskLauncherInitializer.setJobVariables(variablesToPut);
         return taskLauncherInitializer;
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -35,6 +35,7 @@ import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.common.usage.JobUsage;
 import org.ow2.proactive.scheduler.common.usage.TaskUsage;
@@ -104,7 +105,7 @@ public class JobData implements Serializable {
 
     private Map<String, String> genericInformation;
 
-    private Map<String, String> variables;
+    private Map<String, JobVariable> variables;
 
     private String owner;
 
@@ -267,11 +268,11 @@ public class JobData implements Serializable {
 
     @Column(name = "VARIABLES", length = Integer.MAX_VALUE)
     @Type(type = "org.hibernate.type.SerializableToBlobType", parameters = @Parameter(name = SerializableToBlobType.CLASS_NAME, value = "java.lang.Object"))
-    public Map<String, String> getVariables() {
+    public Map<String, JobVariable> getVariables() {
         return variables;
     }
 
-    public void setVariables(Map<String, String> variables) {
+    public void setVariables(Map<String, JobVariable> variables) {
         this.variables = variables;
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
@@ -34,6 +34,12 @@
  */
 package org.ow2.proactive.scheduler.core.helpers;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import org.ow2.proactive.db.DatabaseManagerException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
 import org.ow2.proactive.scheduler.common.job.JobType;
@@ -47,12 +53,6 @@ import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 import org.ow2.proactive.scheduler.util.TaskLogger;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 
 public class TaskResultCreator {
@@ -134,7 +134,7 @@ public class TaskResultCreator {
     private Map<String, byte[]> extractJobVariables(InternalJob job) {
         Map<String, byte[]> jobVariables = new HashMap<>();
         // otherwise use the default job variables
-        for (Entry<String, String> entry : job.getVariables().entrySet()) {
+        for (Entry<String, String> entry : job.getVariablesAsReplacementMap().entrySet()) {
             jobVariables.put(entry.getKey(), entry.getValue().getBytes());
         }
         return jobVariables;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -1139,7 +1139,7 @@ public abstract class InternalTask extends TaskState {
             tli.setWalltime(wallTime);
         }
         tli.setPreciousLogs(isPreciousLogs());
-        tli.setVariables(internalJob.getVariables());
+        tli.setJobVariables(internalJob.getVariables());
         tli.setTaskVariables(getVariables());
 
         tli.setPingPeriod(PASchedulerProperties.SCHEDULER_NODE_PING_FREQUENCY.getValueAsInt());
@@ -1175,7 +1175,7 @@ public abstract class InternalTask extends TaskState {
     public synchronized void updateVariables(SchedulingService schedulingService) {
         if (updatedVariables == null) {
             updatedVariables = new LinkedHashMap<>();
-            updatedVariables.putAll(internalJob.getVariables());
+            updatedVariables.putAll(internalJob.getVariablesAsReplacementMap());
             updatedVariables.putAll(getScopeVariables());
 
             if (internalTasksDependencies != null) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestTaskScriptVariables.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/scripts/TestTaskScriptVariables.java
@@ -81,7 +81,7 @@ public class TestTaskScriptVariables extends SchedulerFunctionalTestNoRestart {
         String[] outputNoVariablesLines = outputNoVariables.getStdoutLogs(false).split(System.lineSeparator());        
 
         //Tests variable access
-        assertEquals("testvarjob3", job.getVariables().get("TESTVAR3"));
+        assertEquals("testvarjob3", job.getVariables().get("TESTVAR3").getValue());
         //Selection files access
         assertTrue(logs.contains("testvartask0"));
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobAttributes.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobAttributes.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.OnTaskError;
 import org.ow2.proactive.scheduler.job.InternalJob;
@@ -68,6 +69,9 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         Assert.assertEquals(JobPriority.HIGHEST, jobData.getPriority());
         Assert.assertNotNull(jobData.getGenericInformation());
         Assert.assertTrue(jobData.getGenericInformation().isEmpty());
+        Map<String, JobVariable> jobDataVariables = jobData.getVariables();
+        Assert.assertNotNull(jobDataVariables);
+        Assert.assertTrue(jobDataVariables.isEmpty());
     }
 
     @Test
@@ -102,6 +106,43 @@ public class TestJobAttributes extends BaseSchedulerDBTest {
         jobData = defaultSubmitJobAndLoadInternal(false, job);
         Assert.assertEquals(1, jobData.getGenericInformation().size());
         Assert.assertEquals(longString.toString(), jobData.getGenericInformation().get("longProperty"));
+    }
+
+    @Test
+    public void testJobVariables() throws Exception {
+        TaskFlowJob job = new TaskFlowJob();
+
+        InternalJob jobData;
+
+        HashMap<String, JobVariable> jobVariables = new HashMap<>();
+        job.setVariables(jobVariables);
+        jobData = defaultSubmitJobAndLoadInternal(false, job);
+        Assert.assertNotNull(jobData.getVariables());
+        Assert.assertTrue(jobData.getVariables().isEmpty());
+
+        jobVariables.put("var1", new JobVariable("var1", "value1", null));
+        jobVariables.put("var2", new JobVariable("var2", "value2", null));
+        job.setVariables(jobVariables);
+
+        jobVariables = new HashMap<>();
+        jobVariables.put("var1", new JobVariable("var1", "value1", null));
+        jobVariables.put("var2", new JobVariable("var2", "value2", null));
+        job.setVariables(jobVariables);
+        jobData = defaultSubmitJobAndLoadInternal(false, job);
+        Assert.assertEquals(2, jobData.getVariables().size());
+        Assert.assertEquals("value1", jobData.getVariables().get("var1").getValue());
+        Assert.assertEquals("value2", jobData.getVariables().get("var2").getValue());
+
+        StringBuilder longString = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            longString.append("0123456789abcdefghijklmnopqrstuvwxyz");
+        }
+        jobVariables = new HashMap<>();
+        jobVariables.put("longProperty", new JobVariable("longProperty", longString.toString()));
+        job.setVariables(jobVariables);
+        jobData = defaultSubmitJobAndLoadInternal(false, job);
+        Assert.assertEquals(1, jobData.getVariables().size());
+        Assert.assertEquals(longString.toString(), jobData.getVariables().get("longProperty").getValue());
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreatorTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreatorTest.java
@@ -6,6 +6,7 @@ import org.ow2.proactive.db.DatabaseManagerException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobType;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskLogs;
@@ -30,12 +31,7 @@ import java.util.Vector;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class TaskResultCreatorTest {
 
@@ -125,13 +121,17 @@ public class TaskResultCreatorTest {
 
         InternalJob mockedInternalJob = this.getMockedInternalJobTaskFlowType(this.getMockedJobDescriptorWithPausedTaskWithoutParent());
         
-        Map<String, String> fakeVariableMap = new HashMap<>();
-                fakeVariableMap.put("TestVar", "h234");
+        Map<String, JobVariable> fakeVariableMap = new HashMap<>();
+        fakeVariableMap.put("TestVar", new JobVariable("TestVar", "h234"));
                 when(mockedInternalJob.getVariables()).thenReturn(fakeVariableMap);
+
+        Map<String, String> fakeReplacementVariableMap = new HashMap<>();
+        fakeReplacementVariableMap.put("TestVar", "h234");
+        when(mockedInternalJob.getVariablesAsReplacementMap()).thenReturn(fakeReplacementVariableMap);
 
         TaskResult taskResult = taskResultCreator.getTaskResult(mockedschedulerDbManager, mockedInternalJob, this.getMockedInternalTask());
 
-        verify(mockedInternalJob, atLeastOnce()).getVariables();
+        verify(mockedInternalJob, atLeastOnce()).getVariablesAsReplacementMap();
 
         assertThat(new String(taskResult
                         .getPropagatedVariables()
@@ -234,7 +234,7 @@ public class TaskResultCreatorTest {
         InternalJob mockedInternalJob = mock(InternalJob.class);
         when(mockedInternalJob.getJobDescriptor()).thenReturn(mockedJobDescriptor);
         when(mockedInternalJob.getType()).thenReturn(JobType.TASKSFLOW);
-        when(mockedInternalJob.getVariables()).thenReturn(new HashMap<String, String>());
+        when(mockedInternalJob.getVariables()).thenReturn(new HashMap<String, JobVariable>());
         return mockedInternalJob;
     }
 


### PR DESCRIPTION
- updated schema version
- added a test in TestJobAttributes to check that variables are correctly stored in the database
- better handling of job variables replacement in StaxJobFactory, allow as well replacements to be performed on all attributes of the job tag
- handle job variable model in DefaultModelJobValidatorServiceProvider
- store job variable model in Job2XMLTransformer
- added a test in TestStaxJobFactory which verifies replacements for different scenarios
- Add Task variables to variables extracted from the TaskContext which allows them to be used dynamically inside the task