### PR TITLE
#2879 : Memory Leak : LOG4J Hierarchy keeps a Hashtable of all dynamic job and task loggers without any cleaning strategy

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogs.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogs.java
@@ -57,7 +57,7 @@ public class Log4JTaskLogs implements TaskLogs {
     private static final long serialVersionUID = 1L;
 
     /** Prefix for job logger */
-    public static final String JOB_LOGGER_PREFIX = "logger.scheduler.";
+    public static final String JOB_LOGGER_PREFIX = "schedulerloggers";
 
     public static final String MDC_JOB_ID = "job.id";
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLogger.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLogger.java
@@ -93,8 +93,7 @@ public class TaskLogger {
     private Logger createLog4jLogger(TaskId taskId) {
         LogLog.setQuietMode(true); // error about log should not be logged
 
-        Logger tempLogger = Logger.getLogger(Log4JTaskLogs.JOB_LOGGER_PREFIX + taskId.getJobId() + "." +
-                                             taskId.value());
+        Logger tempLogger = Logger.getLogger(Log4JTaskLogs.JOB_LOGGER_PREFIX + taskId.toString());
         tempLogger.setLevel(Log4JTaskLogs.STDOUT_LEVEL);
         tempLogger.setAdditivity(false);
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.log4j.Appender;
@@ -170,5 +172,18 @@ public class TaskLoggerTest {
 
         assertEquals(logAppender.getName(), new TaskLoggerRelativePathGenerator(taskId).getFileName());
 
+    }
+
+    @Test
+    public void multipleRemoveLoggers() throws Exception {
+        List<TaskLogger> loggers = new ArrayList<>(1000);
+        for (int i = 0; i < 1000; i++) {
+            loggers.add(new TaskLogger(TaskIdImpl.createTaskId(new JobIdImpl(1000, "job"), "task", i), "myhost"));
+        }
+
+        for (int i = 0; i < 1000; i++) {
+            loggers.get(i).close();
+            assertNull(LogManager.exists(loggers.get(i).getName()));
+        }
     }
 }


### PR DESCRIPTION

Change the logger names to avoid hierarchy : in case of hierarchy, parent logger keeps a reference to all children.