### PR TITLE
fix NullPointerException in byte array conversion

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/utils/ObjectByteConverter.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/utils/ObjectByteConverter.java
@@ -42,7 +42,7 @@ import org.apache.commons.codec.binary.Base64;
 
 /**
  * Utility functions for converting object to a byte array,
- * and vis versa.
+ * and vice versa.
  * <p>
  * This class can also compress stream
  *
@@ -220,6 +220,9 @@ public final class ObjectByteConverter {
     }
 
     public static Map<String, byte[]> mapOfBase64StringToByteArray(Map<String, String> input) {
+        if (input == null) {
+            return null;
+        }
         HashMap<String, byte[]> answer = new HashMap<>(input.size());
         for (Map.Entry<String, String> entry : input.entrySet()) {
             answer.put(entry.getKey(), base64StringToByteArray(entry.getValue()));
@@ -229,6 +232,9 @@ public final class ObjectByteConverter {
 
     public static Map<String, Serializable> mapOfByteArrayToSerializable(Map<String, byte[]> input)
             throws IOException, ClassNotFoundException {
+        if (input == null) {
+            return null;
+        }
         HashMap<String, Serializable> answer = new HashMap<>(input.size());
         for (Map.Entry<String, byte[]> entry : input.entrySet()) {
             answer.put(entry.getKey(), (Serializable) byteArrayToObject(entry.getValue()));


### PR DESCRIPTION
- This fix prevents a NullPointerException when receiving a null input instead of a Map in ObjectByteConverter.
- Other methods of the class already had this `null` validation.
- The exception was identified when attempting to convert a null value for propagatedVariables:
```
Caused by: java.lang.NullPointerException
                at org.ow2.proactive.utils.ObjectByteConverter.mapOfBase64StringToByteArray(ObjectByteConverter.java:223)
                at org.ow2.proactive.scheduler.rest.data.TaskResultImpl.<init>(TaskResultImpl.java:70)
```
... I also corrected a typo ;)