### PR TITLE
Proactive ear wrapper

### DIFF
--- a/war-wrapper/src/main/java/org/ow2/proactive/scheduler/util/WarWrapper.java
+++ b/war-wrapper/src/main/java/org/ow2/proactive/scheduler/util/WarWrapper.java
@@ -113,7 +113,8 @@ public enum WarWrapper {
         SchedulerStarter.setPropIfNotAlreadySet(PASchedulerProperties.SCHEDULER_HOME.getKey(), schedHome);
         schedHome = System.getProperty(PASchedulerProperties.SCHEDULER_HOME.getKey());
 
-        SchedulerStarter.setPropIfNotAlreadySet(PASchedulerProperties.SCHEDULER_HOME.getKey(), schedHome);
+        PASchedulerProperties.SCHEDULER_HOME.updateProperty(schedHome);
+
         SchedulerStarter.setPropIfNotAlreadySet(PAResourceManagerProperties.RM_HOME.getKey(), schedHome);
         SchedulerStarter.setPropIfNotAlreadySet(CentralPAPropertyRepository.PA_HOME.getName(), schedHome);
         SchedulerStarter.setPropIfNotAlreadySet(CentralPAPropertyRepository.PA_CONFIGURATION_FILE.getName(),


### PR DESCRIPTION
Update property 'PASchedulerProperties.SCHEDULER_HOME' to start SchedulerHsqldbStarter properly.