### PR TITLE
Make tests wait until Pending|Running -> Finished

### DIFF
--- a/scheduler/scheduler-server/src/test/java/functionaltests/monitor/SchedulerMonitorsHandler.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/monitor/SchedulerMonitorsHandler.java
@@ -298,21 +298,12 @@ public class SchedulerMonitorsHandler {
      * @param event type to look for
      * @return removed JobEventMonitor, or null if not exists.
      */
-    private Optional<JobEventMonitor> removeJobEvent(JobId id, SchedulerEvent event) {
+    public Optional<JobEventMonitor> removeJobEvent(JobId id, SchedulerEvent event) {
         JobEventMonitor tmp = new JobEventMonitor(event, id);
         if (jobsEvents.containsKey(id) && jobsEvents.get(id).contains(tmp)) {
             return Optional.of(jobsEvents.get(id).remove((jobsEvents.get(id).indexOf(tmp))));
         } else {
             return Optional.empty();
-        }
-    }
-
-    public JobEventMonitor getAndRemoveOrAdd(JobId id, SchedulerEvent event) {
-        final Optional<JobEventMonitor> opJobMonitor = removeJobEvent(id, event);
-        if (opJobMonitor.isPresent()) {
-            return opJobMonitor.get();
-        } else {
-            return (JobEventMonitor) getMonitor(new JobEventMonitor(event, id));
         }
     }
 
@@ -426,7 +417,7 @@ public class SchedulerMonitorsHandler {
      * @param monitor representing event to wait for.
      * @return an EventMonitorJob to use as waiting Monitor.
      */
-    private EventMonitor getMonitor(EventMonitor monitor) {
+    public EventMonitor getMonitor(EventMonitor monitor) {
         if (!eventsMonitors.contains(monitor)) {
             eventsMonitors.add(monitor);
             return monitor;

--- a/scheduler/scheduler-server/src/test/java/functionaltests/monitor/SchedulerMonitorsHandler.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/monitor/SchedulerMonitorsHandler.java
@@ -475,7 +475,8 @@ public class SchedulerMonitorsHandler {
         throw new ProActiveTimeoutException("timeout elapsed");
     }
 
-    public void waitWithAnyMonitor(long timeout, EventMonitor... monitors) throws ProActiveTimeoutException {
+    public void waitWithAnyMonitor(long timeout, EventMonitor... monitors)
+            throws ProActiveTimeoutException, InterruptedException {
         TimeoutAccounter counter = TimeoutAccounter.getAccounter(timeout);
         synchronized (monitors) {
             Arrays.stream(monitors).forEach(monitor -> monitor.setTimeouted(false));
@@ -485,11 +486,7 @@ public class SchedulerMonitorsHandler {
                     return;
                 }
 
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    System.exit(1);
-                }
+                Thread.sleep(1000);
             }
 
             Arrays.stream(monitors).forEach(monitor -> monitor.setTimeouted(true));

--- a/scheduler/scheduler-server/src/test/java/functionaltests/monitor/SchedulerMonitorsHandler.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/monitor/SchedulerMonitorsHandler.java
@@ -26,9 +26,11 @@
 package functionaltests.monitor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Vector;
 
 import org.objectweb.proactive.core.ProActiveTimeoutException;
@@ -134,11 +136,12 @@ public class SchedulerMonitorsHandler {
     public JobState waitForEventJobSubmitted(JobId id, long timeout) throws ProActiveTimeoutException {
         JobEventMonitor monitor = null;
         synchronized (this) {
-            monitor = removeJobEvent(id, SchedulerEvent.JOB_SUBMITTED);
-            if (monitor != null) {
+            final Optional<JobEventMonitor> opJobMonitor = removeJobEvent(id, SchedulerEvent.JOB_SUBMITTED);
+            if (opJobMonitor.isPresent()) {
                 //event occurred, remove it and return associated Job object
-                return monitor.getJobState();
+                return opJobMonitor.get().getJobState();
             }
+
             monitor = (JobEventMonitor) getMonitor(new JobEventMonitor(SchedulerEvent.JOB_SUBMITTED, id));
         }
         waitWithMonitor(monitor, timeout);
@@ -160,13 +163,14 @@ public class SchedulerMonitorsHandler {
     public JobInfo waitForEventJob(SchedulerEvent event, JobId id, long timeout) throws ProActiveTimeoutException {
         JobEventMonitor monitor = null;
         synchronized (this) {
-            monitor = removeJobEvent(id, event);
-            if (monitor != null) {
+            final Optional<JobEventMonitor> opJobMonitor = removeJobEvent(id, event);
+            if (opJobMonitor.isPresent()) {
                 //event occurred, remove it and return associated Job object
-                return monitor.getJobInfo();
+                return opJobMonitor.get().getJobInfo();
             }
             monitor = (JobEventMonitor) getMonitor(new JobEventMonitor(event, id));
         }
+
         waitWithMonitor(monitor, timeout);
         return monitor.getJobInfo();
     }
@@ -294,12 +298,22 @@ public class SchedulerMonitorsHandler {
      * @param event type to look for
      * @return removed JobEventMonitor, or null if not exists.
      */
-    private JobEventMonitor removeJobEvent(JobId id, SchedulerEvent event) {
+    private Optional<JobEventMonitor> removeJobEvent(JobId id, SchedulerEvent event) {
         JobEventMonitor tmp = new JobEventMonitor(event, id);
         if (jobsEvents.containsKey(id) && jobsEvents.get(id).contains(tmp)) {
-            return jobsEvents.get(id).remove((jobsEvents.get(id).indexOf(tmp)));
-        } else
-            return null;
+            return Optional.of(jobsEvents.get(id).remove((jobsEvents.get(id).indexOf(tmp))));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public JobEventMonitor getAndRemoveOrAdd(JobId id, SchedulerEvent event) {
+        final Optional<JobEventMonitor> opJobMonitor = removeJobEvent(id, event);
+        if (opJobMonitor.isPresent()) {
+            return opJobMonitor.get();
+        } else {
+            return (JobEventMonitor) getMonitor(new JobEventMonitor(event, id));
+        }
     }
 
     /**
@@ -457,6 +471,29 @@ public class SchedulerMonitorsHandler {
                 }
             }
             monitor.setTimeouted(true);
+        }
+        throw new ProActiveTimeoutException("timeout elapsed");
+    }
+
+    public void waitWithAnyMonitor(long timeout, EventMonitor... monitors) throws ProActiveTimeoutException {
+        TimeoutAccounter counter = TimeoutAccounter.getAccounter(timeout);
+        synchronized (monitors) {
+            Arrays.stream(monitors).forEach(monitor -> monitor.setTimeouted(false));
+
+            while (!counter.isTimeoutElapsed()) {
+                if (Arrays.stream(monitors).anyMatch(monitor -> monitor.eventOccured)) {
+                    return;
+                }
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    System.exit(1);
+                }
+            }
+
+            Arrays.stream(monitors).forEach(monitor -> monitor.setTimeouted(true));
+
         }
         throw new ProActiveTimeoutException("timeout elapsed");
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -65,6 +65,7 @@ import org.ow2.proactive.scheduler.common.task.TaskStatus;
 
 import com.google.common.collect.ImmutableList;
 
+import functionaltests.monitor.JobEventMonitor;
 import functionaltests.monitor.RMMonitorsHandler;
 import functionaltests.monitor.SchedulerMonitorsHandler;
 
@@ -750,12 +751,30 @@ public class SchedulerTHelper {
         return waitForEventJobFinished(getSchedulerInterface(), id);
     }
 
+    /**
+     * @param userInterface
+     * @param id of the job
+     * @return jobInfo, if job went from RUNNNIG or PENDING to FINISHED, otherwise null will be returned
+     * @throws Exception
+     */
     public JobInfo waitForEventJobFinished(Scheduler userInterface, JobId id) throws Exception {
         try {
-            return waitForJobEvent(userInterface, id, 0, JobStatus.FINISHED, SchedulerEvent.JOB_RUNNING_TO_FINISHED);
+            final JobEventMonitor monitorRunningToFinished = getSchedulerMonitorsHandler().getAndRemoveOrAdd(id,
+                                                                                                             SchedulerEvent.JOB_RUNNING_TO_FINISHED);
+            final JobEventMonitor monitorPendingToFinished = getSchedulerMonitorsHandler().getAndRemoveOrAdd(id,
+                                                                                                             SchedulerEvent.JOB_PENDING_TO_FINISHED);
+
+            getSchedulerMonitorsHandler().waitWithAnyMonitor(0, monitorRunningToFinished, monitorPendingToFinished);
+
+            if (monitorRunningToFinished.eventOccured()) {
+                return monitorRunningToFinished.getJobInfo();
+            } else if (monitorPendingToFinished.eventOccured()) {
+                return monitorPendingToFinished.getJobInfo();
+            } else {
+                // erorr
+                return null;
+            }
         } catch (ProActiveTimeoutException e) {
-            //unreachable block, 0 means infinite, no timeout
-            //log sthing ?
             return null;
         }
     }
@@ -784,6 +803,9 @@ public class SchedulerTHelper {
         return waitForJobEvent(getSchedulerInterface(), id, timeout, jobStatusAfterEvent, jobEvent);
     }
 
+    /**
+     * @param timeout 0 means - infinite timeout
+     */
     private JobInfo waitForJobEvent(Scheduler userInterface, JobId id, long timeout, JobStatus jobStatusAfterEvent,
             SchedulerEvent jobEvent) throws Exception {
         JobState jobState = null;


### PR DESCRIPTION
Some functional tests fails because job state changes from Pending-to-Finished and tests wait for Running-to-Finished. Thus tests will wait for any of these two events.
