### PR TITLE
Do not include addons in proactive-client libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -361,7 +361,11 @@ class CustomCreateStartScripts extends CreateStartScripts {
         generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8"]
         generator.optsEnvironmentVar = getOptsEnvironmentVar()
         generator.exitEnvironmentVar = getExitEnvironmentVar()
-        generator.classpath = ["dist/lib/*", "addons", "addons/*"]
+        if (getApplicationName().equals("proactive-client")) {
+            generator.classpath = ["dist/lib/*"]
+        } else {
+            generator.classpath = ["dist/lib/*", "addons", "addons/*"]
+        }
         generator.scriptRelPath = "bin/${getUnixScript().name}"
 
         generator.windowsStartScriptGenerator.template = project.resources.text.fromFile("src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt")


### PR DESCRIPTION
- when the proactive-client executable is created, do not include addons folder to be added to the classpath because this is useless. Also, this use to create SLF4J jar conflicts that would result in errors polluting the output of the CLI