### PR TITLE
TaskProActiveDataspaces : find files to copy in parallel

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspaces.java
@@ -409,19 +409,15 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             ArrayList<DataSpacesFileObject> globalSpaceCacheFiles = new ArrayList<>();
             ArrayList<DataSpacesFileObject> userSpaceCacheFiles = new ArrayList<>();
 
-            FileSystemException exception = findFilesToCopyFromInput(inputSelectors,
-                                                                     inputSpaceFiles,
-                                                                     outputSpaceFiles,
-                                                                     globalSpaceFiles,
-                                                                     userSpaceFiles,
-                                                                     inputSpaceCacheFiles,
-                                                                     outputSpaceCacheFiles,
-                                                                     globalSpaceCacheFiles,
-                                                                     userSpaceCacheFiles);
-
-            if (exception != null) {
-                throw exception;
-            }
+            findFilesToCopyFromInput(inputSelectors,
+                                     inputSpaceFiles,
+                                     outputSpaceFiles,
+                                     globalSpaceFiles,
+                                     userSpaceFiles,
+                                     inputSpaceCacheFiles,
+                                     outputSpaceCacheFiles,
+                                     globalSpaceCacheFiles,
+                                     userSpaceCacheFiles);
 
             String inputSpaceUri = virtualResolve(INPUT);
             String outputSpaceUri = virtualResolve(OUTPUT);
@@ -446,7 +442,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
 
                     List<Future<Boolean>> transferFuturesCache = doCopyInputDataToSpace(CACHE, filesToCopyToCache);
 
-                    handleResults(transferFuturesCache);
+                    handleResultsWhileTransferringFile(transferFuturesCache);
                 } finally {
                     if (cacheTransferPresent) {
                         cacheTransferLock.unlock();
@@ -469,7 +465,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
 
             List<Future<Boolean>> transferFuturesScratch = doCopyInputDataToSpace(SCRATCH, filesToCopyToScratch);
 
-            handleResults(transferFuturesScratch);
+            handleResultsWhileTransferringFile(transferFuturesScratch);
 
         } finally {
             // display dataspaces error and warns if any
@@ -620,7 +616,8 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         }
     }
 
-    protected void handleResults(List<Future<Boolean>> transferFutures) throws FileSystemException {
+    protected void handleResultsWhileTransferringFile(List<Future<Boolean>> transferFutures)
+            throws FileSystemException {
 
         StringBuilder message = new StringBuilder();
         String nl = System.lineSeparator();
@@ -652,52 +649,87 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         }
     }
 
-    private FileSystemException findFilesToCopyFromInput(List<InputSelector> inputSelectors,
-            ArrayList<DataSpacesFileObject> inResults, ArrayList<DataSpacesFileObject> outResults,
-            ArrayList<DataSpacesFileObject> globResults, ArrayList<DataSpacesFileObject> userResults,
-            ArrayList<DataSpacesFileObject> inResultsCache, ArrayList<DataSpacesFileObject> outResultsCache,
-            ArrayList<DataSpacesFileObject> globResultsCache, ArrayList<DataSpacesFileObject> userResultsCache) {
+    private void findFilesToCopyFromInput(List<InputSelector> inputSelectors, ArrayList<DataSpacesFileObject> inResults,
+            ArrayList<DataSpacesFileObject> outResults, ArrayList<DataSpacesFileObject> globResults,
+            ArrayList<DataSpacesFileObject> userResults, ArrayList<DataSpacesFileObject> inResultsCache,
+            ArrayList<DataSpacesFileObject> outResultsCache, ArrayList<DataSpacesFileObject> globResultsCache,
+            ArrayList<DataSpacesFileObject> userResultsCache) throws FileSystemException, InterruptedException {
 
-        FileSystemException toBeThrown = null;
+        ArrayList<Future<List<DataSpacesFileObject>>> inResultsFutures = new ArrayList<>();
+        ArrayList<Future<List<DataSpacesFileObject>>> outResultsFutures = new ArrayList<>();
+        ArrayList<Future<List<DataSpacesFileObject>>> globResultsFutures = new ArrayList<>();
+        ArrayList<Future<List<DataSpacesFileObject>>> userResultsFutures = new ArrayList<>();
+        ArrayList<Future<List<DataSpacesFileObject>>> inResultsCacheFutures = new ArrayList<>();
+        ArrayList<Future<List<DataSpacesFileObject>>> outResultsCacheFutures = new ArrayList<>();
+        ArrayList<Future<List<DataSpacesFileObject>>> globResultsCacheFutures = new ArrayList<>();
+        ArrayList<Future<List<DataSpacesFileObject>>> userResultsCacheFutures = new ArrayList<>();
 
         for (InputSelector is : inputSelectors) {
             org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector selector = new org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector();
             selector.setIncludes(is.getInputFiles().getIncludes());
             selector.setExcludes(is.getInputFiles().getExcludes());
 
-            logger.debug("Selector used is " + selector);
-
             switch (is.getMode()) {
                 case TransferFromInputSpace:
-                    toBeThrown = findFilesToCopyFromInput(INPUT, "INPUT", is, selector, inResults);
+                    inResultsFutures.add(findFilesToCopyFromInput(INPUT, "INPUT", is, selector));
                     break;
                 case TransferFromOutputSpace:
-                    toBeThrown = findFilesToCopyFromInput(OUTPUT, "OUTPUT", is, selector, outResults);
+                    outResultsFutures.add(findFilesToCopyFromInput(OUTPUT, "OUTPUT", is, selector));
                     break;
                 case TransferFromGlobalSpace:
-                    toBeThrown = findFilesToCopyFromInput(GLOBAL, "GLOBAL", is, selector, globResults);
+                    globResultsFutures.add(findFilesToCopyFromInput(GLOBAL, "GLOBAL", is, selector));
                     break;
                 case TransferFromUserSpace:
-                    toBeThrown = findFilesToCopyFromInput(USER, "USER", is, selector, userResults);
+                    userResultsFutures.add(findFilesToCopyFromInput(USER, "USER", is, selector));
                     break;
                 case CacheFromInputSpace:
-                    toBeThrown = findFilesToCopyFromInput(INPUT, "INPUT", is, selector, inResultsCache);
+                    inResultsCacheFutures.add(findFilesToCopyFromInput(INPUT, "INPUT", is, selector));
                     break;
                 case CacheFromOutputSpace:
-                    toBeThrown = findFilesToCopyFromInput(OUTPUT, "OUTPUT", is, selector, outResultsCache);
+                    outResultsCacheFutures.add(findFilesToCopyFromInput(OUTPUT, "OUTPUT", is, selector));
                     break;
                 case CacheFromGlobalSpace:
-                    toBeThrown = findFilesToCopyFromInput(GLOBAL, "GLOBAL", is, selector, globResultsCache);
+                    globResultsCacheFutures.add(findFilesToCopyFromInput(GLOBAL, "GLOBAL", is, selector));
                     break;
                 case CacheFromUserSpace:
-                    toBeThrown = findFilesToCopyFromInput(USER, "USER", is, selector, userResultsCache);
+                    userResultsCacheFutures.add(findFilesToCopyFromInput(USER, "USER", is, selector));
                 case none:
                     //do nothing
                     break;
             }
         }
 
-        return toBeThrown;
+        addFilesResultToList(inResultsFutures, inResults);
+        addFilesResultToList(outResultsFutures, outResults);
+        addFilesResultToList(globResultsFutures, globResults);
+        addFilesResultToList(userResultsFutures, userResults);
+
+        addFilesResultToList(inResultsCacheFutures, inResultsCache);
+        addFilesResultToList(outResultsCacheFutures, outResultsCache);
+        addFilesResultToList(globResultsCacheFutures, globResultsCache);
+        addFilesResultToList(userResultsCacheFutures, userResultsCache);
+
+    }
+
+    private void addFilesResultToList(List<Future<List<DataSpacesFileObject>>> futures,
+            ArrayList<DataSpacesFileObject> results) throws InterruptedException, FileSystemException {
+
+        StringBuilder message = new StringBuilder();
+        String nl = System.lineSeparator();
+
+        for (Future<List<DataSpacesFileObject>> future : futures) {
+            try {
+                results.addAll(future.get());
+            } catch (InterruptedException | ExecutionException e) {
+                logger.error("Exception while selecting input files to copy ", e);
+                message.append(StackTraceUtil.getStackTrace(e)).append(nl);
+            }
+        }
+
+        if (message.length() > 0) {
+            throw new FileSystemException("Exception(s) occurred when selecting input files to copy: " + nl +
+                                          message.toString());
+        }
     }
 
     private List<Future<Boolean>> doCopyInputDataToSpace(DataSpacesFileObject space,
@@ -723,6 +755,8 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             public Boolean call() throws FileSystemException {
 
                 DataSpacesFileObject target = destinationBase.resolveFile(destinationRelativeToBase);
+
+                target.refresh();
                 if (!target.exists()) {
                     logger.info("Copying " + source.getRealURI() + " to " + destinationBase.getRealURI() + "/" +
                                 destinationRelativeToBase);
@@ -732,11 +766,10 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
                                 destinationRelativeToBase + " (newer version)");
                     target.copyFrom(source, FileSelector.SELECT_SELF);
                 } else {
-                    logger.info("Destination file " + target.getRealURI() + " is already present and newer.");
+                    logger.debug("Destination file " + target.getRealURI() + " is already present and newer.");
                 }
 
                 target.refresh();
-
                 if (!target.exists()) {
                     String message = "There was a problem during the copy of " + source.getRealURI() + " to " +
                                      target.getRealURI() + ". File not present after copy.";
@@ -752,51 +785,58 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
         });
     }
 
-    private FileSystemException findFilesToCopyFromInput(DataSpacesFileObject space, String spaceName,
-            InputSelector inputSelector,
-            org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector selector,
-            List<DataSpacesFileObject> results) {
+    private Future<List<DataSpacesFileObject>> findFilesToCopyFromInput(final DataSpacesFileObject space,
+            final String spaceName, final InputSelector inputSelector,
+            final org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector selector) {
 
-        if (!checkInputSpaceConfigured(space, spaceName, inputSelector)) {
-            return null;
-        }
+        return executorTransfer.submit(new Callable<List<DataSpacesFileObject>>() {
+            @Override
+            public List<DataSpacesFileObject> call() throws Exception {
+                List<DataSpacesFileObject> results = new ArrayList<>();
 
-        try {
-            // A desynchronization has been noticed when multiple dataspaces are mounted on the same folder
-            // The call to refresh ensures that the content of the dataspace cache is resynchronized with the disk
-            // before the transfer
-            space.refresh();
+                if (!checkInputSpaceConfigured(space, spaceName, inputSelector)) {
+                    return results;
+                }
 
-            int oldSize = results.size();
+                logger.debug("Selector used is " + selector);
 
-            Utils.findFiles(space, selector, results);
+                try {
+                    // A desynchronization has been noticed when multiple dataspaces are mounted on the same folder
+                    // The call to refresh ensures that the content of the dataspace cache is resynchronized with the disk
+                    // before the transfer
+                    space.refresh();
 
-            if (results.size() == oldSize) {
-                // we detected that there was no new file in the list
-                String message = "No file is transferred from " + spaceName + " space at " + space.getRealURI() +
-                                 "  for selector " + inputSelector;
+                    Utils.findFiles(space, selector, results);
 
-                logDataspacesStatus(message, DataspacesStatusLevel.WARNING);
-                logger.warn(message);
+                    if (results.isEmpty()) {
+                        // we detected that there was no new file in the list
+                        String message = "No file is transferred from " + spaceName + " space at " +
+                                         space.getRealURI() + "  for selector " + inputSelector;
+
+                        logDataspacesStatus(message, DataspacesStatusLevel.WARNING);
+                        logger.warn(message);
+                    }
+                } catch (FileSystemException e) {
+                    logger.warn("Error occurred while transferring files", e);
+
+                    String message = "Could not contact " + spaceName + " space at " + space.getRealURI() +
+                                     ". An error occurred while resolving selector " + inputSelector;
+
+                    logDataspacesStatus(message, DataspacesStatusLevel.ERROR);
+                    logDataspacesStatus(getStackTraceAsString(e), DataspacesStatusLevel.ERROR);
+
+                    logger.error(message, e);
+
+                    throw new FileSystemException(message);
+                } catch (NullPointerException e) {
+                    // nothing to do
+                    return results;
+                }
+
+                return results;
             }
-        } catch (FileSystemException e) {
-            logger.warn("Error occurred while transferring files", e);
+        });
 
-            String message = "Could not contact " + spaceName + " space at " + space.getRealURI() +
-                             ". An error occurred while resolving selector " + inputSelector;
-
-            logDataspacesStatus(message, DataspacesStatusLevel.ERROR);
-            logDataspacesStatus(getStackTraceAsString(e), DataspacesStatusLevel.ERROR);
-
-            logger.error(message, e);
-
-            return new FileSystemException(message);
-        } catch (NullPointerException e) {
-            // nothing to do
-            return null;
-        }
-
-        return null;
     }
 
     @Override
@@ -806,6 +846,8 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
                 logger.debug("Output selector is empty, no file to copy");
                 return;
             }
+
+            SCRATCH.refresh();
 
             checkOutputSpacesConfigured(outputSelectors);
 
@@ -976,7 +1018,7 @@ public class TaskProActiveDataspaces implements TaskDataspaces {
             transferFutures.add(parallelFileCopy(entry.getValue(), dataspaceDestination, entry.getKey(), false));
         }
 
-        handleResults(transferFutures);
+        handleResultsWhileTransferringFile(transferFutures);
     }
 
 }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspacesTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/data/TaskProActiveDataspacesTest.java
@@ -215,7 +215,7 @@ public class TaskProActiveDataspacesTest {
         }
 
         TaskProActiveDataspaces taskProActiveDataspaces = new TaskProActiveDataspaces();
-        taskProActiveDataspaces.handleResults(builder.build());
+        taskProActiveDataspaces.handleResultsWhileTransferringFile(builder.build());
 
         verify(mock, times(nbFutures)).get();
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestDataspaceConcurrentKilling.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestDataspaceConcurrentKilling.java
@@ -117,7 +117,7 @@ public class TestDataspaceConcurrentKilling extends SchedulerFunctionalTestWithC
         for (int i = 0; i < NB_TASKS; i++) {
             ScriptTask st = new ScriptTask();
             st.setName(TASK_NAME + i);
-            st.setScript(new TaskScript(new SimpleScript("new File(\"" + FILE_NAME + i +
+            st.setScript(new TaskScript(new SimpleScript("new File(localspace, \"" + FILE_NAME + i +
                                                          "\").createNewFile(); java.lang.Thread.sleep(1000)",
                                                          "groovy")));
             st.addOutputFiles(FILE_NAME + i, OutputAccessMode.TransferToUserSpace);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestDataspaceConcurrentTransfer.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestDataspaceConcurrentTransfer.java
@@ -1,0 +1,191 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests.dataspaces;
+
+import static functionaltests.utils.SchedulerTHelper.log;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.net.URI;
+import java.util.HashMap;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.exception.UserException;
+import org.ow2.proactive.scheduler.common.job.Job;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
+import org.ow2.proactive.scheduler.common.task.OnTaskError;
+import org.ow2.proactive.scheduler.common.task.ScriptTask;
+import org.ow2.proactive.scheduler.common.task.dataspaces.InputAccessMode;
+import org.ow2.proactive.scheduler.common.task.dataspaces.OutputAccessMode;
+import org.ow2.proactive.scripting.InvalidScriptException;
+import org.ow2.proactive.scripting.SimpleScript;
+import org.ow2.proactive.scripting.TaskScript;
+
+import functionaltests.utils.SchedulerFunctionalTest;
+import functionaltests.utils.SchedulerFunctionalTestWithCustomConfigAndRestart;
+import functionaltests.utils.SchedulerTHelper;
+
+
+/**
+ * This test is executing a set tasks which produces multiple files and another set of tasks which consume these files and produce new ones
+ *
+ * The test is successful if all files could be processed and there are no missing outputs
+ *
+ * The test starts a clean scheduler in non-fork mode (for memory consumption reasons) with many nodes running in the same JVM
+ */
+public class TestDataspaceConcurrentTransfer extends SchedulerFunctionalTestWithCustomConfigAndRestart {
+
+    static final int NB_NODES = 50;
+
+    static final int NB_TASKS = NB_NODES;
+
+    static final String JOB_NAME = "TestDataspaceConcurrentTransfer";
+
+    static final String TASK_NAME_CREATE = "ConcurrentCreate_";
+
+    static final String TASK_NAME_PROCESS = "ConcurrentProcessFile_";
+
+    static final String FILE_EXT_IN = ".in";
+
+    static final String FILE_EXT_OUT = ".out";
+
+    static final String FILE_NAME = "TASKFILE_";
+
+    static final String FOLDER_IN_NAME = "FOLDER_IN_";
+
+    static final String FOLDER_OUT_NAME = "FOLDER_OUT_";
+
+    File globalSpaceFile;
+
+    @BeforeClass
+    public static void startDedicatedScheduler() throws Exception {
+        // we start a scheduler with an empty RM and add multiple nodes
+        schedulerHelper = new SchedulerTHelper(true,
+                                               true,
+                                               new File(SchedulerFunctionalTest.class.getResource("/functionaltests/config/scheduler-nonforkedscripttasks.ini")
+                                                                                     .toURI()).getAbsolutePath());
+
+        schedulerHelper.createNodeSource(JOB_NAME, NB_NODES);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Scheduler sched = schedulerHelper.getSchedulerInterface();
+        String globalURI = sched.getGlobalSpaceURIs().get(0);
+        assertTrue(globalURI.startsWith("file:"));
+        log("Global Space URI is " + globalURI);
+        globalSpaceFile = new File(new URI(globalURI));
+
+        FileUtils.cleanDirectory(globalSpaceFile);
+    }
+
+    @Test
+    public void multiple_tasks_transferring() throws Throwable {
+        Job job = createJobWithFileTransfers();
+
+        JobId id = schedulerHelper.testJobSubmission(job);
+        assertFalse("The job execution must not fail, check the node source log file : Node-local-" + JOB_NAME + ".log",
+                    schedulerHelper.getJobResult(id).hadException());
+
+        File[] inputDirectories = globalSpaceFile.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File pathname) {
+                return pathname.isDirectory() && pathname.getName().startsWith(FOLDER_IN_NAME);
+            }
+        });
+
+        File[] outputDirectories = globalSpaceFile.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File pathname) {
+                return pathname.isDirectory() && pathname.getName().startsWith(FOLDER_OUT_NAME);
+            }
+        });
+
+        Assert.assertEquals(NB_TASKS, inputDirectories.length);
+        Assert.assertEquals(NB_TASKS, outputDirectories.length);
+
+        HashMap<String, File> directoriesMap = new HashMap<>();
+
+        for (File dir : inputDirectories) {
+            directoriesMap.put(dir.getName(), dir);
+        }
+
+        for (File dir : outputDirectories) {
+            directoriesMap.put(dir.getName(), dir);
+        }
+
+        for (int i = 0; i < NB_TASKS; i++) {
+            File inputDir = directoriesMap.get(FOLDER_IN_NAME + i);
+            assertNotNull(inputDir);
+            File inputFile = new File(inputDir, FILE_NAME + i + FILE_EXT_IN);
+            Assert.assertTrue(inputFile.exists());
+
+            File outputDir = directoriesMap.get(FOLDER_OUT_NAME + i);
+            assertNotNull(outputDir);
+            File outputFile = new File(outputDir, FILE_NAME + i + FILE_EXT_OUT);
+            Assert.assertTrue(outputFile.exists());
+        }
+    }
+
+    public Job createJobWithFileTransfers() throws UserException, InvalidScriptException {
+        TaskFlowJob job = new TaskFlowJob();
+        job.setName(JOB_NAME);
+        job.setOnTaskError(OnTaskError.CONTINUE_JOB_EXECUTION);
+        for (int i = 0; i < NB_TASKS; i++) {
+            ScriptTask st1 = new ScriptTask();
+            st1.setName(TASK_NAME_CREATE + i);
+            st1.setScript(new TaskScript(new SimpleScript("org.apache.commons.io.FileUtils.touch(new File(localspace, \"" +
+                                                          FOLDER_IN_NAME + i + "/" + FILE_NAME + i + FILE_EXT_IN +
+                                                          "\"));", "groovy")));
+            st1.addOutputFiles("**/*" + FILE_EXT_IN, OutputAccessMode.TransferToGlobalSpace);
+            job.addTask(st1);
+
+            ScriptTask st2 = new ScriptTask();
+            st2.setName(TASK_NAME_PROCESS + i);
+            st2.setScript(new TaskScript(new SimpleScript("org.apache.commons.io.FileUtils.copyFile(new File(localspace, \"" +
+                                                          FOLDER_IN_NAME + i + "/" + FILE_NAME + i + FILE_EXT_IN +
+                                                          "\"), new File(localspace, \"" + FOLDER_OUT_NAME + i + "/" +
+                                                          FILE_NAME + i + FILE_EXT_OUT + "\"));", "groovy")));
+            st2.addInputFiles(FOLDER_IN_NAME + i + "/" + FILE_NAME + i + FILE_EXT_IN,
+                              InputAccessMode.TransferFromGlobalSpace);
+            st2.addOutputFiles("**/*" + FILE_EXT_OUT, OutputAccessMode.TransferToGlobalSpace);
+            st2.addDependence(st1);
+            job.addTask(st2);
+        }
+        return job;
+    }
+
+}


### PR DESCRIPTION
Finding file to copy from input, output, global or user spaces was done sequentially for each selector.
As this is a costly operation when there are a large number of files, it is necessary to speed up this process.

Now selectors are all executed in parallel using the TaskProActiveDataspaces transfer thread pool.