### PR TITLE
#2879 : Memory Leak : LOG4J Hierarchy keeps a Hashtable of all dynamic job loggers without any cleaning strategy

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/Log4JRemover.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/Log4JRemover.java
@@ -1,0 +1,87 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.util.logforwarder;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Hashtable;
+
+import org.apache.log4j.Hierarchy;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.DefaultRepositorySelector;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 01/06/2017
+ */
+public class Log4JRemover {
+
+    private static final Logger logger = Logger.getLogger(Log4JRemover.class);
+
+    public static void removeLogger(String name) {
+        removeLogger(name, null);
+    }
+
+    public static void removeLogger(String name, Hierarchy hierarchy) {
+        try {
+
+            Hierarchy usedHierarchy;
+            if (hierarchy == null) {
+                Field repositorySelectorField = LogManager.class.getDeclaredField("repositorySelector");
+                repositorySelectorField.setAccessible(true);
+                DefaultRepositorySelector selector = (DefaultRepositorySelector) repositorySelectorField.get(null);
+
+                Field repositoryField = DefaultRepositorySelector.class.getDeclaredField("repository");
+
+                repositoryField.setAccessible(true);
+                usedHierarchy = (Hierarchy) repositoryField.get(selector);
+            } else {
+                usedHierarchy = hierarchy;
+            }
+
+            Field htField = Hierarchy.class.getDeclaredField("ht");
+            htField.setAccessible(true);
+
+            Hashtable ht = (Hashtable) htField.get(usedHierarchy);
+
+            Class categoryKeyclazz = Class.forName("org.apache.log4j.CategoryKey");
+            Constructor<?> categoryKeyConstructor = categoryKeyclazz.getDeclaredConstructor(String.class);
+
+            categoryKeyConstructor.setAccessible(true);
+
+            Object key = categoryKeyConstructor.newInstance(name);
+
+            synchronized (ht) {
+                ht.remove(key);
+            }
+
+        } catch (Exception e) {
+            logger.warn("Unable to access Log4J logger table, logger removal will be disabled", e);
+        }
+    }
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/LogForwardingService.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/LogForwardingService.java
@@ -67,6 +67,10 @@ public final class LogForwardingService {
         loggingEventProcessor.removeAllAppenders(loggerName);
     }
 
+    public void removeLogger(String loggerName) {
+        loggingEventProcessor.removeAllAppenders(loggerName);
+    }
+
     /**
      * Instantiate the LogForwardingProvider specified by providerClassname value,
      * and create and start the log server.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/LogForwardingService.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/LogForwardingService.java
@@ -105,6 +105,7 @@ public final class LogForwardingService {
      */
     public final synchronized void terminate() throws LogForwardingException {
         this.loggingEventProcessor.removeAllAppenders();
+        this.loggingEventProcessor.shutdown();
         this.serverConnection = null;
         this.initialized = false;
         this.provider.terminateServer();

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/LoggingEventProcessor.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/logforwarder/LoggingEventProcessor.java
@@ -25,22 +25,15 @@
  */
 package org.ow2.proactive.scheduler.common.util.logforwarder;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Hashtable;
-
 import org.apache.log4j.Appender;
 import org.apache.log4j.Category;
 import org.apache.log4j.Hierarchy;
 import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.RootLogger;
 
 
 public class LoggingEventProcessor {
-
-    public static final Logger logger = Logger.getLogger(LoggingEventProcessor.class);
 
     NoWarningHierarchy h = new NoWarningHierarchy();
 
@@ -50,6 +43,9 @@ public class LoggingEventProcessor {
 
     public void removeAllAppenders(String loggerName) {
         h.getLogger(loggerName).removeAllAppenders();
+    }
+
+    public void removeLogger(String loggerName) {
         h.removeLogger(loggerName);
     }
 
@@ -68,29 +64,12 @@ public class LoggingEventProcessor {
 
     private static class NoWarningHierarchy extends Hierarchy {
 
-        private Hashtable loggersTable;
-
         public NoWarningHierarchy() {
             super(new RootLogger(Level.ALL));
-
-            initLoggersTable();
-        }
-
-        private void initLoggersTable() {
-            try {
-                Field ht = Hierarchy.class.getDeclaredField("ht");
-                ht.setAccessible(true);
-                loggersTable = (Hashtable) ht.get(this);
-
-            } catch (Exception e) {
-                logger.warn("Unable to access Log4J logger table, logger removal will be disabled", e);
-            }
         }
 
         public void removeLogger(String loggerName) {
-            if (loggersTable != null) {
-                loggersTable.remove(loggerName);
-            }
+            Log4JRemover.removeLogger(loggerName, this);
         }
 
         @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLogger.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLogger.java
@@ -42,6 +42,7 @@ import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskLogs;
 import org.ow2.proactive.scheduler.common.util.TaskLoggerRelativePathGenerator;
 import org.ow2.proactive.scheduler.common.util.logforwarder.AppenderProvider;
+import org.ow2.proactive.scheduler.common.util.logforwarder.Log4JRemover;
 import org.ow2.proactive.scheduler.common.util.logforwarder.LogForwardingException;
 import org.ow2.proactive.scheduler.common.util.logforwarder.appenders.AsyncAppenderWithStorage;
 import org.ow2.proactive.scheduler.common.util.logforwarder.util.LoggingOutputStream;
@@ -72,13 +73,18 @@ public class TaskLogger {
 
     private final AtomicBoolean loggersActivated = new AtomicBoolean(false);
 
+    private final Logger taskLogger;
+
+    private final String name;
+
     public TaskLogger(TaskId taskId, String hostname) {
         logger.debug("Create task logger");
 
         this.taskId = taskId;
         this.hostname = hostname;
 
-        Logger taskLogger = createLog4jLogger(taskId);
+        taskLogger = createLog4jLogger(taskId);
+        name = taskLogger.getName();
 
         outputSink = new PrintStream(new LoggingOutputStream(taskLogger, Log4JTaskLogs.STDOUT_LEVEL), true);
         errorSink = new PrintStream(new LoggingOutputStream(taskLogger, Log4JTaskLogs.STDERR_LEVEL), true);
@@ -87,18 +93,18 @@ public class TaskLogger {
     private Logger createLog4jLogger(TaskId taskId) {
         LogLog.setQuietMode(true); // error about log should not be logged
 
-        Logger taskLogger = Logger.getLogger(Log4JTaskLogs.JOB_LOGGER_PREFIX + taskId.getJobId() + "." +
+        Logger tempLogger = Logger.getLogger(Log4JTaskLogs.JOB_LOGGER_PREFIX + taskId.getJobId() + "." +
                                              taskId.value());
-        taskLogger.setLevel(Log4JTaskLogs.STDOUT_LEVEL);
-        taskLogger.setAdditivity(false);
+        tempLogger.setLevel(Log4JTaskLogs.STDOUT_LEVEL);
+        tempLogger.setAdditivity(false);
 
         resetLogContextForImmediateService();
 
-        taskLogger.removeAllAppenders();
+        tempLogger.removeAllAppenders();
 
         taskLogAppender = new AsyncAppenderWithStorage(getLogMaxSize(taskId));
-        taskLogger.addAppender(taskLogAppender);
-        return taskLogger;
+        tempLogger.addAppender(taskLogAppender);
+        return tempLogger;
     }
 
     private int getLogMaxSize(TaskId taskId) {
@@ -114,6 +120,10 @@ public class TaskLogger {
             }
         }
         return logMaxSize;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public TaskLogs getLogs() {
@@ -215,6 +225,9 @@ public class TaskLogger {
                 if (taskLogAppender != null) {
                     taskLogAppender.close();
                 }
+
+                taskLogger.removeAllAppenders();
+                Log4JRemover.removeLogger(name);
                 logger.debug("Task logger closed");
             }
         }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
@@ -26,7 +26,9 @@
 package org.ow2.proactive.scheduler.task;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -34,8 +36,10 @@ import java.io.StringWriter;
 import java.util.regex.Pattern;
 
 import org.apache.log4j.Appender;
+import org.apache.log4j.LogManager;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.WriterAppender;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -52,11 +56,20 @@ public class TaskLoggerTest {
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
+    private TaskLogger taskLogger;
+
+    @After
+    public void removeLogger() {
+        if (taskLogger != null) {
+            taskLogger.close();
+            assertNull(LogManager.exists(taskLogger.getName()));
+        }
+    }
+
     @Test
     public void printAndGetLogs() throws Exception {
 
-        TaskLogger taskLogger = new TaskLogger(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L),
-                                               "myhost");
+        taskLogger = new TaskLogger(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L), "myhost");
 
         assertEquals("", taskLogger.getLogs().getAllLogs(false));
 
@@ -71,8 +84,7 @@ public class TaskLoggerTest {
 
     @Test
     public void logStreaming() throws Exception {
-        TaskLogger taskLogger = new TaskLogger(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L),
-                                               "myhost");
+        taskLogger = new TaskLogger(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L), "myhost");
 
         final StringWriter stringAppender = new StringWriter();
         AppenderProvider stringAppenderProvider = new AppenderProvider() {
@@ -99,8 +111,7 @@ public class TaskLoggerTest {
 
     @Test
     public void getStoredLogs() throws Exception {
-        TaskLogger taskLogger = new TaskLogger(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L),
-                                               "myhost");
+        taskLogger = new TaskLogger(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L), "myhost");
 
         final StringWriter stringAppender = new StringWriter();
         AppenderProvider stringAppenderProvider = new AppenderProvider() {
@@ -122,7 +133,7 @@ public class TaskLoggerTest {
     @Test
     public void logPattern() throws Exception {
         TaskId taskId = TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", 42L);
-        TaskLogger taskLogger = new TaskLogger(taskId, "myhost");
+        taskLogger = new TaskLogger(taskId, "myhost");
 
         assertEquals("", taskLogger.getLogs().getAllLogs(false));
 
@@ -147,7 +158,7 @@ public class TaskLoggerTest {
     public void createFileAppenderTest() throws Exception {
         JobId jobid = new JobIdImpl(1000, "job");
         TaskId taskId = TaskIdImpl.createTaskId(jobid, "task", 42L);
-        TaskLogger taskLogger = new TaskLogger(taskId, "myhost");
+        taskLogger = new TaskLogger(taskId, "myhost");
 
         File logFolder = tempFolder.newFolder("logfolder");
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/EnabledListenJobLogsSupport.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/EnabledListenJobLogsSupport.java
@@ -87,7 +87,9 @@ class EnabledListenJobLogsSupport extends ListenJobLogsSupport {
     synchronized void cleanLoggers(JobId jobId) {
         jobsToBeLogged.remove(jobId);
         jlogger.debug(jobId, "cleaning loggers");
-        lfs.removeAllAppenders(Log4JTaskLogs.getLoggerName(jobId));
+        String loggerName = Log4JTaskLogs.getLoggerName(jobId);
+        lfs.removeAllAppenders(loggerName);
+        lfs.removeLogger(loggerName);
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -28,6 +28,7 @@ package org.ow2.proactive.scheduler.core;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -488,11 +489,13 @@ public class SchedulingService {
     }
 
     public void scheduleJobRemove(JobId jobId, long at) {
-        InternalJob job = infrastructure.getDBManager().loadJobWithTasksIfNotRemoved(jobId);
+        List<InternalJob> tempJobs = infrastructure.getDBManager().loadJobWithTasksIfNotRemoved(jobId);
         boolean shouldRemoveFromDb = PASchedulerProperties.JOB_REMOVE_FROM_DB.getValueAsBoolean();
 
-        if (job != null) {
-            infrastructure.getDBManager().scheduleJobForRemoval(job.getJobInfo().getJobId(), at, shouldRemoveFromDb);
+        if (tempJobs.size() == 1) {
+            infrastructure.getDBManager().scheduleJobForRemoval(tempJobs.get(0).getJobInfo().getJobId(),
+                                                                at,
+                                                                shouldRemoveFromDb);
         }
     }
 
@@ -1043,19 +1046,29 @@ public class SchedulingService {
             List<Long> longList = new ArrayList<>(jobIdList.size());
             for (JobId jobId : jobIdList) {
                 TerminationData terminationData = jobs.removeJob(jobId);
+                ServerJobAndTaskLogs.remove(jobId);
                 submitTerminationDataHandler(terminationData);
-                InternalJob job = getInfrastructure().getDBManager().loadJobWithTasksIfNotRemoved(jobId);
+            }
+            List<InternalJob> jobsFromDB;
+            if (!jobIdList.isEmpty()) {
+                jobsFromDB = getInfrastructure().getDBManager()
+                                                .loadJobWithTasksIfNotRemoved(jobIdList.toArray(new JobId[0]));
+            } else {
+                jobsFromDB = Collections.emptyList();
+            }
+
+            for (InternalJob job : jobsFromDB) {
                 if (job != null) {
                     job.setRemovedTime(System.currentTimeMillis());
-                    ServerJobAndTaskLogs.remove(jobId);
                     getListener().jobStateUpdated(job.getOwner(),
                                                   new NotificationData<JobInfo>(SchedulerEvent.JOB_REMOVE_FINISHED,
                                                                                 new JobInfoImpl((JobInfoImpl) job.getJobInfo())));
                     getListener().jobUpdatedFullData(job);
-                    wakeUpSchedulingThread();
                 }
-                longList.add(jobId.longValue());
+                longList.add(job.getId().longValue());
             }
+
+            wakeUpSchedulingThread();
             return longList;
         }
 
@@ -1070,21 +1083,25 @@ public class SchedulingService {
         @Override
         public void run() {
             long timeNow = System.currentTimeMillis();
-            List<JobId> jobIdList = getInfrastructure().getDBManager().getJobsToRemove(timeNow);
+            try {
+                List<JobId> jobIdList = getInfrastructure().getDBManager().getJobsToRemove(timeNow);
 
-            // remove from the memory context
-            long inMemoryTimeStart = System.currentTimeMillis();
-            List<Long> longJobIdList = removeFromContext(jobIdList);
-            long inMemoryTimeStop = System.currentTimeMillis();
+                // remove from the memory context
+                long inMemoryTimeStart = System.currentTimeMillis();
+                List<Long> longJobIdList = removeFromContext(jobIdList);
+                long inMemoryTimeStop = System.currentTimeMillis();
 
-            // set the removedTime and also remove if required by the JOB_REMOVE_FROM_DB setting
-            long dbTimeStart = System.currentTimeMillis();
-            removeFromDB(longJobIdList);
-            long dbTimeStop = System.currentTimeMillis();
+                // set the removedTime and also remove if required by the JOB_REMOVE_FROM_DB setting
+                long dbTimeStart = System.currentTimeMillis();
+                removeFromDB(longJobIdList);
+                long dbTimeStop = System.currentTimeMillis();
 
-            logger.info("HOUSEKEEPING of jobs " + longJobIdList + " performed (Hibernate context removal took " +
-                        (inMemoryTimeStop - inMemoryTimeStart) + " ms" + " and db removal took " +
-                        (dbTimeStop - dbTimeStart) + " ms)");
+                logger.info("HOUSEKEEPING of jobs " + longJobIdList + " performed (Hibernate context removal took " +
+                            (inMemoryTimeStop - inMemoryTimeStart) + " ms" + " and db removal took " +
+                            (dbTimeStop - dbTimeStart) + " ms)");
+            } catch (Throwable e) {
+                logger.error("Error performing HOUSEKEEPING of jobs", e);
+            }
         }
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -853,19 +853,20 @@ public class SchedulerDBManager {
         });
     }
 
-    public InternalJob loadJobWithTasksIfNotRemoved(final JobId id) {
-        return executeReadOnlyTransaction(new SessionWork<InternalJob>() {
+    public List<InternalJob> loadJobWithTasksIfNotRemoved(final JobId... jobIds) {
+        return executeReadOnlyTransaction(new SessionWork<List<InternalJob>>() {
             @Override
-            public InternalJob doInTransaction(Session session) {
+            public List<InternalJob> doInTransaction(Session session) {
                 Query jobQuery = session.getNamedQuery("loadJobDataIfNotRemoved").setReadOnly(true);
 
-                List<InternalJob> result = new ArrayList<>();
-                batchLoadJobs(session, false, jobQuery, Collections.singletonList(jobId(id)), result);
-                if (result.isEmpty()) {
-                    return null;
-                } else {
-                    return result.get(0);
+                List<Long> ids = new ArrayList<>(jobIds.length);
+                for (JobId jobId : jobIds) {
+                    ids.add(jobId(jobId));
                 }
+
+                List<InternalJob> result = new ArrayList<>();
+                batchLoadJobs(session, false, jobQuery, ids, result);
+                return result;
             }
 
         });

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestListenJobLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestListenJobLogs.java
@@ -258,6 +258,8 @@ public class TestListenJobLogs extends SchedulerFunctionalTestWithCustomConfigAn
 
         PAActiveObject.terminateActiveObject(communicationObject1, true);
         PAActiveObject.terminateActiveObject(communicationObject2, true);
+
+        logForwardingService.removeLogger(loggerName);
     }
 
     public class TestAppender extends AppenderSkeleton {

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobRemoveHandlerTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobRemoveHandlerTest.java
@@ -28,6 +28,9 @@ package org.ow2.proactive.scheduler.core;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -85,7 +88,7 @@ public class JobRemoveHandlerTest {
         Mockito.when(infrastructure.getDBManager()).thenReturn(dbManager);
         Mockito.when(infrastructure.getRMProxiesManager()).thenReturn(rmProxiesManager);
         Mockito.when(rmProxiesManager.getRmUrl()).thenReturn(null);
-        Mockito.when(dbManager.loadJobWithTasksIfNotRemoved(jobId)).thenReturn(job);
+        Mockito.when(dbManager.loadJobWithTasksIfNotRemoved(jobId)).thenReturn(Collections.singletonList(job));
         Mockito.when(job.getJobInfo()).thenReturn(jobInfo);
         service = new SchedulingService(infrastructure, listener, null, policyClassName, schedulingMethod);
         jobRemoveHandler = new JobRemoveHandler(service, jobId);
@@ -105,7 +108,7 @@ public class JobRemoveHandlerTest {
 
     @Test
     public void testJobAlreadyRemoved() {
-        Mockito.when(dbManager.loadJobWithTasksIfNotRemoved(jobId)).thenReturn(null);
+        Mockito.when(dbManager.loadJobWithTasksIfNotRemoved(jobId)).thenReturn(new ArrayList<InternalJob>());
         boolean removed = jobRemoveHandler.call();
         assertThat(removed, is(false));
     }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingServiceTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulingServiceTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 
+import java.util.Collections;
 import java.util.Vector;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -320,7 +321,8 @@ public class SchedulingServiceTest {
 
     @Test
     public void testScheduleJobRemoveShouldUseHousekeepingButAlreadyRemoved() {
-        Mockito.when(schedulerDBManager.loadJobWithTasksIfNotRemoved(any(JobId.class))).thenReturn(null);
+        Mockito.when(schedulerDBManager.loadJobWithTasksIfNotRemoved(any(JobId.class)))
+               .thenReturn(Collections.<InternalJob> emptyList());
 
         JobId jobId = JobIdImpl.makeJobId("42");
         schedulingService.scheduleJobRemove(jobId, 42);
@@ -332,7 +334,8 @@ public class SchedulingServiceTest {
     public void testScheduleJobRemoveShouldUseHousekeeping() {
         JobId jobId = JobIdImpl.makeJobId("42");
         InternalJob mockedInternalJob = createMockedInternalJob(jobId);
-        Mockito.when(schedulerDBManager.loadJobWithTasksIfNotRemoved(any(JobId.class))).thenReturn(mockedInternalJob);
+        Mockito.when(schedulerDBManager.loadJobWithTasksIfNotRemoved(any(JobId.class)))
+               .thenReturn(Collections.singletonList(mockedInternalJob));
 
         schedulingService.scheduleJobRemove(jobId, 42);
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobOperations.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/db/schedulerdb/TestJobOperations.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.scheduler.core.db.schedulerdb;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,7 +51,9 @@ public class TestJobOperations extends BaseSchedulerDBTest {
 
         InternalJob job = defaultSubmitJob(jobDef, "user1");
 
-        job = dbManager.loadJobWithTasksIfNotRemoved(job.getId());
+        List<InternalJob> jobs = dbManager.loadJobWithTasksIfNotRemoved(job.getId());
+        Assert.assertEquals(1, jobs.size());
+        job = jobs.get(0);
         Assert.assertEquals(3, job.getTasks().size());
         Assert.assertEquals("user1", job.getOwner());
         Assert.assertEquals(3, job.getJobInfo().getTotalNumberOfTasks());
@@ -61,9 +64,9 @@ public class TestJobOperations extends BaseSchedulerDBTest {
         Assert.assertEquals(JobPriority.HIGHEST, job.getJobInfo().getPriority());
 
         dbManager.removeJob(job.getId(), System.currentTimeMillis(), false);
-        Assert.assertNull(dbManager.loadJobWithTasksIfNotRemoved(job.getId()));
+        Assert.assertTrue(dbManager.loadJobWithTasksIfNotRemoved(job.getId()).isEmpty());
 
-        Assert.assertNull(dbManager.loadJobWithTasksIfNotRemoved(JobIdImpl.makeJobId("123456789")));
+        Assert.assertTrue(dbManager.loadJobWithTasksIfNotRemoved(JobIdImpl.makeJobId("123456789")).isEmpty());
     }
 
     @Test


### PR DESCRIPTION

Use Java reflection to manually remove job logger from the Hashtable when the job is terminated