### PR TITLE
Fix task launcher recovery

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -130,13 +130,9 @@ public class SchedulerStateRecoverHelper {
                 task.getExecuterInformation() != null) {
                 try {
                     TaskLauncher launcher = task.getExecuterInformation().getLauncher();
-                    // attempt to talk to the task launcher to see if it is
-                    // still alive. If this call throws an exception, the task
-                    // will be reset to pending
-                    if (launcher.isActivated()) {
-                        logger.info("Recover running task " + task.getId() + " (" + task.getName() + ") successfully.");
-                        runningTasksCount++;
-                    }
+                    logger.info("Recover running task " + task.getId() + " (" + task.getName() +
+                                ") successfully. Launcher: " + launcher);
+                    runningTasksCount++;
                 } catch (Throwable e) {
                     logger.info("Recover running task " + task.getId() + " (" + task.getName() +
                                 ") failed. Moving back task from status RUNNING TO PENDING.", e);


### PR DESCRIPTION
- in commit 018b485c014c48cf8e4edda66931452d10c9aeaa, task recovery was broken due to an added synchronous call to the task launcher.