### PR TITLE
Improve TaskResult Rest handling

### DIFF
--- a/common/common-api/build.gradle
+++ b/common/common-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    compile 'commons-codec:commons-codec:1.10'
     compile "org.objectweb.proactive:programming-annotation:${programmingVersion}"
     compile "org.objectweb.proactive:programming-util:${programmingVersion}"
 

--- a/common/common-api/src/main/java/org/ow2/proactive/utils/ObjectByteConverter.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/utils/ObjectByteConverter.java
@@ -30,9 +30,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
+
+import org.apache.commons.codec.binary.Base64;
 
 
 /**
@@ -70,6 +75,9 @@ public final class ObjectByteConverter {
     public static final byte[] objectToByteArray(Object obj, boolean compress) throws IOException {
         ByteArrayOutputStream baos = null;
         ObjectOutputStream oos = null;
+        if (obj == null) {
+            return null;
+        }
         try {
             baos = new ByteArrayOutputStream();
             oos = new ObjectOutputStream(baos);
@@ -139,6 +147,9 @@ public final class ObjectByteConverter {
      */
     public static Object byteArrayToObject(byte[] input, boolean uncompress)
             throws IOException, ClassNotFoundException {
+        if (input == null) {
+            return null;
+        }
         if (uncompress) {
             // Uncompress the bytes
             Inflater decompressor = new Inflater();
@@ -181,6 +192,48 @@ public final class ObjectByteConverter {
                 bais.close();
             }
         }
+    }
+
+    public static String serializableToBase64String(Serializable input) throws IOException {
+        return byteArrayToBase64String(objectToByteArray(input));
+    }
+
+    public static String byteArrayToBase64String(byte[] input) {
+        if (input == null) {
+            return null;
+        }
+        return new String(Base64.encodeBase64(input));
+    }
+
+    public static byte[] base64StringToByteArray(String input) {
+        if (input == null) {
+            return null;
+        }
+        return Base64.decodeBase64(input);
+    }
+
+    public static Serializable base64StringToSerializable(String input) throws IOException, ClassNotFoundException {
+        if (input == null) {
+            return null;
+        }
+        return (Serializable) byteArrayToObject(base64StringToByteArray(input));
+    }
+
+    public static Map<String, byte[]> mapOfBase64StringToByteArray(Map<String, String> input) {
+        HashMap<String, byte[]> answer = new HashMap<>(input.size());
+        for (Map.Entry<String, String> entry : input.entrySet()) {
+            answer.put(entry.getKey(), base64StringToByteArray(entry.getValue()));
+        }
+        return answer;
+    }
+
+    public static Map<String, Serializable> mapOfByteArrayToSerializable(Map<String, byte[]> input)
+            throws IOException, ClassNotFoundException {
+        HashMap<String, Serializable> answer = new HashMap<>(input.size());
+        for (Map.Entry<String, byte[]> entry : input.entrySet()) {
+            answer.put(entry.getKey(), (Serializable) byteArrayToObject(entry.getValue()));
+        }
+        return answer;
     }
 
 }

--- a/common/common-client/build.gradle
+++ b/common/common-client/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile 'commons-codec:commons-codec:1.10'
     compile 'org.rrd4j:rrd4j:2.2.1'
     compile 'org.ow2.proactive:process-tree-killer:1.0.0'
     compile group: 'net.sf.jpam', name: 'jpam', version: '1.1'

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/TaskResultData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/TaskResultData.java
@@ -25,7 +25,6 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.dto;
 
-import java.util.Arrays;
 import java.util.Map;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -36,17 +35,23 @@ public class TaskResultData {
 
     private TaskIdData id;
 
-    private byte[] serializedValue;
+    private String serializedValue;
 
-    private byte[] serializedException;
+    private String value;
+
+    private String serializedException;
 
     private String exceptionMessage;
 
     private Map<String, String> metadata;
 
-    private Map<String, byte[]> propagatedVariables;
+    private Map<String, String> propagatedVariables;
+
+    private Map<String, String> serializedPropagatedVariables;
 
     private TaskLogsData output;
+
+    private boolean isRaw;
 
     public TaskIdData getId() {
         return id;
@@ -56,19 +61,19 @@ public class TaskResultData {
         this.id = id;
     }
 
-    public byte[] getSerializedValue() {
+    public String getSerializedValue() {
         return serializedValue;
     }
 
-    public void setSerializedValue(byte[] serializedValue) {
+    public void setSerializedValue(String serializedValue) {
         this.serializedValue = serializedValue;
     }
 
-    public byte[] getSerializedException() {
+    public String getSerializedException() {
         return serializedException;
     }
 
-    public void setSerializedException(byte[] serializedException) {
+    public void setSerializedException(String serializedException) {
         this.serializedException = serializedException;
     }
 
@@ -88,11 +93,19 @@ public class TaskResultData {
         this.exceptionMessage = exceptionMessage;
     }
 
-    public Map<String, byte[]> getPropagatedVariables() {
+    public Map<String, String> getSerializedPropagatedVariables() {
+        return serializedPropagatedVariables;
+    }
+
+    public void setSerializedPropagatedVariables(Map<String, String> serializedPropagatedVariables) {
+        this.serializedPropagatedVariables = serializedPropagatedVariables;
+    }
+
+    public Map<String, String> getPropagatedVariables() {
         return propagatedVariables;
     }
 
-    public void setPropagatedVariables(Map<String, byte[]> propagatedVariables) {
+    public void setPropagatedVariables(Map<String, String> propagatedVariables) {
         this.propagatedVariables = propagatedVariables;
     }
 
@@ -104,10 +117,27 @@ public class TaskResultData {
         this.output = output;
     }
 
+    public boolean isRaw() {
+        return isRaw;
+    }
+
+    public void setRaw(boolean isRaw) {
+        this.isRaw = isRaw;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
     @Override
     public String toString() {
-        return "TaskResultData{" + "id=" + id + ", serializedValue=" + Arrays.toString(serializedValue) +
-               ", serializedException=" + Arrays.toString(serializedException) + ", exception=" + exceptionMessage +
-               ", metadata=" + metadata + ", output=" + output + '}';
+        return "TaskResultData{" + "id=" + id + ", serializedValue=" + serializedValue + ", value=" + value +
+               ", serializedException=" + serializedException + ", exception=" + exceptionMessage + ", metadata=" +
+               metadata + ", output=" + output + ", propagatedVariables=" + propagatedVariables +
+               ", serializedPropagatedVariables=" + serializedPropagatedVariables + ", isRaw=" + isRaw + '}';
     }
 }

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/OutputCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/OutputCommand.java
@@ -28,6 +28,7 @@ package org.ow2.proactive_grid_cloud_portal.cli.cmd;
 import java.io.File;
 import java.util.Stack;
 
+import org.ow2.proactive.utils.ObjectByteConverter;
 import org.ow2.proactive_grid_cloud_portal.cli.ApplicationContext;
 import org.ow2.proactive_grid_cloud_portal.cli.CLIException;
 import org.ow2.proactive_grid_cloud_portal.cli.utils.FileUtility;
@@ -53,7 +54,8 @@ public class OutputCommand extends AbstractCommand implements Command {
             if (result instanceof String) {
                 FileUtility.writeStringToFile(outFile, (String) result);
             } else if (result instanceof TaskResultData) {
-                FileUtility.writeByteArrayToFile(((TaskResultData) result).getSerializedValue(), outFile);
+                FileUtility.writeByteArrayToFile(ObjectByteConverter.base64StringToByteArray(((TaskResultData) result).getSerializedValue()),
+                                                 outFile);
             } else {
                 FileUtility.writeObjectToFile(result, outFile);
             }

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/StringUtility.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/StringUtility.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive_grid_cloud_portal.cli.utils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +36,7 @@ import java.util.Set;
 
 import org.apache.commons.codec.binary.StringUtils;
 import org.ow2.proactive.utils.ObjectArrayFormatter;
+import org.ow2.proactive.utils.ObjectByteConverter;
 import org.ow2.proactive.utils.Tools;
 import org.ow2.proactive_grid_cloud_portal.cli.json.MBeanInfoView;
 import org.ow2.proactive_grid_cloud_portal.cli.json.NodeEventView;
@@ -231,13 +233,15 @@ public final class StringUtility {
     }
 
     public static String jobResultAsString(String id,
-            org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobResultData jobResult) {
+            org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobResultData jobResult)
+            throws IOException, ClassNotFoundException {
         StringBuilder buffer = new StringBuilder();
         buffer.append(String.format("%s result:\n", id));
         Map<String, TaskResultData> allResults = jobResult.getAllResults();
-        for (String taskName : allResults.keySet()) {
-            buffer.append(String.format(taskName + " : " +
-                                        ObjectUtility.object(allResults.get(taskName).getSerializedValue())))
+        for (Map.Entry<String, TaskResultData> entry : allResults.entrySet()) {
+            buffer.append(String.format(entry.getKey() + " : " +
+                                        ObjectUtility.object(ObjectByteConverter.base64StringToByteArray(entry.getValue()
+                                                                                                              .getSerializedValue()))))
                   .append('\n');
         }
         return buffer.toString();
@@ -388,7 +392,7 @@ public final class StringUtility {
         return row;
     }
 
-    public static String taskResultsAsString(List<TaskResultData> results) {
+    public static String taskResultsAsString(List<TaskResultData> results) throws IOException, ClassNotFoundException {
         StringBuffer buf = new StringBuffer();
         for (TaskResultData currentResult : results) {
             buf.append(taskResultAsString(currentResult.getId().getReadableName(), currentResult));
@@ -398,8 +402,12 @@ public final class StringUtility {
     }
 
     public static String taskResultAsString(String id,
-            org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskResultData taskResult) {
-        return String.format("%s result: %s", id, ObjectUtility.object(taskResult.getSerializedValue()).toString());
+            org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskResultData taskResult)
+            throws IOException, ClassNotFoundException {
+        return String.format("%s result: %s",
+                             id,
+                             ObjectUtility.object(ObjectByteConverter.base64StringToByteArray(taskResult.getSerializedValue()))
+                                          .toString());
     }
 
     public static String statsAsString(Map<String, String> stats) {

--- a/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/scheduler/GetJobResultCommandTest.java
+++ b/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/scheduler/GetJobResultCommandTest.java
@@ -39,11 +39,13 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.ow2.proactive.utils.ObjectByteConverter;
 import org.ow2.proactive_grid_cloud_portal.cli.cmd.sched.GetJobResultCommand;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobResultData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskResultData;
 
 import objectFaker.DataFaker;
+import objectFaker.propertyGenerator.FixedPropertyGenerator;
 import objectFaker.propertyGenerator.PrefixPropertyGenerator;
 
 
@@ -61,11 +63,15 @@ public class GetJobResultCommandTest extends AbstractJobTagCommandTest {
         jobResultFaker.setGenerator("id.readableName", new PrefixPropertyGenerator("job", 1));
         jobResultFaker.setGenerator("allResults.key", new PrefixPropertyGenerator("task", 1));
         jobResultFaker.setGenerator("allResults.value.id.readableName", new PrefixPropertyGenerator("task", 1));
+        jobResultFaker.setGenerator("allResults.value.serializedValue",
+                                    new FixedPropertyGenerator(ObjectByteConverter.serializableToBase64String("Hello")));
 
         jobResult = jobResultFaker.fake();
 
         DataFaker<TaskResultData> taskResultsDataFaker = new DataFaker<TaskResultData>(TaskResultData.class);
         taskResultsDataFaker.setGenerator("id.readableName", new PrefixPropertyGenerator("task", 4));
+        taskResultsDataFaker.setGenerator("serializedValue",
+                                          new FixedPropertyGenerator(ObjectByteConverter.serializableToBase64String("Hello")));
 
         taskResults = taskResultsDataFaker.fakeList(3);
     }
@@ -78,9 +84,9 @@ public class GetJobResultCommandTest extends AbstractJobTagCommandTest {
         System.out.println(out);
 
         assertThat(out, containsString("job('1') result:"));
-        assertThat(out, containsString("task1 : serializedValue1"));
-        assertThat(out, containsString("task2 : serializedValue2"));
-        assertThat(out, containsString("task3 : serializedValue3"));
+        assertThat(out, containsString("task1 : Hello"));
+        assertThat(out, containsString("task2 : Hello"));
+        assertThat(out, containsString("task3 : Hello"));
     }
 
     @Test
@@ -91,9 +97,9 @@ public class GetJobResultCommandTest extends AbstractJobTagCommandTest {
         String out = capturedOutput.toString();
         System.out.println(out);
 
-        assertThat(out, containsString("task4 result: serializedValue1"));
-        assertThat(out, containsString("task5 result: serializedValue2"));
-        assertThat(out, containsString("task6 result: serializedValue3"));
+        assertThat(out, containsString("task4 result: Hello"));
+        assertThat(out, containsString("task5 result: Hello"));
+        assertThat(out, containsString("task6 result: Hello"));
     }
 
     @Test

--- a/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
@@ -49,6 +49,7 @@ import org.ow2.proactive.scheduler.common.NotificationData;
 import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.SchedulerEventListener;
 import org.ow2.proactive.scheduler.common.SchedulerStatus;
+import org.ow2.proactive.scheduler.common.exception.TaskAbortedException;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
@@ -358,7 +359,10 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
 
         client.removeEventListener();
         // should return immediately
-        client.waitForJob(jobId, TimeUnit.MINUTES.toMillis(3));
+        JobResult result = client.waitForJob(jobId, TimeUnit.MINUTES.toMillis(3));
+        TaskResult tresult = result.getResult(getTaskName(NonTerminatingJob.class));
+        Assert.assertTrue(tresult.hadException());
+        Assert.assertTrue(tresult.getException() instanceof TaskAbortedException);
     }
 
     @Test(timeout = MAX_WAIT_TIME)

--- a/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
@@ -29,6 +29,7 @@ import static functionaltests.RestFuncTHelper.getRestServerUrl;
 import static functionaltests.jobs.SimpleJob.TEST_JOB;
 
 import java.io.File;
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URL;
 import java.util.Map;
@@ -68,6 +69,7 @@ import org.ow2.proactive.scheduler.rest.SchedulerClient;
 import org.ow2.proactive.scheduler.task.exceptions.TaskException;
 import org.ow2.proactive.scripting.SimpleScript;
 import org.ow2.proactive.scripting.TaskScript;
+import org.ow2.proactive.utils.ObjectByteConverter;
 
 import com.google.common.io.Files;
 
@@ -75,6 +77,7 @@ import functionaltests.jobs.ErrorTask;
 import functionaltests.jobs.LogTask;
 import functionaltests.jobs.MetadataTask;
 import functionaltests.jobs.NonTerminatingJob;
+import functionaltests.jobs.RawTask;
 import functionaltests.jobs.SimpleJob;
 import functionaltests.jobs.VariableTask;
 
@@ -136,7 +139,8 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
                                      ErrorTask.class,
                                      LogTask.class,
                                      VariableTask.class,
-                                     MetadataTask.class);
+                                     MetadataTask.class,
+                                     RawTask.class);
         JobId jobId = submitJob(job, client);
         JobResult result = client.waitForJob(jobId, TimeUnit.MINUTES.toMillis(3));
         // job result
@@ -170,7 +174,10 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         // task result simple
         TaskResult tResSimple = result.getResult(getTaskNameForClass(SimpleJob.class));
         Assert.assertNotNull(tResSimple.value());
+        Assert.assertNotNull(tResSimple.getSerializedValue());
         Assert.assertEquals(new StringWrapper(TEST_JOB), tResSimple.value());
+        Assert.assertEquals(new StringWrapper(TEST_JOB),
+                            ObjectByteConverter.byteArrayToObject(tResSimple.getSerializedValue()));
 
         // task result with error
         TaskResult tResError = result.getResult(getTaskNameForClass(ErrorTask.class));
@@ -189,12 +196,23 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         // task result with variables
         TaskResult tResVar = result.getResult(getTaskNameForClass(VariableTask.class));
         Assert.assertNotNull(tResVar.getPropagatedVariables());
+        Map<String, Serializable> vars = tResVar.getVariables();
+        System.out.println(vars);
         Assert.assertTrue(tResVar.getPropagatedVariables().containsKey(VariableTask.MYVAR));
+        Assert.assertEquals("myvalue", vars.get(VariableTask.MYVAR));
 
         // task result with metadata
         TaskResult tMetaVar = result.getResult(getTaskNameForClass(MetadataTask.class));
         Assert.assertNotNull(tMetaVar.getMetadata());
         Assert.assertTrue(tMetaVar.getMetadata().containsKey(MetadataTask.MYVAR));
+
+        // task result with raw result
+
+        TaskResult tResRaw = result.getResult(getTaskNameForClass(RawTask.class));
+        Assert.assertNotNull(tResRaw.value());
+        Assert.assertNotNull(tResRaw.getSerializedValue());
+        Assert.assertEquals(TEST_JOB.getBytes(), tResRaw.value());
+        Assert.assertEquals(TEST_JOB.getBytes(), tResRaw.getSerializedValue());
 
     }
 

--- a/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
@@ -212,8 +212,8 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         TaskResult tResRaw = result.getResult(getTaskNameForClass(RawTask.class));
         Assert.assertNotNull(tResRaw.value());
         Assert.assertNotNull(tResRaw.getSerializedValue());
-        Assert.assertEquals(TEST_JOB.getBytes(), tResRaw.value());
-        Assert.assertEquals(TEST_JOB.getBytes(), tResRaw.getSerializedValue());
+        Assert.assertArrayEquals(TEST_JOB.getBytes(), (byte[]) tResRaw.value());
+        Assert.assertArrayEquals(TEST_JOB.getBytes(), tResRaw.getSerializedValue());
 
     }
 
@@ -228,8 +228,8 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
 
     private void checkJobInfo(JobInfo jobInfo) {
         Assert.assertNotNull(jobInfo);
-        Assert.assertEquals(5, jobInfo.getTotalNumberOfTasks());
-        Assert.assertEquals(5, jobInfo.getNumberOfFinishedTasks());
+        Assert.assertEquals(6, jobInfo.getTotalNumberOfTasks());
+        Assert.assertEquals(6, jobInfo.getNumberOfFinishedTasks());
         Assert.assertEquals(1, jobInfo.getNumberOfFaultyTasks());
     }
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/ByteArrayToBase64StringCustomConverter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/ByteArrayToBase64StringCustomConverter.java
@@ -23,34 +23,35 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive_grid_cloud_portal.utils;
+package org.ow2.proactive_grid_cloud_portal.scheduler.dto;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-
+import org.dozer.DozerConverter;
 import org.ow2.proactive.utils.ObjectByteConverter;
 
 
-public class ObjectUtility {
+/**
+ * @author ActiveEon Team
+ * @since 16/06/2017
+ */
+public class ByteArrayToBase64StringCustomConverter extends DozerConverter<byte[], String> {
 
-    public static Object object(byte[] bytes) throws IOException, ClassNotFoundException {
-        if (bytes == null) {
-            return "[NULL]";
-        }
-        Object answer;
-        try {
-            answer = ObjectByteConverter.byteArrayToObject(bytes);
-        } catch (ClassNotFoundException cnfe) {
-            return String.format("[De-serialization error : %s]", cnfe.getMessage());
-        } catch (IOException ioe) {
-            return String.format("[De-serialization error : %s]", ioe.getMessage());
-        }
-        if (answer instanceof byte[]) {
-            return "[RAW DATA]";
-        }
-        return answer;
-
+    public ByteArrayToBase64StringCustomConverter() {
+        super(byte[].class, String.class);
     }
 
+    @Override
+    public String convertTo(byte[] source, String destination) {
+        if (source == null) {
+            return null;
+        }
+        return ObjectByteConverter.byteArrayToBase64String(source);
+    }
+
+    @Override
+    public byte[] convertFrom(String source, byte[] destination) {
+        if (source == null) {
+            return null;
+        }
+        return ObjectByteConverter.base64StringToByteArray(source);
+    }
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/PropagatedVariablesCustomConverter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/PropagatedVariablesCustomConverter.java
@@ -1,0 +1,66 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.scheduler.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dozer.DozerConverter;
+import org.ow2.proactive.utils.ObjectByteConverter;
+
+
+public class PropagatedVariablesCustomConverter extends DozerConverter<Map, Map> {
+
+    public PropagatedVariablesCustomConverter() {
+        super(Map.class, Map.class);
+    }
+
+    @Override
+    public Map convertTo(Map source, Map destination) {
+        if (source == null) {
+            return null;
+        }
+
+        Map<String, byte[]> converted = new HashMap<>();
+        for (Map.Entry<String, String> entry : ((Map<String, String>) source).entrySet()) {
+            converted.put(entry.getKey(), ObjectByteConverter.base64StringToByteArray(entry.getValue()));
+        }
+        return converted;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map convertFrom(Map source, Map destination) {
+        if (source == null) {
+            return null;
+        }
+        Map<String, String> converted = new HashMap<>();
+        for (Map.Entry<String, byte[]> entry : ((Map<String, byte[]>) source).entrySet()) {
+            converted.put(entry.getKey(), ObjectByteConverter.byteArrayToBase64String(entry.getValue()));
+        }
+        return converted;
+    }
+}

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/SerializableToStringCustomConverter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/SerializableToStringCustomConverter.java
@@ -23,34 +23,42 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive_grid_cloud_portal.utils;
+package org.ow2.proactive_grid_cloud_portal.scheduler.dto;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
+import java.io.Serializable;
 
+import org.apache.log4j.Logger;
+import org.dozer.DozerConverter;
 import org.ow2.proactive.utils.ObjectByteConverter;
 
 
-public class ObjectUtility {
+/**
+ * @author ActiveEon Team
+ * @since 16/06/2017
+ */
+public class SerializableToStringCustomConverter extends DozerConverter<Serializable, String> {
 
-    public static Object object(byte[] bytes) throws IOException, ClassNotFoundException {
-        if (bytes == null) {
-            return "[NULL]";
-        }
-        Object answer;
-        try {
-            answer = ObjectByteConverter.byteArrayToObject(bytes);
-        } catch (ClassNotFoundException cnfe) {
-            return String.format("[De-serialization error : %s]", cnfe.getMessage());
-        } catch (IOException ioe) {
-            return String.format("[De-serialization error : %s]", ioe.getMessage());
-        }
-        if (answer instanceof byte[]) {
-            return "[RAW DATA]";
-        }
-        return answer;
+    private static final Logger logger = Logger.getLogger(SerializableToStringCustomConverter.class);
 
+    public SerializableToStringCustomConverter() {
+        super(Serializable.class, String.class);
     }
 
+    @Override
+    public String convertTo(Serializable source, String destination) {
+        if (source == null) {
+            return null;
+        }
+        try {
+            return source.toString();
+        } catch (Exception e) {
+            logger.error("Error when converting result to json", e);
+            return null;
+        }
+    }
+
+    @Override
+    public byte[] convertFrom(String source, Serializable destination) {
+        return null;
+    }
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/StringPropagatedVariablesCustomConverter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/StringPropagatedVariablesCustomConverter.java
@@ -1,0 +1,67 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.scheduler.dto;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.dozer.DozerConverter;
+import org.ow2.proactive.utils.ObjectByteConverter;
+
+
+public class StringPropagatedVariablesCustomConverter extends DozerConverter<Map, Map> {
+
+    private static final Logger logger = Logger.getLogger(StringPropagatedVariablesCustomConverter.class);
+
+    public StringPropagatedVariablesCustomConverter() {
+        super(Map.class, Map.class);
+    }
+
+    @Override
+    public Map convertTo(Map source, Map destination) {
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map convertFrom(Map source, Map destination) {
+        if (source == null) {
+            return null;
+        }
+        Map<String, String> converted = new HashMap<>();
+        for (Map.Entry<String, byte[]> entry : ((Map<String, byte[]>) source).entrySet()) {
+            try {
+                converted.put(entry.getKey(), ObjectByteConverter.byteArrayToObject(entry.getValue()).toString());
+            } catch (Exception e) {
+                logger.error("Error when converting variables to json", e);
+                return null;
+            }
+        }
+        return converted;
+    }
+}

--- a/rest/rest-server/src/main/resources/org/ow2/proactive_grid_cloud_portal/scheduler/dozer-mappings.xml
+++ b/rest/rest-server/src/main/resources/org/ow2/proactive_grid_cloud_portal/scheduler/dozer-mappings.xml
@@ -81,7 +81,7 @@
 		<field custom-converter=
 					   "org.ow2.proactive_grid_cloud_portal.scheduler.dto.SerializableToStringCustomConverter">
 			<a>value</a>
-			<b>value</b>
+			<b get-method="getValue">value</b>
 		</field>
 		<field custom-converter=
 					   "org.ow2.proactive_grid_cloud_portal.scheduler.dto.ByteArrayToBase64StringCustomConverter">

--- a/rest/rest-server/src/main/resources/org/ow2/proactive_grid_cloud_portal/scheduler/dozer-mappings.xml
+++ b/rest/rest-server/src/main/resources/org/ow2/proactive_grid_cloud_portal/scheduler/dozer-mappings.xml
@@ -73,11 +73,18 @@
 			<a>id</a>
 			<b>taskId</b>
 		</field>
-		<field>
+		<field custom-converter=
+					   "org.ow2.proactive_grid_cloud_portal.scheduler.dto.ByteArrayToBase64StringCustomConverter">
 			<a>serializedValue</a>
 			<b>serializedValue</b>
 		</field>
-		<field>
+		<field custom-converter=
+					   "org.ow2.proactive_grid_cloud_portal.scheduler.dto.SerializableToStringCustomConverter">
+			<a>value</a>
+			<b>value</b>
+		</field>
+		<field custom-converter=
+					   "org.ow2.proactive_grid_cloud_portal.scheduler.dto.ByteArrayToBase64StringCustomConverter">
 			<a>serializedException</a>
 			<b>serializedException</b>
 		</field>
@@ -89,7 +96,13 @@
 			<a>metadata</a>
 			<b>metadata</b>
 		</field>
-		<field>
+		<field custom-converter=
+					   "org.ow2.proactive_grid_cloud_portal.scheduler.dto.PropagatedVariablesCustomConverter">
+			<a>serializedPropagatedVariables</a>
+			<b>propagatedVariables</b>
+		</field>
+		<field custom-converter=
+					   "org.ow2.proactive_grid_cloud_portal.scheduler.dto.StringPropagatedVariablesCustomConverter">
 			<a>propagatedVariables</a>
 			<b>propagatedVariables</b>
 		</field>
@@ -97,6 +110,10 @@
 			<a>output</a>
 			<b>output</b>
 			<a-hint>org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskLogsData</a-hint>
+		</field>
+		<field>
+			<a>raw</a>
+			<b>raw</b>
 		</field>
 	</mapping>
 

--- a/rest/rest-server/src/test/java/functionaltests/jobs/RawTask.java
+++ b/rest/rest-server/src/test/java/functionaltests/jobs/RawTask.java
@@ -23,34 +23,23 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive_grid_cloud_portal.utils;
+package functionaltests.jobs;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
+import static functionaltests.jobs.SimpleJob.TEST_JOB;
 
-import org.ow2.proactive.utils.ObjectByteConverter;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+
+import org.objectweb.proactive.core.util.wrapper.StringWrapper;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.common.task.executable.JavaExecutable;
 
 
-public class ObjectUtility {
+public class RawTask extends JavaExecutable {
 
-    public static Object object(byte[] bytes) throws IOException, ClassNotFoundException {
-        if (bytes == null) {
-            return "[NULL]";
-        }
-        Object answer;
-        try {
-            answer = ObjectByteConverter.byteArrayToObject(bytes);
-        } catch (ClassNotFoundException cnfe) {
-            return String.format("[De-serialization error : %s]", cnfe.getMessage());
-        } catch (IOException ioe) {
-            return String.format("[De-serialization error : %s]", ioe.getMessage());
-        }
-        if (answer instanceof byte[]) {
-            return "[RAW DATA]";
-        }
-        return answer;
-
+    @Override
+    public Serializable execute(TaskResult... results) throws Throwable {
+        return TEST_JOB.getBytes();
     }
 
 }

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestJobTaskResultTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestJobTaskResultTest.java
@@ -65,7 +65,8 @@ public class SchedulerStateRestJobTaskResultTest extends RestTestServer {
                                                                                             1),
                                                                     null,
                                                                     new byte[0],
-                                                                    null);
+                                                                    null,
+                                                                    false);
         when(mockOfScheduler.getTaskResult("42", "mytask")).thenReturn(taskResultWithException);
 
         String exceptionStackTrace = (String) restInterface.valueOfTaskResult(sessionId, "42", "mytask");
@@ -80,7 +81,8 @@ public class SchedulerStateRestJobTaskResultTest extends RestTestServer {
                                                                                             1),
                                                                     null,
                                                                     new byte[0],
-                                                                    null);
+                                                                    null,
+                                                                    false);
         JobResultImpl jobResultWithException = new JobResultImpl();
         jobResultWithException.addTaskResult("mytask", taskResultWithException, false);
         when(mockOfScheduler.getJobResult("42")).thenReturn(jobResultWithException);

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/webapp/NoVncSecuredTargetResolverTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/webapp/NoVncSecuredTargetResolverTest.java
@@ -84,15 +84,16 @@ public class NoVncSecuredTargetResolverTest {
     @Test
     public void testMagicStringFoundInLogs() throws Exception {
         String sessionId = SharedSessionStoreTestUtils.createValidSession(schedulerMock);
-        when(schedulerMock.getTaskResult("42",
-                                         "remoteVisuTask")).thenReturn(new TaskResultImpl(TaskIdImpl.createTaskId(new JobIdImpl(42,
-                                                                                                                                "job"),
-                                                                                                                  "remoteVisuTask",
-                                                                                                                  1),
-                                                                                          new byte[0],
-                                                                                          new byte[0],
-                                                                                          new SimpleTaskLogs("PA_REMOTE_CONNECTION;42;1;vnc;node.grid.com:5900",
-                                                                                                             "")));
+        when(schedulerMock.getTaskResult("42", "remoteVisuTask")).thenReturn(new TaskResultImpl(
+                                                                                                TaskIdImpl.createTaskId(new JobIdImpl(42,
+                                                                                                                                      "job"),
+                                                                                                                        "remoteVisuTask",
+                                                                                                                        1),
+                                                                                                new byte[0],
+                                                                                                new byte[0],
+                                                                                                new SimpleTaskLogs("PA_REMOTE_CONNECTION;42;1;vnc;node.grid.com:5900",
+                                                                                                                   ""),
+                                                                                                true));
 
         InetSocketAddress targetVncHost = new NoVncSecuredTargetResolver().doResolve(sessionId, "42", "remoteVisuTask");
 
@@ -103,15 +104,16 @@ public class NoVncSecuredTargetResolverTest {
     @Test
     public void testMagicStringFoundInLogs_MagicStringOnSeveralLines() throws Exception {
         String sessionId = SharedSessionStoreTestUtils.createValidSession(schedulerMock);
-        when(schedulerMock.getTaskResult("42",
-                                         "remoteVisuTask")).thenReturn(new TaskResultImpl(TaskIdImpl.createTaskId(new JobIdImpl(42,
-                                                                                                                                "job"),
-                                                                                                                  "remoteVisuTask",
-                                                                                                                  1),
-                                                                                          new byte[0],
-                                                                                          new byte[0],
-                                                                                          new SimpleTaskLogs("PA_REMOTE_CONNECTION\nPA_REMOTE_CONNECTION;42;1;vnc;node.grid.com:5900",
-                                                                                                             "")));
+        when(schedulerMock.getTaskResult("42", "remoteVisuTask")).thenReturn(new TaskResultImpl(
+                                                                                                TaskIdImpl.createTaskId(new JobIdImpl(42,
+                                                                                                                                      "job"),
+                                                                                                                        "remoteVisuTask",
+                                                                                                                        1),
+                                                                                                new byte[0],
+                                                                                                new byte[0],
+                                                                                                new SimpleTaskLogs("PA_REMOTE_CONNECTION\nPA_REMOTE_CONNECTION;42;1;vnc;node.grid.com:5900",
+                                                                                                                   ""),
+                                                                                                true));
 
         InetSocketAddress targetVncHost = new NoVncSecuredTargetResolver().doResolve(sessionId, "42", "remoteVisuTask");
 
@@ -143,14 +145,16 @@ public class NoVncSecuredTargetResolverTest {
                           .getJobsOutputController()
                           .addJobOutputAppender("42",
                                                 createLiveLogs("[Visualization_task@node2;10:38:06]PA_REMOTE_CONNECTION;42;1;vnc;node.grid.com:5900"));
-        when(schedulerMock.getTaskResult("42",
-                                         "remoteVisuTask")).thenReturn(new TaskResultImpl(TaskIdImpl.createTaskId(new JobIdImpl(42,
-                                                                                                                                "job"),
-                                                                                                                  "remoteVisuTask",
-                                                                                                                  1),
-                                                                                          new byte[0],
-                                                                                          new byte[0],
-                                                                                          new SimpleTaskLogs("", "")));
+        when(schedulerMock.getTaskResult("42", "remoteVisuTask")).thenReturn(new TaskResultImpl(
+                                                                                                TaskIdImpl.createTaskId(new JobIdImpl(42,
+                                                                                                                                      "job"),
+                                                                                                                        "remoteVisuTask",
+                                                                                                                        1),
+                                                                                                new byte[0],
+                                                                                                new byte[0],
+                                                                                                new SimpleTaskLogs("",
+                                                                                                                   ""),
+                                                                                                true));
 
         InetSocketAddress targetVncHost = new NoVncSecuredTargetResolver().doResolve(sessionId, "42", "remoteVisuTask");
 
@@ -166,14 +170,16 @@ public class NoVncSecuredTargetResolverTest {
                           .getJobsOutputController()
                           .addJobOutputAppender("42",
                                                 createLiveLogs("PA_REMOTE_CONNECTION\nPA_REMOTE_CONNECTION;42;1;vnc;node.grid.com:5900 "));
-        when(schedulerMock.getTaskResult("42",
-                                         "remoteVisuTask")).thenReturn(new TaskResultImpl(TaskIdImpl.createTaskId(new JobIdImpl(42,
-                                                                                                                                "job"),
-                                                                                                                  "remoteVisuTask",
-                                                                                                                  1),
-                                                                                          new byte[0],
-                                                                                          new byte[0],
-                                                                                          new SimpleTaskLogs("", "")));
+        when(schedulerMock.getTaskResult("42", "remoteVisuTask")).thenReturn(new TaskResultImpl(
+                                                                                                TaskIdImpl.createTaskId(new JobIdImpl(42,
+                                                                                                                                      "job"),
+                                                                                                                        "remoteVisuTask",
+                                                                                                                        1),
+                                                                                                new byte[0],
+                                                                                                new byte[0],
+                                                                                                new SimpleTaskLogs("",
+                                                                                                                   ""),
+                                                                                                true));
 
         InetSocketAddress targetVncHost = new NoVncSecuredTargetResolver().doResolve(sessionId, "42", "remoteVisuTask");
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskResult.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskResult.java
@@ -71,10 +71,9 @@ public interface TaskResult extends Serializable {
     Serializable value() throws Throwable;
 
     /**
-     * Get the value of the task. Throw the exception if the task generate
+     * Get the value of the task. Returns null if an exception occurred during the task execution
      *
      * @return the value of the task.
-     * @throws Throwable If the value has generate an exception.
      */
     Serializable getValue() throws Throwable;
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskResult.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskResult.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.scheduler.common.task;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -70,6 +71,14 @@ public interface TaskResult extends Serializable {
     Serializable value() throws Throwable;
 
     /**
+     * Get the value of the task. Throw the exception if the task generate
+     *
+     * @return the value of the task.
+     * @throws Throwable If the value has generate an exception.
+     */
+    Serializable getValue() throws Throwable;
+
+    /**
      * Get the serialized value of the task.
      *
      * @return the value of the task, null if an exception occurred.
@@ -113,6 +122,22 @@ public interface TaskResult extends Serializable {
      */
     TaskLogs getOutput();
 
+    /**
+     * Return the content of propagated variables, in byte array format
+     * @return a map of byte arrays
+     */
     Map<String, byte[]> getPropagatedVariables();
+
+    /**
+     * Returns the deserialized version of the propagated variables
+     * @return a map of variables
+     */
+    Map<String, Serializable> getVariables() throws IOException, ClassNotFoundException;
+
+    /**
+     * Returns true if this result contains raw data (i.e. a byte array) instead of an object
+     * @return result object type
+     */
+    boolean isRaw();
 
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/TaskResultImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/TaskResultImpl.java
@@ -280,7 +280,7 @@ public class TaskResultImpl implements TaskResult {
 
     @Override
     public Serializable getValue() throws Throwable {
-        return value();
+        return value;
     }
 
     /**

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/InProcessTaskExecutorTest.java
@@ -291,7 +291,8 @@ public class InProcessTaskExecutorTest {
                                                                  null,
                                                                  null,
                                                                  null,
-                                                                 SerializationUtil.serializeVariableMap(variablesFromParent)) };
+                                                                 SerializationUtil.serializeVariableMap(variablesFromParent),
+                                                                 false) };
 
         new InProcessTaskExecutor().execute(new TaskContext(new ScriptExecutableContainer(new TaskScript(new SimpleScript("print(variables.get('var'));print(variables.get('PA_TASK_ID'))",
                                                                                                                           "groovy"))),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
@@ -62,6 +62,8 @@ public class TaskResultData {
 
     private byte[] serializedException;
 
+    private Boolean isRaw;
+
     private String previewerClassName;
 
     private Map<String, byte[]> propagatedVariables;
@@ -79,7 +81,8 @@ public class TaskResultData {
                                                    getSerializedException(),
                                                    getLogs(),
                                                    getMetadata(),
-                                                   getPropagatedVariables());
+                                                   getPropagatedVariables(),
+                                                   isRaw());
 
         result.setPreviewerClassName(getPreviewerClassName());
         FlowActionData actionData = getFlowAction();
@@ -105,6 +108,7 @@ public class TaskResultData {
         resultData.setSerializedException(result.getSerializedException());
         resultData.setSerializedValue(result.getSerializedValue());
         resultData.setResultTime(System.currentTimeMillis());
+        resultData.setRaw(result.isRaw());
 
         FlowAction flowAction = result.getAction();
         if (flowAction != null) {
@@ -218,5 +222,17 @@ public class TaskResultData {
 
     public void setPropagatedVariables(Map<String, byte[]> executionVariables) {
         this.propagatedVariables = executionVariables;
+    }
+
+    @Column(name = "RAW", nullable = true)
+    public Boolean isRaw() {
+        if (isRaw == null) {
+            return false;
+        }
+        return isRaw;
+    }
+
+    public void setRaw(Boolean isRaw) {
+        this.isRaw = isRaw;
     }
 }


### PR DESCRIPTION
- fix issues related to raw results (byte array), add a isRaw information to know that the result is in byte array format and should not be deserialized using an ObjectInputStream
- use Base64 conversion for TaskResult's serialized objects in dozer mappings
- Enable variable retrieval from the rest TaskResult (TaskResultData). Variables are accessible either in serialized/base64 format or in text format (toString)