### PR TITLE
fix for #2860 Multi-node tasks with cleaning scripts can create a deadlock

### DIFF
--- a/rm/rm-client/src/main/java/org/ow2/proactive/utils/NodeSet.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/utils/NodeSet.java
@@ -136,4 +136,9 @@ public class NodeSet extends ArrayList<Node> {
             nodesUrls.add(node.getNodeInformation().getURL());
         }
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + (extraNodes != null ? ", extraNodes=" + extraNodes.toString() : "");
+    }
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1270,16 +1270,20 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         // exception to throw in case of problems
         RuntimeException exception = null;
 
+        NodeSet nodesReleased = new NodeSet();
+        NodeSet nodesFailedToRelease = new NodeSet();
+
         for (Node node : nodes) {
             String nodeURL = null;
             try {
                 nodeURL = node.getNodeInformation().getURL();
                 logger.debug("Releasing node " + nodeURL);
             } catch (RuntimeException e) {
-                logger.debug("A Runtime exception occured while obtaining information on the node," +
+                logger.debug("A Runtime exception occurred while obtaining information on the node," +
                              "the node must be down (it will be detected later)", e);
                 // node is down, will be detected by pinger
                 exception = new IllegalStateException(e.getMessage(), e);
+                nodesFailedToRelease.add(node);
             }
 
             // verify whether the node has not been removed from the RM
@@ -1290,8 +1294,10 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                 // free
                 if (rmnode.isFree()) {
                     logger.warn("Client " + caller + " tries to release the already free node " + nodeURL);
+                    nodesFailedToRelease.add(node);
                 } else if (rmnode.isDown()) {
                     logger.warn("Node was down, it cannot be released");
+                    nodesFailedToRelease.add(node);
                 } else {
                     Set<? extends IdentityPrincipal> userPrincipal = rmnode.getOwner()
                                                                            .getSubject()
@@ -1304,18 +1310,27 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
                         if (rmnode.isToRemove()) {
                             removeNodeFromCoreAndSource(rmnode, caller);
+                            nodesReleased.add(node);
                         } else {
                             internalSetFree(rmnode);
+                            nodesReleased.add(node);
                         }
                     } catch (SecurityException ex) {
                         logger.error(ex.getMessage(), ex);
+                        nodesFailedToRelease.add(node);
                         exception = ex;
                     }
                 }
             } else {
                 logger.warn("Cannot release unknown node " + nodeURL);
+                nodesFailedToRelease.add(node);
                 exception = new IllegalArgumentException("Cannot release unknown node " + nodeURL);
             }
+        }
+
+        logger.info("Nodes released : " + nodesReleased);
+        if (!nodesFailedToRelease.isEmpty()) {
+            logger.warn("Nodes failed to release : " + nodesFailedToRelease);
         }
 
         if (exception != null) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
@@ -27,10 +27,8 @@ package org.ow2.proactive.scheduler.core.rmproxies;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
@@ -68,12 +68,7 @@ public class RMProxyActiveObject {
 
     protected ResourceManager rm;
 
-    /**
-     * list of nodes and clean script being executed
-     */
-    private Map<Node, ScriptResult<?>> nodeScriptResult = new ConcurrentHashMap<>();
-
-    private Map<Node, TaskId> nodesTaskId = new ConcurrentHashMap<>();
+    private Map<NodeSet, TaskId> nodesTaskId = new ConcurrentHashMap<>();
 
     public RMProxyActiveObject() {
     }
@@ -165,9 +160,8 @@ public class RMProxyActiveObject {
             if (cleaningScript == null) {
                 releaseNodes(nodes);
             } else if (InternalTask.isScriptAuthorized(taskId, cleaningScript)) {
-                for (Node node : nodes) {
-                    handleCleaningScript(node, cleaningScript, variables, genericInformation, taskId);
-                }
+                handleCleaningScript(nodes, cleaningScript, variables, genericInformation, taskId);
+
             } else {
                 TaskLogger.getInstance().error(taskId,
                                                "Unauthorized clean script: " + System.getProperty("line.separator") +
@@ -179,35 +173,38 @@ public class RMProxyActiveObject {
 
     /**
      * Execute the given script on the given node.
-     * Also register a callback on {@link #cleanCallBack(Future)} method when script has returned.
-     * @param node           the node on which to start the script
+     * Also register a callback on {@link #cleanCallBack(Future, NodeSet)} method when script has returned.
+     * @param nodes           the nodeset on which to start the script
      * @param cleaningScript the script to be executed
      * @param variables
      * @param genericInformation
      */
-    private void handleCleaningScript(Node node, Script<?> cleaningScript, VariablesMap variables,
+    private void handleCleaningScript(NodeSet nodes, Script<?> cleaningScript, VariablesMap variables,
             Map<String, String> genericInformation, TaskId taskId) {
+        TaskLogger instance = TaskLogger.getInstance();
         try {
-            this.nodesTaskId.put(node, taskId);
-            ScriptHandler handler = ScriptLoader.createHandler(node);
+            this.nodesTaskId.put(nodes, taskId);
+            ScriptHandler handler = ScriptLoader.createHandler(nodes.get(0));
             handler.addBinding(SchedulerConstants.VARIABLES_BINDING_NAME, (Serializable) variables);
             handler.addBinding(SchedulerConstants.GENERIC_INFO_BINDING_NAME, (Serializable) genericInformation);
             ScriptResult<?> future = handler.handle(cleaningScript);
             try {
-                PAEventProgramming.addActionOnFuture(future, "cleanCallBack");
+                PAEventProgramming.addActionOnFuture(future, "cleanCallBack", nodes);
             } catch (IllegalArgumentException e) {
                 //TODO - linked to PROACTIVE-936 -> IllegalArgumentException is raised if method name is unknown
                 //should be replaced by checked exception
-                logger.error("ERROR : Callback method won't be executed, node won't be released. This is a critical state, check the callback method name",
-                             e);
+                instance.error(taskId,
+                               "ERROR : Callback method won't be executed, node won't be released. This is a critical state, check the callback method name",
+                               e);
             }
-            this.nodeScriptResult.put(node, future);
-            logger.info("Cleaning Script started on node" + node.getNodeInformation().getURL());
+            instance.info(taskId, "Cleaning Script started on node " + nodes.get(0).getNodeInformation().getURL());
 
         } catch (Exception e) {
             //if active object cannot be created or script has failed
-            logger.error("", e);
-            releaseNode(node);
+            instance.error(taskId,
+                           "Error while starting cleaning script for task " + taskId + " on " + nodes.get(0),
+                           e);
+            releaseNodes(nodes);
         }
     }
 
@@ -215,40 +212,31 @@ public class RMProxyActiveObject {
      * Called when a script has returned (call is made as an active object call)
      * <p>
      * Check the nodes to release and release the one that have to (clean script has returned)
-     * Take care when renaming this method, method name is linked to {@link #handleCleaningScript(Node, Script, Map, Map,TaskId)}
+     * Take care when renaming this method, method name is linked to {@link #handleCleaningScript(NodeSet, Script, VariablesMap, Map,TaskId)}
      */
     @ImmediateService
-    public synchronized void cleanCallBack(Future<ScriptResult<?>> future) {
-        Iterator<Entry<Node, ScriptResult<?>>> iterator = nodeScriptResult.entrySet().iterator();
-        NodeSet ns = new NodeSet();
-        while (iterator.hasNext()) {
-            Entry<Node, ScriptResult<?>> entry = iterator.next();
-            if (!PAFuture.isAwaited(entry.getValue())) { // !awaited = arrived
-                String nodeUrl = entry.getKey().getNodeInformation().getURL();
-                ScriptResult<?> sResult = null;
-                TaskId taskId = nodesTaskId.get(entry.getKey());
-                try {
-                    sResult = future.get();
-                } catch (Exception e) {
-                    logger.error("Exception occurred while executing cleaning script on node " + nodeUrl + ":", e);
-                }
-                printCleaningScriptInformations(nodeUrl, sResult, taskId);
-                ns.add(entry.getKey());
-                iterator.remove();
-            }
+    public synchronized void cleanCallBack(Future<ScriptResult<?>> future, NodeSet nodes) {
+
+        String nodeUrl = nodes.get(0).getNodeInformation().getURL();
+        ScriptResult<?> sResult = null;
+        TaskId taskId = nodesTaskId.get(nodes);
+        try {
+            sResult = future.get();
+        } catch (Exception e) {
+            logger.error("Exception occurred while executing cleaning script on node " + nodeUrl + ":", e);
         }
-        if (ns.size() > 0) {
-            releaseNodes(ns);
-        }
+        printCleaningScriptInformations(nodes, sResult, taskId);
+        releaseNodes(nodes);
     }
 
-    private void printCleaningScriptInformations(String nodeUrl, ScriptResult<?> sResult, TaskId taskId) {
+    private void printCleaningScriptInformations(NodeSet nodes, ScriptResult<?> sResult, TaskId taskId) {
         if (logger.isInfoEnabled()) {
             TaskLogger instance = TaskLogger.getInstance();
+            String nodeUrl = nodes.get(0).getNodeInformation().getURL();
             if (sResult.errorOccured()) {
                 instance.error(taskId, "Exception while running cleaning script on " + nodeUrl, sResult.getException());
             } else {
-                instance.info(taskId, "Cleaning script successful, node freed : " + nodeUrl);
+                instance.info(taskId, "Cleaning script successful.");
             }
             if (sResult.getOutput() != null && !sResult.getOutput().isEmpty()) {
                 instance.info(taskId, "Cleaning script output on node " + nodeUrl + ":");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/scripts/clean/TestCleaningScriptMultiNodes.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/scripts/clean/TestCleaningScriptMultiNodes.java
@@ -1,0 +1,82 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests.scripts.clean;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.ow2.proactive.resourcemanager.common.event.RMEventType;
+import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
+import org.ow2.proactive.scheduler.common.job.JobId;
+
+import functionaltests.monitor.RMMonitorsHandler;
+import functionaltests.utils.SchedulerFunctionalTestWithRestart;
+
+
+/**
+ * Test checks that a cleaning script on a multi-node task terminates and does not keep nodes busy
+ */
+public class TestCleaningScriptMultiNodes extends SchedulerFunctionalTestWithRestart {
+
+    private static URL jobDescriptor = TestCleaningScriptMultiNodes.class.getResource("/functionaltests/descriptors/Job_CleaningScript_multinode.xml");
+
+    @Test
+    public void testCleaningScriptMultiNodes() throws Throwable {
+        //submit job
+        JobId id = schedulerHelper.submitJob(new File(jobDescriptor.toURI()).getAbsolutePath());
+        //connect to RM
+        schedulerHelper.addExtraNodes(4);
+
+        //wait job is running
+        schedulerHelper.waitForEventJobRunning(id);
+
+        //wait for job to be finished
+        schedulerHelper.waitForEventJobFinished(id);
+
+        // the job is finished before the last tasks cleaning scripts are complete, so we need to wait a bit
+        schedulerHelper.log("Wait for the nodes the be released");
+        waitUntilAllNodesAreFreeOrFail(schedulerHelper.getResourceManager(), 30);
+
+    }
+
+    private void waitUntilAllNodesAreFreeOrFail(ResourceManager rm, int nbSeconds) throws InterruptedException {
+        int cpt = nbSeconds;
+        boolean busyNodes = true;
+        do {
+            Thread.sleep(1000);
+            cpt--;
+            busyNodes = !rm.listAliveNodeUrls().equals(rm.getState().getFreeNodes());
+        } while (busyNodes && cpt > 0);
+        if (busyNodes) {
+            Assert.fail("Busy nodes remaining after " + nbSeconds + " seconds");
+        }
+
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -757,14 +757,8 @@ public class SchedulerTHelper {
             System.err.println("Job is already finished - do not wait for the 'job finished' event");
             return jobState.getJobInfo();
         } else {
-            try {
-                System.err.println("Waiting for the job finished event");
-                return getSchedulerMonitorsHandler().waitForEventJob(jobEvent, id, timeout);
-            } catch (ProActiveTimeoutException e) {
-                //unreachable block, 0 means infinite, no timeout
-                //log something ?
-                return null;
-            }
+            System.err.println("Waiting for the job finished event");
+            return getSchedulerMonitorsHandler().waitForEventJob(jobEvent, id, timeout);
         }
     }
 
@@ -1021,7 +1015,7 @@ public class SchedulerTHelper {
         return scheduler.getUrl();
     }
 
-    private RMMonitorsHandler getRMMonitorsHandler() throws Exception {
+    public RMMonitorsHandler getRMMonitorsHandler() throws Exception {
         return RMTestUser.getInstance().getMonitorsHandler();
     }
 

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CleaningScript_multinode.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_CleaningScript_multinode.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
+	name="job_multiNodes" priority="low">
+	<description>Multi nodes job that sleeps indefinitely.</description>
+	<taskFlow>
+		<task name="Cleaner1">
+			<parallel numberOfNodes="2"/>
+			<javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+			</javaExecutable>
+			<cleaning>
+				<script>
+					<code language="groovy">
+						println "CleanMe"
+					</code>
+				</script>
+			</cleaning>
+		</task>
+		<task name="Cleaner2">
+			<parallel numberOfNodes="2"/>
+			<javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+			</javaExecutable>
+			<cleaning>
+				<script>
+					<code language="groovy">
+						println "CleanMe"
+					</code>
+				</script>
+			</cleaning>
+		</task>
+		<task name="Cleaner3">
+			<parallel numberOfNodes="2"/>
+			<javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+			</javaExecutable>
+			<cleaning>
+				<script>
+					<code language="groovy">
+						println "CleanMe"
+					</code>
+				</script>
+			</cleaning>
+		</task>
+		<task name="Cleaner4">
+			<parallel numberOfNodes="2"/>
+			<javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+			</javaExecutable>
+			<cleaning>
+				<script>
+					<code language="groovy">
+						println "CleanMe"
+					</code>
+				</script>
+			</cleaning>
+		</task>
+		<task name="Cleaner5">
+			<parallel numberOfNodes="2"/>
+			<javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+			</javaExecutable>
+			<cleaning>
+				<script>
+					<code language="groovy">
+						println "CleanMe"
+					</code>
+				</script>
+			</cleaning>
+		</task>
+		<task name="Cleaner6">
+			<parallel numberOfNodes="2"/>
+			<javaExecutable class="org.ow2.proactive.scheduler.examples.EmptyTask">
+			</javaExecutable>
+			<cleaning>
+				<script>
+					<code language="groovy">
+						println "CleanMe"
+					</code>
+				</script>
+			</cleaning>
+		</task>
+	</taskFlow>
+</job>


### PR DESCRIPTION
- cleaning script is started on main node only
- pass the NodeSet as an extra parameter to the clean script callback (PAEventProgramming) to avoid deadlock
- improved a few logs
- added a functional test