### PR TITLE
correct JsonMappingException for UserIdentification

### DIFF
--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerEventReceiver.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerEventReceiver.java
@@ -48,11 +48,11 @@ import org.atmosphere.wasync.Socket;
 import org.ow2.proactive.scheduler.common.NotificationData;
 import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.SchedulerEventListener;
-import org.ow2.proactive.scheduler.common.job.UserIdentification;
 import org.ow2.proactive.scheduler.rest.data.DataUtility;
 import org.ow2.proactive.scheduler.rest.utils.EventCodecUtil;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobInfoData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobStateData;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerUserData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskInfoData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventNotification;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventNotification.Action;
@@ -242,7 +242,8 @@ public class SchedulerEventReceiver {
                                                                                DataUtility.taskInfo((TaskInfoData) eventData.getData())));
                     break;
                 case USERS_UPDATED:
-                    eventListener.usersUpdatedEvent((NotificationData<UserIdentification>) eventData.getData());
+                    eventListener.usersUpdatedEvent(new NotificationData<>(SchedulerEvent.valueOf(eventData.getSchedulerEvent()),
+                                                                           DataUtility.userIdentification((SchedulerUserData) eventData.getData())));
                     break;
                 default:
                     throw new RuntimeException(String.format("Unknown action: %s", action));

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
@@ -30,12 +30,7 @@ import static org.ow2.proactive.scheduler.task.TaskIdImpl.createTaskId;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.job.JobPriority;
-import org.ow2.proactive.scheduler.common.job.JobResult;
-import org.ow2.proactive.scheduler.common.job.JobState;
-import org.ow2.proactive.scheduler.common.job.JobStatus;
+import org.ow2.proactive.scheduler.common.job.*;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -174,6 +169,16 @@ public class DataUtility {
                                                          sud.getSubmitNumber()));
         }
         return schedulerUserInfos;
+    }
+
+    public static UserIdentification userIdentification(SchedulerUserData d) {
+        return new UserIdentificationImpl(d.getUsername(),
+                                          d.getGroups(),
+                                          d.getSubmitNumber(),
+                                          d.getHostName(),
+                                          d.getConnectionTime(),
+                                          d.getLastSubmitTime(),
+                                          d.isMyEventsOnly());
     }
 
     public static TaskId taskId(JobId jobId, TaskIdData taskIdData) {

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
@@ -23,66 +23,99 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive_grid_cloud_portal.scheduler.dto;
+package org.ow2.proactive.scheduler.rest.data;
 
 import java.util.Set;
+import java.util.TimerTask;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import org.ow2.proactive.scheduler.common.job.UserIdentification;
 
 
-@XmlRootElement
-public class SchedulerUserData {
-    private String hostName;
-
-    private Set<String> groups;
+public class UserIdentificationImpl extends UserIdentification {
 
     private String username;
 
-    private long connectionTime;
-
-    private long lastSubmitTime;
+    private Set<String> groups;
 
     private int submitNumber;
 
+    private String hostName;
+
+    private long connectionTime;
+
+    private long lastSubmitTime = -1;
+
     private boolean myEventsOnly;
 
-    public SchedulerUserData() {
+    public UserIdentificationImpl() {
+
     }
 
-    public String getHostName() {
-        return hostName;
+    public UserIdentificationImpl(String username, Set<String> groups, int submitNumber, String hostName,
+            long connectionTime, long lastSubmitTime, boolean myEventsOnly) {
+        this.username = username;
+        this.groups = groups;
+        this.submitNumber = submitNumber;
+        this.hostName = hostName;
+        this.connectionTime = connectionTime;
+        this.lastSubmitTime = lastSubmitTime;
+        this.myEventsOnly = myEventsOnly;
     }
 
-    public Set<String> getGroups() {
-        return groups;
-    }
-
+    @Override
     public String getUsername() {
         return username;
     }
 
-    public long getConnectionTime() {
-        return connectionTime;
+    @Override
+    public Set<String> getGroups() {
+        return groups;
     }
 
-    public long getLastSubmitTime() {
-        return lastSubmitTime;
-    }
-
+    @Override
     public int getSubmitNumber() {
         return submitNumber;
     }
 
-    public void setHostName(String hostName) {
-        this.hostName = hostName;
+    @Override
+    public String getHostName() {
+        return hostName;
+    }
+
+    @Override
+    public long getConnectionTime() {
+        return connectionTime;
+    }
+
+    @Override
+    public long getLastSubmitTime() {
+        return lastSubmitTime;
+    }
+
+    @Override
+    public boolean isMyEventsOnly() {
+        return myEventsOnly;
+    }
+
+    @Override
+    public TimerTask getSession() {
+        return null;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public void setGroups(Set<String> groups) {
         this.groups = groups;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
+    public void setSubmitNumber(int submitNumber) {
+        this.submitNumber = submitNumber;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
     }
 
     public void setConnectionTime(long connectionTime) {
@@ -93,22 +126,8 @@ public class SchedulerUserData {
         this.lastSubmitTime = lastSubmitTime;
     }
 
-    public void setSubmitNumber(int submitNumber) {
-        this.submitNumber = submitNumber;
-    }
-
-    public boolean isMyEventsOnly() {
-        return myEventsOnly;
-    }
-
     public void setMyEventsOnly(boolean myEventsOnly) {
         this.myEventsOnly = myEventsOnly;
     }
 
-    @Override
-    public String toString() {
-        return "SchedulerUserData{" + "hostName='" + hostName + '\'' + ", username='" + username + '\'' +
-               ", connectionTime=" + connectionTime + ", lastSubmitTime=" + lastSubmitTime + ", submitNumber=" +
-               submitNumber + '}';
-    }
 }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/utils/EventCodecUtil.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/utils/EventCodecUtil.java
@@ -37,7 +37,6 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.deser.std.StdDeserializer;
 import org.codehaus.jackson.map.module.SimpleModule;
 import org.codehaus.jackson.node.ObjectNode;
-import org.ow2.proactive.scheduler.common.job.UserIdentification;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobInfoData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobStateData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerUserData;

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/utils/EventCodecUtil.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/utils/EventCodecUtil.java
@@ -40,6 +40,7 @@ import org.codehaus.jackson.node.ObjectNode;
 import org.ow2.proactive.scheduler.common.job.UserIdentification;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobInfoData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobStateData;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerUserData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskInfoData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventNotification;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventNotification.Action;
@@ -105,7 +106,7 @@ public class EventCodecUtil {
                     notification.setData(mapper.readValue(data, TaskInfoData.class));
                     break;
                 case USERS_UPDATED:
-                    notification.setData(mapper.readValue(data, UserIdentification.class));
+                    notification.setData(mapper.readValue(data, SchedulerUserData.class));
                     break;
                 default:
                     break;

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/StringPropagatedVariablesCustomConverter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/StringPropagatedVariablesCustomConverter.java
@@ -56,7 +56,12 @@ public class StringPropagatedVariablesCustomConverter extends DozerConverter<Map
         Map<String, String> converted = new HashMap<>();
         for (Map.Entry<String, byte[]> entry : ((Map<String, byte[]>) source).entrySet()) {
             try {
-                converted.put(entry.getKey(), ObjectByteConverter.byteArrayToObject(entry.getValue()).toString());
+                Object valueAsObject = ObjectByteConverter.byteArrayToObject(entry.getValue());
+                if (valueAsObject != null) {
+                    converted.put(entry.getKey(), valueAsObject.toString());
+                } else if (entry.getValue() != null) {
+                    logger.debug("Could not convert " + entry.toString());
+                }
             } catch (Exception e) {
                 logger.error("Error when converting variables to json", e);
                 return null;

--- a/rest/rest-server/src/main/resources/org/ow2/proactive_grid_cloud_portal/scheduler/dozer-mappings.xml
+++ b/rest/rest-server/src/main/resources/org/ow2/proactive_grid_cloud_portal/scheduler/dozer-mappings.xml
@@ -139,4 +139,8 @@
 		</field>
 	</mapping>
 
+	<mapping>
+		<class-a>org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerUserData</class-a>
+		<class-b>org.ow2.proactive.scheduler.common.job.UserIdentification</class-b>
+	</mapping>
 </mappings>


### PR DESCRIPTION
Corrections corresponding to the JsonMappingException raised during the testing at CEA:

`Caused by: org.codehaus.jackson.map.JsonMappingException: Can not construct instance of org.ow2.proactive.scheduler.common.job.UserIdentification, problem: abstract types can only be instantiated with additional type information`