### PR TITLE
Add diagnostic messages to unstable TestJobServerLogs

### DIFF
--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
@@ -29,11 +29,20 @@ import static functionaltests.utils.SchedulerTHelper.log;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.junit.Test;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
@@ -148,6 +157,8 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
         schedulerHelper.removeJob(jobId);
         schedulerHelper.waitForEventJobRemoved(jobId);
 
+        System.out.println("Suppose to remove all logs at " + new SimpleDateFormat("kk:mm:ss:SSS").format(new Date()));
+
         checkNoLogsFromAPI(jobId, tasks);
         checkJobAndTaskLogFiles(jobId, tasks, false);
     }
@@ -177,7 +188,33 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
 
     private void checkFile(boolean shouldExist, File jobLogFile) {
         String message = String.format("Log file %s should %s", jobLogFile, shouldExist ? "exist" : "not exist");
-        assertEquals(message, shouldExist, jobLogFile.exists());
+        final boolean actualExistings = jobLogFile.exists();
+        if (actualExistings != shouldExist) {
+            System.out.println("This test is going to fail, but before we print diagnostic message." +
+                               new SimpleDateFormat("kk:mm:ss:SSS").format(new Date()));
+            // iterate over all files in the 'logsLocation'
+            for (File file : FileUtils.listFiles(new File(logsLocation),
+                                                 TrueFileFilter.INSTANCE,
+                                                 TrueFileFilter.INSTANCE)) {
+                try {
+                    BasicFileAttributes attr = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
+                    System.out.println(String.format("Name: %s, Size: %d, Created: %s, Modified: %s",
+                                                     file.getAbsolutePath(),
+                                                     attr.size(),
+                                                     attr.creationTime(),
+                                                     attr.lastModifiedTime()));
+                    BufferedReader br = new BufferedReader(new FileReader(file));
+                    String line;
+                    for (int i = 0; i < 5 && (line = br.readLine()) != null; ++i) {
+                        System.out.println(line);
+                    }
+                    System.out.println("............");
+                } catch (IOException e) {
+                    System.out.println("Exception ocurred during accessing file attributes " + e);
+                }
+            }
+        }
+        assertEquals(message, shouldExist, actualExistings);
     }
 
     public static boolean matchLine(String text, String regex) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
@@ -193,7 +193,7 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
         final boolean actualExistings = jobLogFile.exists();
         if (actualExistings != shouldExist) {
             System.out.println("This test is going to fail, but before we print diagnostic message." +
-                    simpleDateFormat.format(new Date()));
+                               simpleDateFormat.format(new Date()));
             // iterate over all files in the 'logsLocation'
             for (File file : FileUtils.listFiles(new File(logsLocation),
                                                  TrueFileFilter.INSTANCE,

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
@@ -81,6 +81,8 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
 
     private String logsLocation = ServerJobAndTaskLogs.getLogsLocation();
 
+    private SimpleDateFormat simpleDateFormat = new SimpleDateFormat("kk:mm:ss:SSS");
+
     private Job createPendingJob() throws Exception {
         final TaskFlowJob job = new TaskFlowJob();
         JavaTask task = new JavaTask();
@@ -157,7 +159,7 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
         schedulerHelper.removeJob(jobId);
         schedulerHelper.waitForEventJobRemoved(jobId);
 
-        System.out.println("Suppose to remove all logs at " + new SimpleDateFormat("kk:mm:ss:SSS").format(new Date()));
+        System.out.println("Suppose to remove all logs at " + simpleDateFormat.format(new Date()));
 
         checkNoLogsFromAPI(jobId, tasks);
         checkJobAndTaskLogFiles(jobId, tasks, false);
@@ -191,7 +193,7 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
         final boolean actualExistings = jobLogFile.exists();
         if (actualExistings != shouldExist) {
             System.out.println("This test is going to fail, but before we print diagnostic message." +
-                               new SimpleDateFormat("kk:mm:ss:SSS").format(new Date()));
+                    simpleDateFormat.format(new Date()));
             // iterate over all files in the 'logsLocation'
             for (File file : FileUtils.listFiles(new File(logsLocation),
                                                  TrueFileFilter.INSTANCE,

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
@@ -195,50 +195,50 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
     private void checkFile(boolean shouldExist, File jobLogFile) {
         String message = String.format("Log file %s should %s", jobLogFile, shouldExist ? "exist" : "not exist");
         final boolean actualExistings = jobLogFile.exists();
-        //        if (actualExistings != shouldExist) {
-        int LIMIT = 5;
-        System.out.println("This test is going to fail, but before we print diagnostic message." +
-                           simpleDateFormat.format(new Date()));
-        // iterate over all files in the 'logsLocation'
-        for (File file : FileUtils.listFiles(new File(logsLocation),
-                                             TrueFileFilter.INSTANCE,
-                                             TrueFileFilter.INSTANCE)) {
-            try {
-                BasicFileAttributes attr = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
-                System.out.println(String.format("Name: %s, Size: %d, Created: %s, Modified: %s",
-                                                 file.getAbsolutePath(),
-                                                 attr.size(),
-                                                 attr.creationTime(),
-                                                 attr.lastModifiedTime()));
-                BufferedReader br = new BufferedReader(new FileReader(file));
-                String line;
-                int i;
-                // print up to LIMIT first lines
-                for (i = 0; i < LIMIT && (line = br.readLine()) != null; ++i) {
-                    System.out.println(line);
-                }
-                Queue<String> queue = new CircularFifoQueue<>(LIMIT);
+        if (actualExistings != shouldExist) {
+            int LIMIT = 5;
+            System.out.println("This test is going to fail, but before we print diagnostic message." +
+                               simpleDateFormat.format(new Date()));
+            // iterate over all files in the 'logsLocation'
+            for (File file : FileUtils.listFiles(new File(logsLocation),
+                                                 TrueFileFilter.INSTANCE,
+                                                 TrueFileFilter.INSTANCE)) {
+                try {
+                    BasicFileAttributes attr = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
+                    System.out.println(String.format("Name: %s, Size: %d, Created: %s, Modified: %s",
+                                                     file.getAbsolutePath(),
+                                                     attr.size(),
+                                                     attr.creationTime(),
+                                                     attr.lastModifiedTime()));
+                    BufferedReader br = new BufferedReader(new FileReader(file));
+                    String line;
+                    int i;
+                    // print up to LIMIT first lines
+                    for (i = 0; i < LIMIT && (line = br.readLine()) != null; ++i) {
+                        System.out.println(line);
+                    }
+                    Queue<String> queue = new CircularFifoQueue<>(LIMIT);
 
-                // gather up to LIMIT last lines
-                for (i = 0; i < LIMIT && (line = br.readLine()) != null; ++i) {
-                    queue.add(line);
-                }
-                if (br.readLine() != null) { // if there is more line than 2*LIMIT
-                    System.out.println(".......");
-                    System.out.println("....... (skipped content)");
-                    System.out.println(".......");
-                }
-                for (String l : queue) { // print rest of the file
-                    System.out.println(l);
-                }
+                    // gather up to LIMIT last lines
+                    for (i = 0; i < LIMIT && (line = br.readLine()) != null; ++i) {
+                        queue.add(line);
+                    }
+                    if (br.readLine() != null) { // if there is more line than 2*LIMIT
+                        System.out.println(".......");
+                        System.out.println("....... (skipped content)");
+                        System.out.println(".......");
+                    }
+                    for (String l : queue) { // print rest of the file
+                        System.out.println(l);
+                    }
 
-                System.out.println("------------------------------------");
-                System.out.println();
-            } catch (IOException e) {
-                System.out.println("Exception ocurred during accessing file attributes " + e);
+                    System.out.println("------------------------------------");
+                    System.out.println();
+                } catch (IOException e) {
+                    System.out.println("Exception ocurred during accessing file attributes " + e);
+                }
             }
         }
-        //        }
         assertEquals(message, shouldExist, actualExistings);
     }
 


### PR DESCRIPTION
TestJobServerLogs fails because there are logs dedicated for the job in the logs folder after we removed job. It does not happen all the time. I guess it happens because after we remove files, some task writes to to file. I do not want to guess what is wrong right now. I added diagnostic messages, which will print first 5 and last 5 lines of EVERY files in the /logs folder. So we will see who prints what. 