### PR TITLE
Be able to remove a node source if in inconsistent state

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2174,19 +2174,19 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         logger.info("Remove node source " + nodeSourceName + " with preempt=" + preempt + REQUESTED_BY_STRING +
                     this.caller.getName());
 
-        if (!this.definedNodeSources.containsKey(nodeSourceName)) {
+        NodeSource nodeSourceToRemove;
+        if (this.definedNodeSources.containsKey(nodeSourceName)) {
+            nodeSourceToRemove = this.definedNodeSources.get(nodeSourceName);
+        } else if (this.deployedNodeSources.containsKey(nodeSourceName)) {
+            nodeSourceToRemove = this.deployedNodeSources.get(nodeSourceName);
+        } else {
             throw new IllegalArgumentException("Unknown node source " + nodeSourceName);
         }
-
-        NodeSource nodeSourceToRemove = this.definedNodeSources.get(nodeSourceName);
-
         this.caller.checkPermission(nodeSourceToRemove.getAdminPermission(),
                                     this.caller + " is not authorized to remove " + nodeSourceName);
 
         this.shutDownNodeSourceIfDeployed(nodeSourceName, preempt);
-
         this.removeDefinedNodeSource(nodeSourceName, nodeSourceToRemove);
-
         return new BooleanWrapper(true);
     }
 

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureTimeSlotPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureTimeSlotPolicy.java
@@ -73,7 +73,7 @@ public class TestLocalInfrastructureTimeSlotPolicy extends RMFunctionalTest {
         repeater.accept(NODES_NUMBER, () -> this.rmHelper.waitForAnyNodeEvent(RMEventType.NODE_REMOVED));
 
         log("Waiting for the time slot policy to add the nodes again");
-        repeater.accept(NODES_NUMBER, () -> this.rmHelper.waitForAnyNodeEvent(RMEventType.NODE_ADDED));
+        RMTHelper.waitForNodesToBeUp(NODES_NUMBER, this.rmHelper.getMonitorsHandler());
 
         log("Waiting for the time slot policy to remove the nodes again");
         repeater.accept(NODES_NUMBER, () -> this.rmHelper.waitForAnyNodeEvent(RMEventType.NODE_REMOVED));


### PR DESCRIPTION
- before only defined node source could be removed from the RMCore. Now we also remove it if it is only present in the deployed node source list. This situation should not happen in a regular execution but might show up when an added node source does not go through activation successfully.