### PR TITLE
Set constant serialUID in Client class

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/Client.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/Client.java
@@ -58,6 +58,10 @@ import org.ow2.proactive.resourcemanager.core.history.UserHistory;
  */
 public class Client implements Serializable {
 
+    // This serial version uid is meant to prevent issues when restoring Resource Manager database from a previous version.
+    // any addition to this class (new method, field, etc) should imply to change this uid.
+    private static final long serialVersionUID = 1L;
+
     /** The security entity that represents this client */
     private final Subject subject;
 


### PR DESCRIPTION
To prevent compatibility issues when serializing in the database