### PR TITLE
Add START_AT job into templates

### DIFF
--- a/config/workflows/templates/17/job.xml
+++ b/config/workflows/templates/17/job.xml
@@ -11,7 +11,7 @@
     <![CDATA[ START_AT generic information is defined for Job Computing PI according to MonteCarlo method. ]]>
   </description>
   <genericInformation>
-    <info name="START_AT" value="2017-04-01T12:00:00+01:00"/>
+    <info name="START_AT" value="2199-01-01T12:00:00+01:00"/>
   </genericInformation>
   <taskFlow>
     <task name="Computation1">

--- a/config/workflows/templates/17/job.xml
+++ b/config/workflows/templates/17/job.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:jobdescriptor:3.8"
+        xsi:schemaLocation="urn:proactive:jobdescriptor:3.8 http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/3.8/schedulerjob.xsd"
+        name="Start at" projectName="1. Basic Workflows"
+        priority="normal"
+        onTaskError="continueJobExecution">
+
+  <description>
+    <![CDATA[ START_AT generic information is defined for Job Computing PI according to MonteCarlo method. ]]>
+  </description>
+  <genericInformation>
+    <info name="START_AT" value="2017-04-01T12:00:00+01:00"/>
+  </genericInformation>
+  <taskFlow>
+    <task name="Computation1">
+      <description>
+        <![CDATA[ Compute Pi and return it ]]>
+      </description>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+        <parameters>
+          <parameter name="steps" value="20"/>
+          <parameter name="iterations" value="100000000"/>
+        </parameters>
+      </javaExecutable>
+    </task>
+    <task name="Computation2">
+      <description>
+        <![CDATA[ Compute Pi and return it ]]>
+      </description>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+        <parameters>
+          <parameter name="steps" value="20"/>
+          <parameter name="iterations" value="100000000"/>
+        </parameters>
+      </javaExecutable>
+    </task>
+    <task name="Computation3">
+      <description>
+        <![CDATA[ Compute Pi and return it ]]>
+      </description>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+        <parameters>
+          <parameter name="steps" value="20"/>
+          <parameter name="iterations" value="100000000"/>
+        </parameters>
+      </javaExecutable>
+    </task>
+    <task name="Computation4">
+      <description>
+        <![CDATA[ Compute Pi and return it ]]>
+      </description>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+        <parameters>
+          <parameter name="steps" value="20"/>
+          <parameter name="iterations" value="100000000"/>
+        </parameters>
+      </javaExecutable>
+    </task>
+    <task name="Computation5">
+      <description>
+        <![CDATA[ Compute Pi and return it ]]>
+      </description>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+        <parameters>
+          <parameter name="steps" value="20"/>
+          <parameter name="iterations" value="100000000"/>
+        </parameters>
+      </javaExecutable>
+    </task>
+    <task name="Computation6">
+      <description>
+        <![CDATA[ Compute Pi and return it ]]>
+      </description>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarlo">
+        <parameters>
+          <parameter name="steps" value="20"/>
+          <parameter name="iterations" value="100000000"/>
+        </parameters>
+      </javaExecutable>
+    </task>
+    <task name="Average1">
+      <description>
+        <![CDATA[ Do the average of 1 2 3 and return it. ]]>
+      </description>
+      <depends>
+        <task ref="Computation1"/>
+        <task ref="Computation2"/>
+        <task ref="Computation3"/>
+      </depends>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarloAverage"></javaExecutable>
+    </task>
+    <task name="Average2">
+      <description>
+        <![CDATA[ Do the average of 4 5 6 and return it. ]]>
+      </description>
+      <depends>
+        <task ref="Computation4"/>
+        <task ref="Computation5"/>
+        <task ref="Computation6"/>
+      </depends>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarloAverage"></javaExecutable>
+    </task>
+    <task name="LastAverage" preciousResult="true" >
+      <description>
+        <![CDATA[ Do the average of average 1 2 and return it. ]]>
+      </description>
+      <depends>
+        <task ref="Average1"/>
+        <task ref="Average2"/>
+      </depends>
+      <javaExecutable class="org.ow2.proactive.scheduler.examples.MonteCarloAverage"></javaExecutable>
+    </task>
+  </taskFlow>
+</job>

--- a/config/workflows/templates/17/metadata
+++ b/config/workflows/templates/17/metadata
@@ -1,0 +1,1 @@
+{"offsets":{"Start at":{"top":290,"left":966}},"project":"1. Basic Workflows"}

--- a/config/workflows/templates/17/name
+++ b/config/workflows/templates/17/name
@@ -1,0 +1,1 @@
+Start at


### PR DESCRIPTION
- Add a "Start At" Job, in Template Studio Menu, just below 2 Min CRON.
- Put in the START_AT Variable: 2017-04-01T12:00:00+01:00
- Use the Tasks from the existing Distributed Computing Job to define this "Start At" Job 