### PR TITLE
QualityCheck: simplify SpEL expressions

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
@@ -25,9 +25,10 @@
  */
 package org.ow2.proactive.scheduler.common.job;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
@@ -77,7 +78,7 @@ public abstract class Job extends CommonAttribute {
     protected String userSpace = null;
 
     /** A map to holds job descriptor variables */
-    protected ConcurrentHashMap<String, JobVariable> variables = new ConcurrentHashMap<>();
+    protected Map<String, JobVariable> variables = Collections.synchronizedMap(new LinkedHashMap());
 
     /** ProActive Empty Constructor */
     public Job() {
@@ -238,7 +239,7 @@ public abstract class Job extends CommonAttribute {
      */
     public void setVariables(Map<String, JobVariable> variables) {
         verifyVariableMap(variables);
-        this.variables = new ConcurrentHashMap<>(variables);
+        this.variables = Collections.synchronizedMap(new LinkedHashMap(variables));
     }
 
     public static void verifyVariableMap(Map<String, ? extends JobVariable> variables) {
@@ -266,7 +267,7 @@ public abstract class Job extends CommonAttribute {
      * @return a variable map
      */
     public Map<String, String> getVariablesAsReplacementMap() {
-        HashMap<String, String> replacementVariables = new HashMap<>(variables.size());
+        HashMap<String, String> replacementVariables = new LinkedHashMap<>(variables.size());
         for (JobVariable variable : variables.values()) {
             replacementVariables.put(variable.getName(), variable.getValue());
         }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
@@ -61,9 +61,10 @@ public class DefaultModelJobValidatorServiceProvider implements JobValidatorServ
             context.updateJobWithContext(job);
         }
         for (Task task : job.getTasks()) {
+            context = new ModelValidatorContext(task);
             for (TaskVariable taskVariable : task.getVariables().values()) {
                 checkVariableFormat(task, taskVariable, context);
-                context.updateJobWithContext(job);
+                context.updateTaskWithContext(task);
             }
         }
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidator.java
@@ -47,14 +47,16 @@ public class SpelValidator implements Validator<String> {
     public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
         try {
             context.getSpELContext().setVariable("value", parameterValue);
-            boolean evaluationResult = (Boolean) spelExpression.getValue(context.getSpELContext());
+            Object untypedResult = spelExpression.getValue(context.getSpELContext());
+            if (!(untypedResult instanceof Boolean)) {
+                throw new ValidationException("SPEL expression did not return a boolean value.");
+            }
+            boolean evaluationResult = (Boolean) untypedResult;
             if (!evaluationResult) {
-                throw new ValidationException("SPEL expression '" + spelExpression.getExpressionString() +
-                                              "' returned false, received " + parameterValue);
+                throw new ValidationException("SPEL expression returned false, received " + parameterValue);
             }
         } catch (EvaluationException e) {
-            throw new ValidationException("SPEL expression '" + spelExpression + "' raised an error: " + e.getMessage(),
-                                          e);
+            throw new ValidationException("SPEL expression raised an error: " + e.getMessage(), e);
         }
         return parameterValue;
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
@@ -26,10 +26,10 @@
 package org.ow2.proactive.scheduler.common.task;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -147,7 +147,7 @@ public abstract class Task extends CommonAttribute {
     protected ForkEnvironment forkEnvironment;
 
     /** A map to hold task variables */
-    protected ConcurrentHashMap<String, TaskVariable> variables = new ConcurrentHashMap<>();
+    protected Map<String, TaskVariable> variables = Collections.synchronizedMap(new LinkedHashMap());
 
     /**
      * Add a dependence to the task. <font color="red">Warning : the dependence order is very
@@ -687,7 +687,7 @@ public abstract class Task extends CommonAttribute {
      */
     public void setVariables(Map<String, TaskVariable> variables) {
         Job.verifyVariableMap(variables);
-        this.variables = new ConcurrentHashMap<>(variables);
+        this.variables = Collections.synchronizedMap(new LinkedHashMap(variables));
     }
 
     /**
@@ -705,7 +705,7 @@ public abstract class Task extends CommonAttribute {
      * @return a variable map
      */
     public Map<String, String> getVariablesOverriden(Job job) {
-        Map<String, String> taskVariables = new HashMap<>();
+        Map<String, String> taskVariables = new LinkedHashMap<>();
         if (job != null) {
             taskVariables.putAll(job.getVariablesAsReplacementMap());
         }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidatorTest.java
@@ -65,7 +65,7 @@ public class SpelValidatorTest {
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
         Assert.assertEquals(value, validator.validate(value, context));
-        Assert.assertEquals("toto1", context.getSpELJobAndTaskVariables().getVariables().get("var1"));
+        Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var1"));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class SpelValidatorTest {
         } catch (Exception e) {
             Assert.assertTrue(e instanceof ValidationException);
         }
-        Assert.assertEquals("value1", context.getSpELJobAndTaskVariables().getVariables().get("var1"));
+        Assert.assertEquals("value1", context.getSpELVariables().getVariables().get("var1"));
     }
 
     @Test
@@ -88,7 +88,7 @@ public class SpelValidatorTest {
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
         Assert.assertEquals(value, validator.validate(value, context));
-        Assert.assertEquals("toto1", context.getSpELJobAndTaskVariables().getVariables().get("var4"));
+        Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var4"));
     }
 
     @Test
@@ -97,32 +97,30 @@ public class SpelValidatorTest {
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
         Assert.assertEquals(value, validator.validate(value, context));
-        Assert.assertEquals("value2", context.getSpELJobAndTaskVariables().getVariables().get("var2"));
+        Assert.assertEquals("value2", context.getSpELVariables().getVariables().get("var2"));
     }
 
     @Test
     public void testSpelOKUpdateTaskVariable() throws ValidationException, UserException {
-        SpelValidator validator = new SpelValidator("#value == 'MyString'?(tasks['task1'].variables['var1'] = 'toto1') instanceof T(String) : false");
+        SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String) : false");
         String value = "MyString";
-        ModelValidatorContext context = new ModelValidatorContext(createJob());
+        ModelValidatorContext context = new ModelValidatorContext(createTask());
         Assert.assertEquals(value, validator.validate(value, context));
-        Assert.assertEquals("toto1",
-                            context.getSpELJobAndTaskVariables().getTasks().get("task1").getVariables().get("var1"));
+        Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var1"));
     }
 
     @Test
     public void testSpelKOUpdateTaskVariable() throws ValidationException, UserException {
-        SpelValidator validator = new SpelValidator("#value == 'MyString'?(tasks['task1'].variables['var1'] = 'toto1') instanceof T(String) : false");
+        SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String) : false");
         String value = "MyString123";
-        ModelValidatorContext context = new ModelValidatorContext(createJob());
+        ModelValidatorContext context = new ModelValidatorContext(createTask());
         try {
             validator.validate(value, context);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof ValidationException);
         }
-        Assert.assertEquals("value1",
-                            context.getSpELJobAndTaskVariables().getTasks().get("task1").getVariables().get("var1"));
+        Assert.assertEquals("value1", context.getSpELVariables().getVariables().get("var1"));
     }
 
     @Test(expected = PatternSyntaxException.class)
@@ -142,6 +140,11 @@ public class SpelValidatorTest {
                                          "var4",
                                          new JobVariable("var4", null)));
 
+        return job;
+    }
+
+    private Task createTask() throws UserException {
+
         Task task = new JavaTask();
 
         task.setVariables(ImmutableMap.of("var1",
@@ -155,8 +158,6 @@ public class SpelValidatorTest {
 
         task.setName("task1");
 
-        job.addTask(task);
-
-        return job;
+        return task;
     }
 }


### PR DESCRIPTION
- removed the possibility to change variables of another task and use only variables['varname'] syntax.