### PR TITLE
Do not persit infrastructure variables when node source is not yet set

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/BatchJobInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/BatchJobInfrastructure.java
@@ -493,7 +493,8 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
                 throw new IllegalArgumentException("Credentials must be specified");
             }
             try {
-                setCredentials(Credentials.getCredentialsBase64((byte[]) parameters[index++]));
+                persistedInfraVariables.put(CREDENTIALS_KEY,
+                                            Credentials.getCredentialsBase64((byte[]) parameters[index++]));
             } catch (KeyException e) {
                 throw new IllegalArgumentException("Could not retrieve base64 credentials", e);
             }
@@ -819,16 +820,6 @@ public abstract class BatchJobInfrastructure extends InfrastructureManager {
             @Override
             public Credentials handle() {
                 return (Credentials) persistedInfraVariables.get(CREDENTIALS_KEY);
-            }
-        });
-    }
-
-    private void setCredentials(final Credentials credentials) {
-        setPersistedInfraVariable(new PersistedInfraVariablesHandler<Void>() {
-            @Override
-            public Void handle() {
-                persistedInfraVariables.put(CREDENTIALS_KEY, credentials);
-                return null;
             }
         });
     }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GenericBatchJobInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/GenericBatchJobInfrastructure.java
@@ -99,7 +99,7 @@ public class GenericBatchJobInfrastructure extends BatchJobInfrastructure {
             FileToBytesConverter.convertByteArrayToFile(implemtationClassfile, classFile);
             URLClassLoader cl = new URLClassLoader(new URL[] { f.toURL() }, this.getClass().getClassLoader());
             Class<? extends BatchJobInfrastructure> implementationClass = (Class<? extends BatchJobInfrastructure>) cl.loadClass(this.implementationClassname);
-            setBatchJobInfrastructure(implementationClass.newInstance());
+            persistedInfraVariables.put(BATCH_JOB_INFRASTRUCTURE_IMPLEMENTATION_KEY, implementationClass.newInstance());
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException("Class " + this.implementationClassname + " does not exist", e);
         } catch (MalformedURLException e) {
@@ -151,16 +151,6 @@ public class GenericBatchJobInfrastructure extends BatchJobInfrastructure {
             @Override
             public BatchJobInfrastructure handle() {
                 return (BatchJobInfrastructure) persistedInfraVariables.get(BATCH_JOB_INFRASTRUCTURE_IMPLEMENTATION_KEY);
-            }
-        });
-    }
-
-    private void setBatchJobInfrastructure(final BatchJobInfrastructure batchJobInfrastructure) {
-        setPersistedInfraVariable(new PersistedInfraVariablesHandler<Void>() {
-            @Override
-            public Void handle() {
-                persistedInfraVariables.put(BATCH_JOB_INFRASTRUCTURE_IMPLEMENTATION_KEY, batchJobInfrastructure);
-                return null;
             }
         });
     }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/InfrastructureManager.java
@@ -175,6 +175,8 @@ public abstract class InfrastructureManager implements Serializable {
         try {
             variable = t.handle();
             persistInfrastructureVariables();
+        } catch (IllegalArgumentException e) {
+            logger.warn("Infrastructure variables not persisted", e);
         } catch (RuntimeException e) {
             logger.error("Exception while setting runtime variable: " + e.getMessage());
             throw e;
@@ -607,6 +609,9 @@ public abstract class InfrastructureManager implements Serializable {
      * the {@link NodeSource#DEFAULT_LOCAL_NODES_NODE_SOURCE_NAME}.
      */
     public void persistInfrastructureVariables() {
+        if (nodeSource == null) {
+            throw new IllegalArgumentException("Invalid invocation to persist infrastructure variables: the node source is not yet set for this infrastructure");
+        }
         if (recoveryActivated()) {
             String nodeSourceName = nodeSource.getName();
             readLock.lock();


### PR DESCRIPTION
- fix error occuring in BatchJobInfrastructure and in GenericBatchJobInfrastructure because infrastructure variables were persisted in the configure method of the infrastructure, where it should not be because the node source is not yet set for this infrastructure.
- add two unit tests to check that this error won't occur anymore