### PR TITLE
Upgrade Java version source compatibility from 1.7 to 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ configure(javaSubprojects) {
     apply plugin: 'jacoco'
 
 
-    sourceCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     compileJava.options.compilerArgs << '-Xlint:-options' // remove warning about bootstrap class path
 


### PR DESCRIPTION
Being unable to spot any obvious issue, we give a try to the upgrade of Java version 8 for scheduling