### PR TITLE
Adapt nodes recovery per node source

### DIFF
--- a/config/security.java.policy-server
+++ b/config/security.java.policy-server
@@ -21,6 +21,8 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeSourcesList";
@@ -100,6 +102,8 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.listAliveNodeUrls";
@@ -187,6 +191,8 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNode";
@@ -236,6 +242,8 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.createNodesource";

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/CommandSet.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/CommandSet.java
@@ -686,8 +686,9 @@ public class CommandSet {
                                                                            .description("Create new node source")
                                                                            .hasArgs(true)
                                                                            .numOfArgs(1)
-                                                                           .argNames("node-source")
-                                                                           .jsCommand("createns(node-source)")
+                                                                           .hasOptionalArg(true)
+                                                                           .argNames("node-source [nodes-recoverable]")
+                                                                           .jsCommand("createns(node-source[,nodes-recoverable])")
                                                                            .commandClass(CreateNodeSourceCommand.class)
                                                                            .entry();
 

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/rm/CreateNodeSourceCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/rm/CreateNodeSourceCommand.java
@@ -45,8 +45,16 @@ import org.ow2.proactive_grid_cloud_portal.cli.utils.QueryStringBuilder;
 public class CreateNodeSourceCommand extends AbstractCommand implements Command {
     private String nodeSource;
 
+    private String nodesRecoverable;
+
     public CreateNodeSourceCommand(String nodeSource) {
         this.nodeSource = nodeSource;
+        this.nodesRecoverable = "true";
+    }
+
+    public CreateNodeSourceCommand(String nodeSource, String nodesRecoverable) {
+        this.nodeSource = nodeSource;
+        this.nodesRecoverable = nodesRecoverable;
     }
 
     @Override
@@ -64,7 +72,10 @@ public class CreateNodeSourceCommand extends AbstractCommand implements Command 
         }
         HttpPost request = new HttpPost(currentContext.getResourceUrl("nodesource/create"));
         QueryStringBuilder queryStringBuilder = new QueryStringBuilder();
-        queryStringBuilder.add("nodeSourceName", nodeSource).addAll(infrastructure).addAll(policy);
+        queryStringBuilder.add("nodeSourceName", nodeSource)
+                          .addAll(infrastructure)
+                          .addAll(policy)
+                          .add("nodesRecoverable", nodesRecoverable);
         request.setEntity(queryStringBuilder.buildEntity(APPLICATION_FORM_URLENCODED));
         HttpResponseWrapper response = execute(request, currentContext);
         if (statusCode(OK) == statusCode(response)) {

--- a/rest/rest-cli/src/main/resources/org/ow2/proactive_grid_cloud_portal/cli/cmd/commands.js
+++ b/rest/rest-cli/src/main/resources/org/ow2/proactive_grid_cloud_portal/cli/cmd/commands.js
@@ -461,10 +461,15 @@ function removenode(nodeUrl, preempt) {
     execute(new RemoveNodeCommand('' + nodeUrl, preempt));
 }
 
-function createns(nodeSource, infrastructure, policy) {
+function createns(nodeSource, infrastructure, policy, nodesRecoverable) {
     execute(new SetInfrastructureCommand(infrastructure));
     execute(new SetPolicyCommand(policy));
-    execute(new CreateNodeSourceCommand('' + nodeSource));
+    if(typeof nodesRecoverable == 'undefined'){
+        execute(new CreateNodeSourceCommand('' + nodeSource));
+    }
+    else{
+        execute(new CreateNodeSourceCommand('' + nodeSource, '' + nodesRecoverable));
+    }
 }
 
 function removens(nodeSource, preempt) {

--- a/rest/rest-cli/src/test/java/functionaltests/NodeSourceCommandsFunctTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/NodeSourceCommandsFunctTest.java
@@ -1,0 +1,105 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.Range;
+
+
+/**
+ * This class tests the CLI commands related to the node sources.
+ */
+public class NodeSourceCommandsFunctTest extends AbstractFunctCmdTest {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        System.out.println("Init class: " + NodeSourceCommandsFunctTest.class);
+        init();
+        System.out.println("Finished init class: " + NodeSourceCommandsFunctTest.class);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    public void testCreateNodeSourceAndListNodeSources() throws Exception {
+        String testLogString = "[" + NodeSourceCommandsFunctTest.class.getSimpleName() + "]";
+
+        int nbNodes = 4;
+        String nodeSourceName = "nsCreatedThroughCLI";
+        String nodeSourceInfrastructureClass = "org.ow2.proactive.resourcemanager.nodesource.infrastructure.LocalInfrastructure";
+        String nodeSourcePolicyClass = "org.ow2.proactive.resourcemanager.nodesource.policy.StaticPolicy";
+
+        System.out.println(testLogString + "Test createns command");
+
+        typeLine("createns( '" + nodeSourceName + "', ['" + nodeSourceInfrastructureClass + "', '" +
+                 RestFuncTHelper.getRmCredentialsPath() + "', " + nbNodes + ", 60000, ''], ['" + nodeSourcePolicyClass +
+                 "', 'ALL', 'ALL'])");
+        runCli();
+
+        String out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println(out);
+
+        assertThat(out).contains("Node source successfully created.");
+
+        System.out.println(testLogString + "Test listns command");
+
+        typeLine("listns()");
+        runCli();
+
+        out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println(out);
+
+        assertThat(out).contains(nodeSourceName);
+
+        System.out.println(testLogString + "Test listnodes command");
+
+        typeLine("listnodes(\"" + nodeSourceName + "\")");
+        runCli();
+
+        out = this.capturedOutput.toString();
+        System.setOut(stdOut);
+        System.out.println(out);
+        int nbOccurrencesOfNodeSourceNameInNodeList = StringUtils.countMatches(out, nodeSourceName);
+
+        // depending on the time it takes to add the nodes to the RM, the node
+        // source name can appear once per node or twice per node, whether the
+        // node is deploying or registered (in which case the node source name
+        // appears also in the URL of the node)
+        assertThat(nbOccurrencesOfNodeSourceNameInNodeList).isIn(Range.closed(nbNodes, nbNodes * 2));
+    }
+
+}

--- a/rest/rest-cli/src/test/java/functionaltests/NodeSourceCommandsFunctTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/NodeSourceCommandsFunctTest.java
@@ -96,10 +96,10 @@ public class NodeSourceCommandsFunctTest extends AbstractFunctCmdTest {
         int nbOccurrencesOfNodeSourceNameInNodeList = StringUtils.countMatches(out, nodeSourceName);
 
         // depending on the time it takes to add the nodes to the RM, the node
-        // source name can appear once per node or twice per node, whether the
+        // source name can appear once per node or more per node, whether the
         // node is deploying or registered (in which case the node source name
         // appears also in the URL of the node)
-        assertThat(nbOccurrencesOfNodeSourceNameInNodeList).isIn(Range.closed(nbNodes, nbNodes * 2));
+        assertThat(nbOccurrencesOfNodeSourceNameInNodeList).isAtLeast(nbNodes);
     }
 
 }

--- a/rest/rest-cli/src/test/java/functionaltests/TagCommandsFunctTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/TagCommandsFunctTest.java
@@ -366,4 +366,5 @@ public class TagCommandsFunctTest extends AbstractFunctCmdTest {
         System.out.println(out);
         assertTrue(out.contains("error"));
     }
+
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -108,6 +108,13 @@ import org.rrd4j.core.RrdDb;
 @Path("/rm")
 public class RMRest implements RMRestInterface {
 
+    /**
+     * The createNodeSource endpoint will create a node source with
+     * recoverable nodes if the nodesRecoverable value is equal to the string
+     * "true", regardless of the case
+     */
+    private static final String CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES_VALUE = "true";
+
     protected static final String[] dataSources = { //
                                                     // "AverageInactivity", // redundant with AverageActivity
                                                     // "ToBeReleasedNodesCo", // useless info
@@ -383,7 +390,8 @@ public class RMRest implements RMRestInterface {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
-            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException {
+            @FormParam("policyFileParameters") String[] policyFileParameters,
+            @FormParam("nodesRecoverable") String nodesRecoverable) throws NotConnectedException {
         ResourceManager rm = checkAccess(sessionId);
         Object[] infraParams = new Object[infrastructureParameters.length + infrastructureFileParameters.length];
         Object[] policyParams = new Object[policyParameters.length + policyFileParameters.length];
@@ -433,7 +441,8 @@ public class RMRest implements RMRestInterface {
                                                   infrastructureType,
                                                   infraParams,
                                                   policyType,
-                                                  policyParams)
+                                                  policyParams,
+                                                  nodesRecoverable.equalsIgnoreCase(CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES_VALUE))
                                 .getBooleanValue());
         } catch (RuntimeException ex) {
             nsState.setResult(false);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -108,13 +108,6 @@ import org.rrd4j.core.RrdDb;
 @Path("/rm")
 public class RMRest implements RMRestInterface {
 
-    /**
-     * The createNodeSource endpoint will create a node source with
-     * recoverable nodes if the nodesRecoverable value is equal to the string
-     * "true", regardless of the case
-     */
-    private static final String CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES_VALUE = "true";
-
     protected static final String[] dataSources = { //
                                                     // "AverageInactivity", // redundant with AverageActivity
                                                     // "ToBeReleasedNodesCo", // useless info
@@ -442,8 +435,7 @@ public class RMRest implements RMRestInterface {
                                                   infraParams,
                                                   policyType,
                                                   policyParams,
-                                                  nodesRecoverable.equalsIgnoreCase(CREATE_NODE_SOURCE_WITH_RECOVERABLE_NODES_VALUE))
-                                .getBooleanValue());
+                                                  Boolean.parseBoolean(nodesRecoverable)).getBooleanValue());
         } catch (RuntimeException ex) {
             nsState.setResult(false);
             nsState.setErrorMessage(cleanDisplayedErrorMessage(ex.getMessage()));

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -349,6 +349,31 @@ public class RMRest implements RMRestInterface {
     }
 
     /**
+     * {@link RMRest#createNodeSource(String, String, String, String[], String[], String, String[], String[], String)}
+     */
+    @Override
+    @POST
+    @Path("nodesource/create")
+    @Produces("application/json")
+    public NSState createNodeSource(@HeaderParam("sessionid") String sessionId,
+            @FormParam("nodeSourceName") String nodeSourceName,
+            @FormParam("infrastructureType") String infrastructureType,
+            @FormParam("infrastructureParameters") String[] infrastructureParameters,
+            @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
+            @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
+            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException {
+        return createNodeSource(sessionId,
+                                nodeSourceName,
+                                infrastructureType,
+                                infrastructureParameters,
+                                infrastructureFileParameters,
+                                policyType,
+                                policyParameters,
+                                policyFileParameters,
+                                Boolean.TRUE.toString());
+    }
+
+    /**
      * Create a NodeSource
      * <p>
      *
@@ -370,12 +395,14 @@ public class RMRest implements RMRestInterface {
      *            containing files or credentials
      * @param policyFileParameters
      *            File or credential parameters
+     * @param nodesRecoverable
+     *            Whether the nodes can be recovered after a crash of the RM
      * @return true if a node source has been created
      * @throws NotConnectedException 
      */
     @Override
     @POST
-    @Path("nodesource/create")
+    @Path("nodesource/create/recovery")
     @Produces("application/json")
     public NSState createNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName,
@@ -435,7 +462,8 @@ public class RMRest implements RMRestInterface {
                                                   infraParams,
                                                   policyType,
                                                   policyParams,
-                                                  Boolean.parseBoolean(nodesRecoverable)).getBooleanValue());
+                                                  Boolean.parseBoolean(nodesRecoverable))
+                                .getBooleanValue());
         } catch (RuntimeException ex) {
             nsState.setResult(false);
             nsState.setErrorMessage(cleanDisplayedErrorMessage(ex.getMessage()));

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
@@ -161,6 +161,17 @@ public interface RMRestInterface {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
+            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException;
+
+    @POST
+    @Path("nodesource/create/recovery")
+    @Produces("application/json")
+    NSState createNodeSource(@HeaderParam("sessionid") String sessionId,
+            @FormParam("nodeSourceName") String nodeSourceName,
+            @FormParam("infrastructureType") String infrastructureType,
+            @FormParam("infrastructureParameters") String[] infrastructureParameters,
+            @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
+            @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
             @FormParam("policyFileParameters") String[] policyFileParameters,
             @FormParam("nodesRecoverable") String nodesRecoverable) throws NotConnectedException;
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
@@ -161,7 +161,8 @@ public interface RMRestInterface {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
-            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException;
+            @FormParam("policyFileParameters") String[] policyFileParameters,
+            @FormParam("nodesRecoverable") String nodesRecoverable) throws NotConnectedException;
 
     @POST
     @Path("nodesource/pingfrequency")

--- a/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
@@ -77,7 +77,8 @@ public class RestFuncTHelper {
 
     public final static int DEFAULT_NUMBER_OF_NODES = 1;
 
-    public static final String RM_CRED_RELATIVE_PATH = "config/authentication/rm.cred";
+    public static final String RM_CRED_RELATIVE_PATH = "config" + File.separator + "authentication" + File.separator +
+                                                       "rm.cred";
 
     private static String restServerUrl;
 

--- a/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
@@ -77,6 +77,8 @@ public class RestFuncTHelper {
 
     public final static int DEFAULT_NUMBER_OF_NODES = 1;
 
+    public static final String RM_CRED_RELATIVE_PATH = "config/authentication/rm.cred";
+
     private static String restServerUrl;
 
     private static String restfulSchedulerUrl;
@@ -229,6 +231,10 @@ public class RestFuncTHelper {
         return new File(defaultJobXml.toURI());
     }
 
+    public static String getRmCredentialsPath() throws Exception {
+        return getRmHome() + File.separator + RM_CRED_RELATIVE_PATH;
+    }
+
     private static String toPath(URL url) throws Exception {
         return (new File(url.toURI())).getCanonicalPath();
     }
@@ -242,7 +248,7 @@ public class RestFuncTHelper {
     }
 
     private static Credentials getRmCredentials() throws Exception {
-        File rmCredentails = new File(getRmHome(), "config/authentication/rm.cred");
+        File rmCredentails = new File(getRmHome(), RM_CRED_RELATIVE_PATH);
         return Credentials.getCredentials(new FileInputStream(rmCredentails));
     }
 

--- a/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
+++ b/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
@@ -20,6 +20,9 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeSourcesList";
@@ -90,6 +93,9 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.listAliveNodeUrls";
@@ -161,6 +167,9 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNode";
@@ -205,6 +214,9 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.createNodesource";

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
@@ -114,10 +114,11 @@ public class RMProxyUserInterface extends RMListenerProxy implements ResourceMan
     }
 
     /**
-     * @see org.ow2.proactive.resourcemanager.frontend.ResourceManager#createNodeSource(java.lang.String, java.lang.String, java.lang.Object[], java.lang.String, java.lang.Object[])
+     * @see ResourceManager#createNodeSource(String, String, Object[], String, Object[], boolean)
      */
-    public BooleanWrapper createNodeSource(String arg0, String arg1, Object[] arg2, String arg3, Object[] arg4) {
-        return target.createNodeSource(arg0, arg1, arg2, arg3, arg4);
+    public BooleanWrapper createNodeSource(String arg0, String arg1, Object[] arg2, String arg3, Object[] arg4,
+            boolean arg5) {
+        return target.createNodeSource(arg0, arg1, arg2, arg3, arg4, arg5);
     }
 
     /**
@@ -384,6 +385,16 @@ public class RMProxyUserInterface extends RMListenerProxy implements ResourceMan
     @Override
     public void releaseBusyNodesNotInList(List<NodeSet> verifiedBusyNodes) {
         target.releaseBusyNodesNotInList(verifiedBusyNodes);
+    }
+
+    @Override
+    public boolean areNodesKnown(NodeSet nodes) {
+        return target.areNodesKnown(nodes);
+    }
+
+    @Override
+    public boolean areNodesRecoverable(NodeSet nodes) {
+        return target.areNodesRecoverable(nodes);
     }
 
 }

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
@@ -80,10 +80,11 @@ public interface ResourceManager {
      * @param infrastructureParameters parameters for infrastructure creation
      * @param policyType name of the policy type. It passed as a string due to plug-able approach
      * @param policyParameters parameters for policy creation
+     * @param nodesRecoverable whether the nodes can be recovered in case of a scheduler crash
      * @return true if a new node source was created successfully, runtime exception otherwise
      */
     BooleanWrapper createNodeSource(String nodeSourceName, String infrastructureType, Object[] infrastructureParameters,
-            String policyType, Object[] policyParameters);
+            String policyType, Object[] policyParameters, boolean nodesRecoverable);
 
     /**
      * Remove a node source from the RM.
@@ -446,5 +447,23 @@ public interface ResourceManager {
      * @param verifiedBusyNodes nodes that should not be released
      */
     void releaseBusyNodesNotInList(List<NodeSet> verifiedBusyNodes);
+
+    /**
+     * Check whether the nodes in the given node set are known by the resource
+     * manager
+     *
+     * @param nodes the node set to verify
+     * @return whether all nodes in the node set appear in the resource manager
+     */
+    boolean areNodesKnown(NodeSet nodes);
+
+    /**
+     * Check whether the nodes in the given node set can be recovered in case
+     * of a crash
+     *
+     * @param nodes the node set to verify
+     * @return whether all nodes in the node set are recoverable
+     */
+    boolean areNodesRecoverable(NodeSet nodes);
 
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -484,18 +484,12 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
         for (NodeSourceData nodeSourceData : nodeSources) {
             String nodeSourceDataName = nodeSourceData.getName();
-
-            if (NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME.equals(nodeSourceDataName)) {
-                // will be recreated by SchedulerStarter
-                dbManager.removeNodeSource(nodeSourceDataName);
-            } else {
-                try {
-                    logger.info("Recovering node source " + nodeSourceDataName);
-                    createNodeSource(nodeSourceData, true);
-                } catch (Throwable t) {
-                    logger.error(t.getMessage(), t);
-                    brokenNodeSources.add(nodeSourceDataName);
-                }
+            try {
+                logger.info("Recovering node source " + nodeSourceDataName);
+                createNodeSource(nodeSourceData, nodeSourceData.getNodesRecoverable());
+            } catch (Throwable t) {
+                logger.error(t.getMessage(), t);
+                brokenNodeSources.add(nodeSourceDataName);
             }
         }
     }
@@ -985,7 +979,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                              DefaultInfrastructureManager.class.getName(),
                              null,
                              StaticPolicy.class.getName(),
-                             null).getBooleanValue();
+                             null,
+                             NodeSource.DEFAULT_RECOVERABLE).getBooleanValue();
         }
 
         if (nodeSources.containsKey(sourceName)) {
@@ -1311,10 +1306,10 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
      * @param infrastructureParameters parameters for infrastructure creation
      * @param policyType               name of the policy type. It passed as a string due to pluggable approach {@link NodeSourcePolicyFactory}
      * @param policyParameters         parameters for policy creation
+     * @param nodesRecoverable         whether the nodes can be recovered in case of a scheduler crash
      */
-
     public BooleanWrapper createNodeSource(String nodeSourceName, String infrastructureType,
-            Object[] infrastructureParameters, String policyType, Object[] policyParameters) {
+            Object[] infrastructureParameters, String policyType, Object[] policyParameters, boolean nodesRecoverable) {
 
         if (nodeSourceName == null) {
             throw new IllegalArgumentException("Node Source name cannot be null");
@@ -1326,11 +1321,12 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                            infrastructureParameters,
                                                            policyType,
                                                            policyParameters,
-                                                           caller);
+                                                           caller,
+                                                           nodesRecoverable);
         boolean added = dbManager.addNodeSource(nodeSourceData);
 
         try {
-            return createNodeSource(nodeSourceData, false);
+            return createNodeSource(nodeSourceData, nodesRecoverable);
         } catch (RuntimeException ex) {
             logger.error(ex.getMessage(), ex);
             if (added) {
@@ -1340,7 +1336,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         }
     }
 
-    protected BooleanWrapper createNodeSource(NodeSourceData nodeSourceData, boolean isRecovery) {
+    protected BooleanWrapper createNodeSource(NodeSourceData nodeSourceData, boolean nodesRecoverable) {
         String nodeSourceName = nodeSourceData.getName();
 
         //checking that nsname doesn't contain invalid characters and doesn't exist yet
@@ -1348,13 +1344,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
         logger.info("Creating a node source : " + nodeSourceName);
 
-        // if this is a recovery, we also need to check whether there are
-        // nodes in database for this node source, otherwise, we will do a
-        // redeployment from scratch. The reason is that when the RM shuts
-        // down correctly, it removes all its nodes. Thus if we restart and
-        // recover the RM afterwards there will be no nodes in the database,
-        // but there will be no redeployment neither, hence the special case here.
-        boolean recoverNodes = existNodesToRecover(nodeSourceName, isRecovery);
+        boolean recoverNodes = existNodesToRecover(nodeSourceName, nodesRecoverable);
 
         InfrastructureManager im;
 
@@ -1380,7 +1370,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                         im,
                                         policy,
                                         (RMCore) PAActiveObject.getStubOnThis(),
-                                        this.monitoring);
+                                        this.monitoring,
+                                        nodesRecoverable);
             nodeSource = PAActiveObject.turnActive(nodeSource, nodeRM);
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
@@ -1429,17 +1420,21 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         return new BooleanWrapper(true);
     }
 
-    private boolean existNodesToRecover(String nodeSourceName, boolean isRecovery) {
+    /**
+     * @return whether there are nodes in database for the given node source
+     *
+     * In case of a recovery, we need to check whether there are nodes in
+     * database for this node source, otherwise, we will do a redeployment
+     * from scratch. The reason is that when the RM shuts down correctly,
+     * it removes all its nodes. Thus if we restart and recover the RM
+     * afterwards there will be no nodes in the database.
+     */
+    private boolean existNodesToRecover(String nodeSourceName, boolean nodesRecoverable) {
         boolean recoverNodes = false;
-        if (isRecovery) {
-            // check what is in database for this node source
+        if (nodesRecoverable) {
             Collection<RMNodeData> nodesData = dbManager.getNodesByNodeSource(nodeSourceName);
-            // if there is no node in database for this node source, then
-            // abort nodes recovery and let the node source being redeployed
-            // from scratch
             if (nodesData.isEmpty()) {
-                logger.info("No node found in database for node source: " + nodeSourceName +
-                            ". Node source will be redeployed");
+                logger.info("No node found in database for node source: " + nodeSourceName);
             } else {
                 recoverNodes = true;
             }
@@ -2427,15 +2422,18 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         nodesCleaner.cleanAndRelease(busyNodesToRelease);
     }
 
-    private List<RMNode> findBusyNodesNotInSet(Set<String> nodesUrlToNotRelease) {
+    private List<RMNode> findBusyNodesNotInSet(Set<String> nodesURL) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Given set of busy nodes URL: " + Arrays.toString(nodesURL.toArray()));
+        }
         List<RMNode> busyNodesNotInGivenSet = new LinkedList<>();
 
         for (Entry<String, RMNode> nodeEntry : allNodes.entrySet()) {
             String nodeUrl = nodeEntry.getKey();
             RMNode node = nodeEntry.getValue();
 
-            if (node.isBusy() && !nodesUrlToNotRelease.contains(nodeUrl)) {
-                logger.debug("Dangling busy node found: " + node.getNodeName());
+            if (node.isBusy() && !nodesURL.contains(nodeUrl)) {
+                logger.debug("Found busy node not in given set: " + node.getNodeName());
                 busyNodesNotInGivenSet.add(node);
             }
         }
@@ -2443,8 +2441,38 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         return busyNodesNotInGivenSet;
     }
 
-    private boolean nodeRecoveryEnabled() {
-        return PAResourceManagerProperties.RM_NODES_RECOVERY.getValueAsBoolean();
+    @Override
+    public boolean areNodesKnown(NodeSet nodes) {
+        Set<String> nodesURL = nodes.getAllNodesUrls();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Check whether RM knows nodes URL: " + Arrays.toString(nodesURL.toArray()));
+        }
+
+        for (String nodeURL : nodesURL) {
+            if (!allNodes.containsKey(nodeURL)) {
+                logger.info("RM is not aware of node URL " + nodeURL);
+                return false;
+            }
+        }
+
+        logger.info("All given nodes are managed by the RM");
+        return true;
+    }
+
+    @Override
+    public boolean areNodesRecoverable(NodeSet nodes) {
+        Set<String> nodesURL = nodes.getAllNodesUrls();
+
+        for (String nodeURL : nodesURL) {
+            RMNode rmNode = allNodes.get(nodeURL);
+            if (rmNode == null || !rmNode.getNodeSource().nodesRecoverable()) {
+                logger.debug("RMNode corresponding to URL " + nodeURL + " is not recoverable");
+                return false;
+            }
+        }
+
+        logger.debug("All given nodes are recoverable");
+        return true;
     }
 
     /**
@@ -2453,13 +2481,11 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
      * @param rmNode the node to add to the database
      */
     private void persistNewRMNodeIfRecoveryEnabled(RMNode rmNode) {
-        if (nodeRecoveryEnabled()) {
+        if (nodesRecoveryEnabled(rmNode)) {
             RMNodeData rmNodeData = RMNodeData.createRMNodeData(rmNode);
             NodeSourceData nodeSourceData = dbManager.getNodeSource(rmNode.getNodeSourceName());
             rmNodeData.setNodeSource(nodeSourceData);
-            if (!NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME.equals(nodeSourceData.getName())) {
-                dbManager.addNode(rmNodeData);
-            }
+            dbManager.addNode(rmNodeData);
         }
     }
 
@@ -2469,12 +2495,15 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
      * @param rmNode the node to update in database
      */
     private void persistUpdatedRMNodeIfRecoveryEnabled(RMNode rmNode) {
-        if (nodeRecoveryEnabled()) {
+        if (nodesRecoveryEnabled(rmNode)) {
             RMNodeData rmNodeData = RMNodeData.createRMNodeData(rmNode);
-            if (!NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME.equals(rmNode.getNodeSourceName())) {
-                dbManager.updateNode(rmNodeData);
-            }
+            dbManager.updateNode(rmNodeData);
         }
+    }
+
+    private boolean nodesRecoveryEnabled(RMNode rmNode) {
+        return PAResourceManagerProperties.RM_NODES_RECOVERY.getValueAsBoolean() &&
+               rmNode.getNodeSource().nodesRecoverable();
     }
 
     private boolean isEligible(RMNode node) {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -62,6 +62,8 @@ public class NodeSourceData implements Serializable {
 
     private Client provider;
 
+    private boolean nodesRecoverable;
+
     /**
      * name of the variable --> value of the variable
      */
@@ -71,7 +73,7 @@ public class NodeSourceData implements Serializable {
     }
 
     public NodeSourceData(String nodeSourceName, String infrastructureType, Object[] infrastructureParameters,
-            String policyType, Object[] policyParameters, Client provider) {
+            String policyType, Object[] policyParameters, Client provider, boolean nodesRecoverable) {
 
         this.name = nodeSourceName;
         this.infrastructureType = infrastructureType;
@@ -79,6 +81,7 @@ public class NodeSourceData implements Serializable {
         this.policyType = policyType;
         this.policyParameters = policyParameters;
         this.provider = provider;
+        this.nodesRecoverable = nodesRecoverable;
         this.infrastructureVariables = new HashMap<>();
     }
 
@@ -139,6 +142,15 @@ public class NodeSourceData implements Serializable {
 
     public void setProvider(Client provider) {
         this.provider = provider;
+    }
+
+    @Column
+    public boolean getNodesRecoverable() {
+        return nodesRecoverable;
+    }
+
+    public void setNodesRecoverable(boolean nodesRecoverable) {
+        this.nodesRecoverable = nodesRecoverable;
     }
 
     @Column(length = Integer.MAX_VALUE)

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -99,7 +99,12 @@ public class NodeSource implements InitActive, RunActive {
     /** Default name for NS with local nodes started with the Scheduler by default */
     public static final String DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME = "LocalNodes";
 
+    /** Default name for NS with local nodes started with the Scheduler by default */
+    public static final boolean DEFAULT_LOCAL_NODES_NODE_SOURCE_RECOVERABLE = false;
+
     public static final String DEFAULT = "Default";
+
+    public static final boolean DEFAULT_RECOVERABLE = true;
 
     public static final int INTERNAL_POOL = 0;
 
@@ -149,6 +154,8 @@ public class NodeSource implements InitActive, RunActive {
     // level is configured by ns admin at the moment of ns creation
     private AccessType nodeUserAccessType;
 
+    private final boolean nodesRecoverable;
+
     static {
         try {
             int maxThreads = PAResourceManagerProperties.RM_NODESOURCE_MAX_THREAD_NUMBER.getValueAsInt();
@@ -178,6 +185,7 @@ public class NodeSource implements InitActive, RunActive {
         adminPermission = null;
         providerPermission = null;
         monitoring = null;
+        nodesRecoverable = PAResourceManagerProperties.RM_NODES_RECOVERY.getValueAsBoolean();
     }
 
     /**
@@ -190,7 +198,7 @@ public class NodeSource implements InitActive, RunActive {
      * @param rmcore resource manager core
      */
     public NodeSource(String registrationURL, String name, Client provider, InfrastructureManager im,
-            NodeSourcePolicy policy, RMCore rmcore, RMMonitoringImpl monitor) {
+            NodeSourcePolicy policy, RMCore rmcore, RMMonitoringImpl monitor, boolean nodesRecoverable) {
         this.registrationURL = registrationURL;
         this.name = name;
         this.administrator = provider;
@@ -214,6 +222,7 @@ public class NodeSource implements InitActive, RunActive {
                                                           nodeSourcePolicy.getProviderAccessType()
                                                                           .getIdentityPrincipals(provider));
         this.nodeUserAccessType = nodeSourcePolicy.getUserAccessType();
+        this.nodesRecoverable = nodesRecoverable;
     }
 
     /**
@@ -662,6 +671,14 @@ public class NodeSource implements InitActive, RunActive {
     @ImmediateService
     public String getName() {
         return name;
+    }
+
+    /**
+     * @return whether nodes recovery is activated for this node source
+     */
+    @ImmediateService
+    public boolean nodesRecoverable() {
+        return nodesRecoverable;
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -59,6 +59,7 @@ import org.ow2.proactive.resourcemanager.common.event.RMNodeEvent;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeSourceEvent;
 import org.ow2.proactive.resourcemanager.core.RMCore;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
+import org.ow2.proactive.resourcemanager.db.NodeSourceData;
 import org.ow2.proactive.resourcemanager.db.RMNodeData;
 import org.ow2.proactive.resourcemanager.exception.AddingNodesException;
 import org.ow2.proactive.resourcemanager.exception.RMException;
@@ -197,8 +198,9 @@ public class NodeSource implements InitActive, RunActive {
      * @param policy nodes acquisition policy
      * @param rmcore resource manager core
      */
-    public NodeSource(String registrationURL, String name, Client provider, InfrastructureManager im,
-            NodeSourcePolicy policy, RMCore rmcore, RMMonitoringImpl monitor, boolean nodesRecoverable) {
+    public NodeSource(String registrationURL, String name, InfrastructureManager im, NodeSourcePolicy policy,
+            RMCore rmcore, RMMonitoringImpl monitor, NodeSourceData nodeSourceData) {
+        Client provider = nodeSourceData.getProvider();
         this.registrationURL = registrationURL;
         this.name = name;
         this.administrator = provider;
@@ -222,7 +224,7 @@ public class NodeSource implements InitActive, RunActive {
                                                           nodeSourcePolicy.getProviderAccessType()
                                                                           .getIdentityPrincipals(provider));
         this.nodeUserAccessType = nodeSourcePolicy.getUserAccessType();
-        this.nodesRecoverable = nodesRecoverable;
+        this.nodesRecoverable = nodeSourceData.getNodesRecoverable();
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/utils/RMStarter.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/utils/RMStarter.java
@@ -155,7 +155,8 @@ public class RMStarter {
                                                  LocalInfrastructure.class.getName(),
                                                  new Object[] { creds, defaultNodesNumber, nodeTimeout, "" },
                                                  RestartDownNodesPolicy.class.getName(),
-                                                 null);
+                                                 null,
+                                                 NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_RECOVERABLE);
                 resourceManager.disconnect();
                 logger.info("The resource manager with " + defaultNodesNumber + " local nodes created on " +
                             auth.getHostURL());

--- a/rm/rm-server/src/test/java/functionaltests/db/NodeSourcesTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/db/NodeSourcesTest.java
@@ -166,7 +166,8 @@ public class NodeSourcesTest extends ProActiveTest {
                                   new String[] { "infrastructure" },
                                   StaticPolicy.class.getName(),
                                   new String[] { "policy" },
-                                  new Client(null, false));
+                                  new Client(null, false),
+                                  false);
     }
 
 }

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureRestartDownNodesPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureRestartDownNodesPolicy.java
@@ -71,7 +71,8 @@ public class TestLocalInfrastructureRestartDownNodesPolicy extends RMFunctionalT
                                   LocalInfrastructure.class.getName(),
                                   new Object[] { creds, defaultDescriptorNodesNb, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                   RestartDownNodesPolicy.class.getName(),
-                                  policyParameters);
+                                  policyParameters,
+                                  NODES_NOT_RECOVERABLE);
 
         rmHelper.waitForNodeSourceCreation(sourceName, defaultDescriptorNodesNb);
     }

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureStaticPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureStaticPolicy.java
@@ -62,7 +62,8 @@ public class TestLocalInfrastructureStaticPolicy extends RMFunctionalTest {
                                                        LocalInfrastructure.class.getName(),
                                                        new Object[] { creds, 0, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                                        StaticPolicy.class.getName(),
-                                                       null);
+                                                       null,
+                                                       NODES_NOT_RECOVERABLE);
 
         rmHelper.waitForNodeSourceCreation(sourceName);
     }
@@ -76,7 +77,8 @@ public class TestLocalInfrastructureStaticPolicy extends RMFunctionalTest {
                                   LocalInfrastructure.class.getName(),
                                   new Object[] { creds, defaultDescriptorNodesNb, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                   StaticPolicy.class.getName(),
-                                  null);
+                                  null,
+                                  NODES_NOT_RECOVERABLE);
 
         rmHelper.waitForNodeSourceCreation(sourceName, defaultDescriptorNodesNb);
     }

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureTimeSlotPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureTimeSlotPolicy.java
@@ -67,7 +67,8 @@ public class TestLocalInfrastructureTimeSlotPolicy extends RMFunctionalTest {
                                                        LocalInfrastructure.class.getName(),
                                                        new Object[] { creds, 0, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                                        TimeSlotPolicy.class.getName(),
-                                                       getPolicyParams());
+                                                       getPolicyParams(),
+                                                       NODES_NOT_RECOVERABLE);
 
         rmHelper.waitForNodeSourceCreation(sourceName);
     }
@@ -81,7 +82,8 @@ public class TestLocalInfrastructureTimeSlotPolicy extends RMFunctionalTest {
                                   new Object[] { creds, descriptorNodeNumber, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                   //first parameter is empty rmHelper url
                                   TimeSlotPolicy.class.getName(),
-                                  getPolicyParams());
+                                  getPolicyParams(),
+                                  NODES_NOT_RECOVERABLE);
 
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, sourceName);
 

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestNodeSourceAfterRestart.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestNodeSourceAfterRestart.java
@@ -51,7 +51,8 @@ public class TestNodeSourceAfterRestart extends RMFunctionalTest {
                                                        new Object[] { creds, 1, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                                        //first parameter is empty rmHelper url
                                                        StaticPolicy.class.getName(),
-                                                       new Object[] { "ME", "ALL" });
+                                                       new Object[] { "ME", "ALL" },
+                                                       NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceCreation(sourceName, 1);
     }
 

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.concurrent.Executors;
 
 import org.apache.sshd.SshServer;
 import org.apache.sshd.common.NamedFactory;
@@ -97,7 +96,8 @@ public class TestSSHInfrastructureV2 extends RMFunctionalTest {
                                          SSHInfrastructureV2.class.getName(),
                                          infraParams,
                                          StaticPolicy.class.getName(),
-                                         policyParameters);
+                                         policyParameters,
+                                         NODES_NOT_RECOVERABLE);
         this.rmHelper.waitForNodeSourceCreation(nsname, NB_NODES, this.rmHelper.getMonitorsHandler());
 
         RMTHelper.log("Checking scheduler state after node source creation");

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
@@ -73,7 +73,8 @@ public class TestSSHInfrastructureV2RestartDownNodesPolicy extends RMFunctionalT
                                          SSHInfrastructureV2.class.getName(),
                                          TestSSHInfrastructureV2.infraParams,
                                          RestartDownNodesPolicy.class.getName(),
-                                         TestSSHInfrastructureV2.policyParameters);
+                                         TestSSHInfrastructureV2.policyParameters,
+                                         NODES_NOT_RECOVERABLE);
         RMMonitorsHandler monitorsHandler = this.rmHelper.getMonitorsHandler();
 
         this.rmHelper.waitForNodeSourceCreation(nsname, NB_NODES, monitorsHandler);

--- a/rm/rm-server/src/test/java/functionaltests/nodesrecovery/NodesRecoveryProcessHelper.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesrecovery/NodesRecoveryProcessHelper.java
@@ -23,7 +23,7 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package functionaltests.utils;
+package functionaltests.nodesrecovery;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -114,7 +114,7 @@ public class NodesRecoveryProcessHelper {
         throw new ProcessNotFoundException(processName, stringBuilder);
     }
 
-    static private class ProcessNotFoundException extends Exception {
+    static class ProcessNotFoundException extends Exception {
 
         ProcessNotFoundException(String processName, StringBuilder stringBuilder) {
             // build sentence in reverse manner

--- a/rm/rm-server/src/test/java/functionaltests/nodesrecovery/NodesRecoveryPropertyTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesrecovery/NodesRecoveryPropertyTest.java
@@ -1,0 +1,182 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests.nodesrecovery;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Test;
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+import org.ow2.proactive.resourcemanager.common.event.RMEventType;
+import org.ow2.proactive.resourcemanager.common.event.RMNodeSourceEvent;
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
+import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
+
+import functionaltests.monitor.RMMonitorEventReceiver;
+import functionaltests.utils.RMFunctionalTest;
+import functionaltests.utils.RMTHelper;
+
+
+public class NodesRecoveryPropertyTest extends RMFunctionalTest {
+
+    private static final String START_CONFIG_NODES_RECOVERY_ENABLED = "/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-enabled.ini";
+
+    private static final String RESTART_CONFIG_NODES_RECOVERY_ENABLED = "/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-enabled.ini";
+
+    private static final String START_CONFIG_NODES_RECOVERY_DISABLED = "/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-disabled.ini";
+
+    private static final String RESTART_CONFIG_NODES_RECOVERY_DISABLED = "/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-disabled.ini";
+
+    private static final String NODE_SOURCE_NAME = "LocalNodeSource" +
+                                                   RecoverLocalInfrastructureTest.class.getSimpleName();
+
+    private static final int NODE_NUMBER = 3;
+
+    private ResourceManager resourceManager = null;
+
+    @After
+    public void tearDown() throws Exception {
+        // kill the remaining nodes that were preserved for the test
+        boolean nodeProcessFound = true;
+        while (nodeProcessFound) {
+            try {
+                RecoverInfrastructureTestHelper.killNodesWithStrongSigKill();
+            } catch (NodesRecoveryProcessHelper.ProcessNotFoundException e) {
+                nodeProcessFound = false;
+            }
+        }
+    }
+
+    @Test
+    public void testRecoverLocalInfrastructureNodesRecoveryEnabledAndNodesRecoverable() throws Exception {
+        final boolean nodesRecoverable = true;
+        startRmAndCheckInitialState(START_CONFIG_NODES_RECOVERY_ENABLED, nodesRecoverable);
+        // kill only the RM by sending a SIGKILL and leave node processes alive
+        RecoverInfrastructureTestHelper.killRmWithStrongSigKill();
+        // nodes should be re-taken into account by the restarted RM
+        restartRmAndCheckFinalState(RESTART_CONFIG_NODES_RECOVERY_ENABLED, false);
+    }
+
+    @Test
+    public void testRecoverLocalInfrastructureNodesRecoveryEnabledAndNodesNotRecoverable() throws Exception {
+        final boolean nodesRecoverable = false;
+        startRmAndCheckInitialState(START_CONFIG_NODES_RECOVERY_ENABLED, nodesRecoverable);
+        // kill only the RM by sending a SIGKILL and leave node processes alive
+        RecoverInfrastructureTestHelper.killRmWithStrongSigKill();
+        // nodes should be re-taken into account by the restarted RM
+        restartRmAndCheckFinalState(RESTART_CONFIG_NODES_RECOVERY_ENABLED, true);
+    }
+
+    @Test
+    public void testRecoverLocalInfrastructureNodesRecoveryDisabledAndNodesRecoverable() throws Exception {
+        final boolean nodesRecoverable = true;
+        startRmAndCheckInitialState(START_CONFIG_NODES_RECOVERY_DISABLED, nodesRecoverable);
+        // kill only the RM by sending a SIGKILL and leave node processes alive
+        RecoverInfrastructureTestHelper.killRmWithStrongSigKill();
+        // nodes should be re-taken into account by the restarted RM
+        restartRmAndCheckFinalState(RESTART_CONFIG_NODES_RECOVERY_DISABLED, true);
+    }
+
+    @Test
+    public void testRecoverLocalInfrastructureNodesRecoveryDisabledAndNodesNotRecoverable() throws Exception {
+        final boolean nodesRecoverable = false;
+        startRmAndCheckInitialState(START_CONFIG_NODES_RECOVERY_DISABLED, nodesRecoverable);
+        // kill only the RM by sending a SIGKILL and leave node processes alive
+        RecoverInfrastructureTestHelper.killRmWithStrongSigKill();
+        // nodes should be re-taken into account by the restarted RM
+        restartRmAndCheckFinalState(RESTART_CONFIG_NODES_RECOVERY_DISABLED, true);
+    }
+
+    private void startRmWithConfig(String configurationFilePath) throws Exception {
+        String rmconf = new File(RMTHelper.class.getResource(configurationFilePath).toURI()).getAbsolutePath();
+        rmHelper.startRM(rmconf);
+        resourceManager = rmHelper.getResourceManager();
+    }
+
+    private void startRmAndCheckInitialState(String rmConfigPath, boolean nodesRecoverable) throws Exception {
+        // start RM
+        startRmWithConfig(rmConfigPath);
+        assertThat(PAResourceManagerProperties.RM_PRESERVE_NODES_ON_SHUTDOWN.getValueAsBoolean()).isTrue();
+        assertThat(rmHelper.isRMStarted()).isTrue();
+
+        // check the initial state of the RM
+        assertThat(resourceManager.getState().getAllNodes().size()).isEqualTo(0);
+        if (nodesRecoverable) {
+            rmHelper.createNodeSourceWithNodesRecoverable(NODE_SOURCE_NAME, NODE_NUMBER);
+        } else {
+            rmHelper.createNodeSource(NODE_SOURCE_NAME, NODE_NUMBER);
+        }
+        RMMonitorEventReceiver resourceManagerMonitor = (RMMonitorEventReceiver) resourceManager;
+        ArrayList<RMNodeSourceEvent> nodeSourceEventPerNodeSource = resourceManagerMonitor.getInitialState()
+                                                                                          .getNodeSource();
+        assertThat(nodeSourceEventPerNodeSource.size()).isEqualTo(1);
+        assertThat(nodeSourceEventPerNodeSource.get(0).getSourceName()).isEqualTo(NODE_SOURCE_NAME);
+        assertThat(resourceManagerMonitor.getState().getAllNodes().size()).isEqualTo(NODE_NUMBER);
+    }
+
+    private void restartRmAndCheckFinalState(String rmConfigPath, boolean nodesShouldBeRecreated) throws Exception {
+        // restart RM
+        rmHelper = new RMTHelper();
+        startRmWithConfig(rmConfigPath);
+        assertThat(PAResourceManagerProperties.RM_PRESERVE_NODES_ON_SHUTDOWN.getValueAsBoolean()).isFalse();
+        assertThat(rmHelper.isRMStarted()).isTrue();
+
+        // re-snapshot the RM state
+        RMMonitorEventReceiver resourceManagerMonitor = (RMMonitorEventReceiver) resourceManager;
+        ArrayList<RMNodeSourceEvent> nodeSourceEvent = resourceManagerMonitor.getInitialState().getNodeSource();
+
+        // the node source has been recovered on restart: we should have one node source with the same name
+        if (PAResourceManagerProperties.RM_NODES_RECOVERY.getValueAsBoolean()) {
+            assertThat(nodeSourceEvent.size()).isEqualTo(1);
+        }
+        assertThat(nodeSourceEvent.get(0).getSourceName()).isEqualTo(NODE_SOURCE_NAME);
+
+        // wait for nodes to be recreated if needed
+        if (nodesShouldBeRecreated) {
+            rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_STATE_CHANGED, NODE_NUMBER);
+        }
+
+        // the nodes should have been recovered too, and should be alive
+        Set<String> allNodes = resourceManagerMonitor.getState().getAllNodes();
+        assertThat(allNodes.size()).isEqualTo(NODE_NUMBER);
+        Set<String> nodeSourceNames = new HashSet<>();
+        nodeSourceNames.add(NODE_SOURCE_NAME);
+        Set<String> aliveNodeUrls = resourceManager.listAliveNodeUrls(nodeSourceNames);
+        assertThat(aliveNodeUrls.size()).isEqualTo(NODE_NUMBER);
+
+        // the recovered nodes should be usable, try to lock/unlock them to see
+        BooleanWrapper lockSucceeded = resourceManager.lockNodes(allNodes);
+        assertThat(lockSucceeded).isEqualTo(new BooleanWrapper(true));
+        BooleanWrapper unlockSucceeded = resourceManager.unlockNodes(allNodes);
+        assertThat(unlockSucceeded).isEqualTo(new BooleanWrapper(true));
+    }
+
+}

--- a/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverInfrastructureTestHelper.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverInfrastructureTestHelper.java
@@ -27,7 +27,6 @@ package functionaltests.nodesrecovery;
 
 import org.ow2.proactive.resourcemanager.utils.RMNodeStarter;
 
-import functionaltests.utils.NodesRecoveryProcessHelper;
 import functionaltests.utils.RMStarterForFunctionalTest;
 import functionaltests.utils.RMTHelper;
 
@@ -37,6 +36,8 @@ import functionaltests.utils.RMTHelper;
  * @since 20/07/17
  */
 public class RecoverInfrastructureTestHelper {
+
+    public static final boolean NODES_RECOVERABLE = true;
 
     public static void killNodesWithStrongSigKill() throws Exception {
         RMTHelper.log("Kill nodes abruptly (for the sake of down nodes recovery test -- expect exceptions)");

--- a/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverLocalInfrastructureTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverLocalInfrastructureTest.java
@@ -52,9 +52,9 @@ import functionaltests.utils.RMTHelper;
  */
 public class RecoverLocalInfrastructureTest extends RMFunctionalTest {
 
-    private static final String START_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-restart-clean-db.ini";
+    private static final String START_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-enabled.ini";
 
-    private static final String RESTART_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-restart-keep-db.ini";
+    private static final String RESTART_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-enabled.ini";
 
     private static final String NODE_SOURCE_NAME = "LocalNodeSource" +
                                                    RecoverLocalInfrastructureTest.class.getSimpleName();
@@ -104,7 +104,7 @@ public class RecoverLocalInfrastructureTest extends RMFunctionalTest {
 
         // check the initial state of the RM
         assertThat(resourceManager.getState().getAllNodes().size()).isEqualTo(0);
-        rmHelper.createNodeSource(NODE_SOURCE_NAME, NODE_NUMBER);
+        rmHelper.createNodeSourceWithNodesRecoverable(NODE_SOURCE_NAME, NODE_NUMBER);
         RMMonitorEventReceiver resourceManagerMonitor = (RMMonitorEventReceiver) resourceManager;
         ArrayList<RMNodeSourceEvent> nodeSourceEventPerNodeSource = resourceManagerMonitor.getInitialState()
                                                                                           .getNodeSource();

--- a/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverSSHInfrastructureV2Test.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverSSHInfrastructureV2Test.java
@@ -26,6 +26,7 @@
 package functionaltests.nodesrecovery;
 
 import static com.google.common.truth.Truth.assertThat;
+import static functionaltests.nodesrecovery.RecoverInfrastructureTestHelper.NODES_RECOVERABLE;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -55,9 +56,9 @@ import functionaltests.utils.RMTHelper;
  */
 public class RecoverSSHInfrastructureV2Test extends RMFunctionalTest {
 
-    private static final String START_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-restart-clean-db.ini";
+    private static final String START_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-enabled.ini";
 
-    private static final String RESTART_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-restart-keep-db.ini";
+    private static final String RESTART_CONFIG = "/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-enabled.ini";
 
     private static final String NODE_SOURCE_NAME = "testRecoverSSHInfra";
 
@@ -112,7 +113,8 @@ public class RecoverSSHInfrastructureV2Test extends RMFunctionalTest {
                                          SSHInfrastructureV2.class.getName(),
                                          TestSSHInfrastructureV2.infraParams,
                                          StaticPolicy.class.getName(),
-                                         TestSSHInfrastructureV2.policyParameters);
+                                         TestSSHInfrastructureV2.policyParameters,
+                                         NODES_RECOVERABLE);
         RMTHelper.waitForNodeSourceCreation(NODE_SOURCE_NAME,
                                             TestSSHInfrastructureV2.NB_NODES,
                                             this.rmHelper.getMonitorsHandler());

--- a/rm/rm-server/src/test/java/functionaltests/nodestate/TestAddRemoveAll.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodestate/TestAddRemoveAll.java
@@ -64,7 +64,8 @@ public class TestAddRemoveAll extends RMFunctionalTest {
                                          DefaultInfrastructureManager.class.getName(),
                                          null,
                                          StaticPolicy.class.getName(),
-                                         null);
+                                         null,
+                                         NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
         resourceManager.setNodeSourcePingFrequency(pingFrequency, nsName);
 

--- a/rm/rm-server/src/test/java/functionaltests/nodestate/TestAdminAddingNodes.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodestate/TestAdminAddingNodes.java
@@ -80,7 +80,8 @@ public class TestAdminAddingNodes extends RMFunctionalTest {
                                          DefaultInfrastructureManager.class.getName(),
                                          null,
                                          StaticPolicy.class.getName(),
-                                         null);
+                                         null,
+                                         NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, NS_NAME);
 
         resourceManager.setNodeSourcePingFrequency(pingFrequency, NS_NAME);

--- a/rm/rm-server/src/test/java/functionaltests/nodestate/TestConcurrentUsers.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodestate/TestConcurrentUsers.java
@@ -70,7 +70,8 @@ public class TestConcurrentUsers extends RMFunctionalTest {
                                          DefaultInfrastructureManager.class.getName(),
                                          null,
                                          StaticPolicy.class.getName(),
-                                         null);
+                                         null,
+                                         NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
         resourceManager.addNode(node1URL, nsName);
 

--- a/rm/rm-server/src/test/java/functionaltests/nodestate/TestNodeEncoding.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodestate/TestNodeEncoding.java
@@ -107,7 +107,8 @@ public class TestNodeEncoding extends RMFunctionalTest {
                                   LocalInfrastructure.class.getName(),
                                   new Object[] { credentials, 1, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                   StaticPolicy.class.getName(),
-                                  null);
+                                  null,
+                                  NODES_NOT_RECOVERABLE);
 
         rmHelper.waitForNodeSourceCreation("testEncoding");
         rmHelper.waitForAnyNodeEvent(RMEventType.NODE_ADDED);

--- a/rm/rm-server/src/test/java/functionaltests/nodestate/TestNodeSourcesActions.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodestate/TestNodeSourcesActions.java
@@ -78,7 +78,8 @@ public class TestNodeSourcesActions extends RMFunctionalTest {
                                          LocalInfrastructure.class.getName(),
                                          new Object[] { creds, nodeNumber, RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                          StaticPolicy.class.getName(),
-                                         null);
+                                         null,
+                                         NODES_NOT_RECOVERABLE);
 
         //wait for creation of GCM Node Source event, and deployment of its nodes
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nodeSourceName);

--- a/rm/rm-server/src/test/java/functionaltests/permissions/TestNSAdminPermissions.java
+++ b/rm/rm-server/src/test/java/functionaltests/permissions/TestNSAdminPermissions.java
@@ -70,7 +70,8 @@ public class TestNSAdminPermissions extends RMFunctionalTest {
                                        DefaultInfrastructureManager.class.getName(),
                                        null,
                                        StaticPolicy.class.getName(),
-                                       new Object[] { "ALL", "ME" });
+                                       new Object[] { "ALL", "ME" },
+                                       NODES_NOT_RECOVERABLE);
 
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
@@ -102,7 +103,8 @@ public class TestNSAdminPermissions extends RMFunctionalTest {
                                       DefaultInfrastructureManager.class.getName(),
                                       null,
                                       StaticPolicy.class.getName(),
-                                      new Object[] { "PROVIDER", "ALL" });
+                                      new Object[] { "PROVIDER", "ALL" },
+                                      NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
         providerRMAccess = rmHelper.getResourceManager(TestUsers.NSADMIN);

--- a/rm/rm-server/src/test/java/functionaltests/permissions/TestNSNodesPermissions.java
+++ b/rm/rm-server/src/test/java/functionaltests/permissions/TestNSNodesPermissions.java
@@ -75,7 +75,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                                  DefaultInfrastructureManager.class.getName(),
                                  null,
                                  StaticPolicy.class.getName(),
-                                 new Object[] { "ME", "ALL" })
+                                 new Object[] { "ME", "ALL" },
+                                 NODES_NOT_RECOVERABLE)
                .getBooleanValue();
 
         List<Node> nodePool = createNodes("node", 2);
@@ -126,7 +127,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "MY_GROUPS", "ALL" })
+                               new Object[] { "MY_GROUPS", "ALL" },
+                               NODES_NOT_RECOVERABLE)
              .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -172,7 +174,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                               DefaultInfrastructureManager.class.getName(),
                               null,
                               StaticPolicy.class.getName(),
-                              new Object[] { "PROVIDER", "ALL" })
+                              new Object[] { "PROVIDER", "ALL" },
+                              NODES_NOT_RECOVERABLE)
             .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -228,7 +231,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                               DefaultInfrastructureManager.class.getName(),
                               null,
                               StaticPolicy.class.getName(),
-                              new Object[] { "PROVIDER_GROUPS", "ALL" })
+                              new Object[] { "PROVIDER_GROUPS", "ALL" },
+                              NODES_NOT_RECOVERABLE)
             .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -289,7 +293,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                               DefaultInfrastructureManager.class.getName(),
                               null,
                               StaticPolicy.class.getName(),
-                              new Object[] { "ALL", "ALL" })
+                              new Object[] { "ALL", "ALL" },
+                              NODES_NOT_RECOVERABLE)
             .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -325,7 +330,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "users=nsadmin", "ALL" })
+                               new Object[] { "users=nsadmin", "ALL" },
+                               NODES_NOT_RECOVERABLE)
              .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -371,7 +377,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "groups=nsadmins", "ALL" })
+                               new Object[] { "groups=nsadmins", "ALL" },
+                               NODES_NOT_RECOVERABLE)
              .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -427,7 +434,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "tokens=token1,token2", "ALL" })
+                               new Object[] { "tokens=token1,token2", "ALL" },
+                               NODES_NOT_RECOVERABLE)
              .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -480,7 +488,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "users=radmin;groups=nsadmins", "ALL" })
+                               new Object[] { "users=radmin;groups=nsadmins", "ALL" },
+                               NODES_NOT_RECOVERABLE)
              .getBooleanValue();
 
         nodePool = createNodes("node", 2);
@@ -534,7 +543,8 @@ public class TestNSNodesPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "users=radmin;tokens=token1", "ALL" })
+                               new Object[] { "users=radmin;tokens=token1", "ALL" },
+                               NODES_NOT_RECOVERABLE)
              .getBooleanValue();
 
         nodePool = createNodes("node", 2);

--- a/rm/rm-server/src/test/java/functionaltests/permissions/TestNSProviderPermissions.java
+++ b/rm/rm-server/src/test/java/functionaltests/permissions/TestNSProviderPermissions.java
@@ -82,7 +82,8 @@ public class TestNSProviderPermissions extends RMFunctionalTest {
                                  DefaultInfrastructureManager.class.getName(),
                                  null,
                                  StaticPolicy.class.getName(),
-                                 new Object[] { "ALL", "ME" });
+                                 new Object[] { "ALL", "ME" },
+                                 NODES_NOT_RECOVERABLE);
 
         List<TestNode> nodePool = rmHelper.createNodes("node", 2);
 
@@ -135,7 +136,8 @@ public class TestNSProviderPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "ALL", "MY_GROUPS" });
+                               new Object[] { "ALL", "MY_GROUPS" },
+                               NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
         List<TestNode> nodePool = rmHelper.createNodes("node", 3);
@@ -198,7 +200,8 @@ public class TestNSProviderPermissions extends RMFunctionalTest {
                                  DefaultInfrastructureManager.class.getName(),
                                  null,
                                  StaticPolicy.class.getName(),
-                                 new Object[] { "ALL", "ALL" });
+                                 new Object[] { "ALL", "ALL" },
+                                 NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
         List<TestNode> nodePool = rmHelper.createNodes("node", 3);
@@ -246,7 +249,8 @@ public class TestNSProviderPermissions extends RMFunctionalTest {
                                  DefaultInfrastructureManager.class.getName(),
                                  null,
                                  StaticPolicy.class.getName(),
-                                 new Object[] { "ALL", "ALL" });
+                                 new Object[] { "ALL", "ALL" },
+                                 NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
         List<TestNode> nodePool = rmHelper.createNodes("node", 2);
@@ -274,7 +278,8 @@ public class TestNSProviderPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "ALL", "users=nsadmin" });
+                               new Object[] { "ALL", "users=nsadmin" },
+                               NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
         List<TestNode> nodePool = rmHelper.createNodes("node", 3);
@@ -330,7 +335,8 @@ public class TestNSProviderPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "ALL", "groups=nsadmins" })
+                               new Object[] { "ALL", "groups=nsadmins" },
+                               NODES_NOT_RECOVERABLE)
              .getBooleanValue();
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
@@ -382,7 +388,8 @@ public class TestNSProviderPermissions extends RMFunctionalTest {
                                DefaultInfrastructureManager.class.getName(),
                                null,
                                StaticPolicy.class.getName(),
-                               new Object[] { "ALL", "users=radmin;groups=nsadmins" });
+                               new Object[] { "ALL", "users=radmin;groups=nsadmins" },
+                               NODES_NOT_RECOVERABLE);
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nsName);
 
         List<TestNode> nodePool = rmHelper.createNodes("node", 3);

--- a/rm/rm-server/src/test/java/functionaltests/selectionscript/SelectionWithSeveralScriptsTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/selectionscript/SelectionWithSeveralScriptsTest.java
@@ -85,7 +85,8 @@ public class SelectionWithSeveralScriptsTest extends RMFunctionalTest {
                                          DefaultInfrastructureManager.class.getName(),
                                          null,
                                          StaticPolicy.class.getName(),
-                                         new Object[] { "ALL", "ALL" })
+                                         new Object[] { "ALL", "ALL" },
+                                         NODES_NOT_RECOVERABLE)
                        .getBooleanValue();
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nodeSourceName);
 

--- a/rm/rm-server/src/test/java/functionaltests/selectionscript/SelectionWithSeveralScriptsTest2.java
+++ b/rm/rm-server/src/test/java/functionaltests/selectionscript/SelectionWithSeveralScriptsTest2.java
@@ -77,7 +77,8 @@ public class SelectionWithSeveralScriptsTest2 extends RMFunctionalTest {
                                          DefaultInfrastructureManager.class.getName(),
                                          null,
                                          StaticPolicy.class.getName(),
-                                         new Object[] { "ALL", "ALL" })
+                                         new Object[] { "ALL", "ALL" },
+                                         NODES_NOT_RECOVERABLE)
                        .getBooleanValue();
         rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, nodeSourceName);
 

--- a/rm/rm-server/src/test/java/functionaltests/topology/SelectionTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/topology/SelectionTest.java
@@ -109,7 +109,8 @@ public class SelectionTest extends RMFunctionalTest {
                                                                              (distantHost + " 2\n" +
                                                                               neighborHost).getBytes() },
                                                               StaticPolicy.class.getName(),
-                                                              null);
+                                                              null,
+                                                              NODES_NOT_RECOVERABLE);
 
             if (result.getBooleanValue()) {
                 rmHelper.waitForAnyNodeEvent(RMEventType.NODE_ADDED);

--- a/rm/rm-server/src/test/java/functionaltests/utils/RMFunctionalTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/RMFunctionalTest.java
@@ -50,6 +50,8 @@ import functionaltests.monitor.RMMonitorEventReceiver;
 
 public class RMFunctionalTest extends ProActiveTest {
 
+    public static final boolean NODES_NOT_RECOVERABLE = false;
+
     static {
         configureLogging();
         ProActiveConfiguration.load();

--- a/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
@@ -25,6 +25,9 @@
  */
 package functionaltests.utils;
 
+import static functionaltests.nodesrecovery.RecoverInfrastructureTestHelper.NODES_RECOVERABLE;
+import static functionaltests.utils.RMFunctionalTest.NODES_NOT_RECOVERABLE;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -59,6 +62,7 @@ import org.ow2.tests.ProActiveSetup;
 
 import functionaltests.monitor.RMMonitorEventReceiver;
 import functionaltests.monitor.RMMonitorsHandler;
+import functionaltests.nodesrecovery.RecoverInfrastructureTestHelper;
 
 
 /**
@@ -138,12 +142,21 @@ public class RMTHelper {
         createNodeSource(name, nodeNumber, getResourceManager(), getMonitorsHandler());
     }
 
+    public void createNodeSourceWithNodesRecoverable(String name, int nodeNumber) throws Exception {
+        createNodeSourceWithNodesRecoverable(name, nodeNumber, getResourceManager(), getMonitorsHandler());
+    }
+
     public void createNodeSourceWithInfiniteTimeout(String name, int nodeNumber) throws Exception {
         createNodeSourceWithInfiniteTimeout(name, nodeNumber, getResourceManager(), getMonitorsHandler());
     }
 
     public static void createNodeSource(String name, int nodeNumber, List<String> vmOptions, ResourceManager rm,
             RMMonitorsHandler monitor) throws Exception {
+        createNodeSource(name, nodeNumber, vmOptions, rm, monitor, NODES_NOT_RECOVERABLE);
+    }
+
+    public static void createNodeSource(String name, int nodeNumber, List<String> vmOptions, ResourceManager rm,
+            RMMonitorsHandler monitor, boolean nodesRecoverable) throws Exception {
         RMFactory.setOsJavaProperty();
         log("Creating a node source " + name);
         //first emtpy im parameter is default rm url
@@ -154,7 +167,8 @@ public class RMTHelper {
                                            vmOptions != null ? setup.listToString(vmOptions)
                                                              : setup.getJvmParameters() },
                             StaticPolicy.class.getName(),
-                            null);
+                            null,
+                            nodesRecoverable);
         rm.setNodeSourcePingFrequency(5000, name);
 
         waitForNodeSourceCreation(name, nodeNumber, monitor);
@@ -172,7 +186,8 @@ public class RMTHelper {
                                            vmOptions != null ? setup.listToString(vmOptions)
                                                              : setup.getJvmParameters() },
                             StaticPolicy.class.getName(),
-                            null);
+                            null,
+                            NODES_RECOVERABLE);
         rm.setNodeSourcePingFrequency(5000, name);
 
         waitForNodeSourceCreation(name, nodeNumber, monitor);
@@ -183,7 +198,12 @@ public class RMTHelper {
      */
     public static void createNodeSource(String name, int nodeNumber, ResourceManager rm, RMMonitorsHandler monitor)
             throws Exception {
-        createNodeSource(name, nodeNumber, setup.getJvmParametersAsList(), rm, monitor);
+        createNodeSource(name, nodeNumber, setup.getJvmParametersAsList(), rm, monitor, NODES_NOT_RECOVERABLE);
+    }
+
+    public static void createNodeSourceWithNodesRecoverable(String name, int nodeNumber, ResourceManager rm,
+            RMMonitorsHandler monitor) throws Exception {
+        createNodeSource(name, nodeNumber, setup.getJvmParametersAsList(), rm, monitor, NODES_RECOVERABLE);
     }
 
     public static void createNodeSourceWithInfiniteTimeout(String name, int nodeNumber, ResourceManager rm,

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
@@ -888,7 +888,7 @@ public class RMCoreTest {
             }
         }).when(rmCore).getNodesRecoveryManagerBuilder();
 
-        rmCore.initiateRecoveryIfRequired();
+        rmCore.initiateRecovery();
     }
 
     private void configureRMNode(MockedRMNodeParameters param) {

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
@@ -888,7 +888,7 @@ public class RMCoreTest {
             }
         }).when(rmCore).getNodesRecoveryManagerBuilder();
 
-        rmCore.initiateRecovery();
+        rmCore.initiateRecoveryIfRequired();
     }
 
     private void configureRMNode(MockedRMNodeParameters param) {

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
@@ -45,6 +45,7 @@ import org.objectweb.proactive.core.runtime.VMInformation;
 import org.ow2.proactive.resourcemanager.authentication.Client;
 import org.ow2.proactive.resourcemanager.core.RMCore;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
+import org.ow2.proactive.resourcemanager.db.NodeSourceData;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.frontend.RMMonitoringImpl;
 import org.ow2.proactive.resourcemanager.frontend.topology.pinging.HostsPinger;
@@ -149,14 +150,16 @@ public class NodeSourceTest {
 
     private NodeSource createNodeSource(InfrastructureManager infrastructureManager, NodeSourcePolicy nodeSourcePolicy,
             Client client) {
+        NodeSourceData nodeSourceData = new NodeSourceData();
+        nodeSourceData.setProvider(client);
+        nodeSourceData.setNodesRecoverable(NODES_NOT_RECOVERABLE);
         return new NodeSource("registrationURL",
                               "name",
-                              client,
                               infrastructureManager,
                               nodeSourcePolicy,
                               mock(RMCore.class),
                               mock(RMMonitoringImpl.class),
-                              NODES_NOT_RECOVERABLE);
+                              nodeSourceData);
     }
 
 }

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/NodeSourceTest.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.resourcemanager.nodesource;
 
 import static com.google.common.truth.Truth.assertThat;
+import static functionaltests.utils.RMFunctionalTest.NODES_NOT_RECOVERABLE;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -154,7 +155,8 @@ public class NodeSourceTest {
                               infrastructureManager,
                               nodeSourcePolicy,
                               mock(RMCore.class),
-                              mock(RMMonitoringImpl.class));
+                              mock(RMMonitoringImpl.class),
+                              NODES_NOT_RECOVERABLE);
     }
 
 }

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManagerTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManagerTest.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
 import static com.google.common.truth.Truth.assertThat;
+import static functionaltests.nodesrecovery.RecoverInfrastructureTestHelper.NODES_RECOVERABLE;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -70,6 +71,7 @@ public class InfrastructureManagerTest {
         infrastructureManager.setRmDbManager(dbManager);
         infrastructureManager.setNodeSource(nodeSource);
         when(nodeSource.getName()).thenReturn("NodeSource#1");
+        when(nodeSource.nodesRecoverable()).thenReturn(NODES_RECOVERABLE);
         when(dbManager.getNodeSource(anyString())).thenReturn(nodeSourceData);
     }
 

--- a/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-disabled.ini
+++ b/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-disabled.ini
@@ -1,0 +1,25 @@
+# ping frequency used by node source for keeping a watch on handled nodes in ms
+pa.rm.node.source.ping.frequency=5000
+
+# GCM application (GCMA) file path, used to perform GCM deployments
+pa.rm.gcm.template.application.file=rm/rm-server/src/test/resources/functionaltests/config/GCMNodeSourceApplicationTemplate.xml
+
+#hibernate configuration file
+pa.rm.db.hibernate.configuration=rm/rm-server/src/test/resources/functionaltests/config/hibernate.cfg.xml
+
+# Accounting refresh rate from the database in seconds
+# By default the accounts are not refreshed
+# Functional tests may set specific values through JMX (see ManagementMBean)
+pa.rm.account.refreshrate=10000000
+
+# The time period when a node has the same dynamic characteristics (in ms).
+# It needs to pause the permanent execution of dynamic scripts on nodes.
+pa.rm.select.node.dynamicity=10000
+
+pa.rm.client.ping.frequency=10000
+pa.rm.select.script.timeout=10000
+
+pa.rm.db.hibernate.dropdb=false
+pa.rm.nodes.recovery=false
+pa.rm.preserve.nodes.on.shutdown=false
+pa.rm.node.db.operations.delay=0

--- a/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-enabled.ini
+++ b/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-restart-keep-db-nodes-recovery-enabled.ini
@@ -20,5 +20,6 @@ pa.rm.client.ping.frequency=10000
 pa.rm.select.script.timeout=10000
 
 pa.rm.db.hibernate.dropdb=false
+pa.rm.nodes.recovery=true
 pa.rm.preserve.nodes.on.shutdown=false
 pa.rm.node.db.operations.delay=0

--- a/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-disabled.ini
+++ b/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-disabled.ini
@@ -1,0 +1,25 @@
+# ping frequency used by node source for keeping a watch on handled nodes in ms
+pa.rm.node.source.ping.frequency=10000
+
+# GCM application (GCMA) file path, used to perform GCM deployments
+pa.rm.gcm.template.application.file=rm/rm-server/src/test/resources/functionaltests/config/GCMNodeSourceApplicationTemplate.xml
+
+#hibernate configuration file
+pa.rm.db.hibernate.configuration=rm/rm-server/src/test/resources/functionaltests/config/hibernate-clean.cfg.xml
+
+# Accounting refresh rate from the database in seconds
+# By default the accounts are not refreshed
+# Functional tests may set specific values through JMX (see ManagementMBean)
+pa.rm.account.refreshrate=10000000
+
+# The time period when a node has the same dynamic characteristics (in ms).
+# It needs to pause the permanent execution of dynamic scripts on nodes.
+pa.rm.select.node.dynamicity=10000
+
+pa.rm.client.ping.frequency=10000
+pa.rm.select.script.timeout=10000
+
+pa.rm.db.hibernate.dropdb=true
+pa.rm.nodes.recovery=false
+pa.rm.preserve.nodes.on.shutdown=true
+pa.rm.node.db.operations.delay=0

--- a/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-enabled.ini
+++ b/rm/rm-server/src/test/resources/functionaltests/config/functionalTRMProperties-RM-start-clean-db-nodes-recovery-enabled.ini
@@ -20,5 +20,6 @@ pa.rm.client.ping.frequency=10000
 pa.rm.select.script.timeout=10000
 
 pa.rm.db.hibernate.dropdb=true
+pa.rm.nodes.recovery=true
 pa.rm.preserve.nodes.on.shutdown=true
 pa.rm.node.db.operations.delay=0

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherRebinder.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherRebinder.java
@@ -31,7 +31,6 @@ import org.apache.log4j.Logger;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeFactory;
-import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherRebinder.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherRebinder.java
@@ -31,6 +31,7 @@ import org.apache.log4j.Logger;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeFactory;
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 
@@ -49,13 +50,16 @@ public class TaskLauncherRebinder {
 
     private static final Logger logger = Logger.getLogger(TaskLauncherRebinder.class);
 
-    private TaskId taskId;
+    private final TaskId taskId;
 
-    private String terminateNotificationNodeURL;
+    private final String terminateNotificationNodeURL;
 
-    void saveTerminateNotificationNodeURL(TaskId taskId, String terminateNotificationNodeURL) {
+    private final boolean taskRecoverable;
+
+    TaskLauncherRebinder(TaskId taskId, String terminateNotificationNodeURL, boolean taskRecoverable) {
         this.taskId = taskId;
         this.terminateNotificationNodeURL = terminateNotificationNodeURL;
+        this.taskRecoverable = taskRecoverable;
     }
 
     /**
@@ -66,13 +70,18 @@ public class TaskLauncherRebinder {
      * @return a correct reference to a TaskTerminateNotification, or null if none can be retrieved
      */
     TaskTerminateNotification makeSureSchedulerIsConnected(TaskTerminateNotification terminateNotification) {
-        try {
-            PAActiveObject.lookupActive(TaskTerminateNotification.class, PAActiveObject.getUrl(terminateNotification));
+        if (taskRecoverable) {
+            try {
+                PAActiveObject.lookupActive(TaskTerminateNotification.class,
+                                            PAActiveObject.getUrl(terminateNotification));
+                return terminateNotification;
+            } catch (Exception e) {
+                logger.warn("TaskTerminatedNotification handler of task " + taskId.getReadableName() +
+                            " is disconnected from the scheduler, try to rebind it", e);
+                return getReboundTaskTerminateNotificationHandler(terminateNotification);
+            }
+        } else {
             return terminateNotification;
-        } catch (Exception e) {
-            logger.warn("TaskTerminatedNotification handler of task " + taskId.getReadableName() +
-                        " is disconnected from the scheduler, try to rebind it", e);
-            return getReboundTaskTerminateNotificationHandler();
         }
     }
 
@@ -82,21 +91,26 @@ public class TaskLauncherRebinder {
      *
      * @return a correct reference to a TaskTerminateNotification, or null if none can be retrieved
      */
-    TaskTerminateNotification getReboundTaskTerminateNotificationHandler() {
-        try {
-            logger.debug("List AOs on " + terminateNotificationNodeURL + " (expect only one): " +
-                         Arrays.toString(NodeFactory.getNode(terminateNotificationNodeURL)
-                                                    .getActiveObjects(TaskTerminateNotification.class.getName())));
-            Node node = NodeFactory.getNode(terminateNotificationNodeURL);
-            Object[] aos = node.getActiveObjects(TaskTerminateNotification.class.getName());
-            logger.info("On node " + node.getNodeInformation().getName() + " number of active objects found is " +
-                        aos.length + " and the first one " + aos[0] + " will be used to send back the task result");
-            return (TaskTerminateNotification) aos[0];
-        } catch (Throwable e) {
-            // error when retrieving the termination handler after reconnection
-            logger.error("Failed to rebind TaskTerminatedNotification handler of task " + taskId.getReadableName() +
-                         " from URL " + terminateNotificationNodeURL, e);
-            return null;
+    TaskTerminateNotification
+            getReboundTaskTerminateNotificationHandler(TaskTerminateNotification taskTerminateNotification) {
+        if (taskRecoverable) {
+            try {
+                logger.debug("List AOs on " + terminateNotificationNodeURL + " (expect only one): " +
+                             Arrays.toString(NodeFactory.getNode(terminateNotificationNodeURL)
+                                                        .getActiveObjects(TaskTerminateNotification.class.getName())));
+                Node node = NodeFactory.getNode(terminateNotificationNodeURL);
+                Object[] aos = node.getActiveObjects(TaskTerminateNotification.class.getName());
+                logger.info("On node " + node.getNodeInformation().getName() + " number of active objects found is " +
+                            aos.length + " and the first one " + aos[0] + " will be used to send back the task result");
+                return (TaskTerminateNotification) aos[0];
+            } catch (Throwable e) {
+                // error when retrieving the termination handler after reconnection
+                logger.error("Failed to rebind TaskTerminatedNotification handler of task " + taskId.getReadableName() +
+                             " from URL " + terminateNotificationNodeURL, e);
+                return taskTerminateNotification;
+            }
+        } else {
+            return taskTerminateNotification;
         }
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTestAbstract.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTestAbstract.java
@@ -49,6 +49,9 @@ public class TaskLauncherTestAbstract extends ProActiveTestClean {
     @Mock
     protected TaskLauncherRebinder taskLauncherRebinder;
 
+    @Mock
+    protected TaskTerminateNotification taskTerminateNotification;
+
     protected TaskTerminateNotificationVerifier taskResult;
 
     @Before
@@ -78,7 +81,7 @@ public class TaskLauncherTestAbstract extends ProActiveTestClean {
     private void injectTaskTerminateNotificationMock() {
         MockitoAnnotations.initMocks(this);
         when(taskLauncherRebinder.makeSureSchedulerIsConnected(taskResult)).thenReturn(taskResult);
-        when(taskLauncherRebinder.getReboundTaskTerminateNotificationHandler()).thenReturn(taskResult);
+        when(taskLauncherRebinder.getReboundTaskTerminateNotificationHandler(taskTerminateNotification)).thenReturn(taskResult);
     }
 
     protected static class TaskTerminateNotificationVerifier implements TaskTerminateNotification {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -315,7 +315,8 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
             logger.debug("Booting jmx...");
             this.jmxHelper.boot(authentication);
 
-            RecoveredSchedulerState recoveredState = new SchedulerStateRecoverHelper(dbManager).recover(loadJobPeriod);
+            RecoveredSchedulerState recoveredState = new SchedulerStateRecoverHelper(dbManager).recover(loadJobPeriod,
+                                                                                                        rmProxy);
 
             this.frontendState = new SchedulerFrontendState(recoveredState.getSchedulerState(), jmxHelper);
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -71,6 +71,7 @@ import org.ow2.proactive.scheduler.task.TaskLauncher;
 import org.ow2.proactive.scheduler.task.containers.ExecutableContainer;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
+import org.ow2.proactive.scheduler.task.internal.TaskRecoveryData;
 import org.ow2.proactive.scheduler.util.JobLogger;
 import org.ow2.proactive.scheduler.util.TaskLogger;
 import org.ow2.proactive.scripting.InvalidScriptException;
@@ -665,13 +666,18 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                         dotaskActionTimeout = PASchedulerProperties.SCHEDULER_STARTTASK_TIMEOUT.getValueAsInt();
                     }
 
+                    boolean taskRecoverable = getRMProxiesManager().getRmProxy().areNodesRecoverable(nodes);
+                    TaskRecoveryData taskRecoveryData = new TaskRecoveryData(terminateNotificationNodeURL,
+                                                                             taskRecoverable);
+
                     Future<Void> taskExecutionSubmittedFuture = threadPool.submitWithTimeout(new TimedDoTaskAction(job,
                                                                                                                    taskDescriptor,
                                                                                                                    launcher,
                                                                                                                    schedulingService,
                                                                                                                    terminateNotification,
                                                                                                                    corePrivateKey,
-                                                                                                                   terminateNotificationNodeURL),
+                                                                                                                   taskRecoveryData),
+
                                                                                              dotaskActionTimeout,
                                                                                              TimeUnit.MILLISECONDS);
                     waitForTaskToBeStarted(taskExecutionSubmittedFuture);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -148,7 +148,7 @@ public class SchedulerStateRecoverHelper {
         // recount existing pending tasks. We base this number on the
         // definition provided in SchedulerDBManager#PENDING_TASKS
         if (task.getStatus().equals(TaskStatus.PENDING) || task.getStatus().equals(TaskStatus.SUBMITTED) ||
-            task.getStatus().equals(TaskStatus.NOT_STARTED) || task.getExecuterInformation() == null) {
+            task.getStatus().equals(TaskStatus.NOT_STARTED)) {
             counter.pendingTasks++;
         } else {
             // recount existing running tasks that are not recoverable

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxy.java
@@ -153,4 +153,21 @@ public class RMProxy {
         }
     }
 
+    public boolean areNodesKnown(NodeSet nodes) {
+        if (proxyActiveObject != null) {
+            return proxyActiveObject.areNodesKnown(nodes);
+        } else {
+            logger.warn("Didn't find RM to check nodes URL");
+            return false;
+        }
+    }
+
+    public boolean areNodesRecoverable(NodeSet nodes) {
+        if (proxyActiveObject != null) {
+            return proxyActiveObject.areNodesRecoverable(nodes);
+        } else {
+            logger.warn("Didn't find RM to check whether nodes are recoverable");
+            return false;
+        }
+    }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
@@ -290,4 +290,14 @@ public class RMProxyActiveObject {
         rm.releaseBusyNodesNotInList(verifiedBusyNodes);
     }
 
+    @ImmediateService
+    public boolean areNodesKnown(NodeSet nodes) {
+        return rm.areNodesKnown(nodes);
+    }
+
+    @ImmediateService
+    public boolean areNodesRecoverable(NodeSet nodes) {
+        return rm.areNodesRecoverable(nodes);
+    }
+
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/TaskRecoveryData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/TaskRecoveryData.java
@@ -1,0 +1,51 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.task.internal;
+
+/**
+ * Data structure to carry information for a task whether it runs on a
+ * recoverable node and what is the URL of the task terminate notification
+ * node.
+ */
+public class TaskRecoveryData {
+
+    private final String terminateNotificationNodeURL;
+
+    private final boolean taskRecoverable;
+
+    public TaskRecoveryData(String terminateNotificationNodeURL, boolean taskRecoverable) {
+        this.terminateNotificationNodeURL = terminateNotificationNodeURL;
+        this.taskRecoverable = taskRecoverable;
+    }
+
+    public String getTerminateNotificationNodeURL() {
+        return terminateNotificationNodeURL;
+    }
+
+    public boolean isTaskRecoverable() {
+        return taskRecoverable;
+    }
+}

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -553,7 +553,8 @@ public class SchedulerStarter {
                               LocalInfrastructure.class.getName(),
                               new Object[] { creds, numberLocalNodes, nodeTimeoutValue, "" },
                               RestartDownNodesPolicy.class.getName(),
-                              new Object[] { "ALL", "ALL", "10000" });
+                              new Object[] { "ALL", "ALL", "10000" },
+                              NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_RECOVERABLE);
 
         credentials = creds;
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerTasksStateRecoverIntegrationTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerTasksStateRecoverIntegrationTest.java
@@ -56,9 +56,7 @@ public class SchedulerTasksStateRecoverIntegrationTest extends BaseSchedulerDBTe
 
         JobStateMatcher expectedJob;
 
-        // A running job recovered from database should be recovered as
-        // running, and not stalled anymore (task recovery feature)
-        expectedJob = job(job.getId(), JobStatus.RUNNING).withRunning(task("task1", TaskStatus.RUNNING))
+        expectedJob = job(job.getId(), JobStatus.STALLED).withPending(task("task1", TaskStatus.PENDING), true)
                                                          .withEligible("task1");
 
         RecoveredSchedulerState state;
@@ -74,9 +72,6 @@ public class SchedulerTasksStateRecoverIntegrationTest extends BaseSchedulerDBTe
         job.newWaitingTask();
         job.reStartTask(task);
         dbManager.taskRestarted(job, task, null);
-
-        expectedJob = job(job.getId(), JobStatus.STALLED).withPending(task("task1", TaskStatus.PENDING), true)
-                                                         .withEligible("task1");
 
         state = checkRecoveredState(recoverHelper.recover(-1), state().withRunning(expectedJob));
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
@@ -95,10 +95,10 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
         startTask(job, task2);
         dbManager.jobTaskStarted(job, task2, false);
 
-        expectedJob = job(job.getId(), JobStatus.RUNNING)
+        expectedJob = job(job.getId(), JobStatus.STALLED)
                                                          .withFinished(task("task1", TaskStatus.FINISHED)
                                                                                                          .checkFinished())
-                                                         .withRunning(task("task2", TaskStatus.RUNNING))
+                                                         .withPending(task("task2", TaskStatus.PENDING), true)
                                                          .withEligible("task2");
         recovered = stateRecoverHelper.recover(-1);
         checkRecoveredState(recovered, state().withRunning(expectedJob));
@@ -106,7 +106,8 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
         job = recovered.getRunningJobs().get(0);
         task2 = job.getTask("task2");
 
-        // task is still running, we just need to terminate it
+        startTask(job, task2);
+        dbManager.jobTaskStarted(job, task2, false);
         terminateTask(job, task2, result);
         dbManager.updateAfterTaskFinished(job, task2, result);
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/rm/nodesource/TestBrokenNodeSourceRemoval.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/rm/nodesource/TestBrokenNodeSourceRemoval.java
@@ -25,6 +25,7 @@
  */
 package functionaltests.rm.nodesource;
 
+import static functionaltests.utils.RMFunctionalTest.NODES_NOT_RECOVERABLE;
 import static functionaltests.utils.RMTHelper.log;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +45,7 @@ import org.ow2.proactive.resourcemanager.common.event.RMEventType;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeSourceEvent;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
+import org.ow2.proactive.resourcemanager.nodesource.NodeSource;
 import org.ow2.proactive.resourcemanager.nodesource.infrastructure.LocalInfrastructure;
 import org.ow2.proactive.scheduler.common.SchedulerAuthenticationInterface;
 import org.ow2.proactive.scheduler.common.SchedulerConnection;
@@ -76,7 +78,8 @@ public class TestBrokenNodeSourceRemoval extends SchedulerFunctionalTestWithCust
                                                               new Object[] { creds, defaultDescriptorNodesNb,
                                                                              RMTHelper.DEFAULT_NODES_TIMEOUT, "" },
                                                               ReleaseResourcesWhenSchedulerIdle.class.getName(),
-                                                              getPolicyParams());
+                                                              getPolicyParams(),
+                                                              NODES_NOT_RECOVERABLE);
 
         schedulerHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_CREATED, sourceName);
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/rm/nodesource/TestJobNodeAccessToken.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/rm/nodesource/TestJobNodeAccessToken.java
@@ -25,6 +25,7 @@
  */
 package functionaltests.rm.nodesource;
 
+import static functionaltests.nodesrecovery.RecoverInfrastructureTestHelper.NODES_RECOVERABLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -90,7 +91,8 @@ public class TestJobNodeAccessToken extends SchedulerFunctionalTestNoRestart {
                                        LocalInfrastructure.class.getName(),
                                        new Object[] { creds, 1, RMTHelper.DEFAULT_NODES_TIMEOUT, nsProps },
                                        StaticPolicy.class.getName(),
-                                       null)
+                                       null,
+                                       NODES_RECOVERABLE)
                      .getBooleanValue());
 
         nsCreated = true;

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerStartForFunctionalTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerStartForFunctionalTest.java
@@ -25,6 +25,8 @@
  */
 package functionaltests.utils;
 
+import static functionaltests.utils.RMFunctionalTest.NODES_NOT_RECOVERABLE;
+
 import java.io.Serializable;
 import java.net.URI;
 
@@ -36,6 +38,7 @@ import org.ow2.proactive.resourcemanager.authentication.RMAuthentication;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.resourcemanager.frontend.RMConnection;
 import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
+import org.ow2.proactive.resourcemanager.nodesource.NodeSource;
 import org.ow2.proactive.resourcemanager.nodesource.infrastructure.LocalInfrastructure;
 import org.ow2.proactive.resourcemanager.nodesource.policy.StaticPolicy;
 import org.ow2.proactive.scheduler.SchedulerFactory;
@@ -114,7 +117,8 @@ public class SchedulerStartForFunctionalTest implements Serializable {
                                                  new Object[] { credentials.getBase64(), RM_NODE_NUMBER,
                                                                 RM_NODE_DEPLOYMENT_TIMEOUT, getJavaPropertiesLine() },
                                                  StaticPolicy.class.getName(),
-                                                 new Object[] { "ALL", "ALL" });
+                                                 new Object[] { "ALL", "ALL" },
+                                                 NODES_NOT_RECOVERABLE);
                         rmAdmin.disconnect();
                     }
                 } catch (Exception e) {

--- a/scheduler/scheduler-server/src/test/java/performancetests/recovery/JobRecoveryTest.java
+++ b/scheduler/scheduler-server/src/test/java/performancetests/recovery/JobRecoveryTest.java
@@ -46,6 +46,7 @@ import org.ow2.proactive.scheduler.core.SchedulingService;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptorImpl;
 
+import functionaltests.nodesrecovery.NodesRecoveryProcessHelper;
 import functionaltests.utils.*;
 import performancetests.helper.LogProcessor;
 


### PR DESCRIPTION
In addition to the global nodes recovery property (pa.rm.nodes.recovery), the nodes recovery can be now specified per node source, as a new endpoint of the RM REST API, and as an optional additional parameter of the CLI (true by default)