### PR TITLE
fix for #3136 Temporary workflow xml files are not deleted

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/helper/selection/SelectionUtils.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/helper/selection/SelectionUtils.java
@@ -87,10 +87,8 @@ public class SelectionUtils {
     public static boolean checkProperties(String configFilePath, Conditions conditions) {
         //open properties file
         Properties properties = new Properties();
-        try {
-            FileInputStream fis = new FileInputStream(configFilePath);
+        try (FileInputStream fis = new FileInputStream(configFilePath);) {
             properties.load(fis);
-            fis.close();
             //Check properties for each condition
             for (Condition condition : conditions) {
                 if (!checkProperty(properties, condition)) {
@@ -147,10 +145,8 @@ public class SelectionUtils {
     public static boolean checkProperty(String configFilePath, Condition condition) {
         // Opening of the property file
         Properties props = new Properties();
-        try {
-            FileInputStream stream = new FileInputStream(configFilePath);
+        try (FileInputStream stream = new FileInputStream(configFilePath)) {
             props.load(stream);
-            stream.close();
         } catch (IOException e) {
             e.printStackTrace();
             return false;

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPProperties.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPProperties.java
@@ -114,10 +114,8 @@ public class LDAPProperties {
      * @param propertiesFileName properties file name
      */
     public LDAPProperties(String propertiesFileName) {
-        try {
-            FileInputStream stream = new FileInputStream(new File(propertiesFileName));
+        try (FileInputStream stream = new FileInputStream(new File(propertiesFileName))) {
             prop.load(stream);
-            stream.close();
             setUserJavaProperties();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/Credentials.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/Credentials.java
@@ -153,11 +153,8 @@ public class Credentials implements Serializable {
      */
     public void writeToDisk(String path) throws KeyException {
         File f = new File(path);
-        FileOutputStream fs;
-        try {
-            fs = new FileOutputStream(f);
+        try (FileOutputStream fs = new FileOutputStream(f)) {
             fs.write(getBase64());
-            fs.close();
         } catch (Exception e) {
             throw new KeyException("Could not write credentials to " + path, e);
         }
@@ -177,12 +174,9 @@ public class Credentials implements Serializable {
 
         byte[] bytes;
         File f = new File(pubPath);
-        FileInputStream fin;
 
         // recover public key bytes
-        try {
-            fin = new FileInputStream(f);
-            DataInputStream in = new DataInputStream(fin);
+        try (DataInputStream in = new DataInputStream(new FileInputStream(f))) {
             int read, tot = 0;
             while ((read = in.read()) != '\n') {
                 algo += (char) read;
@@ -197,7 +191,6 @@ public class Credentials implements Serializable {
 
             bytes = new byte[(int) f.length() - tot];
             in.readFully(bytes);
-            in.close();
         } catch (Exception e) {
             throw new KeyException("Could not retrieve public key from " + pubPath, e);
         }
@@ -273,12 +266,10 @@ public class Credentials implements Serializable {
 
                 // recover private key bytes
                 byte[] bytes;
-                try {
-                    File pkFile = new File(privPath);
-                    DataInputStream pkStream = new DataInputStream(new FileInputStream(pkFile));
+                File pkFile = new File(privPath);
+                try (DataInputStream pkStream = new DataInputStream(new FileInputStream(pkFile))) {
                     bytes = new byte[(int) pkFile.length()];
                     pkStream.readFully(bytes);
-                    pkStream.close();
                 } catch (Exception e) {
                     throw new KeyException("Could not recover private key (algo=" + algo + ")", e);
                 }
@@ -333,11 +324,8 @@ public class Credentials implements Serializable {
     public static Credentials getCredentials(String path) throws KeyException {
         File f = new File(path);
         byte[] bytes = new byte[(int) f.length()];
-        FileInputStream fin;
-        try {
-            fin = new FileInputStream(f);
+        try (FileInputStream fin = new FileInputStream(f)) {
             fin.read(bytes);
-            fin.close();
         } catch (Exception e) {
             throw new KeyException("Could not read credentials from " + path, e);
         }

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/KeyPairUtil.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/crypto/KeyPairUtil.java
@@ -68,22 +68,16 @@ public class KeyPairUtil {
         PrivateKey privKey = keyPair.getPrivate();
         PublicKey pubKey = keyPair.getPublic();
 
-        FileOutputStream out = null;
-
-        try {
-            out = new FileOutputStream(new File(privPath));
+        try (FileOutputStream out = new FileOutputStream(new File(privPath))) {
             out.write(privKey.getEncoded());
-            out.close();
         } catch (Exception e) {
             throw new KeyException("Cannot write private key to disk", e);
         }
 
-        try {
-            out = new FileOutputStream(new File(pubPath));
+        try (FileOutputStream out = new FileOutputStream(new File(pubPath))) {
             out.write((algorithm + "\n").getBytes());
             out.write((size + "\n").getBytes());
             out.write(pubKey.getEncoded());
-            out.close();
         } catch (Exception e) {
             throw new KeyException("Cannot write public key to disk", e);
         }

--- a/common/common-client/src/main/java/org/ow2/proactive/scripting/ScriptLoader.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/scripting/ScriptLoader.java
@@ -86,9 +86,10 @@ public class ScriptLoader {
             System.exit(-2);
         }
 
-        Reader reader = new FileReader(args[0]);
-        ScriptEngineManager sem = new ScriptEngineManager();
-        ScriptEngine engine = sem.getEngineByExtension(split[split.length - 1]);
-        engine.eval(reader);
+        try (Reader reader = new FileReader(args[0])) {
+            ScriptEngineManager sem = new ScriptEngineManager();
+            ScriptEngine engine = sem.getEngineByExtension(split[split.length - 1]);
+            engine.eval(reader);
+        }
     }
 }

--- a/common/common-client/src/main/java/org/ow2/proactive/utils/FileToBytesConverter.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/utils/FileToBytesConverter.java
@@ -50,20 +50,12 @@ public class FileToBytesConverter {
      * @throws IOException
      */
     public static byte[] convertFileToByteArray(File file) throws IOException {
-        FileInputStream fis = new FileInputStream(file);
-        try {
+        try (FileInputStream fis = new FileInputStream(file)) {
             long length = file.length();
             if (length > 0) {
                 return fastConversion(fis, length);
             } else {
                 return slowConversion(fis);
-            }
-        } finally {
-            try {
-                fis.close();
-            } catch (IOException e) {
-                // We want to throw the exception thrown by the outer try block
-                // not by the close()
             }
         }
     }
@@ -121,8 +113,8 @@ public class FileToBytesConverter {
      * @throws IOException
      */
     public static void convertByteArrayToFile(byte[] array, File file) throws IOException {
-        FileOutputStream outStream = new FileOutputStream(file);
-        outStream.write(array);
-        outStream.close();
+        try (FileOutputStream outStream = new FileOutputStream(file)) {
+            outStream.write(array);
+        }
     }
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerClientExample.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerClientExample.java
@@ -55,7 +55,10 @@ public class SchedulerClientExample {
 
         // JOB SUBMISSION
         File xmlJobFile = new File("/home/ybonnaffe/src/cloud_service_provider_conectors/cloudstack/vminfo_job.xml");
-        JobIdData xmlJob = client.submitXml(sessionId, new FileInputStream(xmlJobFile));
+        JobIdData xmlJob;
+        try (FileInputStream inputStream = new FileInputStream(xmlJobFile)) {
+            xmlJob = client.submitXml(sessionId, inputStream);
+        }
         System.out.println(xmlJob.getReadableName() + " " + xmlJob.getId());
 
         // FLAT JOB SUBMISSION

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/UploadFileCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/UploadFileCommand.java
@@ -53,9 +53,7 @@ public class UploadFileCommand extends AbstractCommand implements Command {
 
     @Override
     public void execute(ApplicationContext currentContext) throws CLIException {
-        FileInputStream fileStream = null;
-        try {
-            fileStream = new FileInputStream(localFile);
+        try (FileInputStream fileStream = new FileInputStream(localFile)) {
             boolean uploaded = currentContext.getRestClient().pushFile(currentContext.getSessionId(),
                                                                        spaceName,
                                                                        filePath,
@@ -68,9 +66,6 @@ public class UploadFileCommand extends AbstractCommand implements Command {
                 writeLine(currentContext, "Cannot upload the file: %s.", localFile);
             }
         } catch (Exception error) {
-            if (fileStream != null) {
-                closeQuietly(fileStream);
-            }
             handleError(String.format("An error occurred when uploading the file %s. ", localFile),
                         error,
                         currentContext);

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/FileUtility.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/FileUtility.java
@@ -44,8 +44,8 @@ import org.ow2.proactive_grid_cloud_portal.cli.CLIException;
 public class FileUtility {
 
     public static String md5Checksum(File file) {
-        try {
-            return DigestUtils.md5Hex(new FileInputStream(file));
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            return DigestUtils.md5Hex(inputStream);
         } catch (IOException ioe) {
             throw new CLIException(REASON_IO_ERROR, ioe);
         }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CredentialsCreator.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CredentialsCreator.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyException;
 import java.security.PublicKey;
 import java.util.Arrays;
@@ -97,8 +98,8 @@ public class CredentialsCreator {
     }
 
     private boolean sameCredentialsBytes(byte[] credentialBytes, File credentialsfile) {
-        try {
-            return Arrays.equals(credentialBytes, IOUtils.toByteArray(new FileInputStream(credentialsfile)));
+        try (InputStream inputStream = new FileInputStream(credentialsfile)) {
+            return Arrays.equals(credentialBytes, IOUtils.toByteArray(inputStream));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipper.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipper.java
@@ -40,11 +40,8 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileType;
-import org.ow2.proactive_grid_cloud_portal.dataspace.FileSystem;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.utils.Zipper;
 
-import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 
@@ -56,11 +53,11 @@ public class VFSZipper {
 
     public static class GZIP {
 
-        public static void zip(FileObject fo, OutputStream os) throws FileSystemException, IOException {
+        public static void zip(FileObject fo, OutputStream os) throws IOException {
             Zipper.GZIP.zip(fo.getContent().getInputStream(), os);
         }
 
-        public static void unzip(InputStream is, FileObject outputFile) throws FileSystemException, IOException {
+        public static void unzip(InputStream is, FileObject outputFile) throws IOException {
             Zipper.GZIP.unzip(is, outputFile.getContent().getOutputStream());
         }
     }
@@ -98,7 +95,7 @@ public class VFSZipper {
             return new ZipEntry(name);
         }
 
-        public static void unzip(InputStream is, FileObject outfileObj) throws FileSystemException, IOException {
+        public static void unzip(InputStream is, FileObject outfileObj) throws IOException {
             Closer closer = Closer.create();
             try {
                 ZipInputStream zis = new ZipInputStream(is);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -912,9 +912,9 @@ public class RMRest implements RMRestInterface {
         File rrd4jDb = File.createTempFile("database", "rr4dj");
         rrd4jDb.deleteOnExit();
 
-        OutputStream out = new FileOutputStream(rrd4jDb);
-        out.write(rrd4j);
-        out.close();
+        try (OutputStream out = new FileOutputStream(rrd4jDb)) {
+            out.write(rrd4j);
+        }
 
         // create RRD4J DB, should be identical to the one held by the RM
         RrdDb db = new RrdDb(rrd4jDb.getAbsolutePath(), true);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
@@ -69,9 +69,7 @@ public class WorkflowSubmitter {
     public JobId submit(File workflowFile, Map<String, String> variables) throws NotConnectedRestException,
             PermissionRestException, SubmissionClosedRestException, JobCreationRestException {
         try {
-            JobId jobId = scheduler.submit(createJobObject(workflowFile, variables));
-            storeWorkflowFile(jobId);
-            return jobId;
+            return scheduler.submit(createJobObject(workflowFile, variables));
         } catch (NotConnectedException e) {
             throw new NotConnectedRestException(e);
         } catch (PermissionException e) {
@@ -88,19 +86,6 @@ public class WorkflowSubmitter {
 
     private Job createJobObject(File jobFile, Map<String, String> jobVariables) throws JobCreationException {
         return JobFactory.getFactory().createJob(jobFile.getAbsolutePath(), jobVariables);
-    }
-
-    private void storeWorkflowFile(JobId jobid) {
-        File archiveToStore = new File(PortalConfiguration.jobIdToPath(jobid.value()));
-        // the job is not an archive, however an archive file can
-        // exist for this new job (due to an old submission)
-        // In that case, we remove the existing file preventing erronous
-        // access
-        // to this previously submitted archive.
-
-        if (archiveToStore.exists()) {
-            archiveToStore.delete();
-        }
     }
 
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/storage/FileStorageSupportFactory.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/storage/FileStorageSupportFactory.java
@@ -28,6 +28,7 @@ package org.ow2.proactive_grid_cloud_portal.studio.storage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 import org.apache.log4j.Logger;
@@ -85,8 +86,8 @@ public class FileStorageSupportFactory {
     private static Properties getProperties() {
         File restPropertiesFile = new File(getSchedulerHome(), REST_CONFIG_PATH);
         Properties properties = new Properties();
-        try {
-            properties.load(new FileInputStream(restPropertiesFile));
+        try (InputStream inputStream = new FileInputStream(restPropertiesFile)) {
+            properties.load(inputStream);
         } catch (IOException e) {
             logger.warn("Could not load properties from file " + restPropertiesFile, e);
         }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/RestRuntime.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/RestRuntime.java
@@ -96,11 +96,9 @@ public class RestRuntime {
     private void configureLogger(File log4jConfig) {
         if (loggerNotConfigured()) {
             if (log4jConfig != null) {
-                try {
-                    InputStream in = new FileInputStream(log4jConfig);
+                try (InputStream in = new FileInputStream(log4jConfig)) {
                     Properties p = new Properties();
                     p.load(in);
-                    in.close();
                     System.setProperty("log4j.configuration", log4jConfig.getAbsolutePath()); // avoid reset by ProActiveLogger
                     PropertyConfigurator.configure(p);
                 } catch (Exception e1) {

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
@@ -1365,10 +1365,10 @@ public class RMNodeStarter {
                 logger.warn("NodeURL file already exists ; delete it.");
                 FileUtils.forceDelete(f);
             }
-            BufferedWriter out = new BufferedWriter(new FileWriter(f));
-            out.write(nodeURL);
-            out.write(System.lineSeparator());
-            out.close();
+            try (BufferedWriter out = new BufferedWriter(new FileWriter(f))) {
+                out.write(nodeURL);
+                out.write(System.lineSeparator());
+            }
         } catch (IOException e) {
             logger.warn("NodeURL cannot be created.", e);
         }
@@ -1384,11 +1384,11 @@ public class RMNodeStarter {
         try {
             File f = new File(getNodeURLFilename(nodeName, rank));
             if (f.exists()) {
-                BufferedReader in = new BufferedReader(new FileReader(f));
-                String read = in.readLine();
-                in.close();
-                FileUtils.deleteQuietly(f);
-                return read;
+                try (BufferedReader in = new BufferedReader(new FileReader(f))) {
+                    return in.readLine();
+                } finally {
+                    FileUtils.deleteQuietly(f);
+                }
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostsFileBasedInfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostsFileBasedInfrastructureManager.java
@@ -147,33 +147,34 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
      * @throws IOException parsing failed
      */
     protected void readHosts(File f) throws IOException {
-        BufferedReader in = new BufferedReader(new FileReader(f));
-        String line = "";
+        try (BufferedReader in = new BufferedReader(new FileReader(f))) {
+            String line = "";
 
-        while ((line = in.readLine()) != null) {
-            if (line == "" || line.trim().length() == 0)
-                continue;
+            while ((line = in.readLine()) != null) {
+                if (line == "" || line.trim().length() == 0)
+                    continue;
 
-            String[] elts = line.split(" ");
-            int configuredNodeNumber = 1;
-            if (elts.length > 1) {
-                try {
-                    configuredNodeNumber = Integer.parseInt(elts[1]);
-                    if (configuredNodeNumber < 1) {
-                        throw new IllegalArgumentException("Cannot launch less than one runtime per host.");
+                String[] elts = line.split(" ");
+                int configuredNodeNumber = 1;
+                if (elts.length > 1) {
+                    try {
+                        configuredNodeNumber = Integer.parseInt(elts[1]);
+                        if (configuredNodeNumber < 1) {
+                            throw new IllegalArgumentException("Cannot launch less than one runtime per host.");
+                        }
+                    } catch (Exception e) {
+                        logger.warn("Error while parsing hosts file: " + e.getMessage(), e);
+                        configuredNodeNumber = 1;
                     }
-                } catch (Exception e) {
-                    logger.warn("Error while parsing hosts file: " + e.getMessage(), e);
-                    configuredNodeNumber = 1;
                 }
-            }
-            String hostNameInFile = elts[0];
-            try {
-                InetAddress reifiedHost = InetAddress.getByName(hostNameInFile);
-                HostTracker hostTracker = new HostTracker(hostNameInFile, configuredNodeNumber, reifiedHost);
-                putHostTrackerForHost(hostNameInFile, hostTracker);
-            } catch (UnknownHostException ex) {
-                throw new RuntimeException("Unknown host: " + hostNameInFile, ex);
+                String hostNameInFile = elts[0];
+                try {
+                    InetAddress reifiedHost = InetAddress.getByName(hostNameInFile);
+                    HostTracker hostTracker = new HostTracker(hostNameInFile, configuredNodeNumber, reifiedHost);
+                    putHostTrackerForHost(hostNameInFile, hostTracker);
+                } catch (UnknownHostException ex) {
+                    throw new RuntimeException("Unknown host: " + hostNameInFile, ex);
+                }
             }
         }
     }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManagerFactory.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManagerFactory.java
@@ -107,9 +107,9 @@ public class InfrastructureManagerFactory {
                 propFileName = PAResourceManagerProperties.RM_HOME.getValueAsString() + File.separator + propFileName;
             }
 
-            FileInputStream stream = new FileInputStream(propFileName);
-            properties.load(stream);
-            stream.close();
+            try (FileInputStream stream = new FileInputStream(propFileName)) {
+                properties.load(stream);
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/NodeSourcePolicyFactory.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/NodeSourcePolicyFactory.java
@@ -113,9 +113,9 @@ public class NodeSourcePolicyFactory {
                 propFileName = PAResourceManagerProperties.RM_HOME.getValueAsString() + File.separator + propFileName;
             }
 
-            FileInputStream stream = new FileInputStream(propFileName);
-            properties.load(stream);
-            stream.close();
+            try (FileInputStream stream = new FileInputStream(propFileName)) {
+                properties.load(stream);
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/policies/NodeSourcePriorityPolicy.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/policies/NodeSourcePriorityPolicy.java
@@ -83,14 +83,12 @@ public class NodeSourcePriorityPolicy implements SelectionPolicy {
                 logger.debug("Reading the NodeSourcePriorityPolicy config file");
                 nodeSources = new LinkedList<>();
 
-                try {
-                    BufferedReader br = new BufferedReader(new FileReader(config));
+                try (BufferedReader br = new BufferedReader(new FileReader(config))) {
                     String strLine;
                     while ((strLine = br.readLine()) != null) {
                         logger.debug("Node source name found: " + strLine);
                         nodeSources.add(strLine);
                     }
-                    br.close();
                 } catch (Exception e) {
                     throw new RuntimeException(e.getMessage(), e);
                 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/FlatJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/FlatJobFactory.java
@@ -137,12 +137,13 @@ public class FlatJobFactory {
             String commandLine;
             int task_number = 0;
 
-            BufferedReader reader = new BufferedReader(new FileReader(commandFile));
             ArrayList<String> commandList = new ArrayList<>();
-            while ((commandLine = reader.readLine()) != null) {
-                commandLine = commandLine.trim();
-                if (!commandLine.startsWith(CMD_FILE_COMMENT_CHAR, 0) && !"".equals(commandLine)) {
-                    commandList.add(commandLine);
+            try (BufferedReader reader = new BufferedReader(new FileReader(commandFile))) {
+                while ((commandLine = reader.readLine()) != null) {
+                    commandLine = commandLine.trim();
+                    if (!commandLine.startsWith(CMD_FILE_COMMENT_CHAR, 0) && !"".equals(commandLine)) {
+                        commandList.add(commandLine);
+                    }
                 }
             }
             if (commandList.size() == 0) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
@@ -165,9 +165,9 @@ public class Job2XMLTransformer {
     public void job2xmlFile(TaskFlowJob job, File f)
             throws ParserConfigurationException, TransformerException, IOException {
         String xmlString = jobToxmlString(job);
-        FileWriter fw = new FileWriter(f);
-        fw.write(xmlString);
-        fw.close();
+        try (FileWriter fw = new FileWriter(f)) {
+            fw.write(xmlString);
+        }
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/JarUtils.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/JarUtils.java
@@ -145,9 +145,9 @@ public class JarUtils extends ZipUtils {
                                                mainClass,
                                                jarInternalClasspath,
                                                crc);
-        BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(dest));
-        bos.write(jarred);
-        bos.close();
+        try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(dest))) {
+            bos.write(jarred);
+        }
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/ZipUtils.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/ZipUtils.java
@@ -71,9 +71,9 @@ public class ZipUtils extends FileUtils {
      */
     public static void zip(String[] directoriesAndFiles, File dest, CRC32 crc) throws IOException {
         byte[] zipped = ZipUtils.zipDirectoriesAndFiles(directoriesAndFiles, crc);
-        BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(dest));
-        bos.write(zipped);
-        bos.close();
+        try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(dest))) {
+            bos.write(zipped);
+        }
     }
 
     /**
@@ -167,9 +167,7 @@ public class ZipUtils extends FileUtils {
      */
     protected static void zipFile(String filePath, int iBaseFolderLength, ZipOutputStream jos, CRC32 crc)
             throws IOException {
-        try {
-            FileInputStream fis = new FileInputStream(filePath);
-            BufferedInputStream bis = new BufferedInputStream(fis);
+        try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(filePath))) {
             String fileNameEntry = filePath.substring(iBaseFolderLength).replace(File.separatorChar, '/');
             ZipEntry fileEntry = new ZipEntry(fileNameEntry);
             jos.putNextEntry(fileEntry);
@@ -182,7 +180,6 @@ public class ZipUtils extends FileUtils {
                 jos.write(data, 0, byteCount);
             }
             jos.closeEntry();
-            fis.close();
         } catch (ZipException e) {
             // TODO Other exceptions ?
             // Duplicate entry : ignore it.
@@ -204,16 +201,16 @@ public class ZipUtils extends FileUtils {
                     File destFile = new File(dest, entry.getName());
                     createFileWithPath(destFile);
                     InputStream in = new BufferedInputStream(zipFile.getInputStream(entry));
-                    OutputStream out = new BufferedOutputStream(new FileOutputStream(destFile));
-                    byte[] buffer = new byte[2048];
-                    for (;;) {
-                        int nBytes = in.read(buffer);
-                        if (nBytes <= 0)
-                            break;
-                        out.write(buffer, 0, nBytes);
+                    try (OutputStream out = new BufferedOutputStream(new FileOutputStream(destFile))) {
+                        byte[] buffer = new byte[2048];
+                        for (;;) {
+                            int nBytes = in.read(buffer);
+                            if (nBytes <= 0)
+                                break;
+                            out.write(buffer, 0, nBytes);
+                        }
+                        out.flush();
                     }
-                    out.flush();
-                    out.close();
                     in.close();
                 }
             }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/SchedulerAuthenticationGUIHelper.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/SchedulerAuthenticationGUIHelper.java
@@ -502,18 +502,12 @@ public class SchedulerAuthenticationGUIHelper {
             if (!"".equals((String) jComboBox_url.getSelectedItem())) {
                 URLs.add((String) jComboBox_url.getSelectedItem());
             }
-            PrintWriter pw = null;
-            try {
-                pw = new PrintWriter(new FileOutputStream(TMP_AUTH_FILE));
+            try (PrintWriter pw = new PrintWriter(new FileOutputStream(TMP_AUTH_FILE))) {
                 for (String url : URLs) {
                     pw.println(url);
                 }
             } catch (Exception e) {
                 //not a big deal
-            } finally {
-                if (pw != null) {
-                    pw.close();
-                }
             }
         }
 
@@ -521,9 +515,7 @@ public class SchedulerAuthenticationGUIHelper {
             if (!"".equals(defaultURL)) {
                 URLs.add(defaultURL);
             }
-            BufferedReader br = null;
-            try {
-                br = new BufferedReader(new FileReader(TMP_AUTH_FILE));
+            try (BufferedReader br = new BufferedReader(new FileReader(TMP_AUTH_FILE))) {
                 String url;
                 while ((url = br.readLine()) != null) {
                     if (!"".equals(url)) {
@@ -533,13 +525,6 @@ public class SchedulerAuthenticationGUIHelper {
             } catch (Exception e) {
                 //If file not found, it will be created after
                 //if other, we cannot read historic -> not a big deal
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                    }
-                }
             }
         }
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
@@ -100,12 +100,12 @@ public class InProcessTaskExecutor implements TaskExecutor {
             }
             File nodesFile = new File(directory, NODES_FILE_DIRECTORY_NAME + "_" + taskContext.getTaskId());
 
-            Writer outputWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(nodesFile),
-                                                                            PAProperties.getFileEncoding()));
-            for (String nodeHost : nodesHosts) {
-                outputWriter.append(nodeHost).append(System.lineSeparator());
+            try (Writer outputWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(nodesFile),
+                                                                                 PAProperties.getFileEncoding()))) {
+                for (String nodeHost : nodesHosts) {
+                    outputWriter.append(nodeHost).append(System.lineSeparator());
+                }
             }
-            outputWriter.close();
 
             return nodesFile.getAbsolutePath();
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
@@ -157,10 +157,8 @@ public abstract class Policy implements Serializable {
      */
     public boolean reloadConfig() {
         configProperties = new Properties();
-        try {
-            FileInputStream fis = new FileInputStream(getConfigFile());
+        try (FileInputStream fis = new FileInputStream(getConfigFile())) {
             configProperties.load(fis);
-            fis.close();
             return true;
         } catch (IOException ioe) {
             logger.warn("Cannot read policy configuration file", ioe);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerPortalConfiguration.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerPortalConfiguration.java
@@ -54,8 +54,7 @@ public class SchedulerPortalConfiguration {
 
     public Properties getProperties() {
         Properties props = new Properties();
-        try {
-            InputStream fis = new FileInputStream(path);
+        try (InputStream fis = new FileInputStream(path)) {
             props.load(fis);
         } catch (IOException e) {
             logger.warn("Scheduler Portal Configuration file: " + path + " not found!", e);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SendMail.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SendMail.java
@@ -84,8 +84,7 @@ class EmailConfiguration {
 
     public Properties getProperties() {
         Properties props = new Properties();
-        try {
-            InputStream fis = new FileInputStream(getPath());
+        try (InputStream fis = new FileInputStream(getPath())) {
             props.load(fis);
         } catch (IOException e) {
             logger.warn("Email Configuration file: " + getPath() + " not found!", e);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
@@ -76,6 +76,7 @@ public class ServerJobAndTaskLogs {
 
     public static void remove(JobId jobId) {
         removeFolderLog(jobId.value());
+        removeVisualizationFile(jobId.value());
     }
 
     private static void removeFolderLog(String path) {
@@ -95,6 +96,16 @@ public class ServerJobAndTaskLogs {
             }
         }
 
+    }
+
+    /**
+     * Remove visualization file created by rest server (if present)
+     * see org.ow2.proactive_grid_cloud_portal.studio.StudioRest.updateVisualization
+     */
+    private static void removeVisualizationFile(String jobId) {
+        File visualizationFile = new File(System.getProperty("java.io.tmpdir") + File.separator + "job_" + jobId +
+                                          ".zip.html");
+        org.apache.commons.io.FileUtils.deleteQuietly(visualizationFile);
     }
 
     private static boolean logsLocationIsSet() {


### PR DESCRIPTION
 - rationalize all usages of FileInputStream/OutputStream/Reader/Writer with try-with-resources
 - ServerJobAndTaskLogs: delete temporary html file produced by WorkflowSubmitter when a job is deleted