### PR TITLE
Improve Node Pinging Mechanism

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -23,8 +23,11 @@ pa.scheduler.core.rmconnection.attempts = 360
 pa.scheduler.core.clientpoolnbthreads=5
 
 # Number of threads used to execute internal scheduling operations
-# (e.g. ping task node, handle task termination, etc.)
+# (handle task termination, restart task, etc.)
 pa.scheduler.core.internalpoolnbthreads=5
+
+# Number of threads used to ping tasks regularly to get its progress and detect node failures
+pa.scheduler.core.taskpingerpoolnbthreads=10
 
 # Number of threads used to delay operations which are NOT related to housekeeping
 # (e.g. scheduler shutdown, handle task restart on error, etc.)
@@ -35,7 +38,9 @@ pa.scheduler.core.housekeeping.scheduledpoolnbthreads=5
 
 # Check for failed node frequency in second
 pa.scheduler.core.nodepingfrequency=20
-# Restart a task after this number of attempts
+
+# The scheduler will decide to restart a task, after a given tolerated number of failed attempts.
+# A value of zero means that the scheduler will restart a task after the first failure.
 pa.scheduler.core.node.ping.attempts=1
 
 # Scheduler default policy full name

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -78,7 +78,8 @@ public enum PASchedulerProperties {
     /** Scheduler node ping frequency in s. */
     SCHEDULER_NODE_PING_FREQUENCY("pa.scheduler.core.nodepingfrequency", PropertyType.INTEGER),
 
-    /** Scheduler node ping number before restarting the task. */
+    /** Scheduler number of node ping attempts before restarting the task. This value corresponds to the number of
+     * tolerated failed attempts to ping a node, before the scheduler decides to restart the task running on it */
     SCHEDULER_NODE_PING_ATTEMPTS("pa.scheduler.core.node.ping.attempts", PropertyType.INTEGER),
 
     /** Number of threads used to execute client requests  */
@@ -86,6 +87,9 @@ public enum PASchedulerProperties {
 
     /** Number of threads used to execute internal scheduling operations */
     SCHEDULER_INTERNAL_POOL_NBTHREAD("pa.scheduler.core.internalpoolnbthreads", PropertyType.INTEGER),
+
+    /** Number of threads used to ping tasks */
+    SCHEDULER_TASK_PINGER_POOL_NBTHREAD("pa.scheduler.core.taskpingerpoolnbthreads", PropertyType.INTEGER),
 
     /** Number of threads used to handle scheduled operations other than housekeeping operations */
     SCHEDULER_SCHEDULED_POOL_NBTHREAD("pa.scheduler.core.scheduledpoolnbthreads", PropertyType.INTEGER),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/NodePingThread.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/NodePingThread.java
@@ -48,9 +48,9 @@ class NodePingThread extends Thread {
             try {
                 Thread.sleep(SCHEDULER_NODE_PING_FREQUENCY);
                 for (final RunningTaskData taskData : service.jobs.getRunningTasks()) {
-                    service.getInfrastructure().getInternalOperationsThreadPool().submit(new Runnable() {
+                    service.getInfrastructure().getTaskPingerThreadPool().submit(new Runnable() {
                         public void run() {
-                            service.pingTaskNode(taskData);
+                            service.getProgressAndPingTaskNode(taskData);
                         }
                     });
                 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/RunningTaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/RunningTaskData.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.scheduler.core;
 
+import org.objectweb.proactive.core.node.Node;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
@@ -83,5 +84,9 @@ class RunningTaskData {
      */
     public NodeSet getNodes() {
         return nodes;
+    }
+
+    public Node getNodeExecutor() {
+        return nodes.get(0);
     }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -269,6 +269,9 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
             ExecutorService internalThreadPool = Executors.newFixedThreadPool(PASchedulerProperties.SCHEDULER_INTERNAL_POOL_NBTHREAD.getValueAsInt(),
                                                                               new NamedThreadFactory("InternalOperationsThreadPool"));
 
+            ExecutorService taskPingerThreadPool = Executors.newFixedThreadPool(PASchedulerProperties.SCHEDULER_TASK_PINGER_POOL_NBTHREAD.getValueAsInt(),
+                                                                                new NamedThreadFactory("TaskPingerThreadPool"));
+
             ScheduledExecutorService scheduledThreadPool = new ScheduledThreadPoolExecutor(PASchedulerProperties.SCHEDULER_SCHEDULED_POOL_NBTHREAD.getValueAsInt(),
                                                                                            new NamedThreadFactory("SchedulingServiceTimerThread"));
 
@@ -301,6 +304,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
                                                                                        dsServiceStarter,
                                                                                        clientThreadPool,
                                                                                        internalThreadPool,
+                                                                                       taskPingerThreadPool,
                                                                                        scheduledThreadPool);
 
             this.spacesSupport = infrastructure.getSpacesSupport();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingInfrastructure.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingInfrastructure.java
@@ -42,6 +42,8 @@ public interface SchedulingInfrastructure {
 
     ExecutorService getInternalOperationsThreadPool();
 
+    ExecutorService getTaskPingerThreadPool();
+
     /**
      * Delay the execution of the specified {@code runnable}
      * by the given {@code delay}.

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingInfrastructureImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingInfrastructureImpl.java
@@ -45,6 +45,8 @@ public class SchedulingInfrastructureImpl implements SchedulingInfrastructure {
 
     private final ExecutorService internalExecutorService;
 
+    private final ExecutorService taskPingerService;
+
     private final ScheduledExecutorService scheduledExecutorService;
 
     private final RMProxiesManager rmProxiesManager;
@@ -62,13 +64,15 @@ public class SchedulingInfrastructureImpl implements SchedulingInfrastructure {
 
     public SchedulingInfrastructureImpl(SchedulerDBManager dbManager, RMProxiesManager rmProxiesManager,
             DataSpaceServiceStarter dsStarter, ExecutorService clientExecutorService,
-            ExecutorService internalExecutorService, ScheduledExecutorService scheduledExecutorService) {
+            ExecutorService internalExecutorService, ExecutorService taskPingerService,
+            ScheduledExecutorService scheduledExecutorService) {
         this.dbManager = dbManager;
         this.rmProxiesManager = rmProxiesManager;
         this.dsStarter = dsStarter;
         this.clientExecutorService = clientExecutorService;
         this.internalExecutorService = internalExecutorService;
         this.scheduledExecutorService = scheduledExecutorService;
+        this.taskPingerService = taskPingerService;
         this.spacesSupport = new SchedulerSpacesSupport();
     }
 
@@ -90,6 +94,11 @@ public class SchedulingInfrastructureImpl implements SchedulingInfrastructure {
     @Override
     public ExecutorService getInternalOperationsThreadPool() {
         return internalExecutorService;
+    }
+
+    @Override
+    public ExecutorService getTaskPingerThreadPool() {
+        return taskPingerService;
     }
 
     @Override
@@ -128,6 +137,7 @@ public class SchedulingInfrastructureImpl implements SchedulingInfrastructure {
     @Override
     public void shutdown() {
         clientExecutorService.shutdownNow();
+        taskPingerService.shutdownNow();
         internalExecutorService.shutdownNow();
         scheduledExecutorService.shutdownNow();
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/TaskLogger.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/TaskLogger.java
@@ -53,6 +53,18 @@ public class TaskLogger {
         return PREFIX + id + " (" + id.getReadableName() + ") " + message;
     }
 
+    public void warn(TaskId id, String message) {
+        updateMdcWithTaskLogFilename(id);
+        logger.warn(format(id, message));
+        MDC.remove(FileAppender.FILE_NAME);
+    }
+
+    public void warn(TaskId id, String message, Throwable th) {
+        updateMdcWithTaskLogFilename(id);
+        logger.warn(format(id, message), th);
+        MDC.remove(FileAppender.FILE_NAME);
+    }
+
     public void info(TaskId id, String message) {
         updateMdcWithTaskLogFilename(id);
         logger.info(format(id, message));

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/MockSchedulingInfrastructure.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/MockSchedulingInfrastructure.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.AbstractExecutorService;
@@ -56,7 +55,6 @@ import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.core.rmproxies.RMProxiesManager;
 import org.ow2.proactive.scheduler.core.rmproxies.RMProxy;
 import org.ow2.proactive.scheduler.task.utils.VariablesMap;
-import org.ow2.proactive.scheduler.util.TaskLogger;
 import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.utils.NodeSet;
 
@@ -173,6 +171,11 @@ public class MockSchedulingInfrastructure implements SchedulingInfrastructure {
 
     @Override
     public ExecutorService getInternalOperationsThreadPool() {
+        return executorService;
+    }
+
+    @Override
+    public ExecutorService getTaskPingerThreadPool() {
         return executorService;
     }
 


### PR DESCRIPTION
- when the task launcher ping fails, verify if the node is accessible. If the task launcher is not reachable but the node is still alive, it means that the task has simply initiated its ending sequence (no real node failure). If the node is not reachable, we increase the number of ping attempts.
- added a dedicated threadpool for task pinging to improve regularity of task ping period, not making it dependant of other time consuming operations
- improved the documentation of task ping attempts.