### PR TITLE
Submit a remote job which needs a sessionId to retrieve

### DIFF
--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ISchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ISchedulerClient.java
@@ -126,6 +126,27 @@ public interface ISchedulerClient extends Scheduler {
      * precious result.
      * <p>
      *
+     * @param job       a job provided as a url
+     * @param variables job variables to use during the job execution
+     * @param headerParams map with request header parameters
+     * @return the generated new job ID.
+     * @throws NotConnectedException
+     * @throws JobCreationException
+     * @throws PermissionException
+     * @throws SubmissionClosedException
+     */
+    JobId submit(URL job, Map<String, String> variables, Map<String, String> headerParams)
+            throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException;
+
+    /**
+     * Submit a new job to the scheduler with provided variables.
+     * <p>
+     * It will execute the tasks of the jobs as soon as resources are available.
+     * The job will be considered as finished once every tasks have finished
+     * (error or success). Thus, user could get the job result according to the
+     * precious result.
+     * <p>
+     *
      * @param job       a job provided as a local File
      * @param variables job variables to use during the job execution
      * @return the generated new job ID.

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -223,6 +223,12 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
+    public JobId submit(URL job, Map<String, String> variables, Map<String, String> headerParams)
+            throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
+        return _getScheduler().submit(job, variables, headerParams);
+    }
+
+    @Override
     public JobId submit(File job, Map<String, String> variables)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
         return _getScheduler().submit(job, variables);

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -292,6 +292,12 @@ public class SchedulerNodeClient implements ISchedulerClient {
     }
 
     @Override
+    public JobId submit(URL job, Map<String, String> variables, Map<String, String> headerParams)
+            throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
+        return this.client.submit(job, variables, headerParams);
+    }
+
+    @Override
     public JobId submit(File job, Map<String, String> variables)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
         renewSession();


### PR DESCRIPTION
Problem:
- The secure catalog requests a sessionId to access workflows

Solution:
- Add a new endpoint which allows to retrieve workflows from endpoints which are secured with a sessionId