### PR TITLE
Update a javadoc block

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -1299,8 +1299,6 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      *             if you are not authenticated.
      * @throws PermissionException
      *             if you have not enough permission to access this method.
-     * @throws UnknownJobException
-     *             if one of the job IDs wasn't found
      */
     List<JobInfo> getJobsInfoList(List<String> jobsId) throws PermissionException, NotConnectedException;
 


### PR DESCRIPTION
The alljavadoc gradle task failed because of an inconsistency between a javadoc block and a method signature