### PR TITLE
Fix JobServerLogTest

### DIFF
--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMInitialState.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMInitialState.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -192,7 +193,11 @@ public class RMInitialState implements Serializable {
     }
 
     private <T extends RMEvent> long findLargestCounter(Collection<T> events) {
-        return events.stream().max(Comparator.comparing(RMEvent::getCounter)).get().getCounter();
+        final Optional<T> max = events.stream().max(Comparator.comparing(RMEvent::getCounter));
+        if (max.isPresent()) {
+            return max.get().getCounter();
+        } else {
+            return 0;
+        }
     }
-
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
@@ -160,6 +160,8 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
 
         checkJobAndTaskLogFiles(jobId, tasks, true);
 
+        schedulerHelper.killJob(jobId.value());
+        Thread.sleep(5000);
         schedulerHelper.removeJob(jobId);
         schedulerHelper.waitForEventJobRemoved(jobId);
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
@@ -160,9 +160,22 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
 
         checkJobAndTaskLogFiles(jobId, tasks, true);
 
+        // Before it was only job removal but it was bug prone (for pendingJob only)
+        // because the following sequence of the events could happen:
+        // 1. SchedulerMethodImpl main loop retrieves info about this forever pending job
+        // 2. we call removeJob
+        // 3. SchedulerMethodImpl main loop asks for RM::getRMNodes.
+        //
+        // Third action would print "[SelectionManager.doSelectNodes] "scheduler"..." to the task log
+        // which would actually re-created removed log file which would cause an error
+        // in the last line of this method
+        // that is why kill the job and after wait 5s to make sure that
+        // iteration of SchedulerMethodImpl main loop is finished,
+        // and finally, we remove job with its log files.
         schedulerHelper.killJob(jobId.value());
         Thread.sleep(5000);
         schedulerHelper.removeJob(jobId);
+
         schedulerHelper.waitForEventJobRemoved(jobId);
 
         System.out.println("Suppose to remove all logs at " + simpleDateFormat.format(new Date()));


### PR DESCRIPTION
Before it was only job removal but it was bug prone (for pendingJob only) because the following sequence of the events could happen: 
1. SchedulerMethodImpl main loop retrieves info about this forever pending job
2. we call removeJob
3. SchedulerMethodImpl main loop asks for RM::getRMNodes.

Third action would print "[SelectionManager.doSelectNodes] "scheduler"..." to the task log. Which would actually re-created removed log file that causes an error in the last line of this method. That is why we kill the job and wait 5s to make sure that iteration of SchedulerMethodImpl main loop is finished, and finally, we remove job with its log files.

THIS PR CONTAINS BUG FIX FOR RMINITIALSTATE as well
I introduced this bug 1 commit ago and I would like to merge this PR asap.