### PR TITLE
tentative fix for #2927 RSA decryption randomly fails because of padding issues

### DIFF
--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/KeyPairUtil.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/KeyPairUtil.java
@@ -52,16 +52,6 @@ import javax.crypto.Cipher;
  */
 public class KeyPairUtil {
 
-    private static SecureRandom secureRandom;
-
-    private static synchronized void initSecureRandom() {
-        if (secureRandom == null) {
-            secureRandom = new SecureRandom();
-            final byte[] dummy = new byte[512];
-            secureRandom.nextBytes(dummy);
-        }
-    }
-
     /**
      * Generates a pair of public and private keys
      * 
@@ -99,7 +89,7 @@ public class KeyPairUtil {
         }
     }
 
-    public static KeyPair generateKeyPair(String algorithm, int size) throws KeyException {
+    public static synchronized KeyPair generateKeyPair(String algorithm, int size) throws KeyException {
         KeyPairGenerator keyGen = null;
         try {
             keyGen = KeyPairGenerator.getInstance(algorithm);
@@ -107,7 +97,7 @@ public class KeyPairUtil {
             throw new KeyException("Cannot initialize keypair generator", e);
         }
 
-        SecureRandom random = new SecureRandom();
+        SecureRandom random = KeyUtil.getSecureRandom();
         keyGen.initialize(size, random);
 
         return keyGen.generateKeyPair();
@@ -122,13 +112,13 @@ public class KeyPairUtil {
      * @return the encrypted message
      * @throws KeyException encryption failed, public key recovery failed
      */
-    public static byte[] encrypt(PublicKey pubKey, String cipherParams, byte[] message) throws KeyException {
+    public static synchronized byte[] encrypt(PublicKey pubKey, String cipherParams, byte[] message)
+            throws KeyException {
 
         Cipher ciph = null;
         try {
             ciph = Cipher.getInstance(cipherParams);
-            initSecureRandom();
-            ciph.init(Cipher.ENCRYPT_MODE, pubKey, secureRandom);
+            ciph.init(Cipher.ENCRYPT_MODE, pubKey, KeyUtil.getSecureRandom());
         } catch (Exception e) {
             throw new KeyException("Could not initialize cipher", e);
         }
@@ -152,13 +142,13 @@ public class KeyPairUtil {
      * @return the decrypted message
      * @throws KeyException private key recovery failed, decryption failed
      */
-    public static byte[] decrypt(PrivateKey privKey, String cipherParams, byte[] message) throws KeyException {
+    public static synchronized byte[] decrypt(PrivateKey privKey, String cipherParams, byte[] message)
+            throws KeyException {
 
         Cipher ciph = null;
         try {
             ciph = Cipher.getInstance(cipherParams);
-            initSecureRandom();
-            ciph.init(Cipher.DECRYPT_MODE, privKey, secureRandom);
+            ciph.init(Cipher.DECRYPT_MODE, privKey, KeyUtil.getSecureRandom());
         } catch (Exception e) {
             throw new KeyException("Could not initialize cipher", e);
         }

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/KeyUtil.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/KeyUtil.java
@@ -48,6 +48,18 @@ import javax.crypto.SecretKey;
  */
 public class KeyUtil {
 
+    private static SecureRandom secureRandom;
+
+    public static synchronized SecureRandom getSecureRandom() {
+        if (secureRandom == null) {
+            secureRandom = new SecureRandom();
+            final byte[] dummy = new byte[512];
+            secureRandom.nextBytes(dummy);
+        }
+
+        return secureRandom;
+    }
+
     /**
      * Generates a secret symmetric key
      * 
@@ -57,7 +69,7 @@ public class KeyUtil {
      * @return the generated key
      * @throws KeyException key generation or saving failed
      */
-    public static SecretKey generateKey(String algorithm, int size) throws KeyException {
+    public static synchronized SecretKey generateKey(String algorithm, int size) throws KeyException {
         KeyGenerator keyGen = null;
         try {
             keyGen = KeyGenerator.getInstance(algorithm);
@@ -65,8 +77,7 @@ public class KeyUtil {
             throw new KeyException("Cannot initialize key generator", e);
         }
 
-        SecureRandom random = new SecureRandom();
-        keyGen.init(size, random);
+        keyGen.init(size, getSecureRandom());
 
         return keyGen.generateKey();
     }
@@ -80,11 +91,11 @@ public class KeyUtil {
      * @return the encrypted message
      * @throws KeyException encryption failed, public key recovery failed
      */
-    public static byte[] encrypt(SecretKey key, String cipherParams, byte[] message) throws KeyException {
+    public static synchronized byte[] encrypt(SecretKey key, String cipherParams, byte[] message) throws KeyException {
         Cipher ciph = null;
         try {
             ciph = Cipher.getInstance(cipherParams);
-            ciph.init(Cipher.ENCRYPT_MODE, key);
+            ciph.init(Cipher.ENCRYPT_MODE, key, getSecureRandom());
         } catch (Exception e) {
             throw new KeyException("Coult not initialize cipher", e);
         }
@@ -107,7 +118,7 @@ public class KeyUtil {
      * @return the decrypted message
      * @throws KeyException private key recovery failed, decryption failed
      */
-    public static byte[] decrypt(SecretKey key, String cipherParams, byte[] message) throws KeyException {
+    public static synchronized byte[] decrypt(SecretKey key, String cipherParams, byte[] message) throws KeyException {
         Cipher ciph = null;
         try {
             ciph = Cipher.getInstance(cipherParams);


### PR DESCRIPTION
synchronize the calls to KeyUtil, as the Cipher class is not thread safe.