### PR TITLE
fix for #2960 When a task is killed, job variables available in the c…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ ext.schedulingFunctionalTestConfiguration = {
     systemProperties << ['pa.rm.home': rootDir.absolutePath]
     systemProperties << ['pa.scheduler.home': rootDir.absolutePath]
     systemProperties << ['proactive.communication.protocol': 'pnp']
-    systemProperties << ['proactive.test.timeout': 600000]
+    systemProperties << ['proactive.test.timeout': 800000]
     systemProperties << ['java.awt.headless': 'true']
     systemProperties << ['java.library.path': project.nativeLibsDir]
     systemProperties << ['java.security.policy': file("$rootDir/config/security.java.policy-server").absolutePath]

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Executors;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
@@ -294,8 +295,12 @@ final class TerminationData {
                                                                                new ArrayList(parentIds));
                 getResultsFromListOfTaskResults(variablesMap.getInheritedMap(), taskResults);
             } else {
-                if (internalJob != null)
-                    variablesMap.getInheritedMap().putAll(internalJob.getVariables());
+                if (internalJob != null) {
+                    for (Map.Entry<String, JobVariable> jobVariableEntry : internalJob.getVariables().entrySet()) {
+                        variablesMap.getInheritedMap().put(jobVariableEntry.getKey(),
+                                                           jobVariableEntry.getValue().getValue());
+                    }
+                }
             }
             variablesMap.getInheritedMap().put(SchedulerVars.PA_TASK_SUCCESS.toString(), Boolean.toString(false));
         } else if (taskResult.hadException()) {


### PR DESCRIPTION
…lean script are object instances of JobVariable instead of their values

- when the task is aborted, put in the inherited map the values of the JobVariable map