### PR TITLE
fix TestGetUsers and Address already in use errors

### DIFF
--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
@@ -144,6 +144,8 @@ public class TestSSHInfrastructureV2RestartDownNodesPolicy extends RMFunctionalT
                                       120000,
                                       monitorsHandler);
         }
+        RMTHelper.log("Dumping events not consumed yet");
+        monitorsHandler.dumpEvents();
 
         RMTHelper.log("Wait for nodes restart by the policy");
         rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_ADDED, NB_NODES, monitorsHandler);

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
@@ -145,22 +145,22 @@ public class TestSSHInfrastructureV2RestartDownNodesPolicy extends RMFunctionalT
                                       monitorsHandler);
         }
 
-        nodeset = resourceManager.getNodes(new Criteria(NB_NODES));
-
         RMTHelper.log("Wait for nodes restart by the policy");
-        rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_ADDED, NB_NODES);
+        rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_ADDED, NB_NODES, monitorsHandler);
         for (int i = 0; i < NB_NODES; i++) {
-            rmHelper.waitForAnyNodeEvent(RMEventType.NODE_REMOVED);
-            rmHelper.waitForAnyNodeEvent(RMEventType.NODE_ADDED);
-            rmHelper.waitForAnyNodeEvent(RMEventType.NODE_STATE_CHANGED);
+            rmHelper.waitForAnyNodeEvent(RMEventType.NODE_REMOVED, monitorsHandler);
+            rmHelper.waitForAnyNodeEvent(RMEventType.NODE_ADDED, monitorsHandler);
+            rmHelper.waitForAnyNodeEvent(RMEventType.NODE_STATE_CHANGED, monitorsHandler);
         }
 
         RMTHelper.log("Final checks on the scheduler state");
-        s = resourceManager.getState();
+        nodeset = resourceManager.getNodes(new Criteria(NB_NODES));
 
         for (Node n : nodeset) {
             System.out.println("NODE::" + n.getNodeInformation().getURL());
         }
+
+        s = resourceManager.getState();
 
         assertEquals(NB_NODES, s.getTotalNodesNumber());
         assertEquals(NB_NODES, s.getTotalAliveNodesNumber()); // check amount of all nodes that are not down

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/TestGetUsers.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/TestGetUsers.java
@@ -32,14 +32,12 @@ import java.util.List;
 
 import org.junit.Test;
 import org.ow2.proactive.scheduler.common.Scheduler;
-import org.ow2.proactive.scheduler.common.job.Job;
-import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.job.SchedulerUserInfo;
 
 import functionaltests.executables.EmptyExecutable;
-import functionaltests.utils.SchedulerFunctionalTestNoRestart;
+import functionaltests.utils.SchedulerFunctionalTestWithRestart;
 import functionaltests.utils.TestUsers;
 
 
@@ -47,7 +45,7 @@ import functionaltests.utils.TestUsers;
  * Sanity test against method 'Scheduler.getUsers' and 'Scheduler.getUsersWithJobs'.
  *
  */
-public class TestGetUsers extends SchedulerFunctionalTestNoRestart {
+public class TestGetUsers extends SchedulerFunctionalTestWithRestart {
 
     long testStartTime = System.currentTimeMillis();
 


### PR DESCRIPTION
- the TestGetUsers test is unstable apparently when other tests fail and leave client sessions, so it should be started in clean mode.
- When creating a node in RMTHelper, if a NodeException occurs, retry a couple of times with a different port number.
