### PR TITLE
Junit timedout listener

### DIFF
--- a/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
@@ -26,7 +26,6 @@
 package org.ow2.proactive.junitUtils;
 
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
@@ -48,7 +47,7 @@ import org.junit.runner.notification.RunListener;
  */
 public class TimedOutTestsListener extends RunListener {
 
-    static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
+    private final String TEST_TIMED_OUT_PREFIX = "test timed out after";
 
     private final static String INDENT = "    ";
 
@@ -73,25 +72,28 @@ public class TimedOutTestsListener extends RunListener {
     }
 
     public static String buildThreadDiagnosticString() {
-        StringWriter sw = new StringWriter();
-        PrintWriter output = new PrintWriter(sw);
+        StringBuilder sb = new StringBuilder();
 
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
-        output.println(String.format("Timestamp: %s", dateFormat.format(new Date())));
-        output.println();
-        output.println(buildThreadsDump());
+        sb.append(String.format("Timestamp: %s", dateFormat.format(new Date())));
+        sb.append(System.getProperty("line.separator"));
+        sb.append(System.getProperty("line.separator"));
+        sb.append(System.getProperty("line.separator"));
+        sb.append(buildThreadsDump());
 
         String deadlocksInfo = buildDeadlockInfo();
         if (deadlocksInfo != null) {
-            output.println("====> DEADLOCKS DETECTED <====");
-            output.println();
-            output.println(deadlocksInfo);
+            sb.append("====> DEADLOCKS DETECTED <====");
+            sb.append(System.getProperty("line.separator"));
+            sb.append(System.getProperty("line.separator"));
+            sb.append(deadlocksInfo);
+            sb.append(System.getProperty("line.separator"));
         }
 
-        return sw.toString();
+        return sb.toString();
     }
 
-    static String buildThreadsDump() {
+    private static String buildThreadsDump() {
         StringBuilder dump = new StringBuilder();
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
         for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
@@ -122,69 +124,90 @@ public class TimedOutTestsListener extends RunListener {
                                                                             : thread.getState());
     }
 
-    static String buildDeadlockInfo() {
+    private static String buildDeadlockInfo() {
         ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
         long[] threadIds = threadBean.findMonitorDeadlockedThreads();
         if (threadIds != null && threadIds.length > 0) {
-            StringWriter stringWriter = new StringWriter();
-            PrintWriter out = new PrintWriter(stringWriter);
+            StringBuilder sb = new StringBuilder();
 
             ThreadInfo[] infos = threadBean.getThreadInfo(threadIds, true, true);
             for (ThreadInfo ti : infos) {
-                printThreadInfo(ti, out);
-                printLockInfo(ti.getLockedSynchronizers(), out);
-                out.println();
+                printThreadInfo(ti, sb);
+                printLockInfo(ti.getLockedSynchronizers(), sb);
+                sb.append(System.getProperty("line.separator"));
             }
-
-            out.close();
-            return stringWriter.toString();
+            return sb.toString();
         } else {
             return null;
         }
     }
 
-    private static void printThreadInfo(ThreadInfo ti, PrintWriter out) {
+    private static void printThreadInfo(ThreadInfo ti, StringBuilder sb) {
         // print thread information
-        printThread(ti, out);
+        printThread(ti, sb);
 
         // print stack trace with locks
         StackTraceElement[] stacktrace = ti.getStackTrace();
         MonitorInfo[] monitors = ti.getLockedMonitors();
         for (int i = 0; i < stacktrace.length; i++) {
             StackTraceElement ste = stacktrace[i];
-            out.println(INDENT + "at " + ste.toString());
+            sb.append(INDENT);
+            sb.append("at ");
+            sb.append(ste.toString());
+            sb.append(System.getProperty("line.separator"));
             for (MonitorInfo mi : monitors) {
                 if (mi.getLockedStackDepth() == i) {
-                    out.println(INDENT + "  - locked " + mi);
+                    sb.append(INDENT);
+                    sb.append("  - locked ");
+                    sb.append(mi);
+                    sb.append(System.getProperty("line.separator"));
                 }
             }
         }
-        out.println();
+        sb.append(System.getProperty("line.separator"));
     }
 
-    private static void printThread(ThreadInfo ti, PrintWriter out) {
-        out.print("\"" + ti.getThreadName() + "\"" + " Id=" + ti.getThreadId() + " in " + ti.getThreadState());
+    private static void printThread(ThreadInfo ti, StringBuilder sb) {
+        sb.append("\"");
+        sb.append(ti.getThreadName());
+        sb.append("\"");
+        sb.append(" Id=");
+        sb.append(ti.getThreadId());
+        sb.append(" in ");
+        sb.append(ti.getThreadState());
         if (ti.getLockName() != null) {
-            out.print(" on lock=" + ti.getLockName());
+            sb.append(" on lock=");
+            sb.append(ti.getLockName());
         }
         if (ti.isSuspended()) {
-            out.print(" (suspended)");
+            sb.append(" (suspended)");
         }
         if (ti.isInNative()) {
-            out.print(" (running in native)");
+            sb.append(" (running in native)");
         }
-        out.println();
+        sb.append(System.getProperty("line.separator"));
         if (ti.getLockOwnerName() != null) {
-            out.println(INDENT + " owned by " + ti.getLockOwnerName() + " Id=" + ti.getLockOwnerId());
+            sb.append(INDENT);
+            sb.append(" owned by ");
+            sb.append(ti.getLockOwnerName());
+            sb.append(" Id=");
+            sb.append(ti.getLockOwnerId());
+            sb.append(System.getProperty("line.separator"));
         }
     }
 
-    private static void printLockInfo(LockInfo[] locks, PrintWriter out) {
-        out.println(INDENT + "Locked synchronizers: count = " + locks.length);
+    private static void printLockInfo(LockInfo[] locks, StringBuilder sb) {
+        sb.append(INDENT);
+        sb.append("Locked synchronizers: count = ");
+        sb.append(locks.length);
+        sb.append(System.getProperty("line.separator"));
         for (LockInfo li : locks) {
-            out.println(INDENT + "  - " + li);
+            sb.append(INDENT);
+            sb.append("  - ");
+            sb.append(li);
+            sb.append(System.getProperty("line.separator"));
         }
-        out.println();
+        sb.append(System.getProperty("line.separator"));
     }
 
 }

--- a/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
@@ -50,7 +50,7 @@ public class TimedOutTestsListener extends RunListener {
 
     static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
 
-    private static String INDENT = "    ";
+    private final static String INDENT = "    ";
 
     private final PrintWriter output;
 

--- a/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
@@ -1,0 +1,186 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.frontend.topology.clustering;
+
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * JUnit run listener which prints full thread dump into System.err
+ * in case a test is failed due to timeout.
+ * @author Xiaoyan Lin (Netty project)
+ */
+public class TimedOutTestsListener extends RunListener {
+
+    static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
+
+    private static String INDENT = "    ";
+
+    private final PrintWriter output;
+
+    public TimedOutTestsListener() {
+        this.output = new PrintWriter(System.err);
+    }
+
+    public TimedOutTestsListener(PrintWriter output) {
+        this.output = output;
+    }
+
+    @Override
+    public void testFailure(Failure failure) throws Exception {
+        if (failure != null && failure.getMessage() != null
+                && failure.getMessage().startsWith(TEST_TIMED_OUT_PREFIX)) {
+            output.println("====> TEST TIMED OUT. PRINTING THREAD DUMP. <====");
+            output.println();
+            output.print(buildThreadDiagnosticString());
+            output.flush();
+        }
+    }
+
+    public static String buildThreadDiagnosticString() {
+        StringWriter sw = new StringWriter();
+        PrintWriter output = new PrintWriter(sw);
+
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+        output.println(String.format("Timestamp: %s", dateFormat.format(new Date())));
+        output.println();
+        output.println(buildThreadDump());
+
+        String deadlocksInfo = buildDeadlockInfo();
+        if (deadlocksInfo != null) {
+            output.println("====> DEADLOCKS DETECTED <====");
+            output.println();
+            output.println(deadlocksInfo);
+        }
+
+        return sw.toString();
+    }
+
+    static String buildThreadDump() {
+        StringBuilder dump = new StringBuilder();
+        Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
+        for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
+            Thread thread = e.getKey();
+            dump.append(String.format(
+                    "\"%s\" %s prio=%d tid=%d %s\njava.lang.Thread.State: %s",
+                    thread.getName(),
+                    thread.isDaemon() ? "daemon" : "",
+                    thread.getPriority(),
+                    thread.getId(),
+                    Thread.State.WAITING.equals(thread.getState()) ?
+                            "in Object.wait()" :
+                            (thread.getState().name() == null? "" : thread.getState().name().toLowerCase()),
+                    Thread.State.WAITING.equals(thread.getState()) ?
+                            "WAITING (on object monitor)" : thread.getState()));
+            for (StackTraceElement stackTraceElement : e.getValue()) {
+                dump.append("\n        at ");
+                dump.append(stackTraceElement);
+            }
+            dump.append("\n");
+        }
+        return dump.toString();
+    }
+
+    static String buildDeadlockInfo() {
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        long[] threadIds = threadBean.findMonitorDeadlockedThreads();
+        if (threadIds != null && threadIds.length > 0) {
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter out = new PrintWriter(stringWriter);
+
+            ThreadInfo[] infos = threadBean.getThreadInfo(threadIds, true, true);
+            for (ThreadInfo ti : infos) {
+                printThreadInfo(ti, out);
+                printLockInfo(ti.getLockedSynchronizers(), out);
+                out.println();
+            }
+
+            out.close();
+            return stringWriter.toString();
+        } else {
+            return null;
+        }
+    }
+
+    private static void printThreadInfo(ThreadInfo ti, PrintWriter out) {
+        // print thread information
+        printThread(ti, out);
+
+        // print stack trace with locks
+        StackTraceElement[] stacktrace = ti.getStackTrace();
+        MonitorInfo[] monitors = ti.getLockedMonitors();
+        for (int i = 0; i < stacktrace.length; i++) {
+            StackTraceElement ste = stacktrace[i];
+            out.println(INDENT + "at " + ste.toString());
+            for (MonitorInfo mi : monitors) {
+                if (mi.getLockedStackDepth() == i) {
+                    out.println(INDENT + "  - locked " + mi);
+                }
+            }
+        }
+        out.println();
+    }
+
+    private static void printThread(ThreadInfo ti, PrintWriter out) {
+        out.print("\"" + ti.getThreadName() + "\"" + " Id="
+                + ti.getThreadId() + " in " + ti.getThreadState());
+        if (ti.getLockName() != null) {
+            out.print(" on lock=" + ti.getLockName());
+        }
+        if (ti.isSuspended()) {
+            out.print(" (suspended)");
+        }
+        if (ti.isInNative()) {
+            out.print(" (running in native)");
+        }
+        out.println();
+        if (ti.getLockOwnerName() != null) {
+            out.println(INDENT + " owned by " + ti.getLockOwnerName() + " Id="
+                    + ti.getLockOwnerId());
+        }
+    }
+
+    private static void printLockInfo(LockInfo[] locks, PrintWriter out) {
+        out.println(INDENT + "Locked synchronizers: count = " + locks.length);
+        for (LockInfo li : locks) {
+            out.println(INDENT + "  - " + li);
+        }
+        out.println();
+    }
+
+}

--- a/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsListener.java
@@ -23,8 +23,7 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive.resourcemanager.frontend.topology.clustering;
-
+package org.ow2.proactive.junitUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -37,8 +36,10 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
+
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
+
 
 /**
  * JUnit run listener which prints full thread dump into System.err
@@ -63,8 +64,7 @@ public class TimedOutTestsListener extends RunListener {
 
     @Override
     public void testFailure(Failure failure) throws Exception {
-        if (failure != null && failure.getMessage() != null
-                && failure.getMessage().startsWith(TEST_TIMED_OUT_PREFIX)) {
+        if (failure != null && failure.getMessage() != null && failure.getMessage().startsWith(TEST_TIMED_OUT_PREFIX)) {
             output.println("====> TEST TIMED OUT. PRINTING THREAD DUMP. <====");
             output.println();
             output.print(buildThreadDiagnosticString());
@@ -79,7 +79,7 @@ public class TimedOutTestsListener extends RunListener {
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
         output.println(String.format("Timestamp: %s", dateFormat.format(new Date())));
         output.println();
-        output.println(buildThreadDump());
+        output.println(buildThreadsDump());
 
         String deadlocksInfo = buildDeadlockInfo();
         if (deadlocksInfo != null) {
@@ -91,22 +91,12 @@ public class TimedOutTestsListener extends RunListener {
         return sw.toString();
     }
 
-    static String buildThreadDump() {
+    static String buildThreadsDump() {
         StringBuilder dump = new StringBuilder();
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
         for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
             Thread thread = e.getKey();
-            dump.append(String.format(
-                    "\"%s\" %s prio=%d tid=%d %s\njava.lang.Thread.State: %s",
-                    thread.getName(),
-                    thread.isDaemon() ? "daemon" : "",
-                    thread.getPriority(),
-                    thread.getId(),
-                    Thread.State.WAITING.equals(thread.getState()) ?
-                            "in Object.wait()" :
-                            (thread.getState().name() == null? "" : thread.getState().name().toLowerCase()),
-                    Thread.State.WAITING.equals(thread.getState()) ?
-                            "WAITING (on object monitor)" : thread.getState()));
+            dump.append(formatThreadDump(thread));
             for (StackTraceElement stackTraceElement : e.getValue()) {
                 dump.append("\n        at ");
                 dump.append(stackTraceElement);
@@ -114,6 +104,22 @@ public class TimedOutTestsListener extends RunListener {
             dump.append("\n");
         }
         return dump.toString();
+    }
+
+    private static String formatThreadDump(Thread thread) {
+        return String.format("\"%s\" %s prio=%d tid=%d %s\njava.lang.Thread.State: %s",
+                             thread.getName(),
+                             thread.isDaemon() ? "daemon" : "",
+                             thread.getPriority(),
+                             thread.getId(),
+                             Thread.State.WAITING.equals(thread.getState()) ? "in Object.wait()"
+                                                                            : (thread.getState()
+                                                                                     .name() == null ? ""
+                                                                                                     : thread.getState()
+                                                                                                             .name()
+                                                                                                             .toLowerCase()),
+                             Thread.State.WAITING.equals(thread.getState()) ? "WAITING (on object monitor)"
+                                                                            : thread.getState());
     }
 
     static String buildDeadlockInfo() {
@@ -157,8 +163,7 @@ public class TimedOutTestsListener extends RunListener {
     }
 
     private static void printThread(ThreadInfo ti, PrintWriter out) {
-        out.print("\"" + ti.getThreadName() + "\"" + " Id="
-                + ti.getThreadId() + " in " + ti.getThreadState());
+        out.print("\"" + ti.getThreadName() + "\"" + " Id=" + ti.getThreadId() + " in " + ti.getThreadState());
         if (ti.getLockName() != null) {
             out.print(" on lock=" + ti.getLockName());
         }
@@ -170,8 +175,7 @@ public class TimedOutTestsListener extends RunListener {
         }
         out.println();
         if (ti.getLockOwnerName() != null) {
-            out.println(INDENT + " owned by " + ti.getLockOwnerName() + " Id="
-                    + ti.getLockOwnerId());
+            out.println(INDENT + " owned by " + ti.getLockOwnerName() + " Id=" + ti.getLockOwnerId());
         }
     }
 

--- a/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsRunner.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsRunner.java
@@ -1,0 +1,49 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.junitUtils;
+
+
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * JUnit custom runner which use TimedOutTestsListener to print full thread dump into System.err
+ * in case a test is failed due to timeout.
+ * @author ActiveEon Team
+ * @since 4/12/17
+ */
+public class TimedOutTestsRunner  extends BlockJUnit4ClassRunner {
+
+    public TimedOutTestsRunner(Class<?> _class) throws InitializationError {
+        super(_class);
+    }
+
+    @Override public void run(RunNotifier notifier){
+        notifier.addListener(new org.ow2.proactive.resourcemanager.frontend.topology.clustering.TimedOutTestsListener());
+        super.run(notifier);
+    }
+}

--- a/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsRunner.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/junitUtils/TimedOutTestsRunner.java
@@ -25,10 +25,10 @@
  */
 package org.ow2.proactive.junitUtils;
 
-
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.InitializationError;
+
 
 /**
  * JUnit custom runner which use TimedOutTestsListener to print full thread dump into System.err
@@ -36,14 +36,15 @@ import org.junit.runners.model.InitializationError;
  * @author ActiveEon Team
  * @since 4/12/17
  */
-public class TimedOutTestsRunner  extends BlockJUnit4ClassRunner {
+public class TimedOutTestsRunner extends BlockJUnit4ClassRunner {
 
     public TimedOutTestsRunner(Class<?> _class) throws InitializationError {
         super(_class);
     }
 
-    @Override public void run(RunNotifier notifier){
-        notifier.addListener(new org.ow2.proactive.resourcemanager.frontend.topology.clustering.TimedOutTestsListener());
+    @Override
+    public void run(RunNotifier notifier) {
+        notifier.addListener(new TimedOutTestsListener());
         super.run(notifier);
     }
 }

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/frontend/topology/clustering/MatrixBasedTests.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/frontend/topology/clustering/MatrixBasedTests.java
@@ -42,6 +42,7 @@ import org.ow2.proactive.resourcemanager.frontend.topology.Topology;
 import org.ow2.proactive.topology.descriptor.BestProximityDescriptor;
 import org.ow2.proactive.topology.descriptor.DistanceFunction;
 
+
 /**
  * Class which holds the tests that read their input from a a visual description of a grid (a string)
  * @author Zsolt Istvan

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/frontend/topology/clustering/MatrixBasedTests.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/frontend/topology/clustering/MatrixBasedTests.java
@@ -35,17 +35,20 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.runner.RunWith;
 import org.objectweb.proactive.core.node.Node;
+import org.ow2.proactive.junitUtils.TimedOutTestsRunner;
 import org.ow2.proactive.resourcemanager.frontend.topology.Topology;
 import org.ow2.proactive.topology.descriptor.BestProximityDescriptor;
 import org.ow2.proactive.topology.descriptor.DistanceFunction;
-
 
 /**
  * Class which holds the tests that read their input from a a visual description of a grid (a string)
  * @author Zsolt Istvan
  *
  */
+
+@RunWith(TimedOutTestsRunner.class)
 public class MatrixBasedTests {
 
     protected static HashMap<Node, HashMap<Node, Long>> distances = new HashMap<>();


### PR DESCRIPTION
Create custom JUnit Runner and Listener to print threads dumps when test fails on time out. Use them on MatrixBasedTests to debug the unstable test reasonableTimeTestNoPivot.
 
See "Print thread dumps on timed out JUnit Tests" on the ActiveEon google drive for more details.