### PR TITLE
useBashScriptEngineWithShutdownHook

### DIFF
--- a/common/common-api/build.gradle
+++ b/common/common-api/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     testRuntime 'org.jruby:jruby-complete:9.0.5.0'
     testRuntime 'org.python:jython-standalone:2.7.0'
     testRuntime 'org.codehaus.groovy:groovy-all:2.4.6'
-    testRuntime 'jsr223:jsr223-nativeshell:0.4.1'
+    testRuntime 'jsr223:jsr223-nativeshell:0.4.3'
     testCompile 'junit:junit:4.12'
 }
 

--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -24,6 +24,6 @@ dependencies {
     runtime 'org.python:jython-standalone:2.7.0'
 
     runtime 'org.codehaus.groovy:groovy-all:2.4.6'
-    runtime 'jsr223:jsr223-nativeshell:0.4.2'
+    runtime 'jsr223:jsr223-nativeshell:0.4.3'
     runtime 'jsr223:jsr223-docker-compose:0.2.1'
 }


### PR DESCRIPTION
Use bash script engine with shutdown hook

Problem:
- The bash script engine terminates immediately in run as me forked mode, when a task is killed.

Solution:
- Use bash script engine in which that problem is fixed