### PR TITLE
Cache keyPair for each Node

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -34,6 +34,7 @@ import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.log4j.Logger;
@@ -41,6 +42,7 @@ import org.objectweb.proactive.Body;
 import org.objectweb.proactive.InitActive;
 import org.objectweb.proactive.annotation.ImmediateService;
 import org.objectweb.proactive.api.PAActiveObject;
+import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.core.util.ProActiveInet;
 import org.objectweb.proactive.extensions.annotation.ActiveObject;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
@@ -83,6 +85,8 @@ import com.google.common.base.Stopwatch;
 public class TaskLauncher implements InitActive {
 
     private static final Logger logger = Logger.getLogger(TaskLauncher.class);
+
+    private static final Map<String, KeyPair> KEY_PAIR_MAP = new ConcurrentHashMap<>();
 
     final private TaskContextVariableExtractor taskContextVariableExtractor = new TaskContextVariableExtractor();
 
@@ -449,11 +453,23 @@ public class TaskLauncher implements InitActive {
         taskLogger.getStoredLogs(logSink);
     }
 
-    public PublicKey generatePublicKey() throws NoSuchAlgorithmException {
-        KeyPairGenerator keyGen;
-        keyGen = KeyPairGenerator.getInstance("RSA");
-        keyGen.initialize(1024, new SecureRandom());
-        KeyPair keyPair = keyGen.generateKeyPair();
+    private static KeyPair getKeyPair() throws NodeException, NoSuchAlgorithmException {
+        final String nodeUrl = PAActiveObject.getNode().getNodeInformation().getURL();
+        if (!KEY_PAIR_MAP.containsKey(nodeUrl)) {
+            synchronized (KEY_PAIR_MAP) {
+                if (!KEY_PAIR_MAP.containsKey(nodeUrl)) {
+                    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+                    keyGen.initialize(1024, new SecureRandom());
+                    KeyPair keyPair = keyGen.generateKeyPair();
+                    KEY_PAIR_MAP.put(nodeUrl, keyPair);
+                }
+            }
+        }
+        return KEY_PAIR_MAP.get(nodeUrl);
+    }
+
+    public PublicKey generatePublicKey() throws NoSuchAlgorithmException, NodeException {
+        KeyPair keyPair = TaskLauncher.getKeyPair();
         decrypter = new Decrypter(keyPair.getPrivate());
         return keyPair.getPublic();
     }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -453,8 +453,18 @@ public class TaskLauncher implements InitActive {
         taskLogger.getStoredLogs(logSink);
     }
 
-    private static KeyPair getKeyPair() throws NodeException, NoSuchAlgorithmException {
-        final String nodeUrl = PAActiveObject.getNode().getNodeInformation().getURL();
+    /**
+     * this method exist as a separate method only for test purpose
+     * because in some test (e.g. TaskLauncherTest) we do not mock PAActiveObject
+     * so it is easy to mock this method.
+     * @return
+     * @throws NodeException
+     */
+    public String nodeUrl() throws NodeException {
+        return PAActiveObject.getNode().getNodeInformation().getURL();
+    }
+
+    private static KeyPair getKeyPair(String nodeUrl) throws NodeException, NoSuchAlgorithmException {
         if (!KEY_PAIR_MAP.containsKey(nodeUrl)) {
             synchronized (KEY_PAIR_MAP) {
                 if (!KEY_PAIR_MAP.containsKey(nodeUrl)) {
@@ -469,7 +479,7 @@ public class TaskLauncher implements InitActive {
     }
 
     public PublicKey generatePublicKey() throws NoSuchAlgorithmException, NodeException {
-        KeyPair keyPair = TaskLauncher.getKeyPair();
+        KeyPair keyPair = TaskLauncher.getKeyPair(nodeUrl());
         decrypter = new Decrypter(keyPair.getPrivate());
         return keyPair.getPublic();
     }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
@@ -151,9 +151,9 @@ public class TaskLauncherTest extends TaskLauncherTestAbstract {
         // PAActiveObject.getNode, which is not stubbed in this test case.
         doReturn("1").when(spyTaskLauncher).nodeUrl();
 
-        Credentials thirdPartyCredentials = Credentials.createCredentials(credData, spyTaskLauncher.generatePublicKey());
+        Credentials thirdPartyCredentials = Credentials.createCredentials(credData,
+                                                                          spyTaskLauncher.generatePublicKey());
         executableContainer.setCredentials(thirdPartyCredentials);
-
 
         TaskResult taskResult = runTaskLauncher(spyTaskLauncher, executableContainer);
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -38,6 +38,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.log4j.Logger;
+import org.objectweb.proactive.core.node.NodeException;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.authentication.crypto.HybridEncryptionUtil;
@@ -167,7 +168,7 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
         return null;
     }
 
-    protected void fillContainer() throws KeyException, NoSuchAlgorithmException {
+    protected void fillContainer() throws KeyException, NoSuchAlgorithmException, NodeException {
         boolean isRunAsMeEnabled = task.isRunAsMe();
 
         task.getExecutableContainer().setRunAsUser(isRunAsMeEnabled);
@@ -175,7 +176,7 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
         createAndSetCredentials();
     }
 
-    private void createAndSetCredentials() throws KeyException, NoSuchAlgorithmException {
+    private void createAndSetCredentials() throws KeyException, NoSuchAlgorithmException, NodeException {
         CredData decryptedUserCredentials = job.getCredentials().decrypt(corePrivateKey);
 
         enrichWithThirdPartyCredentials(decryptedUserCredentials);


### PR DESCRIPTION
In order to improve Task Dispatching time, we decided to have single key pair for each Node and not for each task. Thus they are cached in RMNodeStarter.