### PR TITLE
Fix and improve RMNodeUpdater

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,6 +393,7 @@ def createStartScripts(className, name, String outputFolder) {
 createStartScripts('org.ow2.proactive.scheduler.util.SchedulerStarter', 'proactive-server', 'bin')
 createStartScripts('org.ow2.proactive_grid_cloud_portal.cli.CommonEntryPoint', 'proactive-client', 'bin')
 createStartScripts('org.ow2.proactive.resourcemanager.utils.RMNodeStarter', 'proactive-node', 'bin')
+createStartScripts('org.ow2.proactive.resourcemanager.updater.RMNodeUpdater', 'proactive-node-autoupdate', 'bin')
 createStartScripts('org.objectweb.proactive.extensions.vfsprovider.console.PADataserverStarter', 'proactive-dataserver', 'tools')
 createStartScripts('org.objectweb.proactive.extensions.vfsprovider.gui.ServerBrowser', 'proactive-dataserver-gui', 'tools')
 createStartScripts('org.ow2.proactive.authentication.crypto.CreateCredentials', 'proactive-create-cred', 'tools')

--- a/rm/rm-node-updater/build.gradle
+++ b/rm/rm-node-updater/build.gradle
@@ -1,18 +1,5 @@
 dependencies {
     compile 'commons-io:commons-io:2.5'
+    compile project(':rm:rm-node')
 
-}
-jar {
-    manifest {
-        attributes("Implementation-Title": "ProActive",
-                "Implementation-Version": version,
-                "Specification-Version": version,
-                "Implementation-Vendor": "Activeeon - OASIS - INRIA Sophia Antipolis",
-                "Implementation-URL": "http://proactive.inria.fr",
-                'Main-Class': 'org.ow2.proactive.resourcemanager.updater.RMNodeUpdater',
-                'Class-Path' : "scheduler-node.jar"
-        )
-    }
-    from configurations.compile.collect { zipTree(it) }
-    archiveName = 'node-updater.jar'
 }

--- a/rm/rm-node-updater/src/main/java/org/ow2/proactive/resourcemanager/updater/RMNodeUpdater.java
+++ b/rm/rm-node-updater/src/main/java/org/ow2/proactive/resourcemanager/updater/RMNodeUpdater.java
@@ -125,7 +125,7 @@ public class RMNodeUpdater extends RMNodeStarter {
     public static final int NUMBER_OF_ATTEMPTS = 10;
 
     public RMNodeUpdater() {
-
+        // empty constructor
     }
 
     private static Logger initLogger() {
@@ -345,7 +345,7 @@ public class RMNodeUpdater extends RMNodeStarter {
             checkUserSuppliedParameters();
             return nodeName;
         } catch (ParseException pe) {
-            pe.printStackTrace();
+            logger.error("Error when parsing arguments", pe);
             System.exit(ExitStatus.RMNODE_PARSE_ERROR.exitCode);
         }
 
@@ -551,9 +551,11 @@ public class RMNodeUpdater extends RMNodeStarter {
             SSLContext context = SSLContext.getInstance("TLS");
             context.init(null, new X509TrustManager[] { new X509TrustManager() {
                 public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                    // always trusted
                 }
 
                 public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                    // always trusted
                 }
 
                 public X509Certificate[] getAcceptedIssuers() {

--- a/rm/rm-node-updater/src/main/java/org/ow2/proactive/resourcemanager/updater/RMNodeUpdater.java
+++ b/rm/rm-node-updater/src/main/java/org/ow2/proactive/resourcemanager/updater/RMNodeUpdater.java
@@ -28,15 +28,21 @@ package org.ow2.proactive.resourcemanager.updater;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+
+import com.google.common.base.StandardSystemProperty;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 
 /**
@@ -48,15 +54,31 @@ import org.apache.commons.io.FileUtils;
  */
 public class RMNodeUpdater {
 
+    /**
+     * Url used to download node.jar
+     */
     private static final String NODE_URL_PROPERTY = "node.jar.url";
 
-    private static final String NODE_JAR_PROPERTY = "node.jar.saveas";
+    /**
+     * Local path where the node jar should be stored
+     */
+    private static final String NODE_JAR_SAVEAS_PROPERTY = "node.jar.saveas";
 
-    private static final String TMP_DIR_PROPERTY = "java.io.tmpdir";
+    /**
+     * Default name of the local node jar
+     */
+    private static final String DEFAULT_SCHEDULER_NODE_JAR = "node.jar";
 
-    public static final String ONE_JAR_JAR_PATH = "one-jar.jar.path";
+    /**
+     * optional One-Jar property, path used to expand librairies
+     */
+    private static final String ONEJAR_EXPAND_DIR_PROPERTY = "one-jar.expand.dir";
 
-    public static final String SCHEDULER_NODE_JAR = "scheduler-node.jar";
+    /**
+     * Java Property prefix used to enter extra java command line options
+     * For example -Xmn256m can be configured by using -DXtraOption1=Xmn256m
+     */
+    private static final String XTRA_OPTION = "XtraOption";
 
     private static boolean isLocalJarUpToDate(String url, String filePath) {
 
@@ -67,8 +89,8 @@ public class RMNodeUpdater {
             System.out.println("Url date=" + new Date(urlConnection.getLastModified()));
             System.out.println("File date=" + new Date(file.lastModified()));
 
-            if (file.lastModified() < urlConnection.getLastModified()) {
-                System.out.println("Local jar " + file + " is obsolete");
+            if (!file.exists() || file.lastModified() < urlConnection.getLastModified()) {
+                System.out.println("Local jar " + file + " is obsolete or not present");
             } else {
                 System.out.println("Local jar " + file + " is up to date");
                 return true;
@@ -85,10 +107,10 @@ public class RMNodeUpdater {
         if (System.getProperty(NODE_URL_PROPERTY) != null) {
 
             String jarUrl = System.getProperty(NODE_URL_PROPERTY);
-            String jarFile = SCHEDULER_NODE_JAR;
+            String jarFile = DEFAULT_SCHEDULER_NODE_JAR;
 
-            if (System.getProperty(NODE_JAR_PROPERTY) != null) {
-                jarFile = System.getProperty(NODE_JAR_PROPERTY);
+            if (System.getProperty(NODE_JAR_SAVEAS_PROPERTY) != null) {
+                jarFile = System.getProperty(NODE_JAR_SAVEAS_PROPERTY);
             }
 
             if (!isLocalJarUpToDate(jarUrl, jarFile)) {
@@ -101,7 +123,7 @@ public class RMNodeUpdater {
 
                     if (destination.exists()) {
 
-                        lockFile = new File(System.getProperty(TMP_DIR_PROPERTY) + "/lock");
+                        lockFile = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value(), "lock");
                         if (!lockFile.exists()) {
                             lockFile.createNewFile();
                         }
@@ -123,36 +145,156 @@ public class RMNodeUpdater {
                     FileUtils.copyURLToFile(new URL(jarUrl), destination);
                     System.out.println("Download finished");
 
+                    cleanExpandDirectory(jarFile);
+
                     if (lock != null && lockFile != null) {
                         System.out.println("Releasing the lock on " + lockFile.getAbsoluteFile());
                         lock.release();
                     }
-
                     return true;
 
                 } catch (Exception e) {
                     System.err.println("Cannot download node.jar from " + jarUrl);
                     e.printStackTrace();
+                    return false;
                 }
+            } else {
+                return true;
             }
         } else {
-            System.out.println("No java property " + NODE_URL_PROPERTY +
-                               " specified. Do not check for the new version.");
+            throw new IllegalArgumentException("No java property " + NODE_URL_PROPERTY +
+                                               " specified. This property must be set when using " +
+                                               RMNodeUpdater.class.getSimpleName());
         }
-
-        return false;
     }
 
-    public static void main(String[] args) throws IOException, InterruptedException, ClassNotFoundException,
-            NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        makeNodeUpToDate();
-
-        if (System.getProperty(ONE_JAR_JAR_PATH) == null) {
-            System.setProperty(ONE_JAR_JAR_PATH, SCHEDULER_NODE_JAR);
+    private static void cleanExpandDirectory(String jarFile) throws IOException {
+        File directoryToClean;
+        String oneJarExpandDir = System.getProperty(ONEJAR_EXPAND_DIR_PROPERTY);
+        if (oneJarExpandDir == null) {
+            // Default scheme used by one-jar
+            String jar = new File(jarFile).getName().replaceFirst("\\.[^\\.]*$", "");
+            directoryToClean = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value(), jar);
+        } else {
+            directoryToClean = new File(oneJarExpandDir);
         }
+
+        FileUtils.deleteQuietly(directoryToClean);
+    }
+
+    public static void main(String[] args) throws Exception {
+        while (!makeNodeUpToDate()) {
+            Thread.sleep(5000);
+        }
+        String jarFile = DEFAULT_SCHEDULER_NODE_JAR;
+
+        if (System.getProperty(NODE_JAR_SAVEAS_PROPERTY) != null) {
+            jarFile = System.getProperty(NODE_JAR_SAVEAS_PROPERTY);
+        }
+
         System.out.println("Launching a computing node");
-        Class<?> cls = Class.forName("OneJar");
-        Method meth = cls.getMethod("main", String[].class);
-        meth.invoke(null, (Object) args);
+        ProcessBuilder pb = generateSubProcess(args, jarFile);
+
+        final Process p = pb.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    p.destroy();
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+        }));
+        p.waitFor();
     }
+
+    private static ProcessBuilder generateSubProcess(String[] args, String jarFile) {
+        ProcessBuilder pb;
+        List<String> command = new ArrayList<>();
+        if (StandardSystemProperty.OS_NAME.value().toLowerCase().contains("windows")) {
+            command.add((new File(StandardSystemProperty.JAVA_HOME.value(), "bin/java.exe")).getAbsolutePath());
+        } else {
+            command.add((new File(StandardSystemProperty.JAVA_HOME.value(), "bin/java")).getAbsolutePath());
+        }
+        command.addAll(extractUserSystemPropertiesFromCurrentJVM());
+        command.add("-jar");
+        command.add(jarFile);
+        command.addAll(Lists.newArrayList(args));
+        pb = new ProcessBuilder(command);
+        pb.inheritIO();
+        if (pb.environment().containsKey("CLASSPATH")) {
+            pb.environment().remove("CLASSPATH");
+        }
+        return pb;
+    }
+
+    private static List<String> extractUserSystemPropertiesFromCurrentJVM() {
+        ArrayList<String> commandLineProperties = new ArrayList<>();
+
+        Set<String> standardPropertySet = Sets.union(allSystemProperties(), allInternalProperties());
+
+        for (String propertyName : System.getProperties().stringPropertyNames()) {
+            if (!standardPropertySet.contains(propertyName)) {
+                commandLineProperties.add("-D" + propertyName + "=" + System.getProperty(propertyName));
+            }
+        }
+        commandLineProperties.addAll(allNonStandardXOptionsConvertedToProperties());
+        return commandLineProperties;
+    }
+
+    private static Set<String> allSystemProperties() {
+        Set<String> standardPropertySet = new HashSet<>();
+        for (StandardSystemProperty stdProperty : StandardSystemProperty.values()) {
+            if (stdProperty != StandardSystemProperty.JAVA_IO_TMPDIR &&
+                stdProperty != StandardSystemProperty.JAVA_LIBRARY_PATH) {
+                // tmp dir and java library path can be overridden by user
+                standardPropertySet.add(stdProperty.key());
+            }
+        }
+        return standardPropertySet;
+    }
+
+    private static Set<String> allInternalProperties() {
+        Set<String> internalPropertySet = new HashSet<>();
+        for (String propertyName : System.getProperties().stringPropertyNames()) {
+            if (propertyName.startsWith("sun.") || (propertyName.startsWith(XTRA_OPTION))) {
+                internalPropertySet.add(propertyName);
+            } else {
+                switch (propertyName) {
+                    case "file.encoding.pkg":
+                    case "user.script":
+                    case "user.country":
+                    case "java.runtime.version":
+                    case "java.awt.graphicsenv":
+                    case "java.endorsed.dirs":
+                    case "user.variant":
+                    case "user.timezone":
+                    case "java.runtime.name":
+                    case "java.vendor.url.bug":
+                    case "java.security.manager":
+                    case "java.awt.printerjob":
+                    case "awt.toolkit":
+                    case "java.vm.info":
+                        internalPropertySet.add(propertyName);
+                        break;
+                    default:
+                        // do nothing
+                }
+
+            }
+        }
+        return internalPropertySet;
+    }
+
+    private static List<String> allNonStandardXOptionsConvertedToProperties() {
+        List<String> xOptions = new ArrayList<>();
+        for (String propertyName : System.getProperties().stringPropertyNames()) {
+            if (propertyName.startsWith(XTRA_OPTION)) {
+                xOptions.add("-" + System.getProperty(propertyName));
+            }
+        }
+        return xOptions;
+    }
+
 }

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
@@ -297,11 +297,16 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
                 if (cacheCleaningRWLock.writeLock().tryLock()) {
                     try {
                         FileObject rootFO = fileSystemManager.resolveFile(rootCacheUri);
+                        if (!rootFO.exists()) {
+                            rootFO.createFolder();
+                        }
                         FileObject[] files = rootFO.findFiles(Selectors.EXCLUDE_SELF);
-                        for (FileObject file : files) {
-                            if (currentTime - file.getContent().getLastModifiedTime() > invalidationPeriod) {
-                                logger.info("[Cache Space cleaner] deleting " + file);
-                                file.delete();
+                        if (files != null) {
+                            for (FileObject file : files) {
+                                if (currentTime - file.getContent().getLastModifiedTime() > invalidationPeriod) {
+                                    logger.info("[Cache Space cleaner] deleting " + file);
+                                    file.delete();
+                                }
                             }
                         }
                     } finally {

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/OneJar.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/OneJar.java
@@ -47,6 +47,7 @@ public class OneJar {
         if (isRunningWithOneJar()) {
             String expandedDir = System.getProperty("one-jar.expand.dir", "");
             return asList(expandedDir + File.separatorChar + "lib" + File.separatorChar + "*",
+                          expandedDir + File.separatorChar + "binlib" + File.separatorChar + "*",
                           expandedDir + File.separatorChar + "main" + File.separatorChar + "*");
         } else {
             return emptyList();

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
@@ -1041,7 +1041,7 @@ public class RMNodeStarter {
     /**
      * Checks that user has supplied parameters or override them with java properties values...
      */
-    private void checkUserSuppliedParameters() {
+    protected void checkUserSuppliedParameters() {
         //need an exhaustive list...
         //first, the number of add attempts
         if (!NB_OF_ADD_NODE_ATTEMPTS_USER_SUPPLIED) {
@@ -1392,7 +1392,7 @@ public class RMNodeStarter {
         return new File(tmpDir, URL_TMPFILE_PREFIX + "_" + nodeName + "-" + rank).getAbsolutePath();
     }
 
-    private enum ExitStatus {
+    protected enum ExitStatus {
         OK(0, "Exit success."),
         //mustn't be changed, return value set in the JVM itself
         JVM_ERROR(1, "Problem with the Java process itself ( classpath, main method... )."),

--- a/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -67,7 +67,7 @@ cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >&-
 APP_HOME="`pwd -P`"
 cd "\$SAVED" >&-
 
-DEFAULT_JVM_OPTS="\$DEFAULT_JVM_OPTS -Djava.library.path=\$APP_HOME/dist/lib -Dpa.scheduler.home=\$APP_HOME"
+DEFAULT_JVM_OPTS="\$DEFAULT_JVM_OPTS -Djava.library.path=\$APP_HOME/dist/lib -Dpa.scheduler.home=\$APP_HOME -Dpa.rm.home=\$APP_HOME"
 
 CLASSPATH=$classpath
 

--- a/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -19,7 +19,7 @@ if "%DIRNAME%" == "" set DIRNAME=.\
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%${appHomeRelativePath}
 
-set "DEFAULT_JVM_OPTS=%DEFAULT_JVM_OPTS% -Dpa.scheduler.home="%APP_HOME%""
+set "DEFAULT_JVM_OPTS=%DEFAULT_JVM_OPTS% -Dpa.scheduler.home="%APP_HOME%" -Dpa.rm.home="%APP_HOME%""
 
 @rem================================================
 IF exist "%APP_HOME%/jre" (set JAVA_HOME="%APP_HOME%/jre")


### PR DESCRIPTION
 - fork a new JVM to execute the up-to-date node.jar (otherwise, there are classpath conflicts)
 - forward properties from the current JVM to the new one (filtering system properties)
 - clean the One-Jar expand dir (to prevent jar duplicates coming from different versions).
 - add binlib to the OneJar forked JVM classpath (only way to allow powershell script engine execution)