### PR TITLE
fix and improve performance for merge tasks with a large number of parents

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -352,6 +352,9 @@ pa.scheduler.db.transactions.damping.factor=2
 # Batch size to load Jobs from database when scheduler is restarted
 pa.scheduler.db.recovery.load.jobs.batch_size=100
 
+# Batch size to fetch parent tasks'results in a merge task
+pa.scheduler.db.fetch.batch_size=50
+
 #-------------------------------------------------------
 #----------  EMAIL NOTIFICATION PROPERTIES  ------------
 #-------------------------------------------------------

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -354,6 +354,8 @@ public enum PASchedulerProperties implements PACommonProperties {
             PropertyType.INTEGER,
             "100"),
 
+    SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE("pa.scheduler.db.fetch.batch_size", PropertyType.INTEGER, "50"),
+
     /* ***************************************************************** */
     /* ***************** EMAIL NOTIFICATION PROPERTIES ***************** */
     /* ***************************************************************** */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -102,7 +102,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
     protected static final int ACTIVEOBJECT_CREATION_RETRY_TIME_NUMBER = 3;
 
     /** Maximum blocking time for the do task action */
-    protected static int DOTASK_ACTION_TIMEOUT = PASchedulerProperties.SCHEDULER_STARTTASK_TIMEOUT.getValueAsInt();
+    protected int dotaskActionTimeout;
 
     protected int activeObjectCreationRetryTimeNumber;
 
@@ -274,7 +274,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 LinkedList<EligibleTaskDescriptor> tasksToSchedule = new LinkedList<>();
                 int neededResourcesNumber = 0;
 
-                while (taskRetrievedFromPolicy.size() > 0 && neededResourcesNumber == 0) {
+                while (taskRetrievedFromPolicy.isEmpty() && neededResourcesNumber == 0) {
                     //the loop will search for next compatible task until it find something
                     neededResourcesNumber = getNextcompatibleTasks(jobMap,
                                                                    taskRetrievedFromPolicy,
@@ -661,11 +661,11 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                     // Dynamically adjust the start-task-timeout according to the number dependency tasks in a merge.
                     // above 500 parent tasks, it is worth adjusting.
                     if (taskDescriptor.getParents().size() > 500) {
-                        DOTASK_ACTION_TIMEOUT = (int) (taskDescriptor.getParents().size() / 500.0 *
-                                                       PASchedulerProperties.SCHEDULER_STARTTASK_TIMEOUT.getValueAsInt());
+                        dotaskActionTimeout = (int) (taskDescriptor.getParents().size() / 500.0 *
+                                                     PASchedulerProperties.SCHEDULER_STARTTASK_TIMEOUT.getValueAsInt());
                     } else {
-                        // reset the DOTASK_ACTION_TIMEOUT to its default value otherwise.
-                        DOTASK_ACTION_TIMEOUT = PASchedulerProperties.SCHEDULER_STARTTASK_TIMEOUT.getValueAsInt();
+                        // reset the dotaskActionTimeout to its default value otherwise.
+                        dotaskActionTimeout = PASchedulerProperties.SCHEDULER_STARTTASK_TIMEOUT.getValueAsInt();
                     }
 
                     Future<Void> taskExecutionSubmittedFuture = threadPool.submitWithTimeout(new TimedDoTaskAction(job,
@@ -675,7 +675,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                                                                                                                    terminateNotification,
                                                                                                                    corePrivateKey,
                                                                                                                    terminateNotificationNodeURL),
-                                                                                             DOTASK_ACTION_TIMEOUT,
+                                                                                             dotaskActionTimeout,
                                                                                              TimeUnit.MILLISECONDS);
                     waitForTaskToBeStarted(taskExecutionSubmittedFuture);
 
@@ -708,7 +708,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
             // before signaling that the task is started, we need
             // to make sure the task is correctly submitted to the
             // task launcher
-            taskExecutionSubmittedFuture.get(DOTASK_ACTION_TIMEOUT, TimeUnit.MILLISECONDS);
+            taskExecutionSubmittedFuture.get(dotaskActionTimeout, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             logger.warn("Error while waiting for the task to be started.", e);
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -274,7 +274,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 LinkedList<EligibleTaskDescriptor> tasksToSchedule = new LinkedList<>();
                 int neededResourcesNumber = 0;
 
-                while (taskRetrievedFromPolicy.isEmpty() && neededResourcesNumber == 0) {
+                while (!taskRetrievedFromPolicy.isEmpty() && neededResourcesNumber == 0) {
                     //the loop will search for next compatible task until it find something
                     neededResourcesNumber = getNextcompatibleTasks(jobMap,
                                                                    taskRetrievedFromPolicy,

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TerminationData.java
@@ -293,11 +293,11 @@ final class TerminationData {
 
                 // Batch fetching of parent tasks results
                 Map<TaskId, TaskResult> taskResults = new HashMap<>();
-                for (List<TaskId> parentsSublit : ListUtils.partition(new ArrayList<>(parentIds),
-                                                                      PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+                for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
+                                                                       PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
                     taskResults.putAll(service.getInfrastructure()
                                               .getDBManager()
-                                              .loadTasksResults(taskData.getTask().getJobId(), parentsSublit));
+                                              .loadTasksResults(taskData.getTask().getJobId(), parentsSubList));
                 }
                 getResultsFromListOfTaskResults(variablesMap.getInheritedMap(), taskResults);
             } else {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -30,10 +30,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.collections4.ListUtils;
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
@@ -44,6 +47,7 @@ import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
 import org.ow2.proactive.scheduler.common.job.JobType;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptorImpl;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
@@ -121,11 +125,14 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
 
                 params = new TaskResult[parentIds.size()];
 
-                Map<TaskId, TaskResult> taskResults = schedulingService.getInfrastructure()
-                                                                       .getDBManager()
-                                                                       .loadTasksResults(job.getId(),
-                                                                                         new ArrayList<>(parentIds));
-
+                Map<TaskId, TaskResult> taskResults = new HashMap<>();
+                // Batch fetching of parent tasks results
+                for (List<TaskId> parentsSublit : ListUtils.partition(new ArrayList<>(parentIds),
+                                                                      PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+                    taskResults.putAll(schedulingService.getInfrastructure()
+                                                        .getDBManager()
+                                                        .loadTasksResults(job.getId(), parentsSublit));
+                }
                 int i = 0;
                 for (TaskId taskId : parentIds) {
                     params[i] = taskResults.get(taskId);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -127,11 +127,11 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
 
                 Map<TaskId, TaskResult> taskResults = new HashMap<>();
                 // Batch fetching of parent tasks results
-                for (List<TaskId> parentsSublit : ListUtils.partition(new ArrayList<>(parentIds),
-                                                                      PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+                for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
+                                                                       PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
                     taskResults.putAll(schedulingService.getInfrastructure()
                                                         .getDBManager()
-                                                        .loadTasksResults(job.getId(), parentsSublit));
+                                                        .loadTasksResults(job.getId(), parentsSubList));
                 }
                 int i = 0;
                 for (TaskId taskId : parentIds) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
@@ -145,9 +145,9 @@ public class TaskResultCreator {
 
         // Batch fetching of parent tasks results
         Map<TaskId, TaskResult> taskResults = new HashMap<>();
-        for (List<TaskId> parentsSublit : ListUtils.partition(new ArrayList<>(parentIds),
-                                                              PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
-            taskResults.putAll(dbManager.loadTasksResults(job.getId(), parentsSublit));
+        for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
+                                                               PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+            taskResults.putAll(dbManager.loadTasksResults(job.getId(), parentsSubList));
         }
 
         for (TaskResult taskResult : taskResults.values()) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.collections4.ListUtils;
 import org.ow2.proactive.db.DatabaseManagerException;
 import org.ow2.proactive.scheduler.common.JobDescriptor;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
@@ -39,6 +40,7 @@ import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskLogs;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptor;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
@@ -140,7 +142,14 @@ public class TaskResultCreator {
         for (int i = 0; i < numberOfParentTasks; i++) {
             parentIds.add(eligibleTaskDescriptor.getParents().get(i).getTaskId());
         }
-        Map<TaskId, TaskResult> taskResults = dbManager.loadTasksResults(job.getId(), parentIds);
+
+        // Batch fetching of parent tasks results
+        Map<TaskId, TaskResult> taskResults = new HashMap<>();
+        for (List<TaskId> parentsSublit : ListUtils.partition(new ArrayList<>(parentIds),
+                                                              PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+            taskResults.putAll(dbManager.loadTasksResults(job.getId(), parentsSublit));
+        }
+
         for (TaskResult taskResult : taskResults.values()) {
             if (taskResult.getPropagatedVariables() != null) {
                 mergedVariables.putAll(taskResult.getPropagatedVariables());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -42,6 +42,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlTransient;
 
+import org.apache.commons.collections4.ListUtils;
 import org.objectweb.proactive.ActiveObjectCreationException;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeException;
@@ -1180,11 +1181,18 @@ public abstract class InternalTask extends TaskState {
                     parentIds.addAll(InternalTaskParentFinder.getInstance()
                                                              .getFirstNotSkippedParentTaskIds(parentTask));
                 }
+
+                // Batch fetching of parent tasks results
+                Map<TaskId, TaskResult> taskResults = new HashMap<>();
+                for (List<TaskId> parentsSublit : ListUtils.partition(new ArrayList<>(parentIds),
+                                                                      PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+
+                    taskResults.putAll(schedulingService.getInfrastructure()
+                                                        .getDBManager()
+                                                        .loadTasksResults(internalJob.getId(), parentsSublit));
+
+                }
                 if (!parentIds.isEmpty()) {
-                    Map<TaskId, TaskResult> taskResults = schedulingService.getInfrastructure()
-                                                                           .getDBManager()
-                                                                           .loadTasksResults(internalJob.getId(),
-                                                                                             new ArrayList(parentIds));
                     updateVariablesWithTaskResults(taskResults);
                 }
             }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -1184,12 +1184,12 @@ public abstract class InternalTask extends TaskState {
 
                 // Batch fetching of parent tasks results
                 Map<TaskId, TaskResult> taskResults = new HashMap<>();
-                for (List<TaskId> parentsSublit : ListUtils.partition(new ArrayList<>(parentIds),
-                                                                      PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+                for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
+                                                                       PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
 
                     taskResults.putAll(schedulingService.getInfrastructure()
                                                         .getDBManager()
-                                                        .loadTasksResults(internalJob.getId(), parentsSublit));
+                                                        .loadTasksResults(internalJob.getId(), parentsSubList));
 
                 }
                 if (!parentIds.isEmpty()) {


### PR DESCRIPTION
In this PR, we fix and improve the following aspects related to merge tasks :
1. We fix the issue that causes merge tasks with a BIG number of parent tasks to fail. This was basically a database-related issue because the parent-task-results queries were VERY BIG.

- We fix it by BATCH PROCESSING (manually) the process of fetching parent tasks'results.
- We introduce a new property in settings.ini that defines the batch_size used to partition and batch the aforementioned querying process.

2. We fix another issue related to merges with a big number of parent tasks. This second issue consisted in a task-start-timeout that caused the merge task to fail because the fetching of its parents'results takes too long and the scheduler wouldn't wait for it to start. 
- We fix this by adjusting the start-task-timeout dynamically according to the number of parents tasks in a merge.
- We use the following formulae that takes into account the user defined property `pa.scheduler.core.starttask.timeout`:
```
if(merge_task)
     START-TASK-TIMEOUT = NBR_PARENTS /500 * pa.scheduler.core.starttask.timeout
else //the default user defined value
     pa.scheduler.core.starttask.timeout
```