### PR TITLE
Replace the housekeeping cron property name to improve readability

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -103,7 +103,7 @@ pa.scheduler.job.removeFromDataBase=true
 # This cron expression determines the housekeeping call frequency.
 # Default value is 10 minutes: this will invoke the housekeeping mechanism
 # to remove every jobs which are set to be removed and has their scheduled time for removal reached.
-pa.scheduler.core.automaticremovejobexpression=*/10 * * * *
+pa.scheduler.core.automaticremovejobcronexpression=*/10 * * * *
 
 # Specific character encoding when parsing the job xml file
 pa.file.encoding=UTF-8


### PR DESCRIPTION
This is a small modification to the name of the property used to set the housekeeping triggering frequency. This PR also references this [PR on documentation](https://github.com/ow2-proactive/documentation/pull/332).