### PR TITLE
Synchronize tark started notification with task execution submitted t…

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -667,14 +667,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                                                                                                                    terminateNotificationNodeURL),
                                                                                              DOTASK_ACTION_TIMEOUT,
                                                                                              TimeUnit.MILLISECONDS);
-                    try {
-                        // before signaling that the task is started, we need
-                        // to make sure the task is correctly submitted to the
-                        // task launcher
-                        taskExecutionSubmittedFuture.get(DOTASK_ACTION_TIMEOUT, TimeUnit.MILLISECONDS);
-                    } catch (Exception e) {
-                        logger.warn("Could not wait for the task to be started on TaskLauncher.", e);
-                    }
+                    waitForTaskToBeStarted(taskExecutionSubmittedFuture);
 
                     finalizeStarting(job, task, node, launcher);
                     return true;
@@ -698,6 +691,17 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
             }
         }
 
+    }
+
+    private void waitForTaskToBeStarted(Future<Void> taskExecutionSubmittedFuture) {
+        try {
+            // before signaling that the task is started, we need
+            // to make sure the task is correctly submitted to the
+            // task launcher
+            taskExecutionSubmittedFuture.get(DOTASK_ACTION_TIMEOUT, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            logger.warn("Could not wait for the task to be started on TaskLauncher.", e);
+        }
     }
 
     /**

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -700,7 +700,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
             // task launcher
             taskExecutionSubmittedFuture.get(DOTASK_ACTION_TIMEOUT, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            logger.warn("Could not wait for the task to be started on TaskLauncher.", e);
+            logger.warn("Error while waiting for the task to be started.", e);
         }
     }
 


### PR DESCRIPTION
…o TaskLauncher

- the notification and persistence of the task started status was done in parallel with the submission of the task to the TaskLauncher. This small gap led to inconsistencies, especially in the case of a crash of the scheduler within this gap. This commit introduces a small synchronization to be sure to notify the task started status once the doTask request has been received by the TaskLauncher.
- the existing TaskRecoveryWhenNodesAreReservedInBatchTest from commit 018b485c014c48cf8e4edda66931452d10c9aeaa exhibits this particular case.