### PR TITLE
Use job generic information in TaskState.getRuntimeGenericInformation

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskState.java
@@ -477,19 +477,27 @@ public abstract class TaskState extends Task implements Comparable<TaskState> {
      */
     public Map<String, String> getRuntimeGenericInformation() {
 
+        Map<String, String> runtimeGenericInformation = new HashMap<>();
+
         if (getTaskInfo() == null) {
             // task is not yet properly initialized
-            return new HashMap<>();
+            return runtimeGenericInformation;
+        }
+        Map<String, Serializable> runtimeVariables = getRuntimeVariables();
+
+        // Add job generic information
+        if (getTaskInfo().getJobInfo().getGenericInformation() != null) {
+            runtimeGenericInformation.putAll(applyReplacementsOnGenericInformation(getTaskInfo().getJobInfo()
+                                                                                                .getGenericInformation(),
+                                                                                   runtimeVariables));
         }
 
-        HashMap<String, String> gInfo = new HashMap<>();
-
+        // Add task generic information
         if (genericInformation != null) {
-            Map<String, String> updatedTaskGenericInfo = applyReplacementsOnGenericInformation(genericInformation,
-                                                                                               getRuntimeVariables());
-            gInfo.putAll(updatedTaskGenericInfo);
+            runtimeGenericInformation.putAll(applyReplacementsOnGenericInformation(genericInformation,
+                                                                                   runtimeVariables));
         }
 
-        return gInfo;
+        return runtimeGenericInformation;
     }
 }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractor.java
@@ -99,9 +99,9 @@ public class TaskContextVariableExtractor implements Serializable {
         Map<String, Serializable> dictionary = new HashMap<>();
 
         try {
-            inherited.putAll(extractSystemVariables(taskContext, ""));
             inherited.putAll(extractJobVariables(taskContext));
             inherited.putAll(extractInheritedVariables(taskContext));
+            inherited.putAll(extractSystemVariables(taskContext, ""));
 
             for (TaskVariable taskVariable : taskContext.getInitializer().getTaskVariables().values()) {
                 if (!taskVariable.isJobInherited()) {
@@ -135,9 +135,9 @@ public class TaskContextVariableExtractor implements Serializable {
 
         try {
             if (taskContext != null) {
-                variables.putAll(extractSystemVariables(taskContext, ""));
                 variables.putAll(extractJobVariables(taskContext));
                 variables.putAll(extractInheritedVariables(taskContext));
+                variables.putAll(extractSystemVariables(taskContext, ""));
             }
             dictionary = extractAllVariables(taskContext, null, "");
         } catch (IOException | ClassNotFoundException e) {

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractorTest.java
@@ -58,6 +58,8 @@ public class TaskContextVariableExtractorTest extends ProActiveTestClean {
 
     private String taskNameValue = "TestTaskName";
 
+    private long previousTaskIdValue = 12L;
+
     private long taskIdValue = 20L;
 
     private long jobIdValue = 12L;
@@ -116,6 +118,9 @@ public class TaskContextVariableExtractorTest extends ProActiveTestClean {
         taskResultVariables.put(taskResultPropagatedVariables1Key,
                                 AllObjects2BytesConverterHandler.convertObject2Byte(taskResultPropagatedVariables1Key,
                                                                                     taskResultPropagatedVariables1Value));
+        taskResultVariables.put(SchedulerVars.PA_TASK_ID.name(),
+                                AllObjects2BytesConverterHandler.convertObject2Byte(SchedulerVars.PA_TASK_ID.name(),
+                                                                                    "" + previousTaskIdValue));
 
         TaskResultImpl taskResult = new TaskResultImpl(taskLauncherInitializer.getTaskId(), new Exception("Exception"));
         taskResult.setPropagatedVariables(taskResultVariables);
@@ -132,6 +137,15 @@ public class TaskContextVariableExtractorTest extends ProActiveTestClean {
 
         assertThat((String) contextVariables.get(taskResultPropagatedVariables1Key),
                    is(taskResultPropagatedVariables1Value));
+        // Makes sure the previous task id has been overwritten by the current task id
+        assertThat((String) contextVariables.get(SchedulerVars.PA_TASK_ID.name()), is("" + taskIdValue));
+
+        contextVariables = new TaskContextVariableExtractor().getAllNonTaskVariables(taskContext);
+
+        assertThat((String) contextVariables.get(taskResultPropagatedVariables1Key),
+                   is(taskResultPropagatedVariables1Value));
+        // Makes sure the previous task id has been overwritten by the current task id
+        assertThat((String) contextVariables.get(SchedulerVars.PA_TASK_ID.name()), is("" + taskIdValue));
     }
 
     @Test

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -42,6 +42,7 @@ import org.objectweb.proactive.api.PAFuture;
 import org.objectweb.proactive.core.ProActiveTimeoutException;
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.core.node.Node;
+import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.core.node.NodeFactory;
 import org.objectweb.proactive.core.process.JVMProcessImpl;
 import org.objectweb.proactive.extensions.pnp.PNPConfig;
@@ -1147,34 +1148,46 @@ public class SchedulerTHelper {
     }
 
     public List<TestNode> createRMNodeStarterNodes(String nodeName, int number) throws Exception {
-        int pnpPort = RMTHelper.findFreePort();
-        List<String> nodeUrls = new ArrayList<>(number);
-        List<String> nodeNames = RMNodeStarter.getWorkersNodeNames(nodeName, number);
-        for (int i = 0; i < number; i++) {
-            nodeUrls.add("pnp://localhost:" + pnpPort + "/" + nodeNames.get(i));
-        }
-        String nodeUrl = "pnp://localhost:" + pnpPort + "/" + nodeName;
-        Map<String, String> vmParameters = new HashMap<>();
-        vmParameters.put(PNPConfig.PA_PNP_PORT.getName(), Integer.toString(pnpPort));
-        JVMProcessImpl nodeProcess = RMTHelper.createJvmProcess(RMNodeStarter.class.getName(),
-                                                                Arrays.asList("-n",
-                                                                              nodeName,
-                                                                              "-r",
-                                                                              getLocalUrl(),
-                                                                              "-w",
-                                                                              "" + number,
-                                                                              "-Dproactive.net.nolocal=false"),
-                                                                vmParameters,
-                                                                null);
-        ArrayList<TestNode> nodes = new ArrayList<>(number);
+        return createRMNodeStarterNodesWithRetry(nodeName, number, 1);
 
-        // lookup all subsequent nodes remotely
-        for (int i = 0; i < number; i++) {
-            TestNode node0 = RMTHelper.createNode(nodeNames.get(i), nodeUrls.get(i), nodeProcess);
-            nodes.add(node0);
-        }
-        return nodes;
+    }
 
+    private List<TestNode> createRMNodeStarterNodesWithRetry(String nodeName, int number, int attempts)
+            throws IOException, NodeException, InterruptedException {
+        try {
+            int pnpPort = RMTHelper.findFreePort();
+            List<String> nodeUrls = new ArrayList<>(number);
+            List<String> nodeNames = RMNodeStarter.getWorkersNodeNames(nodeName, number);
+            for (int i = 0; i < number; i++) {
+                nodeUrls.add("pnp://localhost:" + pnpPort + "/" + nodeNames.get(i));
+            }
+            String nodeUrl = "pnp://localhost:" + pnpPort + "/" + nodeName;
+            Map<String, String> vmParameters = new HashMap<>();
+            vmParameters.put(PNPConfig.PA_PNP_PORT.getName(), Integer.toString(pnpPort));
+            JVMProcessImpl nodeProcess = RMTHelper.createJvmProcess(RMNodeStarter.class.getName(),
+                                                                    Arrays.asList("-n",
+                                                                                  nodeName,
+                                                                                  "-r",
+                                                                                  getLocalUrl(),
+                                                                                  "-w",
+                                                                                  "" + number,
+                                                                                  "-Dproactive.net.nolocal=false"),
+                                                                    vmParameters,
+                                                                    null);
+            ArrayList<TestNode> nodes = new ArrayList<>(number);
+
+            // lookup all subsequent nodes remotely
+            for (int i = 0; i < number; i++) {
+                TestNode node0 = RMTHelper.createNode(nodeNames.get(i), nodeUrls.get(i), nodeProcess);
+                nodes.add(node0);
+            }
+            return nodes;
+        } catch (NodeException e) {
+            if (attempts <= 3) {
+                return createRMNodeStarterNodesWithRetry(nodeName, number, attempts + 1);
+            }
+            throw e;
+        }
     }
 
     public RMNodeEvent waitForAnyNodeEvent(RMEventType nodeStateChanged) throws Exception {


### PR DESCRIPTION
 TaskState.getRuntimeGenericInformation made only use of the task generic info. This change fixes the issue by using job generic info available in getTaskInfo().getJobInfo()