### PR TITLE
Remove deploying nodes from persistence

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -435,8 +435,6 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
             initiateRecoveryIfRequired();
 
-            signalRMCoreIsInitialized();
-
         } catch (ActiveObjectCreationException e) {
             logger.error("", e);
         } catch (NodeException e) {
@@ -445,6 +443,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             logger.error("", e);
         } catch (ClassNotFoundException e) {
             logger.error("", e);
+        } finally {
+            signalRMCoreIsInitialized();
         }
 
         if (logger.isDebugEnabled()) {
@@ -1271,7 +1271,6 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
     private void waitForRMCoreToBeInitialized() {
         try {
-            logger.info("Waiting for Resource Manager to be initialized");
             countDownLatch.await();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostTracker.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostTracker.java
@@ -219,13 +219,15 @@ public class HostTracker implements Serializable {
         return nodeUrlsWithStatus;
     }
 
-    private enum NodeStatus {
+    private enum NodeStatus implements Serializable {
 
         ALIVE,
 
         DOWN,
 
-        REMOVED
+        REMOVED;
+
+        private static final long serialVersionUID = 1L;
 
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
@@ -43,6 +43,8 @@ import org.ow2.proactive.utils.NodeSet;
  */
 public class ExecuterInformationData implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger logger = Logger.getLogger(ExecuterInformationData.class);
 
     private long taskId;


### PR DESCRIPTION
- avoid storing Node objects in DB, as part of the acquired nodes managed by the InfrastructureManager. Store only node names instead.
- deploying and lost nodes (instances of RMDeployingNode) were stored in database as part of the InfrastructureManager variables. However, RMDeployingNode includes Nodes and versioned Serializable objects, so it is preferable not to store these objects in database, for db upgrade convenience. As storing a lightweigh version of RMDeployingNode requires a big refactoring, we prefer to abandon the storage of deploying nodes in db for the moment.
- fixed serial version of ExecuterInformationData, and of enum in HostTracker
- remove recurring and erroneous log in RMCore#setNodesAvailable
- move countDown of countDownlatch in a finally block to avoid blocking the RM in exceptional cases.