### PR TITLE
fix for #3052 Junk output appear in task logs

### DIFF
--- a/scheduler/scheduler-node/src/main/resources/config/log/scriptengines.properties
+++ b/scheduler/scheduler-node/src/main/resources/config/log/scriptengines.properties
@@ -1,3 +1,5 @@
+log4j.rootLogger=INFO, CONSOLE
+
 # Console appender
 log4j.logger.jsr223.docker.compose.utils.DockerComposePropertyLoader=INFO, CONSOLE
 log4j.logger.jsr223.perl.utils.PerlPropertyLoader=INFO, CONSOLE


### PR DESCRIPTION
added scriptengines.properties file as resource of scheduler-node project.

Load the log4j configuration from this file when the forked JVM is started.