### PR TITLE
Enable by default the use of AccessType for NS.

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -317,7 +317,7 @@ pa.scheduler.resourcemanager.authentication.credentials=config/authentication/sc
 # Use single or multiple connection to RM :
 # (If true)  the scheduler user will do the requests to rm
 # (If false) each Scheduler users have their own connection to RM using their scheduling credentials
-pa.scheduler.resourcemanager.authentication.single=true
+pa.scheduler.resourcemanager.authentication.single=false
 
 # Set a timeout for initial connection to the RM connection (in ms)
 pa.scheduler.resourcemanager.connection.timeout=120000


### PR DESCRIPTION
The goal of these small change is to make userAccessType and providerAccessType taken into account when setting up a nodesource and associated policy. 