### PR TITLE
Fix of LogsCheckingAfterRestartTest

### DIFF
--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
@@ -367,6 +367,11 @@ public class RMProxyUserInterface extends RMListenerProxy implements ResourceMan
     }
 
     @Override
+    public boolean isNodeSourceAlreadyExist(String nodeSourceName) {
+        return this.target.isNodeSourceAlreadyExist(nodeSourceName);
+    }
+
+    @Override
     public List<ScriptResult<Object>> executeScript(String script, String scriptEngine, String targetType,
             Set<String> targets) {
         return this.target.executeScript(script, scriptEngine, targetType, targets);

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
@@ -367,8 +367,8 @@ public class RMProxyUserInterface extends RMListenerProxy implements ResourceMan
     }
 
     @Override
-    public boolean isNodeSourceAlreadyExist(String nodeSourceName) {
-        return this.target.isNodeSourceAlreadyExist(nodeSourceName);
+    public boolean isNodeSourceAlreadyExisting(String nodeSourceName) {
+        return this.target.isNodeSourceAlreadyExisting(nodeSourceName);
     }
 
     @Override

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
@@ -367,7 +367,7 @@ public class RMProxyUserInterface extends RMListenerProxy implements ResourceMan
     }
 
     @Override
-    public boolean isNodeSourceAlreadyExisting(String nodeSourceName) {
+    public BooleanWrapper isNodeSourceAlreadyExisting(String nodeSourceName) {
         return this.target.isNodeSourceAlreadyExisting(nodeSourceName);
     }
 

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
@@ -351,6 +351,13 @@ public interface ResourceManager {
     NodeSet getNodes(Criteria criteria);
 
     /**
+     *
+     * @param nodeSourceName
+     * @return true if RM already has node source with given name
+     */
+    boolean isNodeSourceAlreadyExist(String nodeSourceName);
+
+    /**
      * Releases the node after computations. The specified node is marked as free and become
      * available to other users.
      *

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
@@ -355,7 +355,7 @@ public interface ResourceManager {
      * @param nodeSourceName
      * @return true if RM already has node source with given name
      */
-    boolean isNodeSourceAlreadyExist(String nodeSourceName);
+    boolean isNodeSourceAlreadyExisting(String nodeSourceName);
 
     /**
      * Releases the node after computations. The specified node is marked as free and become

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
@@ -355,7 +355,7 @@ public interface ResourceManager {
      * @param nodeSourceName
      * @return true if RM already has node source with given name
      */
-    boolean isNodeSourceAlreadyExisting(String nodeSourceName);
+    BooleanWrapper isNodeSourceAlreadyExisting(String nodeSourceName);
 
     /**
      * Releases the node after computations. The specified node is marked as free and become

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1638,7 +1638,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     }
 
     @Override
-    public boolean isNodeSourceAlreadyExist(String nodeSourceName) {
+    public boolean isNodeSourceAlreadyExisting(String nodeSourceName) {
         return this.nodeSources.containsKey(nodeSourceName.trim());
     }
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1638,8 +1638,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     }
 
     @Override
-    public boolean isNodeSourceAlreadyExisting(String nodeSourceName) {
-        return this.nodeSources.containsKey(nodeSourceName.trim());
+    public BooleanWrapper isNodeSourceAlreadyExisting(String nodeSourceName) {
+        return new BooleanWrapper(this.nodeSources.containsKey(nodeSourceName.trim()));
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1637,6 +1637,11 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         }
     }
 
+    @Override
+    public boolean isNodeSourceAlreadyExist(String nodeSourceName) {
+        return this.nodeSources.containsKey(nodeSourceName.trim());
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -549,12 +549,14 @@ public class SchedulerStarter {
         ResourceManager rman = rmAuth.login(Credentials.getCredentials(PAResourceManagerProperties.getAbsolutePath(PAResourceManagerProperties.RM_CREDS.getValueAsString())));
         //first im parameter is default rm url
         byte[] creds = FileToBytesConverter.convertFileToByteArray(new File(PAResourceManagerProperties.getAbsolutePath(PAResourceManagerProperties.RM_CREDS.getValueAsString())));
-        rman.createNodeSource(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME,
-                              LocalInfrastructure.class.getName(),
-                              new Object[] { creds, numberLocalNodes, nodeTimeoutValue, "" },
-                              RestartDownNodesPolicy.class.getName(),
-                              new Object[] { "ALL", "ALL", "10000" },
-                              NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_RECOVERABLE);
+        if (!rman.isNodeSourceAlreadyExist(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME)) {
+            rman.createNodeSource(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME,
+                                  LocalInfrastructure.class.getName(),
+                                  new Object[] { creds, numberLocalNodes, nodeTimeoutValue, "" },
+                                  RestartDownNodesPolicy.class.getName(),
+                                  new Object[] { "ALL", "ALL", "10000" },
+                                  NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_RECOVERABLE);
+        }
 
         credentials = creds;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -549,7 +549,8 @@ public class SchedulerStarter {
         ResourceManager rman = rmAuth.login(Credentials.getCredentials(PAResourceManagerProperties.getAbsolutePath(PAResourceManagerProperties.RM_CREDS.getValueAsString())));
         //first im parameter is default rm url
         byte[] creds = FileToBytesConverter.convertFileToByteArray(new File(PAResourceManagerProperties.getAbsolutePath(PAResourceManagerProperties.RM_CREDS.getValueAsString())));
-        if (!rman.isNodeSourceAlreadyExist(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME)) {
+        // check if 'LocalNodes' nodesource already exists. It can exist if it was retrieved from db during initializing.
+        if (!rman.isNodeSourceAlreadyExisting(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME)) {
             rman.createNodeSource(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME,
                                   LocalInfrastructure.class.getName(),
                                   new Object[] { creds, numberLocalNodes, nodeTimeoutValue, "" },

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -550,7 +550,7 @@ public class SchedulerStarter {
         //first im parameter is default rm url
         byte[] creds = FileToBytesConverter.convertFileToByteArray(new File(PAResourceManagerProperties.getAbsolutePath(PAResourceManagerProperties.RM_CREDS.getValueAsString())));
         // check if 'LocalNodes' nodesource already exists. It can exist if it was retrieved from db during initializing.
-        if (!rman.isNodeSourceAlreadyExisting(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME)) {
+        if (!rman.isNodeSourceAlreadyExisting(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME).getBooleanValue()) {
             rman.createNodeSource(NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME,
                                   LocalInfrastructure.class.getName(),
                                   new Object[] { creds, numberLocalNodes, nodeTimeoutValue, "" },


### PR DESCRIPTION
Workaround to fix LogsCheckingAfterRestartTest test. In this test we start, stop, and start server again.
When we perform second start, during initializing process RMCore retrieves LocalNodes nodesource from db. And after initialization we try to add another nodesource with the same name. So that is why I added isNodeSourceAlreadyExist method to RMCore, thus during server start-up we can check first if there is already nodesource with this name and if it exists we do not add new nodesource.