### PR TITLE
Make Scheduler state recovery faster

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -97,6 +97,9 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Number of threads used to handle scheduled operations related to housekeeping */
     SCHEDULER_HOUSEKEEPING_SCHEDULED_POOL_NBTHREAD("pa.scheduler.core.housekeeping.scheduledpoolnbthreads", PropertyType.INTEGER, "5"),
 
+    /** The number of threads in the thread pool that serves to recover jobs in parallel at scheduler start up */
+    SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVERER_NBTHREAD("pa.scheduler.core.parallel.scheduler.state.recoverer.job.pool.nbthreads", PropertyType.INTEGER, "16"),
+
     /** Name of the JMX MBean for the scheduler */
     SCHEDULER_JMX_CONNECTOR_NAME("pa.scheduler.core.jmx.connectorname", PropertyType.STRING, "JMXSchedulerAgent"),
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -97,8 +97,11 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Number of threads used to handle scheduled operations related to housekeeping */
     SCHEDULER_HOUSEKEEPING_SCHEDULED_POOL_NBTHREAD("pa.scheduler.core.housekeeping.scheduledpoolnbthreads", PropertyType.INTEGER, "5"),
 
-    /** The number of threads in the thread pool that serves to recover jobs in parallel at scheduler start up */
-    SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVERER_NBTHREAD("pa.scheduler.core.parallel.scheduler.state.recoverer.job.pool.nbthreads", PropertyType.INTEGER, "16"),
+    /** The number of threads in the thread pool that serves to recover running tasks in parallel at scheduler start up */
+    SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_NBTHREAD("pa.scheduler.core.parallel.scheduler.state.recover.nbthreads", PropertyType.INTEGER, "16"),
+
+    /** The timeout - to be used in minutes - for the scheduler state to be fully recovered */
+    SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_TIMEOUT("pa.scheduler.core.parallel.scheduler.state.recover.timeout", PropertyType.INTEGER, "60"),
 
     /** Name of the JMX MBean for the scheduler */
     SCHEDULER_JMX_CONNECTOR_NAME("pa.scheduler.core.jmx.connectorname", PropertyType.STRING, "JMXSchedulerAgent"),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
@@ -88,22 +88,23 @@ public class ExecuterInformationData implements Serializable {
                 if (loadFullState) {
                     logger.warn("Task launcher " + taskLauncherNodeUrl + " of task " + taskId +
                                 " cannot be looked up, try to rebind it");
-                    taskLauncher = getReboundTaskLauncher(e);
+                    taskLauncher = getReboundTaskLauncherIfStillExist(e);
                 }
             }
         }
         return new ExecuterInformation(taskLauncher, nodes, nodeName, hostName);
     }
 
-    private TaskLauncher getReboundTaskLauncher(Exception e) {
+    private TaskLauncher getReboundTaskLauncherIfStillExist(Exception e) {
         try {
             logger.debug("List AOs on " + taskLauncherNodeUrl + " (expect only one): " +
                          Arrays.toString(NodeFactory.getNode(taskLauncherNodeUrl).getActiveObjects()));
             Object[] aos = NodeFactory.getNode(taskLauncherNodeUrl).getActiveObjects();
             return (TaskLauncher) aos[0];
         } catch (Throwable t) {
-            logger.error("Failed to rebind TaskLauncher " + taskLauncherNodeUrl + " of task " + taskId +
-                         " after exception " + e.getMessage(), t);
+            logger.warn("Failed to rebind TaskLauncher of task " + taskId + ". TaskLauncher with node URL: " +
+                        taskLauncherNodeUrl +
+                        " could not be looked up. Running task cannot be recovered, it will be restarted if possible.");
             return new TaskLauncher();
         }
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
@@ -88,14 +88,14 @@ public class ExecuterInformationData implements Serializable {
                 if (loadFullState) {
                     logger.warn("Task launcher " + taskLauncherNodeUrl + " of task " + taskId +
                                 " cannot be looked up, try to rebind it");
-                    taskLauncher = getReboundTaskLauncherIfStillExist(e);
+                    taskLauncher = getReboundTaskLauncherIfStillExist();
                 }
             }
         }
         return new ExecuterInformation(taskLauncher, nodes, nodeName, hostName);
     }
 
-    private TaskLauncher getReboundTaskLauncherIfStillExist(Exception e) {
+    private TaskLauncher getReboundTaskLauncherIfStillExist() {
         try {
             logger.debug("List AOs on " + taskLauncherNodeUrl + " (expect only one): " +
                          Arrays.toString(NodeFactory.getNode(taskLauncherNodeUrl).getActiveObjects()));

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateNotRecoveredException.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateNotRecoveredException.java
@@ -1,0 +1,38 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.core.db;
+
+public class SchedulerStateNotRecoveredException extends RuntimeException {
+
+    public SchedulerStateNotRecoveredException(String message) {
+        super(message);
+    }
+
+    public SchedulerStateNotRecoveredException(Exception exception) {
+        super(exception);
+    }
+
+}

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -90,6 +90,7 @@ public class SchedulerStateRecoverHelper {
                                                                                       TimeUnit.MINUTES);
         } catch (InterruptedException e) {
             logger.error("Interrupted while waiting for the Scheduler state to be recovered", e);
+            Thread.currentThread().interrupt();
             throw new SchedulerStateNotRecoveredException(e);
         }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/RegressionTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/RegressionTestSuite.java
@@ -37,9 +37,10 @@ import functionaltests.db.schedulerdb.TestJobRemove;
 import functionaltests.db.schedulerdb.TestMultipleTasks;
 import functionaltests.job.taskkill.TestJobKilled;
 import functionaltests.job.taskkill.TestProcessTreeKiller;
-import functionaltests.recover.TaskReconnectionWithForkedTaskExecutorTest;
-import functionaltests.recover.TaskReconnectionWithInProcessTaskExecutorTest;
-import functionaltests.recover.TaskRecoveryWhenNodesAreReservedInBatchTest;
+import functionaltests.recover.RunningTaskRecoveryWhenNodesAreReservedInBatchTest;
+import functionaltests.recover.RunningTaskRecoveryWithDownNodeTest;
+import functionaltests.recover.RunningTaskRecoveryWithForkedTaskExecutorTest;
+import functionaltests.recover.RunningTaskRecoveryWithInProcessTaskExecutorTest;
 import functionaltests.rm.TestOperationsWhenUnlinked;
 import functionaltests.workflow.TestJobLegacySchemas;
 import functionaltests.workflow.TestWorkflowSubmission;
@@ -82,9 +83,9 @@ import functionaltests.workflow.complex.TestWorkflowReplicateJobs3;
                       TestJobKilled.class,
 
                       TestDataspaceConcurrentTransfer.class, TestDataspaceConcurrentKilling.class,
-                      TaskReconnectionWithForkedTaskExecutorTest.class,
-                      TaskReconnectionWithInProcessTaskExecutorTest.class,
-                      TaskRecoveryWhenNodesAreReservedInBatchTest.class })
+                      RunningTaskRecoveryWithDownNodeTest.class, RunningTaskRecoveryWithForkedTaskExecutorTest.class,
+                      RunningTaskRecoveryWithInProcessTaskExecutorTest.class,
+                      RunningTaskRecoveryWhenNodesAreReservedInBatchTest.class })
 
 /**
  * @author ActiveEon Team

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWhenNodesAreReservedInBatchTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWhenNodesAreReservedInBatchTest.java
@@ -57,17 +57,18 @@ import functionaltests.utils.TestScheduler;
  * the tasks still manage to be continued/started/restarted depending on their
  * state when the scheduler crashed.
  */
-public class TaskRecoveryWhenNodesAreReservedInBatchTest extends SchedulerFunctionalTestWithCustomConfigAndRestart {
+public class RunningTaskRecoveryWhenNodesAreReservedInBatchTest
+        extends SchedulerFunctionalTestWithCustomConfigAndRestart {
 
-    private static final URL SCHEDULER_CONFIGURATION_START = TaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
+    private static final URL SCHEDULER_CONFIGURATION_START = RunningTaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
 
-    private static final URL SCHEDULER_CONFIGURATION_RESTART = TaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
+    private static final URL SCHEDULER_CONFIGURATION_RESTART = RunningTaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
 
-    private static final URL JOB_DESCRIPTOR = TaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/descriptors/Job_TaskReconnectionOnRestart_25_Parallel_Tasks.xml");
+    private static final URL JOB_DESCRIPTOR = RunningTaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/descriptors/Job_TaskReconnectionOnRestart_25_Parallel_Tasks.xml");
 
-    private static final URL RM_CONFIGURATION_START = TaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
+    private static final URL RM_CONFIGURATION_START = RunningTaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
 
-    private static final URL RM_CONFIGURATION_RESTART = TaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTRMProperties-keep-db.ini");
+    private static final URL RM_CONFIGURATION_RESTART = RunningTaskRecoveryWhenNodesAreReservedInBatchTest.class.getResource("/functionaltests/config/functionalTRMProperties-keep-db.ini");
 
     private static final int NB_NODES = 26;
 
@@ -84,7 +85,7 @@ public class TaskRecoveryWhenNodesAreReservedInBatchTest extends SchedulerFuncti
 
     @Test
     public void action() throws Throwable {
-        nodes = schedulerHelper.createRMNodeStarterNodes(TaskRecoveryWhenNodesAreReservedInBatchTest.class.getSimpleName(),
+        nodes = schedulerHelper.createRMNodeStarterNodes(RunningTaskRecoveryWhenNodesAreReservedInBatchTest.class.getSimpleName(),
                                                          NB_NODES);
         for (int i = 0; i < NB_NODES; i++) {
             schedulerHelper.waitForAnyNodeEvent(RMEventType.NODE_ADDED);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithDownNodeTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithDownNodeTest.java
@@ -63,15 +63,15 @@ import functionaltests.utils.TestScheduler;
  * down, then we avoid waiting for the ping timeout to continue the scheduler
  * state recovery.
  */
-public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithCustomConfigAndRestart {
+public class RunningTaskRecoveryWithDownNodeTest extends SchedulerFunctionalTestWithCustomConfigAndRestart {
 
-    private static final URL SCHEDULER_CONFIGURATION_START = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
+    private static final URL SCHEDULER_CONFIGURATION_START = RunningTaskRecoveryWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
 
-    private static final URL SCHEDULER_CONFIGURATION_RESTART = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
+    private static final URL SCHEDULER_CONFIGURATION_RESTART = RunningTaskRecoveryWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
 
-    private static final URL RM_CONFIGURATION_START = TaskReconnectionToDownNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
+    private static final URL RM_CONFIGURATION_START = RunningTaskRecoveryWithDownNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
 
-    private static final URL RM_CONFIGURATION_RESTART = TaskReconnectionToDownNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-keep-db.ini");
+    private static final URL RM_CONFIGURATION_RESTART = RunningTaskRecoveryWithDownNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-keep-db.ini");
 
     private static final int NUMBER_OF_NODES = 10;
 
@@ -79,7 +79,7 @@ public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithC
 
     private static final int RESTART_SCHEDULER_INTER_TIME_MILLIS = 1000;
 
-    private static final String TASK_BASE_NAME = "TASK-" + TaskReconnectionToDownNodeTest.class.getSimpleName();
+    private static final String TASK_BASE_NAME = "TASK-" + RunningTaskRecoveryWithDownNodeTest.class.getSimpleName();
 
     private List<TestNode> nodes;
 
@@ -183,7 +183,7 @@ public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithC
     private JobId submitJob() throws Exception {
         TaskFlowJob job = new TaskFlowJob();
 
-        job.setName("JOB-" + TaskReconnectionToDownNodeTest.class.getSimpleName());
+        job.setName("JOB-" + RunningTaskRecoveryWithDownNodeTest.class.getSimpleName());
 
         for (int i = 0; i < NUMBER_OF_TASKS; i++) {
 
@@ -199,7 +199,7 @@ public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithC
     }
 
     private void createNodes() throws Exception {
-        this.nodes = schedulerHelper.createRMNodeStarterNodes(TaskReconnectionWithForkedTaskExecutorTest.class.getSimpleName(),
+        this.nodes = schedulerHelper.createRMNodeStarterNodes(RunningTaskRecoveryWithForkedTaskExecutorTest.class.getSimpleName(),
                                                               NUMBER_OF_NODES);
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithDownNodeTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithDownNodeTest.java
@@ -168,12 +168,8 @@ public class RunningTaskRecoveryWithDownNodeTest extends SchedulerFunctionalTest
     }
 
     private void killSchedulerAndNodes() throws Exception {
-        Thread.sleep(RESTART_SCHEDULER_INTER_TIME_MILLIS);
-
         TestScheduler.kill();
         RecoverInfrastructureTestHelper.killNodesWithStrongSigKill();
-
-        Thread.sleep(RESTART_SCHEDULER_INTER_TIME_MILLIS);
     }
 
     private void waitForAllTasksToRun(JobId jobid) throws Exception {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithForkedTaskExecutorTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithForkedTaskExecutorTest.java
@@ -34,11 +34,11 @@ import java.net.URL;
  * @author ActiveEon Team
  * @since 20/09/17
  */
-public class TaskReconnectionWithForkedTaskExecutorTest extends TaskReconnectionToRecoveredNodeTest {
+public class RunningTaskRecoveryWithForkedTaskExecutorTest extends RunningTaskRecoveryWithRecoveredNodeTestBase {
 
-    private static final URL SCHEDULER_CONFIGURATION_START = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
+    private static final URL SCHEDULER_CONFIGURATION_START = RunningTaskRecoveryWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
 
-    private static final URL SCHEDULER_CONFIGURATION_RESTART = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
+    private static final URL SCHEDULER_CONFIGURATION_RESTART = RunningTaskRecoveryWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
 
     @Override
     protected URL getSchedulerStartConfigurationURL() {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithForkedTaskExecutorTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithForkedTaskExecutorTest.java
@@ -34,6 +34,7 @@ import java.net.URL;
  * @author ActiveEon Team
  * @since 20/09/17
  */
+@SuppressWarnings("squid:S2187")
 public class RunningTaskRecoveryWithForkedTaskExecutorTest extends RunningTaskRecoveryWithRecoveredNodeTestBase {
 
     private static final URL SCHEDULER_CONFIGURATION_START = RunningTaskRecoveryWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithInProcessTaskExecutorTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithInProcessTaskExecutorTest.java
@@ -34,6 +34,7 @@ import java.net.URL;
  * @author ActiveEon Team
  * @since 20/09/17
  */
+@SuppressWarnings("squid:S2187")
 public class RunningTaskRecoveryWithInProcessTaskExecutorTest extends RunningTaskRecoveryWithRecoveredNodeTestBase {
 
     private static final URL SCHEDULER_CONFIGURATION_START = RunningTaskRecoveryWithInProcessTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-nonforkedtasks.ini");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithInProcessTaskExecutorTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithInProcessTaskExecutorTest.java
@@ -34,11 +34,11 @@ import java.net.URL;
  * @author ActiveEon Team
  * @since 20/09/17
  */
-public class TaskReconnectionWithInProcessTaskExecutorTest extends TaskReconnectionToRecoveredNodeTest {
+public class RunningTaskRecoveryWithInProcessTaskExecutorTest extends RunningTaskRecoveryWithRecoveredNodeTestBase {
 
-    private static final URL SCHEDULER_CONFIGURATION_START = TaskReconnectionWithInProcessTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-nonforkedtasks.ini");
+    private static final URL SCHEDULER_CONFIGURATION_START = RunningTaskRecoveryWithInProcessTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-nonforkedtasks.ini");
 
-    private static final URL SCHEDULER_CONFIGURATION_RESTART = TaskReconnectionWithInProcessTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB-nonforkedtasks.ini");
+    private static final URL SCHEDULER_CONFIGURATION_RESTART = RunningTaskRecoveryWithInProcessTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB-nonforkedtasks.ini");
 
     @Override
     protected URL getSchedulerStartConfigurationURL() {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithRecoveredNodeTestBase.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/RunningTaskRecoveryWithRecoveredNodeTestBase.java
@@ -34,7 +34,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.ow2.proactive.resourcemanager.RMFactory;
-import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobState;
@@ -55,13 +54,14 @@ import functionaltests.utils.TestScheduler;
  * @author ActiveEon Team
  * @since 20/09/17
  */
-public abstract class TaskReconnectionToRecoveredNodeTest extends SchedulerFunctionalTestWithCustomConfigAndRestart {
+public abstract class RunningTaskRecoveryWithRecoveredNodeTestBase
+        extends SchedulerFunctionalTestWithCustomConfigAndRestart {
 
-    private static final URL JOB_DESCRIPTOR = TaskReconnectionToRecoveredNodeTest.class.getResource("/functionaltests/descriptors/Job_TaskReconnectionOnRestart.xml");
+    private static final URL JOB_DESCRIPTOR = RunningTaskRecoveryWithRecoveredNodeTestBase.class.getResource("/functionaltests/descriptors/Job_TaskReconnectionOnRestart.xml");
 
-    private static final URL RM_CONFIGURATION_START = TaskReconnectionToRecoveredNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
+    private static final URL RM_CONFIGURATION_START = RunningTaskRecoveryWithRecoveredNodeTestBase.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
 
-    private static final URL RM_CONFIGURATION_RESTART = TaskReconnectionToRecoveredNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-keep-db.ini");
+    private static final URL RM_CONFIGURATION_RESTART = RunningTaskRecoveryWithRecoveredNodeTestBase.class.getResource("/functionaltests/config/functionalTRMProperties-keep-db.ini");
 
     private static final int NB_NODES = 3;
 
@@ -101,7 +101,7 @@ public abstract class TaskReconnectionToRecoveredNodeTest extends SchedulerFunct
     @Test
     public void action() throws Throwable {
 
-        nodes = schedulerHelper.createRMNodeStarterNodes(TaskReconnectionWithForkedTaskExecutorTest.class.getSimpleName(),
+        nodes = schedulerHelper.createRMNodeStarterNodes(RunningTaskRecoveryWithForkedTaskExecutorTest.class.getSimpleName(),
                                                          NB_NODES);
 
         JobId jobid = schedulerHelper.submitJob(new File(JOB_DESCRIPTOR.toURI()).getAbsolutePath());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/TaskReconnectionToDownNodeTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/TaskReconnectionToDownNodeTest.java
@@ -1,0 +1,245 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests.recover;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.ow2.proactive.resourcemanager.RMFactory;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
+import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobResult;
+import org.ow2.proactive.scheduler.common.job.JobState;
+import org.ow2.proactive.scheduler.common.task.TaskInfo;
+import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatus;
+
+import functionaltests.nodesrecovery.RecoverInfrastructureTestHelper;
+import functionaltests.utils.SchedulerFunctionalTestWithCustomConfigAndRestart;
+import functionaltests.utils.SchedulerTHelper;
+import functionaltests.utils.TestNode;
+import functionaltests.utils.TestScheduler;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+
+
+/**
+ * This test verifies that when
+ * @author ActiveEon Team
+ * @since 20/09/17
+ */
+public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithCustomConfigAndRestart {
+
+    private static final URL JOB_DESCRIPTOR = TaskReconnectionToDownNodeTest.class.getResource("/functionaltests/descriptors/Job_TaskReconnectionOnRestart_25_Parallel_Tasks.xml");
+
+    private static final URL RM_CONFIGURATION_START = TaskReconnectionToDownNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
+
+    private static final URL RM_CONFIGURATION_RESTART = TaskReconnectionToDownNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-keep-db.ini");
+
+    private static final int NUMBER_OF_NODES = 25;
+
+    private static final int NUMBER_OF_REPLICATE_TASKS = 25;
+
+    private static final int RESTART_SCHEDULER_INTER_TIME_IN_MILLISECONDS = 1000;
+
+    private static final String LAST_REPLICATE_TASK_NAME = "Groovy_Task26";
+
+    private List<TestNode> nodes;
+
+    private Map<Long, String> taskExecutionHostnamePerTaskId;
+
+    private static final URL SCHEDULER_CONFIGURATION_START = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
+
+    private static final URL SCHEDULER_CONFIGURATION_RESTART = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
+
+    protected URL getSchedulerStartConfigurationURL() {
+        return SCHEDULER_CONFIGURATION_START;
+    }
+
+    protected URL getSchedulerReStartConfigurationURL() {
+        return SCHEDULER_CONFIGURATION_RESTART;
+    }
+
+    @Before
+    public void startDedicatedScheduler() throws Exception {
+        RMFactory.setOsJavaProperty();
+        schedulerHelper = new SchedulerTHelper(false,
+                                               new File(getSchedulerStartConfigurationURL().toURI()).getAbsolutePath(),
+                                               new File(RM_CONFIGURATION_START.toURI()).getAbsolutePath(),
+                                               null);
+        this.taskExecutionHostnamePerTaskId = new HashMap<>();
+    }
+
+    @Test
+    public void action() throws Throwable {
+
+        this.createNodes();
+
+        JobId jobid = this.submitJob();
+
+        this.waitForAllTasksToRun(jobid);
+
+        this.recordTaskExecutionHostInfo(jobid);
+
+        this.killSchedulerAndNodes();
+
+        long schedulerStartTime = System.currentTimeMillis();
+        this.restartScheduler();
+        long schedulerUpTime = System.currentTimeMillis();
+
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface();
+        JobState jobState = scheduler.getJobState(jobid);
+
+        this.checkFirstAndLastTask(jobState);
+
+        this.checkReplicateTasks(jobState);
+
+        this.waitForJobToFinish(jobid);
+
+        this.checkJobResult(jobid, scheduler);
+
+        this.checkSchedulerStateRecoveryDoesNotWaitTaskPingAttemptTimesFrequency(schedulerStartTime, schedulerUpTime);
+    }
+
+    private void checkSchedulerStateRecoveryDoesNotWaitTaskPingAttemptTimesFrequency(long schedulerStartTime, long schedulerUpTime) {
+        int attempts = PASchedulerProperties.SCHEDULER_NODE_PING_ATTEMPTS.getValueAsInt();
+        int frequency = PASchedulerProperties.SCHEDULER_NODE_PING_FREQUENCY.getValueAsInt();
+        int minimumTotalRecoveryDurationIfRetryMechanismIsExecuted = attempts * frequency * 1000 * NUMBER_OF_REPLICATE_TASKS;
+
+        int schedulerTimeToBeUpAndRunning = (int) (schedulerUpTime - schedulerStartTime);
+        assertThat(schedulerTimeToBeUpAndRunning).isLessThan(minimumTotalRecoveryDurationIfRetryMechanismIsExecuted);
+    }
+
+    private void checkJobResult(JobId jobid, Scheduler scheduler)
+            throws NotConnectedException, PermissionException, UnknownJobException {
+        JobResult jobResult = scheduler.getJobResult(jobid);
+        Assert.assertFalse(jobResult.hadException());
+    }
+
+    private void waitForJobToFinish(JobId jobid) throws Exception {
+        schedulerHelper.waitForEventJobFinished(jobid);
+    }
+
+    private void checkReplicateTasks(JobState jobState) {
+        int maximumNumberOfPendingReplicateTasks = jobState.getNumberOfPendingTasks() - 1;
+
+        for (int i = 1; i <= maximumNumberOfPendingReplicateTasks; i++) {
+
+            TaskState taskState = jobState.getTasks().get(i);
+            TaskStatus taskStatus = taskState.getTaskInfo().getStatus();
+
+            assertThat(taskStatus.equals(TaskStatus.PENDING) || taskStatus.equals(TaskStatus.RUNNING)).isTrue();
+
+            if (taskStatus.equals(TaskStatus.RUNNING)) {
+                this.checkThatExecutionHostnameIsDifferent(taskState);
+            }
+        }
+    }
+
+    private void checkThatExecutionHostnameIsDifferent(TaskState taskState) {
+        String formerExecutionHost = this.taskExecutionHostnamePerTaskId.get(taskState.getTaskInfo()
+                                                                                      .getTaskId()
+                                                                                      .longValue());
+        String currentExecutionHost = taskState.getTaskInfo().getExecutionHostName();
+
+        assertThat(formerExecutionHost).isNotEqualTo(currentExecutionHost);
+    }
+
+    private void checkFirstAndLastTask(JobState jobState) {
+        // we have exactly one task that is finished (the first one)
+        assertThat(jobState.getNumberOfFinishedTasks()).isEqualTo(1);
+        // at least we have the last task that is pending (the merge task)
+        assertThat(jobState.getNumberOfPendingTasks()).isAtLeast(1);
+    }
+
+    private void recordTaskExecutionHostInfo(JobId jobid) throws Exception {
+        for (int i = 0; i < NUMBER_OF_REPLICATE_TASKS; i++) {
+            TaskState taskState = schedulerHelper.getSchedulerInterface().getJobState(jobid).getTasks().get(i);
+            TaskInfo taskInfo = taskState.getTaskInfo();
+            this.taskExecutionHostnamePerTaskId.put(taskInfo.getTaskId().longValue(), taskInfo.getExecutionHostName());
+        }
+    }
+
+    private void restartScheduler() throws Exception {
+        schedulerHelper = new SchedulerTHelper(false,
+                                               new File(this.getSchedulerReStartConfigurationURL()
+                                                            .toURI()).getAbsolutePath(),
+                                               new File(RM_CONFIGURATION_RESTART.toURI()).getAbsolutePath(),
+                                               null,
+                                               false);
+        this.createNodes();
+    }
+
+    private void killSchedulerAndNodes() throws Exception {
+        Thread.sleep(RESTART_SCHEDULER_INTER_TIME_IN_MILLISECONDS);
+
+        TestScheduler.kill();
+        RecoverInfrastructureTestHelper.killNodesWithStrongSigKill();
+
+        Thread.sleep(RESTART_SCHEDULER_INTER_TIME_IN_MILLISECONDS);
+    }
+
+    private void waitForAllTasksToRun(JobId jobid) throws Exception {
+        schedulerHelper.waitForEventTaskRunning(jobid, LAST_REPLICATE_TASK_NAME);
+    }
+
+    private JobId submitJob() throws Exception {
+        JobId jobid = schedulerHelper.submitJob(new File(JOB_DESCRIPTOR.toURI()).getAbsolutePath());
+        schedulerHelper.waitForEventJobRunning(jobid);
+        return jobid;
+    }
+
+    private void createNodes() throws Exception {
+        this.nodes = schedulerHelper.createRMNodeStarterNodes(TaskReconnectionWithForkedTaskExecutorTest.class.getSimpleName(),
+                                                              NUMBER_OF_NODES);
+    }
+
+    @After
+    public void after() throws Exception {
+        if (this.nodes != null) {
+            for (TestNode node : this.nodes) {
+                try {
+                    node.kill();
+                } catch (Exception e) {
+                    // keep exceptions there silent
+                }
+            }
+        }
+    }
+
+}

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/TaskReconnectionToDownNodeTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/TaskReconnectionToDownNodeTest.java
@@ -49,19 +49,19 @@ import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 
 import functionaltests.nodesrecovery.RecoverInfrastructureTestHelper;
 import functionaltests.utils.SchedulerFunctionalTestWithCustomConfigAndRestart;
 import functionaltests.utils.SchedulerTHelper;
 import functionaltests.utils.TestNode;
 import functionaltests.utils.TestScheduler;
-import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 
 
 /**
- * This test verifies that when
- * @author ActiveEon Team
- * @since 20/09/17
+ * This test verifies that when a running task cannot be recovered because the
+ * node is down, then we avoid waiting for the ping timeout to continue the
+ * scheduler state recovery.
  */
 public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithCustomConfigAndRestart {
 
@@ -136,10 +136,12 @@ public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithC
         this.checkSchedulerStateRecoveryDoesNotWaitTaskPingAttemptTimesFrequency(schedulerStartTime, schedulerUpTime);
     }
 
-    private void checkSchedulerStateRecoveryDoesNotWaitTaskPingAttemptTimesFrequency(long schedulerStartTime, long schedulerUpTime) {
+    private void checkSchedulerStateRecoveryDoesNotWaitTaskPingAttemptTimesFrequency(long schedulerStartTime,
+            long schedulerUpTime) {
         int attempts = PASchedulerProperties.SCHEDULER_NODE_PING_ATTEMPTS.getValueAsInt();
         int frequency = PASchedulerProperties.SCHEDULER_NODE_PING_FREQUENCY.getValueAsInt();
-        int minimumTotalRecoveryDurationIfRetryMechanismIsExecuted = attempts * frequency * 1000 * NUMBER_OF_REPLICATE_TASKS;
+        int minimumTotalRecoveryDurationIfRetryMechanismIsExecuted = attempts * frequency * 1000 *
+                                                                     NUMBER_OF_REPLICATE_TASKS;
 
         int schedulerTimeToBeUpAndRunning = (int) (schedulerUpTime - schedulerStartTime);
         assertThat(schedulerTimeToBeUpAndRunning).isLessThan(minimumTotalRecoveryDurationIfRetryMechanismIsExecuted);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/recover/TaskReconnectionToDownNodeTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/recover/TaskReconnectionToDownNodeTest.java
@@ -65,6 +65,10 @@ import functionaltests.utils.TestScheduler;
  */
 public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithCustomConfigAndRestart {
 
+    private static final URL SCHEDULER_CONFIGURATION_START = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
+
+    private static final URL SCHEDULER_CONFIGURATION_RESTART = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
+
     private static final URL JOB_DESCRIPTOR = TaskReconnectionToDownNodeTest.class.getResource("/functionaltests/descriptors/Job_TaskReconnectionOnRestart_25_Parallel_Tasks.xml");
 
     private static final URL RM_CONFIGURATION_START = TaskReconnectionToDownNodeTest.class.getResource("/functionaltests/config/functionalTRMProperties-clean-db.ini");
@@ -83,23 +87,11 @@ public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithC
 
     private Map<Long, String> taskExecutionHostnamePerTaskId;
 
-    private static final URL SCHEDULER_CONFIGURATION_START = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties.ini");
-
-    private static final URL SCHEDULER_CONFIGURATION_RESTART = TaskReconnectionWithForkedTaskExecutorTest.class.getResource("/functionaltests/config/functionalTSchedulerProperties-updateDB.ini");
-
-    protected URL getSchedulerStartConfigurationURL() {
-        return SCHEDULER_CONFIGURATION_START;
-    }
-
-    protected URL getSchedulerReStartConfigurationURL() {
-        return SCHEDULER_CONFIGURATION_RESTART;
-    }
-
     @Before
     public void startDedicatedScheduler() throws Exception {
         RMFactory.setOsJavaProperty();
         schedulerHelper = new SchedulerTHelper(false,
-                                               new File(getSchedulerStartConfigurationURL().toURI()).getAbsolutePath(),
+                                               new File(SCHEDULER_CONFIGURATION_START.toURI()).getAbsolutePath(),
                                                new File(RM_CONFIGURATION_START.toURI()).getAbsolutePath(),
                                                null);
         this.taskExecutionHostnamePerTaskId = new HashMap<>();
@@ -199,8 +191,7 @@ public class TaskReconnectionToDownNodeTest extends SchedulerFunctionalTestWithC
 
     private void restartScheduler() throws Exception {
         schedulerHelper = new SchedulerTHelper(false,
-                                               new File(this.getSchedulerReStartConfigurationURL()
-                                                            .toURI()).getAbsolutePath(),
+                                               new File(SCHEDULER_CONFIGURATION_RESTART.toURI()).getAbsolutePath(),
                                                new File(RM_CONFIGURATION_RESTART.toURI()).getAbsolutePath(),
                                                null,
                                                false);


### PR DESCRIPTION
Attempt to parallelize the recovery of jobs and tasks at scheduler startup. Use Java stream to recover jobs and tasks. Depending on Scheduler property, use a parallel or a sequential stream. Use a dedicated thread pool for parallel streams, depending on two Scheduler properties, and depending on the size of a job. Handle exceptions in streams by applying the legacy sequential recovery.