### PR TITLE
Fix for #3195 DataSpace Client does not preserve directory hierarchy when transferring single file

### DIFF
--- a/config/log/server.properties
+++ b/config/log/server.properties
@@ -9,6 +9,8 @@ log4j.rootLogger=INFO, SCHEDULER
 log4j.logger.org.ow2.proactive.scheduler=INFO
 log4j.logger.org.ow2.proactive.resourcemanager=INFO
 
+log4j.logger.org.ow2.proactive_grid_cloud_portal.dataspace=DEBUG
+
 # ...except statistics and database
 log4j.logger.org.ow2.proactive.scheduler.db=INFO
 log4j.logger.org.ow2.proactive.scheduler.core.jmx=INFO

--- a/config/log/server.properties
+++ b/config/log/server.properties
@@ -9,8 +9,6 @@ log4j.rootLogger=INFO, SCHEDULER
 log4j.logger.org.ow2.proactive.scheduler=INFO
 log4j.logger.org.ow2.proactive.resourcemanager=INFO
 
-log4j.logger.org.ow2.proactive_grid_cloud_portal.dataspace=DEBUG
-
 # ...except statistics and database
 log4j.logger.org.ow2.proactive.scheduler.db=INFO
 log4j.logger.org.ow2.proactive.scheduler.core.jmx=INFO

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipper.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/util/VFSZipper.java
@@ -40,6 +40,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.apache.log4j.Logger;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.utils.Zipper;
 
 import com.google.common.io.ByteStreams;
@@ -47,6 +48,8 @@ import com.google.common.io.Closer;
 
 
 public class VFSZipper {
+
+    private static final Logger logger = Logger.getLogger(VFSZipper.class);
 
     private VFSZipper() {
     }
@@ -105,10 +108,14 @@ public class VFSZipper {
                     FileObject entryFile = outfileObj.resolveFile(zipEntry.getName());
 
                     if (zipEntry.isDirectory()) {
+                        logger.debug("Creating folder " + entryFile.getURL());
                         entryFile.createFolder();
                     } else {
                         if (!entryFile.exists()) {
+                            logger.debug("Creating file " + entryFile.getURL());
                             entryFile.createFile();
+                        } else {
+                            logger.debug("Overwriting file " + entryFile.getURL());
                         }
                         Zipper.ZIP.unzipEntry(zis, entryFile.getContent().getOutputStream());
                     }


### PR DESCRIPTION
 - added more debug output and loggers
 - Fixed issue which was due to a wrong decision in class Zipper