### PR TITLE
Only set maxNumberOfNodes if property is set

### DIFF
--- a/rm/rm-server/build.gradle
+++ b/rm/rm-server/build.gradle
@@ -84,14 +84,11 @@ clean.dependsOn rootProject.cleanDist
 //gradlew build limitNumberOfNodes dist
 // Because it changes a class file it must be used in the same task list. Otherwise the class file
 // is recompiled -> the limitation changes are overwritten.
+if (project.hasProperty('maxNumberOfNodes')) {
 task limitTheMaximumNumberOfNodes(type: maxNodes.ReplaceMaxNumberOfNodesTask, dependsOn: classes) {
-    if (project.hasProperty('maxNumberOfNodes')) {
         print 'The maximum number of nodes will be limited, maxNumberOfNodes is set to: '
         println project.maxNumberOfNodes
         maxNumberOfNodes = project.maxNumberOfNodes
-    } else {
-        println 'The maximum number of nodes will be unlimited, maxNumberOfNodes is set to -1'
-        maxNumberOfNodes = -1
     }
+    build.dependsOn limitTheMaximumNumberOfNodes
 }
-build.dependsOn limitTheMaximumNumberOfNodes


### PR DESCRIPTION
The maxNumberOfNodes property is most likely set to -1, during every gradle build. That probably hinders us from setting the variable later on. 