### PR TITLE
Remove previously persisted node urls when redeploying nodes on host

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
@@ -594,15 +594,24 @@ public abstract class InfrastructureManager implements Serializable {
      * the infrastructure, and then update in database the {@link NodeSourceData}.
      */
     public void persistInfraVariables() {
-        if (!nodeSource.getName().equals(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME)) {
+        String nodeSourceName = nodeSource.getName();
+        if (!nodeSourceName.equals(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME)) {
             readLock.lock();
             try {
                 if (dbManager == null) {
                     setRmDbManager(RMDBManager.getInstance());
                 }
+                if (nodeSourceData == null) {
+                    logger.debug("Node source data of node source " + nodeSourceName +
+                                 " needs to be retrieved from database");
+                    nodeSourceData = dbManager.getNodeSource(nodeSourceName);
+                }
                 if (nodeSourceData != null) {
                     nodeSourceData.setInfrastructureVariables(persistedInfraVariables);
                     dbManager.updateNodeSource(nodeSourceData);
+                } else {
+                    logger.warn("Node source " + nodeSourceName +
+                                " is unknown. Cannot persist infrastructure variables");
                 }
             } catch (RuntimeException e) {
                 logger.error("Exception while persisting runtime variables: " + e.getMessage());


### PR DESCRIPTION
- remove all the node URLs for a given host when it is redeployed in HostsFileBaseInfrastructureManager, because these URLs are not contactable anymore and all the nodes on this host will be redeployed. We need to do this to avoid having more nodes than required handled per host.
- retrieve the node source information from database if the node source acannot be found in memory before updating and persisting it.