### PR TITLE
Remove synchronization when task is started

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -33,6 +33,7 @@ import java.security.PublicKey;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.Body;
@@ -103,6 +104,8 @@ public class TaskLauncher implements InitActive {
 
     private TaskLauncherRebinder taskLauncherRebinder;
 
+    private AtomicBoolean doTaskInvoked = new AtomicBoolean(false);
+
     /**
      * Needed for ProActive but should never be used manually to create an instance of the object.
      */
@@ -142,6 +145,11 @@ public class TaskLauncher implements InitActive {
         return true;
     }
 
+    @ImmediateService
+    public boolean getDoTaskInvoked() {
+        return doTaskInvoked.get();
+    }
+
     void doTask(ExecutableContainer executableContainer, TaskResult[] previousTasksResults,
             TaskTerminateNotification terminateNotification) {
         doTask(executableContainer, previousTasksResults, terminateNotification, null, false);
@@ -158,6 +166,8 @@ public class TaskLauncher implements InitActive {
         TaskDataspaces dataspaces = null;
 
         try {
+            doTaskInvoked.set(true);
+
             logger.info("Task started " + taskId.getJobId().getReadableName() + " : " + taskId.getReadableName());
 
             this.taskKiller = this.replaceTaskKillerWithDoubleTimeoutValueIfRunAsMe(executableContainer.isRunAsUser());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -192,9 +192,17 @@ public class SchedulerStateRecoverHelper {
 
             if (taskNodesKnownByRM) {
                 TaskLauncher launcher = task.getExecuterInformation().getLauncher();
-                logger.info("Recover running task " + task.getId() + " (" + task.getName() +
-                            ") successfully with task launcher " + launcher);
-                resetToPending = false;
+                logger.debug("Checking whether task launcher has called its doTask method: " +
+                             launcher.getDoTaskInvoked());
+                if (launcher.getDoTaskInvoked()) {
+                    logger.info("Recover running task " + task.getId() + " (" + task.getName() +
+                                ") successfully with task launcher " + launcher);
+                    resetToPending = false;
+                } else {
+                    logger.info(FAIL_TO_RECOVER_RUNNING_TASK_STRING + task.getId() + " (" + task.getName() +
+                                ") because its task launcher has not started to execute the task");
+                    resetToPending = true;
+                }
             } else {
                 logger.info(FAIL_TO_RECOVER_RUNNING_TASK_STRING + task.getId() + " (" + task.getName() +
                             ") because the task's node is not known by the resource manager");


### PR DESCRIPTION
- instead of waiting for the task to be started, we check at recovery time whether the doTask method of the task laucnher has already been called.