### PR TITLE
Handle node source creation in case of recovery with deploying nodes …

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/NodeSourceNameAlreadyExistException.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/NodeSourceNameAlreadyExistException.java
@@ -1,0 +1,34 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.core;
+
+public class NodeSourceNameAlreadyExistException extends RuntimeException {
+
+    public NodeSourceNameAlreadyExistException(String message) {
+        super(message);
+    }
+
+}

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1334,9 +1334,12 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
         try {
             return createNodeSource(nodeSourceData, nodesRecoverable);
+        } catch (NodeSourceNameAlreadyExistException e) {
+            logger.error(e.getMessage(), e);
+            throw e;
         } catch (RuntimeException ex) {
             logger.error(ex.getMessage(), ex);
-            if (added && !(ex instanceof NodeSourceNameAlreadyExistException)) {
+            if (added) {
                 dbManager.removeNodeSource(nodeSourceName);
             }
             throw ex;

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1336,7 +1336,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             return createNodeSource(nodeSourceData, nodesRecoverable);
         } catch (RuntimeException ex) {
             logger.error(ex.getMessage(), ex);
-            if (added) {
+            if (added && !(ex instanceof NodeSourceNameAlreadyExistException)) {
                 dbManager.removeNodeSource(nodeSourceName);
             }
             throw ex;
@@ -1351,14 +1351,19 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
         logger.info("Creating a node source : " + nodeSourceName);
 
-        boolean recoverNodes = existNodesToRecover(nodeSourceName, nodesRecoverable);
+        boolean existPersistedNodes = existPersistedNodes(nodeSourceName, nodesRecoverable);
 
         InfrastructureManager im;
 
         // we need to reload the infrastructure variables saved in database if
         // we recover the nodes
-        if (recoverNodes) {
+        if (existPersistedNodes) {
             im = InfrastructureManagerFactory.recover(nodeSourceData);
+            if (!im.getDeployingAndLostNodes().isEmpty()) {
+                dbManager.removeAllNodesFromNodeSource(nodeSourceName);
+                im = InfrastructureManagerFactory.create(nodeSourceData);
+                existPersistedNodes = false;
+            }
         } else {
             im = InfrastructureManagerFactory.create(nodeSourceData);
         }
@@ -1383,8 +1388,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             throw new RuntimeException("Cannot create node source " + nodeSourceName, e);
         }
 
-        // finally recover the nodes from a saved state if needed
-        if (recoverNodes) {
+        if (existPersistedNodes) {
             recoverNodes(nodeSource);
         }
 
@@ -1436,7 +1440,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
      * it removes all its nodes. Thus if we restart and recover the RM
      * afterwards there will be no nodes in the database.
      */
-    private boolean existNodesToRecover(String nodeSourceName, boolean nodesRecoverable) {
+    private boolean existPersistedNodes(String nodeSourceName, boolean nodesRecoverable) {
         boolean recoverNodes = false;
         if (PAResourceManagerProperties.RM_NODES_RECOVERY.getValueAsBoolean() && nodesRecoverable) {
             Collection<RMNodeData> nodesData = dbManager.getNodesByNodeSource(nodeSourceName);
@@ -2112,7 +2116,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             throw new IllegalArgumentException("Node Source Name cannot be empty");
         }
         if (this.nodeSources.containsKey(nodeSourceName)) {
-            throw new IllegalArgumentException("Node Source name " + nodeSourceName + " already exist");
+            throw new NodeSourceNameAlreadyExistException("Node Source name " + nodeSourceName + " already exist");
         }
         Pattern pattern = Pattern.compile("[^-\\w]");//letters,digits,_and-
         Matcher matcher = pattern.matcher(nodeSourceName);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMDBManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMDBManager.java
@@ -497,6 +497,24 @@ public class RMDBManager {
         }
     }
 
+    public void removeAllNodesFromNodeSource(final String nodeSourceName) {
+        try {
+            logger.info("Remove all nodes from node source " + nodeSourceName + IN_DATABASE_STRING);
+            executeReadWriteTransaction(new SessionWork<Void>() {
+                @Override
+                public Void doInTransaction(Session session) {
+                    session.getNamedQuery("deleteAllRMNodeDataFromNodeSource")
+                           .setParameter("name", nodeSourceName)
+                           .executeUpdate();
+                    return null;
+                }
+            });
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Exception occurred while removing all nodes from node source " +
+                                       nodeSourceName + " in the database", e);
+        }
+    }
+
     public RMNodeData getNodeByNameAndUrl(final String nodeName, final String nodeUrl) {
         logger.debug(REQUEST_BUFFER_STRING + "retrieve node with node name " + nodeName + IN_DATABASE_STRING);
         rmdbManagerBuffer.debounceNodeUpdatesIfNeeded();

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMNodeData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMNodeData.java
@@ -53,6 +53,7 @@ import org.ow2.proactive.resourcemanager.rmnode.RMNode;
  */
 @Entity
 @NamedQueries({ @NamedQuery(name = "deleteAllRMNodeData", query = "delete from RMNodeData"),
+                @NamedQuery(name = "deleteAllRMNodeDataFromNodeSource", query = "delete from RMNodeData where nodeSource.name=:name"),
                 @NamedQuery(name = "getAllRMNodeData", query = "from RMNodeData"),
                 @NamedQuery(name = "getRMNodeDataByNameAndUrl", query = "from RMNodeData where name=:name and nodeUrl=:url"),
                 @NamedQuery(name = "getRMNodeDataByNodeSource", query = "from RMNodeData where nodeSource.name=:name") })

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
@@ -89,11 +89,6 @@ public abstract class InfrastructureManager implements Serializable {
     /** class' logger */
     protected static final Logger logger = Logger.getLogger(InfrastructureManager.class);
 
-    /** delay that is waited at startup of the scheduler to initialize the
-     * variables and persist them
-     */
-    private static final int PERSISTED_INFRA_VARIABLES_INIT_DELAY = 2000;
-
     /** manager's node source */
     protected NodeSource nodeSource;
 
@@ -442,11 +437,6 @@ public abstract class InfrastructureManager implements Serializable {
      */
     protected List<String> addMultipleDeployingNodes(List<String> nodeNames, String obfuscatedCmd, String message,
             long nodeTimeout) {
-        try {
-            Thread.sleep(PERSISTED_INFRA_VARIABLES_INIT_DELAY);
-        } catch (InterruptedException e) {
-            logger.warn("Could not wait for persisted infrastructure variables init delay to end", e);
-        }
         List<String> answer = new ArrayList<>(nodeNames.size());
         for (String nodeName : nodeNames) {
             String depNodeURL = this.addDeployingNode(nodeName, obfuscatedCmd, message, nodeTimeout);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/RegressionTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/RegressionTestSuite.java
@@ -39,6 +39,7 @@ import functionaltests.job.taskkill.TestJobKilled;
 import functionaltests.job.taskkill.TestProcessTreeKiller;
 import functionaltests.recover.TaskReconnectionWithForkedTaskExecutorTest;
 import functionaltests.recover.TaskReconnectionWithInProcessTaskExecutorTest;
+import functionaltests.recover.TaskRecoveryWhenNodesAreReservedInBatchTest;
 import functionaltests.rm.TestOperationsWhenUnlinked;
 import functionaltests.workflow.TestJobLegacySchemas;
 import functionaltests.workflow.TestWorkflowSubmission;
@@ -82,7 +83,8 @@ import functionaltests.workflow.complex.TestWorkflowReplicateJobs3;
 
                       TestDataspaceConcurrentTransfer.class, TestDataspaceConcurrentKilling.class,
                       TaskReconnectionWithForkedTaskExecutorTest.class,
-                      TaskReconnectionWithInProcessTaskExecutorTest.class })
+                      TaskReconnectionWithInProcessTaskExecutorTest.class,
+                      TaskRecoveryWhenNodesAreReservedInBatchTest.class })
 
 /**
  * @author ActiveEon Team

--- a/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
@@ -114,7 +114,6 @@ import functionaltests.job.workingdir.TestForkedTaskWorkingDir;
 import functionaltests.job.workingdir.TestWorkingDirStaticCommand;
 import functionaltests.policy.license.TestLicensePolicy;
 import functionaltests.policy.ram.TestRamPolicy;
-import functionaltests.recover.TaskRecoveryWhenNodesAreReservedInBatchTest;
 import functionaltests.rm.TestNodeDiesAtSchedulerRestart;
 import functionaltests.rm.TestRMProxy;
 import functionaltests.rm.TestRMProxyRebind;
@@ -241,7 +240,7 @@ import functionaltests.workflow.variables.Test_SCHEDULING_2034;
                       TestSubmitJobWithPartiallyUnaccessibleDataSpaces.class,
                       TestSubmitJobWithUnaccessibleDataSpaces.class, TestTaskRestartOnNodeFailure.class,
                       TestTasksCompleteAfterSelectiontimeout.class, TestUnauthorizedScripts.class,
-                      TestVariablesPropagation.class, TaskRecoveryWhenNodesAreReservedInBatchTest.class })
+                      TestVariablesPropagation.class })
 
 /**
  * @author ActiveEon Team


### PR DESCRIPTION
…and in case of invalid name

- recreate new InfrastructureManager if deploying nodes are found in recovered infrastructure, and remove nodes in database for this node source
- do not remove node source and nodes in database if node source name exist already
- remove useless sleep in InfrastructureManager
- put back recovery functional test in Regression test