### PR TITLE
#2866 Memory Leak issue in SchedulerFrontendState

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -1037,7 +1037,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
     public synchronized void jobSubmitted(JobState job) {
         ClientJobState storedJobState = new ClientJobState(job);
         jobsMap.put(job.getId(), storedJobState);
-        sState.getPendingJobs().add(storedJobState);
+        sState.update(storedJobState);
         dispatchJobSubmitted(job);
     }
 
@@ -1047,8 +1047,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         js.update(notification.getData());
         switch (notification.getEventType()) {
             case JOB_PENDING_TO_RUNNING:
-                sState.getPendingJobs().remove(js);
-                sState.getRunningJobs().add(js);
+                sState.pendingToRunning(js);
                 break;
             case JOB_PAUSED:
             case JOB_IN_ERROR:
@@ -1059,20 +1058,18 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
             case TASK_SKIPPED:
                 break;
             case JOB_PENDING_TO_FINISHED:
-                sState.getPendingJobs().remove(js);
-                sState.getFinishedJobs().add(js);
+                sState.pendingToFinished(js);
                 // set this job finished, user can get its result
                 jobs.get(notification.getData().getJobId()).setFinished(true);
                 break;
             case JOB_RUNNING_TO_FINISHED:
-                sState.getRunningJobs().remove(js);
-                sState.getFinishedJobs().add(js);
+                sState.runningToFinished(js);
                 // set this job finished, user can get its result
                 jobs.get(notification.getData().getJobId()).setFinished(true);
                 break;
             case JOB_REMOVE_FINISHED:
                 // removing jobs from the global list : this job is no more managed
-                sState.getFinishedJobs().remove(js);
+                sState.removeFinished(js);
                 jobsMap.remove(js.getId());
                 jobs.remove(notification.getData().getJobId());
                 break;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -1051,6 +1051,7 @@ public class SchedulingService {
                     getListener().jobStateUpdated(job.getOwner(),
                                                   new NotificationData<JobInfo>(SchedulerEvent.JOB_REMOVE_FINISHED,
                                                                                 new JobInfoImpl((JobInfoImpl) job.getJobInfo())));
+                    getListener().jobUpdatedFullData(job);
                     wakeUpSchedulingThread();
                 }
                 longList.add(jobId.longValue());

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/RecoveredSchedulerStateTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/RecoveredSchedulerStateTest.java
@@ -37,6 +37,7 @@ import org.ow2.proactive.scheduler.core.SchedulerStateImpl;
 import org.ow2.proactive.scheduler.job.ClientJobState;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.job.InternalTaskFlowJob;
+import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.job.JobInfoImpl;
 import org.ow2.proactive.scheduler.task.internal.InternalScriptTask;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
@@ -76,13 +77,13 @@ public class RecoveredSchedulerStateTest {
         Vector<InternalJob> result = new Vector<>(count);
 
         for (int i = 0; i < count; i++) {
-            result.add(createJob(jobStatus));
+            result.add(createJob(jobStatus, i));
         }
 
         return result;
     }
 
-    public InternalJob createJob(JobStatus jobStatus) {
+    public InternalJob createJob(JobStatus jobStatus, int id) {
         InternalTaskFlowJob job = new InternalTaskFlowJob("MyJob",
                                                           JobPriority.HIGH,
                                                           OnTaskError.CANCEL_JOB,
@@ -91,6 +92,8 @@ public class RecoveredSchedulerStateTest {
         InternalScriptTask internalScriptTask = new InternalScriptTask(job);
 
         job.addTasks(ImmutableList.<InternalTask> of(internalScriptTask));
+
+        job.setId(JobIdImpl.makeJobId("" + id));
 
         JobInfoImpl jobInfo = (JobInfoImpl) job.getJobInfo();
         jobInfo.setStatus(jobStatus);


### PR DESCRIPTION
- Back-portable fix which uses in SchedulerStateImpl LinkedHashSet instead of Vector. As vector does not enforce unicity, remove only removes the first occurrence of the job in the collection.

- Additionnally, job was not removed from jobs map in SchedulerStateImpl

- TestJobRemoved was not testing anything as the scheduler state was not updated during the test.