### PR TITLE
Fix update of node source dynamic parameters

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/NodeSourceParameterHelper.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/NodeSourceParameterHelper.java
@@ -71,19 +71,6 @@ public class NodeSourceParameterHelper {
         return mergedParameters;
     }
 
-    private String getStringValue(Object[] newParameters, int index, Configurable meta) {
-
-        String newValue;
-
-        if (meta.credential() || meta.fileBrowser() || meta.password()) {
-            newValue = new String((byte[]) newParameters[index]);
-        } else {
-            newValue = (String) newParameters[index];
-        }
-
-        return newValue;
-    }
-
     public Collection<PluginDescriptor> getPluginsDescriptor(Collection<Class<?>> plugins) {
         return plugins.stream().map(cls -> new PluginDescriptor(cls, new HashMap<>())).collect(Collectors.toList());
     }
@@ -101,17 +88,27 @@ public class NodeSourceParameterHelper {
         return new PluginDescriptor(pluginClass, parameters);
     }
 
+    private String getStringValue(Object[] newParameters, int index, Configurable meta) {
+
+        String newValue;
+
+        if (meta.credential() || meta.fileBrowser() || meta.password()) {
+            newValue = new String((byte[]) newParameters[index]);
+        } else {
+            newValue = String.valueOf(newParameters[index]);
+        }
+
+        return newValue;
+    }
+
     private void updateDynamicParameterIfNotEqual(List<Serializable> mergedParameters, String newValue, String oldValue,
             int valueIndex, ConfigurableField configurableField) {
 
-        if (!newValue.equals(oldValue)) {
+        String cleanNewValue = newValue.trim();
+        String cleanOldValue = oldValue.trim();
 
-            if (configurableField.getMeta().dynamic()) {
-                mergedParameters.set(valueIndex, newValue);
-            } else {
-                throw new IllegalArgumentException("Attempt to update parameter " + configurableField.getName() +
-                                                   " failed because this parameter is not dynamic");
-            }
+        if (configurableField.getMeta().dynamic() && !cleanNewValue.equals(cleanOldValue)) {
+            mergedParameters.set(valueIndex, cleanNewValue);
         }
     }
 

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/NodeSourceParameterHelperTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/NodeSourceParameterHelperTest.java
@@ -1,0 +1,165 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.core;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ow2.proactive.resourcemanager.nodesource.common.Configurable;
+import org.ow2.proactive.resourcemanager.nodesource.common.ConfigurableField;
+
+import com.google.common.collect.Lists;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class NodeSourceParameterHelperTest {
+
+    public static final String APPLIED_CHANGE_VALUE = "changeApplied";
+
+    public static final String ATTEMPTED_CHANGE_VALUE = "changeNotApplied";
+
+    public static final String TO_BE_CHANGED_VALUE = "toBeChanged";
+
+    public static final String TO_BE_KEPT_VALUE = "toBeKept";
+
+    public static final String TO_BE_KEPT_WITHOUT_TRIM_VALUE = "toBeKept\n";
+
+    @Mock
+    private ConfigurableField dynamicField;
+
+    @Mock
+    private Configurable dynamicMeta;
+
+    @Mock
+    private ConfigurableField notDynamicField;
+
+    @Mock
+    private Configurable notDynamicMeta;
+
+    private NodeSourceParameterHelper nodeSourceParameterHelper;
+
+    @Before
+    public void setup() {
+        this.nodeSourceParameterHelper = new NodeSourceParameterHelper();
+
+        when(this.dynamicField.getMeta()).thenReturn(this.dynamicMeta);
+        when(this.dynamicMeta.dynamic()).thenReturn(true);
+        when(this.notDynamicField.getMeta()).thenReturn(this.notDynamicMeta);
+        when(this.notDynamicMeta.dynamic()).thenReturn(false);
+    }
+
+    @Test
+    public void emptyUpdate() {
+
+        List<Serializable> mergedParameters = this.nodeSourceParameterHelper.getParametersWithDynamicParametersUpdatedOnly(Collections.emptyList(),
+                                                                                                                           new Object[] {},
+                                                                                                                           Collections.emptyList());
+        assertThat(mergedParameters).hasSize(0);
+    }
+
+    @Test
+    public void testDynamicParameterUpdated() {
+
+        List<ConfigurableField> configurableFields = Lists.asList(this.dynamicField, new ConfigurableField[] {});
+        Object[] newParameters = { APPLIED_CHANGE_VALUE };
+        List<Serializable> oldParameters = Lists.asList(TO_BE_CHANGED_VALUE, new Serializable[] {});
+
+        List<Serializable> mergedParameters = this.nodeSourceParameterHelper.getParametersWithDynamicParametersUpdatedOnly(configurableFields,
+                                                                                                                           newParameters,
+                                                                                                                           oldParameters);
+        assertThat(mergedParameters).hasSize(1);
+        assertThat(mergedParameters.get(0)).isEqualTo(APPLIED_CHANGE_VALUE);
+    }
+
+    @Test
+    public void testNotDynamicParameterNotUpdated() {
+
+        List<ConfigurableField> configurableFields = Lists.asList(this.notDynamicField, new ConfigurableField[] {});
+        Object[] newParameters = { ATTEMPTED_CHANGE_VALUE };
+        List<Serializable> oldParameters = Lists.asList(TO_BE_KEPT_VALUE, new Serializable[] {});
+
+        List<Serializable> mergedParameters = this.nodeSourceParameterHelper.getParametersWithDynamicParametersUpdatedOnly(configurableFields,
+                                                                                                                           newParameters,
+                                                                                                                           oldParameters);
+        assertThat(mergedParameters).hasSize(1);
+        assertThat(mergedParameters.get(0)).isEqualTo(TO_BE_KEPT_VALUE);
+    }
+
+    @Test
+    public void testDynamicParametersAndNotDynamicParametersAreMixed() {
+
+        List<ConfigurableField> configurableFields = Lists.asList(this.dynamicField,
+                                                                  this.notDynamicField,
+                                                                  new ConfigurableField[] {});
+        Object[] newParameters = { APPLIED_CHANGE_VALUE, ATTEMPTED_CHANGE_VALUE };
+        List<Serializable> oldParameters = Lists.asList(TO_BE_CHANGED_VALUE, TO_BE_KEPT_VALUE, new Serializable[] {});
+
+        List<Serializable> mergedParameters = this.nodeSourceParameterHelper.getParametersWithDynamicParametersUpdatedOnly(configurableFields,
+                                                                                                                           newParameters,
+                                                                                                                           oldParameters);
+        assertThat(mergedParameters).hasSize(2);
+        assertThat(mergedParameters.get(0)).isEqualTo(APPLIED_CHANGE_VALUE);
+        assertThat(mergedParameters.get(1)).isEqualTo(TO_BE_KEPT_VALUE);
+    }
+
+    @Test
+    public void testDynamicParameterWithoutTrimInNewNotUpdated() {
+
+        List<ConfigurableField> configurableFields = Lists.asList(this.dynamicField, new ConfigurableField[] {});
+        Object[] newParameters = { TO_BE_KEPT_WITHOUT_TRIM_VALUE };
+        List<Serializable> oldParameters = Lists.asList(TO_BE_KEPT_VALUE, new Serializable[] {});
+
+        List<Serializable> mergedParameters = this.nodeSourceParameterHelper.getParametersWithDynamicParametersUpdatedOnly(configurableFields,
+                                                                                                                           newParameters,
+                                                                                                                           oldParameters);
+        assertThat(mergedParameters).hasSize(1);
+        assertThat(mergedParameters.get(0)).isEqualTo(TO_BE_KEPT_VALUE);
+    }
+
+    @Test
+    public void testDynamicParameterWithoutTrimInOldNotUpdated() {
+
+        List<ConfigurableField> configurableFields = Lists.asList(this.dynamicField, new ConfigurableField[] {});
+        Object[] newParameters = { TO_BE_KEPT_VALUE };
+        List<Serializable> oldParameters = Lists.asList(TO_BE_KEPT_WITHOUT_TRIM_VALUE, new Serializable[] {});
+
+        List<Serializable> mergedParameters = this.nodeSourceParameterHelper.getParametersWithDynamicParametersUpdatedOnly(configurableFields,
+                                                                                                                           newParameters,
+                                                                                                                           oldParameters);
+        assertThat(mergedParameters).hasSize(1);
+        assertThat(mergedParameters.get(0)).isEqualTo(TO_BE_KEPT_WITHOUT_TRIM_VALUE);
+    }
+
+}


### PR DESCRIPTION
- clean string before comparing old value to new value: characters not printable were added to the old value causing the values to be different. This case did not show up in testing.
- remove exception thrown when attempting to update a non dynamic parameter: all parameters can be potentially run through, only the dynamic field will decide whether it should be updated
- add unit tests to cover the failure
- apply cascade of these modifications