### PR TITLE
Large description

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobContent.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobContent.java
@@ -46,6 +46,7 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Type;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.util.ByteCompressionUtils;
@@ -67,6 +68,7 @@ public class JobContent implements Serializable {
     private static final Logger LOGGER = Logger.getLogger(JobContent.class);
 
     @Lob
+    @Type(type = "org.hibernate.type.BinaryType")
     @Column(name = "CONTENT", length = Integer.MAX_VALUE)
     private byte[] jobContentAsByteArray;
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -26,7 +26,6 @@
 package org.ow2.proactive.scheduler.core.db;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -407,7 +406,8 @@ public class JobData implements Serializable {
         this.userSpace = userSpace;
     }
 
-    @Column(name = "DESCRIPTION", length = 1000, updatable = false)
+    @Lob
+    @Column(name = "DESCRIPTION", length = Integer.MAX_VALUE, updatable = false)
     public String getDescription() {
         return description;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -861,7 +861,8 @@ public class TaskData {
         }
     }
 
-    @Column(name = "DESCRIPTION", updatable = false)
+    @Lob
+    @Column(name = "DESCRIPTION", length = Integer.MAX_VALUE, updatable = false)
     public String getDescription() {
         return description;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
@@ -175,8 +175,9 @@ public class TaskResultData {
         this.resultTime = resultTime;
     }
 
-    @Column(name = "RESULT_VALUE", length = Integer.MAX_VALUE)
     @Lob
+    @Type(type = "org.hibernate.type.BinaryType")
+    @Column(name = "RESULT_VALUE", length = Integer.MAX_VALUE)
     public byte[] getSerializedValue() {
         return serializedValue;
     }
@@ -185,8 +186,9 @@ public class TaskResultData {
         this.serializedValue = serializedValue;
     }
 
-    @Column(name = "RESULT_EXCEPTION", length = Integer.MAX_VALUE)
     @Lob
+    @Type(type = "org.hibernate.type.BinaryType")
+    @Column(name = "RESULT_EXCEPTION", length = Integer.MAX_VALUE)
     public byte[] getSerializedException() {
         return serializedException;
     }


### PR DESCRIPTION
Store the `DESCRIPTION` fields into Large Objects (Blobs) to allow longer descriptions and avoid slowdown (fixes #3002 and #3028, see issues descriptions for more details).

In addition, new `@Type` annotations have been set to `byte[]` fields to comply with recent PostgreSQL versions (see https://github.com/ow2-proactive/workflow-catalog-old/pull/45 for more details about Hibernate behaviour).