### PR TITLE
Avoid retrieve node source before persisting node

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/NodesRecoveryManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/NodesRecoveryManager.java
@@ -218,7 +218,7 @@ public class NodesRecoveryManager {
         } else {
             // the node is not recoverable and does not appear in any data
             // structures: we can remove it safely from database
-            this.rmCore.getDbManager().removeNode(rmNodeData);
+            this.rmCore.getDbManager().removeNode(rmNodeData, rmNodeData.getNodeSource().getName());
             this.markNodesNotInDeployingStateAsDown(nodeSource, rmNodeData, nodeUrl);
             this.updateRecoveredNodeStateCounter(nodeStates, NodeState.DOWN);
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2457,7 +2457,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     private void persistNewRMNodeIfRecoveryEnabled(RMNode rmNode) {
         if (nodesRecoveryEnabledForNode(rmNode)) {
             RMNodeData rmNodeData = RMNodeData.createRMNodeData(rmNode);
-            NodeSourceData nodeSourceData = dbManager.getNodeSource(rmNode.getNodeSourceName());
+            NodeSourceData nodeSourceData = new NodeSourceData(rmNode.getNodeSourceName());
             rmNodeData.setNodeSource(nodeSourceData);
             dbManager.addNode(rmNodeData);
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2457,9 +2457,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     private void persistNewRMNodeIfRecoveryEnabled(RMNode rmNode) {
         if (nodesRecoveryEnabledForNode(rmNode)) {
             RMNodeData rmNodeData = RMNodeData.createRMNodeData(rmNode);
-            NodeSourceData nodeSourceData = new NodeSourceData(rmNode.getNodeSourceName());
-            rmNodeData.setNodeSource(nodeSourceData);
-            dbManager.addNode(rmNodeData);
+            dbManager.addNode(rmNodeData, rmNode.getNodeSourceName());
         }
     }
 
@@ -2471,7 +2469,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     private void persistUpdatedRMNodeIfRecoveryEnabled(RMNode rmNode) {
         if (nodesRecoveryEnabledForNode(rmNode)) {
             RMNodeData rmNodeData = RMNodeData.createRMNodeData(rmNode);
-            dbManager.updateNode(rmNodeData);
+            dbManager.updateNode(rmNodeData, rmNode.getNodeSourceName());
         }
     }
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -81,8 +81,10 @@ public class NodeSourceData implements Serializable {
         this.name = name;
     }
 
-    public NodeSourceData(String nodeSourceName, String infrastructureType, Object[] infrastructureParameters,
-            String policyType, Object[] policyParameters, Client provider, boolean nodesRecoverable) {
+    public NodeSourceData(String nodeSourceName, String infrastructureType, List<Serializable> infrastructureParameters,
+            String policyType, List<Serializable> policyParameters, Client provider, boolean nodesRecoverable,
+            NodeSourceStatus status) {
+
         this.name = nodeSourceName;
         this.infrastructureType = infrastructureType;
         this.infrastructureParameters = infrastructureParameters;

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -77,10 +77,12 @@ public class NodeSourceData implements Serializable {
     public NodeSourceData() {
     }
 
-    public NodeSourceData(String nodeSourceName, String infrastructureType, List<Serializable> infrastructureParameters,
-            String policyType, List<Serializable> policyParameters, Client provider, boolean nodesRecoverable,
-            NodeSourceStatus status) {
+    public NodeSourceData(String name) {
+        this.name = name;
+    }
 
+    public NodeSourceData(String nodeSourceName, String infrastructureType, Object[] infrastructureParameters,
+            String policyType, Object[] policyParameters, Client provider, boolean nodesRecoverable) {
         this.name = nodeSourceName;
         this.infrastructureType = infrastructureType;
         this.infrastructureParameters = infrastructureParameters;

--- a/rm/rm-server/src/test/java/functionaltests/db/RMDBManagerBufferTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/db/RMDBManagerBufferTest.java
@@ -29,7 +29,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.security.Permission;
-import java.util.AbstractMap;
 import java.util.List;
 
 import org.junit.Before;
@@ -235,13 +234,13 @@ public class RMDBManagerBufferTest {
                                                JMX_URLS,
                                                JVM_NAME);
         rmNodeData.setNodeSource(nodeSourceData);
-        dbManager.addNode(rmNodeData);
+        dbManager.addNode(rmNodeData, NODE_SOURCE_NAME_BASE);
         return rmNodeData;
     }
 
     private void updateRMNodeData(RMNodeData rmNodeData, NodeState nodeState) {
         rmNodeData.setState(nodeState);
-        dbManager.updateNode(rmNodeData);
+        dbManager.updateNode(rmNodeData, NODE_SOURCE_NAME_BASE);
     }
 
     private void checkPendingNodeOperationsIsEmpty() {

--- a/rm/rm-server/src/test/java/functionaltests/db/RMDBManagerTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/db/RMDBManagerTest.java
@@ -292,7 +292,7 @@ public class RMDBManagerTest {
         newNodeSourceData.setPolicyType("aPolicyType");
         dbManager.addNodeSource(newNodeSourceData);
         rmNodeData2.setNodeSource(newNodeSourceData);
-        dbManager.addNode(rmNodeData2, NODE_SOURCE_NAME_BASE);
+        dbManager.addNode(rmNodeData2, newNodeSourceData.getName());
 
         Collection<RMNodeData> nodes = dbManager.getNodesByNodeSource(nodeSourceData.getName());
 
@@ -324,7 +324,7 @@ public class RMDBManagerTest {
         newNodeSourceData.setPolicyType("aPolicyType");
         dbManager.addNodeSource(newNodeSourceData);
         rmNodeData2.setNodeSource(newNodeSourceData);
-        dbManager.addNode(rmNodeData2, NODE_SOURCE_NAME_BASE);
+        dbManager.addNode(rmNodeData2, newNodeSourceData.getName());
 
         RMNodeData rmNodeData3 = addRMNodeData(NODE_NAME_BASE + "3", NODE_STATE_BASE);
 

--- a/rm/rm-server/src/test/java/functionaltests/db/RMDBManagerTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/db/RMDBManagerTest.java
@@ -217,7 +217,7 @@ public class RMDBManagerTest {
         RMNodeData rmNodeData = addRMNodeData(NODE_NAME_BASE, NODE_STATE_BASE);
         rmNodeData.setState(NodeState.BUSY);
         rmNodeData.setStateChangeTime(5678);
-        dbManager.updateNode(rmNodeData);
+        dbManager.updateNode(rmNodeData, NODE_SOURCE_NAME_BASE);
 
         Collection<RMNodeData> allNodes = dbManager.getAllNodes();
         assertThat(allNodes).hasSize(1);
@@ -265,7 +265,7 @@ public class RMDBManagerTest {
     public void testRemoveRMNodeData() {
 
         RMNodeData rmNodeData = addRMNodeData(NODE_NAME_BASE, NODE_STATE_BASE);
-        dbManager.removeNode(rmNodeData);
+        dbManager.removeNode(rmNodeData, NODE_SOURCE_NAME_BASE);
 
         Collection<RMNodeData> allNodes = dbManager.getAllNodes();
         assertThat(allNodes).hasSize(0);
@@ -292,7 +292,7 @@ public class RMDBManagerTest {
         newNodeSourceData.setPolicyType("aPolicyType");
         dbManager.addNodeSource(newNodeSourceData);
         rmNodeData2.setNodeSource(newNodeSourceData);
-        dbManager.addNode(rmNodeData2);
+        dbManager.addNode(rmNodeData2, NODE_SOURCE_NAME_BASE);
 
         Collection<RMNodeData> nodes = dbManager.getNodesByNodeSource(nodeSourceData.getName());
 
@@ -324,7 +324,7 @@ public class RMDBManagerTest {
         newNodeSourceData.setPolicyType("aPolicyType");
         dbManager.addNodeSource(newNodeSourceData);
         rmNodeData2.setNodeSource(newNodeSourceData);
-        dbManager.addNode(rmNodeData2);
+        dbManager.addNode(rmNodeData2, NODE_SOURCE_NAME_BASE);
 
         RMNodeData rmNodeData3 = addRMNodeData(NODE_NAME_BASE + "3", NODE_STATE_BASE);
 
@@ -367,7 +367,7 @@ public class RMDBManagerTest {
         RMNodeData rmNodeData = addRMNodeData(NODE_NAME_BASE + "2", NodeState.DEPLOYING);
         addRMNodeData(NODE_NAME_BASE + "3", NODE_STATE_BASE);
 
-        dbManager.removeNode(rmNodeData);
+        dbManager.removeNode(rmNodeData, NODE_SOURCE_NAME_BASE);
 
         Collection<RMNodeData> allNodes = dbManager.getAllNodes();
         assertThat(allNodes).hasSize(2);
@@ -407,7 +407,7 @@ public class RMDBManagerTest {
                                                JMX_URLS,
                                                JVM_NAME);
         rmNodeData.setNodeSource(nodeSourceData);
-        dbManager.addNode(rmNodeData);
+        dbManager.addNode(rmNodeData, NODE_SOURCE_NAME_BASE);
         return rmNodeData;
     }
 


### PR DESCRIPTION
- prefer loading the node source in the database transaction to persist a node instead to retrieve it at the application level
- set a maximum number of bufferized database request so that the buffer does not grow too big in case there is continuous income of database requests.