### PR TITLE
fix for #3150 SelectionScript result is not memorized when an exception occurs

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/ScriptExecutor.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/ScriptExecutor.java
@@ -130,7 +130,6 @@ public class ScriptExecutor implements Callable<Node> {
                             exception = new ScriptException(scriptResult.getException());
                             logger.warn(rmnode.getNodeURL() + " : exception during the script execution",
                                         scriptResult.getException());
-                            break;
                         }
 
                         // processing script result and updating knowledge base of


### PR DESCRIPTION

 - before this change, the processScriptResult was never called when an error occurred in a selection script, which prevents the ProbabilisticSelectionManager to memorize the result