### PR TITLE
fix for #2936 ConcurrentModificationException when calling SchedulerProxyUserInterface.getJobState

### DIFF
--- a/rm/rm-policy/rm-policy-scheduler/src/main/java/org/ow2/proactive/scheduler/resourcemanager/nodesource/policy/SchedulerAwarePolicy.java
+++ b/rm/rm-policy/rm-policy-scheduler/src/main/java/org/ow2/proactive/scheduler/resourcemanager/nodesource/policy/SchedulerAwarePolicy.java
@@ -58,7 +58,7 @@ public abstract class SchedulerAwarePolicy extends NodeSourcePolicy implements S
     @Configurable(credential = true)
     protected File schedulerCredentialsPath;
 
-    protected SchedulerState state;
+    protected SchedulerState<JobState> state;
 
     protected Scheduler scheduler;
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerState.java
@@ -44,28 +44,28 @@ import org.ow2.proactive.scheduler.common.job.JobState;
  */
 @PublicAPI
 @XmlRootElement(name = "schedulerstate")
-public interface SchedulerState extends Serializable {
+public interface SchedulerState<T extends JobState> extends Serializable {
 
     /**
      * Get the finished Jobs list
      *
      * @return the finished Jobs list
      */
-    Vector<JobState> getFinishedJobs();
+    Vector<T> getFinishedJobs();
 
     /**
      * Get the pending Jobs list
      *
      * @return the pending Jobs list
      */
-    Vector<JobState> getPendingJobs();
+    Vector<T> getPendingJobs();
 
     /**
      * Get the running Jobs list
      *
      * @return the running Jobs list
      */
-    Vector<JobState> getRunningJobs();
+    Vector<T> getRunningJobs();
 
     /**
      * Get the status of the scheduler
@@ -95,5 +95,5 @@ public interface SchedulerState extends Serializable {
     /**
      * Updates the scheduler state given the event passed as a parameter
      */
-    void update(JobState jobState);
+    void update(T jobState);
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -56,7 +56,7 @@ import org.ow2.proactive.scheduler.task.TaskInfoImpl;
  * 
  * @author esalagea
  */
-public final class ClientJobState extends JobState {
+public class ClientJobState extends JobState {
 
     private final ClientJobSerializationHelper clientJobSerializationHelper;
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/RecoveredSchedulerState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/RecoveredSchedulerState.java
@@ -45,14 +45,14 @@ public class RecoveredSchedulerState {
 
     private final Vector<InternalJob> finishedJobs;
 
-    private final SchedulerStateImpl schedulerState;
+    private final SchedulerStateImpl<ClientJobState> schedulerState;
 
     public RecoveredSchedulerState(Vector<InternalJob> pendingJobs, Vector<InternalJob> runningJobs,
             Vector<InternalJob> finishedJobs) {
         this.pendingJobs = pendingJobs;
         this.runningJobs = runningJobs;
         this.finishedJobs = finishedJobs;
-        schedulerState = new SchedulerStateImpl();
+        schedulerState = new SchedulerStateImpl<>();
         schedulerState.setPendingJobs(convertToClientJobState(pendingJobs));
         schedulerState.setRunningJobs(convertToClientJobState(runningJobs));
         schedulerState.setFinishedJobs(convertToClientJobState(finishedJobs));
@@ -70,12 +70,12 @@ public class RecoveredSchedulerState {
         return finishedJobs;
     }
 
-    public SchedulerStateImpl getSchedulerState() {
+    public SchedulerStateImpl<ClientJobState> getSchedulerState() {
         return schedulerState;
     }
 
-    private Vector<JobState> convertToClientJobState(List<InternalJob> jobs) {
-        Vector<JobState> result = new Vector<>(jobs.size());
+    private Vector<ClientJobState> convertToClientJobState(List<InternalJob> jobs) {
+        Vector<ClientJobState> result = new Vector<>(jobs.size());
         for (InternalJob internalJob : jobs) {
             result.add(new ClientJobState(internalJob));
         }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/BaseSchedulerDBTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/BaseSchedulerDBTest.java
@@ -64,6 +64,7 @@ import org.ow2.proactive.scheduler.core.db.RecoveredSchedulerState;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptor;
+import org.ow2.proactive.scheduler.job.ClientJobState;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.job.InternalJobFactory;
 import org.ow2.proactive.scheduler.task.internal.ExecuterInformation;
@@ -125,7 +126,7 @@ public class BaseSchedulerDBTest extends ProActiveTest {
         }
     }
 
-    static class StateMatcher extends TypeSafeMatcher<SchedulerState> {
+    static class StateMatcher extends TypeSafeMatcher<SchedulerState<ClientJobState>> {
 
         private final List<JobStateMatcher> pending = new ArrayList<>();
 
@@ -163,7 +164,7 @@ public class BaseSchedulerDBTest extends ProActiveTest {
         }
 
         @Override
-        protected boolean matchesSafely(SchedulerState item) {
+        protected boolean matchesSafely(SchedulerState<ClientJobState> item) {
             assertThat(item.getPendingJobs(), containsInAnyOrder(pending.toArray(new JobStateMatcher[] {})));
             assertThat(item.getRunningJobs(), containsInAnyOrder(running.toArray(new JobStateMatcher[] {})));
             assertThat(item.getFinishedJobs(), containsInAnyOrder(finished.toArray(new JobStateMatcher[] {})));

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendStateTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendStateTest.java
@@ -45,6 +45,7 @@ import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.core.jmx.SchedulerJMXHelper;
 import org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.ow2.proactive.scheduler.job.ClientJobState;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.job.UserIdentificationImpl;
 import org.ow2.tests.ProActiveTestClean;
@@ -60,7 +61,7 @@ public class SchedulerFrontendStateTest extends ProActiveTestClean {
         SchedulerJMXHelper mockJMX = mock(SchedulerJMXHelper.class);
         when(mockJMX.getSchedulerRuntimeMBean()).thenReturn(new RuntimeDataMBeanImpl(null));
 
-        final SchedulerFrontendState schedulerFrontendState = new SchedulerFrontendState(new SchedulerStateImpl(),
+        final SchedulerFrontendState schedulerFrontendState = new SchedulerFrontendState(new SchedulerStateImpl<ClientJobState>(),
                                                                                          mockJMX);
 
         // create a bunch of active sessions, they will be removed in 1s
@@ -98,11 +99,11 @@ public class SchedulerFrontendStateTest extends ProActiveTestClean {
         SchedulerJMXHelper mockJMX = mock(SchedulerJMXHelper.class);
         when(mockJMX.getSchedulerRuntimeMBean()).thenReturn(new RuntimeDataMBeanImpl(null));
 
-        SchedulerStateImpl schedulerStateImpl = new SchedulerStateImpl();
+        SchedulerStateImpl<ClientJobState> schedulerStateImpl = new SchedulerStateImpl<>();
 
         JobIdImpl jobId = new JobIdImpl(1234L, "job name");
 
-        JobState jobState = mock(JobState.class);
+        ClientJobState jobState = mock(ClientJobState.class);
 
         when(jobState.getId()).thenReturn(jobId);
 


### PR DESCRIPTION
 - synchronize access to a given jobState in SchedulerFrontendState
 - make a deep copy in method getJobState to ensure that the object is not modified while sending the result
 - use of generics in SchedulerState for code clarity.