### PR TITLE
fix ow2-proactive/studio#277 Studio not usable when authenticated with credential file

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -42,7 +42,6 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -1553,20 +1552,15 @@ public interface SchedulerRestInterface {
      * Get the login string associated to the {@code sessionId} if it exists
      * 
      * In case that the given sessionId doesn't have an associated login (session id expired, or invalid), 
-     * this endpoint will throw a {@link javax.ws.rs.NotFoundException}
+     * this endpoint will return an empty string
      * 
      * @param sessionId with which the endpoint is going to look for the login value
-     * @return the associated login value
-     * @throws SchedulerRestException
-     * @throws LoginException
-     * @throws NotConnectedRestException
-     * @throws NotFoundException if the given session id doesn't have an associated login value found
+     * @return the associated login value or an empty string
      */
     @GET
     @Path("logins/sessionid/{sessionId}")
     @Produces("application/json")
-    String getLoginFromSessionId(@PathParam("sessionId") String sessionId)
-            throws SchedulerRestException, LoginException, NotConnectedRestException;
+    String getLoginFromSessionId(@PathParam("sessionId") String sessionId);
 
     /**
      * login to the scheduler using a multipart form can be used either by

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
@@ -83,6 +83,10 @@ public interface StudioInterface {
     boolean isConnected(@HeaderParam("sessionid") String sessionId);
 
     @GET
+    @Path("currentuser")
+    String currentUser(@HeaderParam("sessionid") String sessionId);
+
+    @GET
     @Path("workflows")
     List<Workflow> getWorkflows(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedRestException, IOException;

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -1161,4 +1161,14 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         }
     }
 
+    @Override
+    public String getCurrentUser() throws NotConnectedException {
+
+        String connectedUser = restApi().getLoginFromSessionId(sid);
+        if ("".equals(connectedUser)) {
+            throw new NotConnectedException("Session " + sid + " is not connected");
+        }
+        return connectedUser;
+    }
+
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/Session.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/Session.java
@@ -84,12 +84,14 @@ public class Session {
             throws LoginException, ActiveObjectCreationException, SchedulerException, NodeException {
         scheduler = schedulerRMProxyFactory.connectToScheduler(credentials);
         this.credentials = credentials;
+        setUserName(scheduler.getCurrentUser());
     }
 
     public void connectToScheduler(CredData credData)
             throws LoginException, ActiveObjectCreationException, SchedulerException, NodeException {
         scheduler = schedulerRMProxyFactory.connectToScheduler(credData);
         this.credData = credData;
+        setUserName(credData.getLogin());
     }
 
     public SchedulerProxyUserInterface getScheduler() {
@@ -113,12 +115,14 @@ public class Session {
             throws LoginException, ActiveObjectCreationException, KeyException, NodeException, RMException {
         rm = schedulerRMProxyFactory.connectToRM(credentials);
         this.credentials = credentials;
+        setUserName(rm.getCurrentUser().getStringValue());
     }
 
     public void connectToRM(CredData credData)
             throws LoginException, ActiveObjectCreationException, KeyException, NodeException, RMException {
         rm = schedulerRMProxyFactory.connectToRM(credData);
         this.credData = credData;
+        setUserName(credData.getLogin());
     }
 
     public RMProxyUserInterface getRM() {

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -197,6 +197,14 @@ public class RMRest implements RMRestInterface {
         return session.getSessionId();
     }
 
+    @Override
+    public String getLoginFromSessionId(String sessionId) {
+        if (sessionId != null && sessionStore.exists(sessionId)) {
+            return sessionStore.get(sessionId).getUserName();
+        }
+        return "";
+    }
+
     /**
      * Returns the state of the Resource Manager
      * @param sessionId a valid session id

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
@@ -43,6 +43,7 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -84,6 +85,20 @@ public interface RMRestInterface {
     @Produces("application/json")
     String loginWithCredential(@MultipartForm LoginForm multipart)
             throws ActiveObjectCreationException, NodeException, KeyException, IOException, LoginException, RMException;
+
+    /**
+     * Get the login string associated to the {@code sessionId} if it exists
+     *
+     * In case that the given sessionId doesn't have an associated login (session id expired, or invalid),
+     * this endpoint will return an empty string
+     *
+     * @param sessionId with which the endpoint is going to look for the login value
+     * @return the associated login value or an empty string
+     */
+    @GET
+    @Path("logins/sessionid/{sessionId}")
+    @Produces("application/json")
+    String getLoginFromSessionId(@PathParam("sessionId") String sessionId);
 
     @GET
     @Path("state")

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -2842,8 +2842,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     @GET
     @Path("logins/sessionid/{sessionId}")
     @Produces("application/json")
-    public String getLoginFromSessionId(@PathParam("sessionId") String sessionId)
-            throws SchedulerRestException, LoginException, NotConnectedRestException {
+    public String getLoginFromSessionId(@PathParam("sessionId") String sessionId) {
         if (sessionId != null && sessionStore.exists(sessionId)) {
             return sessionStore.get(sessionId).getUserName();
         }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -121,6 +121,15 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
+    public String currentUser(@HeaderParam("sessionid") String sessionId) {
+        try {
+            return getUserName(sessionId);
+        } catch (NotConnectedRestException e) {
+            return null;
+        }
+    }
+
+    @Override
     public List<Workflow> getWorkflows(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);

--- a/rest/rest-server/src/test/java/functionaltests/AbstractRestFuncTestCase.java
+++ b/rest/rest-server/src/test/java/functionaltests/AbstractRestFuncTestCase.java
@@ -120,10 +120,11 @@ public abstract class AbstractRestFuncTestCase {
         assertEquals(STATUS_OK, getStatusCode(response));
     }
 
-    protected void assertContentNotEmpty(HttpResponse response) throws Exception {
+    protected String assertContentNotEmpty(HttpResponse response) throws Exception {
         String content = getContent(response);
         assertNotNull(content);
         assertTrue(content.length() != 0);
+        return content;
     }
 
     protected int getStatusCode(HttpResponse response) {

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/common/SessionStoreTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/common/SessionStoreTest.java
@@ -25,7 +25,9 @@
  */
 package org.ow2.proactive_grid_cloud_portal.common;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -35,7 +37,6 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.resourcemanager.common.util.RMProxyUserInterface;
-import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
 
 
@@ -83,6 +84,7 @@ public class SessionStoreTest {
 
         assertNotNull(session.getScheduler());
         assertNotNull(session.getRM());
+        assertEquals("login", session.getUserName());
     }
 
     @Test
@@ -99,6 +101,7 @@ public class SessionStoreTest {
 
         assertNotNull(session.getRM());
         assertNotNull(session.getScheduler());
+        assertEquals("login", session.getUserName());
     }
 
     @Test

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -597,4 +597,9 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
         return _getScheduler().getPortalConfiguration();
     }
 
+    @Override
+    public String getCurrentUser() throws NotConnectedException {
+        return ((ISchedulerClient) _getScheduler()).getCurrentUser();
+    }
+
 }

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
@@ -41,6 +41,7 @@ import org.objectweb.proactive.annotation.ImmediateService;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.objectweb.proactive.core.util.wrapper.IntWrapper;
+import org.objectweb.proactive.core.util.wrapper.StringWrapper;
 import org.objectweb.proactive.extensions.annotation.ActiveObject;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.resourcemanager.common.RMState;
@@ -318,6 +319,11 @@ public class RMProxyUserInterface extends RMListenerProxy implements ResourceMan
     public List<ScriptResult<Object>> executeScript(String script, String scriptEngine, String targetType,
             Set<String> targets) {
         return this.target.executeScript(script, scriptEngine, targetType, targets);
+    }
+
+    @Override
+    public StringWrapper getCurrentUser() {
+        return this.target.getCurrentUser();
     }
 
 }

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
@@ -33,6 +33,7 @@ import org.objectweb.proactive.annotation.PublicAPI;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.objectweb.proactive.core.util.wrapper.IntWrapper;
+import org.objectweb.proactive.core.util.wrapper.StringWrapper;
 import org.ow2.proactive.resourcemanager.common.RMState;
 import org.ow2.proactive.resourcemanager.common.event.RMEvent;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeSourceEvent;
@@ -426,4 +427,10 @@ public interface ResourceManager {
      */
     List<ScriptResult<Object>> executeScript(String script, String scriptEngine, String targetType,
             Set<String> targets);
+
+    /**
+     * Returns the user currently connected
+     * @return user name
+     */
+    StringWrapper getCurrentUser();
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -62,6 +62,7 @@ import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.objectweb.proactive.core.util.wrapper.IntWrapper;
+import org.objectweb.proactive.core.util.wrapper.StringWrapper;
 import org.objectweb.proactive.extensions.annotation.ActiveObject;
 import org.ow2.proactive.authentication.principals.IdentityPrincipal;
 import org.ow2.proactive.authentication.principals.UserNamePrincipal;
@@ -2130,6 +2131,11 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     public boolean setDeploying(RMNode rmNode) {
         nodesLockRestorationManager.handle(rmNode);
         return true;
+    }
+
+    @Override
+    public StringWrapper getCurrentUser() {
+        return new StringWrapper(caller.getName());
     }
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -1396,4 +1396,10 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      */
     Map<Object, Object> getPortalConfiguration() throws NotConnectedException, PermissionException;
 
+    /**
+     * Returns the user currently connected
+     * @return user name
+     */
+    String getCurrentUser() throws NotConnectedException;
+
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -642,4 +642,9 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
         return uischeduler.getPortalConfiguration();
     }
 
+    @Override
+    public String getCurrentUser() throws NotConnectedException {
+        return uischeduler.getCurrentUser();
+    }
+
 }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -694,4 +694,10 @@ public class SchedulerNodeClient implements ISchedulerClient {
         renewSession();
         return client.getPortalConfiguration();
     }
+
+    @Override
+    public String getCurrentUser() throws NotConnectedException {
+        renewSession();
+        return client.getCurrentUser();
+    }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -1321,4 +1321,9 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
         return schedulerPortalConfiguration.getProperties();
     }
 
+    @Override
+    public String getCurrentUser() throws NotConnectedException {
+        return frontendState.getCurrentUser();
+    }
+
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -880,10 +880,8 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
     /**
      * Dispatch the job state updated event
      * 
-     * @param owner
-     *            the owner of this job
-     * @param notification
-     *            the data to send to every client
+     * @param job
+     *            the job state
      */
     private void dispatchJobUpdatedFullData(JobState job) {
         try {
@@ -1128,6 +1126,15 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
                 logger.warn("**WARNING** - Unconsistent update type received from Scheduler Core : " +
                             notification.getEventType());
         }
+    }
+
+    public String getCurrentUser() throws NotConnectedException {
+        UniqueID id = checkAccess();
+
+        UserIdentificationImpl ident = identifications.get(id).getUser();
+        // renew session for this user
+        renewUserSession(id, ident);
+        return ident.getUsername();
     }
 
     synchronized List<SchedulerUserInfo> getUsers() {

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -817,4 +817,9 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
         return schedulerProxy.getPortalConfiguration();
     }
 
+    @Override
+    public String getCurrentUser() throws NotConnectedException {
+        return schedulerProxy.getCurrentUser();
+    }
+
 }


### PR DESCRIPTION
Even if this issue occurs on the studio portal, it's root cause is related to the fact that it's not possible to know the user name associated with a rest session generated from a credential file login.

The solution was to allow the retrieval of the authenticated user name from the scheduler and resource manager interfaces, and attach this user name to the rest sessionid.