### PR TITLE
Resolve conflict of versions of dependencies of scheduler-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,11 @@ allprojects {
         }
     }
 
+    configurations.all {
+        resolutionStrategy.force "org.ow2.proactive:scheduler-api:${schedulingVersion}"
+    }
+
+
     rootProject.buildscript.repositories.each {
         repositories.add(it)
     }


### PR DESCRIPTION
We are forcing to use one single version of scheduling-api so that we do not have conflict of versions (and rc jars in the /dist/lib)

It happened that one of the dependencies in rm-node: runtime 'jsr223:jsr223-cpython:+' itself depends on scheduler-api:+ , when scheduling project depends on specific version of scheduler-api. Because of that gradle resolved conflict automatically by taking latest version which is RC version of scheduler-api. To prevent this behaviour we force gradle to take only one version of scheduler-api.

Also, we have to change sonarqube gradle plugin version, because we have experiences this critical bug https://jira.sonarsource.com/browse/SONARGITUB-35

I have closed previous 2992 PR because it was waiting for sonarqube results when we did not have sonarqube anymore.