### PR TITLE
Exclude jackson from server classpath

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
@@ -350,6 +350,8 @@ public class JettyStarter {
     private WebAppContext createWebAppContext(String contextPath, String[] virtualHost) {
         WebAppContext webApp = new WebAppContext();
         webApp.setParentLoaderPriority(true);
+        // The following setting allows to avoid conflicts between server jackson jars and individual war jackson versions.
+        webApp.addServerClass("com.fasterxml.jackson.");
         webApp.setContextPath(contextPath);
         webApp.setVirtualHosts(virtualHost);
         return webApp;


### PR DESCRIPTION
- this is to avoid conflicts with different versions of jackson embedded in the web applications