### PR TITLE
API Responsiveness: Add @immediateServie to submit(job)

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -420,6 +420,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
      * {@inheritDoc}
      */
     @Override
+    @ImmediateService
     public JobId submit(Job userJob)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
         try {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobSubmittedParallel.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobSubmittedParallel.java
@@ -72,6 +72,8 @@ public class TestJobSubmittedParallel extends SchedulerFunctionalTestNoRestart {
                 final JobId jobId = schedulerHelper.submitJob(simpleJob.getPath());
                 final JobState jobState = schedulerHelper.getSchedulerInterface().getJobState(jobId);
                 jobState.getId().equals(jobId);
+                jobState.getSubmittedTime(); // call to chech there is no exception thrown
+                jobState.isFinished(); // call to chech there is no exception thrown
                 result.add(jobId);
             });
             return result;

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobSubmittedParallel.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TestJobSubmittedParallel.java
@@ -72,7 +72,6 @@ public class TestJobSubmittedParallel extends SchedulerFunctionalTestNoRestart {
                 final JobId jobId = schedulerHelper.submitJob(simpleJob.getPath());
                 final JobState jobState = schedulerHelper.getSchedulerInterface().getJobState(jobId);
                 jobState.getId().equals(jobId);
-                jobState.getSubmittedTime();
                 result.add(jobId);
             });
             return result;


### PR DESCRIPTION
[trello ](https://trello.com/c/SNBYK90S/2983-benchmark-azure-make-api-responsiveness-1s)

This is second PR (after [PR3156](https://github.com/ow2-proactive/scheduling/commit/babae684040dc9dfa9547c37207d1ec69e0449fe)). 

Making submit method ImmediateService will un-freeze SchedulerFrontend - it will be available for other requests. However, this PR wont make submit method faster. 