### PR TITLE
Revert default local node source removal

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -484,12 +484,17 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
         for (NodeSourceData nodeSourceData : nodeSources) {
             String nodeSourceDataName = nodeSourceData.getName();
-            try {
-                logger.info("Recovering node source " + nodeSourceDataName);
-                createNodeSource(nodeSourceData, nodeSourceData.getNodesRecoverable());
-            } catch (Throwable t) {
-                logger.error(t.getMessage(), t);
-                brokenNodeSources.add(nodeSourceDataName);
+            if (NodeSource.DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME.equals(nodeSourceDataName)) {
+                // will be recreated by SchedulerStarter
+                dbManager.removeNodeSource(nodeSourceDataName);
+            } else {
+                try {
+                    logger.info("Recovering node source " + nodeSourceDataName);
+                    createNodeSource(nodeSourceData, nodeSourceData.getNodesRecoverable());
+                } catch (Throwable t) {
+                    logger.error(t.getMessage(), t);
+                    brokenNodeSources.add(nodeSourceDataName);
+                }
             }
         }
     }


### PR DESCRIPTION
In place of the work around proposed in https://github.com/ow2-proactive/scheduling/pull/3126, this will fix the source of the issue introduced in commit https://github.com/ow2-proactive/scheduling/commit/916f14a107f2c4dc5de4321df81de5ddb8d8741a, where the check of the default node source existence was removed.

This will fix the LogsCheckingAfterRestartTest in scheduling-system-tests