### PR TITLE
Improve merge task performance by reducing redundant DB calls

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -236,7 +236,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
         if (logger.isTraceEnabled() && jobMap == null || jobMap.isEmpty()) {
             logger.trace("No jobs selected to be scheduled");
         }
-        if (logger.isDebugEnabled() && !jobMap.isEmpty()) {
+        if (logger.isDebugEnabled() && jobMap != null && !jobMap.isEmpty()) {
             logger.debug("jobs selected to be scheduled : " + (jobMap.size() < 5 ? jobMap : jobMap.size()));
         }
     }
@@ -255,7 +255,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 loggingEligibleTasksDetails(fullListOfTaskRetrievedFromPolicy, taskRetrievedFromPolicy);
             }
 
-            updateVariablesForTasksToSchedule(jobMap, taskRetrievedFromPolicy);
+            updateVariablesForTasksToSchedule(taskRetrievedFromPolicy);
 
             for (EligibleTaskDescriptor etd : taskRetrievedFromPolicy) {
                 // load and Initialize the executable container
@@ -301,7 +301,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                     while (nodeSet != null && !nodeSet.isEmpty()) {
                         EligibleTaskDescriptor taskDescriptor = tasksToSchedule.removeFirst();
                         currentJob = ((JobDescriptorImpl) jobMap.get(taskDescriptor.getJobId())).getInternal();
-                        InternalTask internalTask = currentJob.getIHMTasks().get(taskDescriptor.getTaskId());
+                        InternalTask internalTask = ((EligibleTaskDescriptorImpl) taskDescriptor).getInternal();
 
                         if (currentPolicy.isTaskExecutable(nodeSet, taskDescriptor)) {
                             //create launcher and try to start the task
@@ -459,7 +459,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
      */
     protected NodeSet getRMNodes(Map<JobId, JobDescriptor> jobMap, int neededResourcesNumber,
             LinkedList<EligibleTaskDescriptor> tasksToSchedule, Set<String> freeResources) {
-        NodeSet nodeSet = new NodeSet();
+        NodeSet nodeSet;
         if (neededResourcesNumber <= 0) {
             throw new IllegalArgumentException("'neededResourcesNumber' must be greater than 0");
         }
@@ -541,11 +541,9 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
     /**
      * Update all variables for the given scheduled tasks
      */
-    private void updateVariablesForTasksToSchedule(Map<JobId, JobDescriptor> jobMap,
-            LinkedList<EligibleTaskDescriptor> tasksToSchedule) {
+    private void updateVariablesForTasksToSchedule(LinkedList<EligibleTaskDescriptor> tasksToSchedule) {
         for (EligibleTaskDescriptor taskDescriptor : tasksToSchedule) {
-            InternalJob associatedJob = ((JobDescriptorImpl) jobMap.get(taskDescriptor.getJobId())).getInternal();
-            InternalTask internalTask = associatedJob.getIHMTasks().get(taskDescriptor.getTaskId());
+            InternalTask internalTask = ((EligibleTaskDescriptorImpl) taskDescriptor).getInternal();
             internalTask.updateVariables(schedulingService);
         }
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -29,14 +29,10 @@ import java.security.KeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections4.ListUtils;
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
@@ -47,7 +43,6 @@ import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
 import org.ow2.proactive.scheduler.common.job.JobType;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
-import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptorImpl;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
@@ -127,17 +122,9 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
 
                 params = new TaskResult[parentIds.size()];
 
-                Map<TaskId, TaskResult> taskResults = new HashMap<>();
-                // Batch fetching of parent tasks results
-                for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
-                                                                       PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
-                    taskResults.putAll(schedulingService.getInfrastructure()
-                                                        .getDBManager()
-                                                        .loadTasksResults(job.getId(), parentsSubList));
-                }
                 int i = 0;
                 for (TaskId taskId : parentIds) {
-                    params[i] = taskResults.get(taskId);
+                    params[i] = task.getParentTasksResults().get(taskId);
                     i++;
                 }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -29,10 +29,14 @@ import java.security.KeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.collections4.ListUtils;
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
@@ -43,6 +47,7 @@ import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
 import org.ow2.proactive.scheduler.common.job.JobType;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptorImpl;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
@@ -121,6 +126,20 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
                 }
 
                 params = new TaskResult[parentIds.size()];
+
+                // If parentTaskResults is null after a system failure (a very rare case)
+                if (task.getParentTasksResults() == null) {
+                    Map<TaskId, TaskResult> taskResults = new HashMap<>();
+                    // Batch fetching of parent tasks results
+                    for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
+                                                                           PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
+                        taskResults.putAll(schedulingService.getInfrastructure()
+                                                            .getDBManager()
+                                                            .loadTasksResults(job.getId(), parentsSubList));
+                    }
+                    // store the parent tasks results in InternalTask for future executions.
+                    task.setParentTasksResults(taskResults);
+                }
 
                 int i = 0;
                 for (TaskId taskId : parentIds) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -815,10 +815,10 @@ public abstract class InternalTask extends TaskState {
 
     /** Remove all the results of the parent tasks */
     public void removeParentTasksResults() {
-        if(parentTasksResults!=null) {
+        if (parentTasksResults != null) {
             parentTasksResults.clear();
             // reset to default
-            parentTasksResults=null;
+            parentTasksResults = null;
         }
     }
 
@@ -1200,7 +1200,7 @@ public abstract class InternalTask extends TaskState {
                                                              .getFirstNotSkippedParentTaskIds(parentTask));
                 }
 
-                parentTasksResults=new HashMap<>();
+                parentTasksResults = new HashMap<>();
 
                 // Batch fetching of parent tasks results
                 for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -104,6 +104,10 @@ public abstract class InternalTask extends TaskState {
     @XmlTransient
     private transient List<InternalTask> internalTasksDependencies = null;
 
+    /** Results of the parent tasks. Null if no dependency*/
+    @XmlTransient
+    private transient Map<TaskId, TaskResult> parentTasksResults = null;
+
     /** Information about the launcher and node, mutable can change overtime, in case of restart for instance */
     // These information are not required during task process
     private transient ExecuterInformation executerInformation;
@@ -535,7 +539,7 @@ public abstract class InternalTask extends TaskState {
      * @return true if this task has dependencies, false otherwise.
      */
     public boolean hasDependences() {
-        return (internalTasksDependencies != null && internalTasksDependencies.size() > 0);
+        return (internalTasksDependencies != null && !internalTasksDependencies.isEmpty());
     }
 
     /**
@@ -713,7 +717,7 @@ public abstract class InternalTask extends TaskState {
      */
     public List<InternalTask> getIDependences() {
         //set to null if needed
-        if (internalTasksDependencies != null && internalTasksDependencies.size() == 0) {
+        if (internalTasksDependencies != null && internalTasksDependencies.isEmpty()) {
             internalTasksDependencies = null;
         }
         return internalTasksDependencies;
@@ -726,7 +730,7 @@ public abstract class InternalTask extends TaskState {
     @XmlTransient
     public List<TaskState> getDependences() {
         //set to null if needed
-        if (internalTasksDependencies == null || internalTasksDependencies.size() == 0) {
+        if (internalTasksDependencies == null || internalTasksDependencies.isEmpty()) {
             internalTasksDependencies = null;
             return null;
         }
@@ -802,6 +806,20 @@ public abstract class InternalTask extends TaskState {
     @Override
     public int getMaxNumberOfExecutionOnFailure() {
         return maxNumberOfExecutionOnFailure;
+    }
+
+    /** Get the results of the parent tasks */
+    public Map<TaskId, TaskResult> getParentTasksResults() {
+        return parentTasksResults;
+    }
+
+    /** Remove all the results of the parent tasks */
+    public void removeParentTasksResults() {
+        if(parentTasksResults!=null) {
+            parentTasksResults.clear();
+            // reset to default
+            parentTasksResults=null;
+        }
     }
 
     /**
@@ -1182,18 +1200,19 @@ public abstract class InternalTask extends TaskState {
                                                              .getFirstNotSkippedParentTaskIds(parentTask));
                 }
 
+                parentTasksResults=new HashMap<>();
+
                 // Batch fetching of parent tasks results
-                Map<TaskId, TaskResult> taskResults = new HashMap<>();
                 for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
                                                                        PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
 
-                    taskResults.putAll(schedulingService.getInfrastructure()
-                                                        .getDBManager()
-                                                        .loadTasksResults(internalJob.getId(), parentsSubList));
+                    parentTasksResults.putAll(schedulingService.getInfrastructure()
+                                                               .getDBManager()
+                                                               .loadTasksResults(internalJob.getId(), parentsSubList));
 
                 }
                 if (!parentIds.isEmpty()) {
-                    updateVariablesWithTaskResults(taskResults);
+                    updateVariablesWithTaskResults(parentTasksResults);
                 }
             }
 
@@ -1203,7 +1222,7 @@ public abstract class InternalTask extends TaskState {
 
     private void updateVariablesWithTaskResults(Map<TaskId, TaskResult> taskResults) {
         for (TaskResult taskResult : taskResults.values()) {
-            Map<String, Serializable> propagatedVariables = new HashMap<>();
+            Map<String, Serializable> propagatedVariables;
             if (taskResult.getPropagatedVariables() != null) {
                 try {
                     propagatedVariables = SerializationUtil.deserializeVariableMap(taskResult.getPropagatedVariables());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -813,6 +813,11 @@ public abstract class InternalTask extends TaskState {
         return parentTasksResults;
     }
 
+    /** Set the results of the parent tasks */
+    public void setParentTasksResults(Map<TaskId, TaskResult> parentTasksResults) {
+        this.parentTasksResults = parentTasksResults;
+    }
+
     /** Remove all the results of the parent tasks */
     public void removeParentTasksResults() {
         if (parentTasksResults != null) {


### PR DESCRIPTION
In this PR, @Aminelouati and I update the scheduling Implementation to at least 50% in execution time for merge tasks.
- The merge tasks, like all tasks, need to get the results of all its parent tasks from the DB. This operation is quite costly and was performed twice before this PR.
- In this PR, we modify the scheduling implementation to only make this call once and store the `parentTasksResults` in ÌnternalTask`.
- We also improve some code fragments as suggested by SonarLint. 