### PR TITLE
Integrate IAM microservice

### DIFF
--- a/boot-microservices/build.gradle
+++ b/boot-microservices/build.gradle
@@ -1,0 +1,29 @@
+repositories {
+    maven {
+        url "http://repository.activeeon.com/content/groups/proactive/"
+    }
+
+    mavenCentral()
+}
+
+configurations {
+    iamWar
+}
+
+dependencies {
+    compile project(':rm:rm-node')
+
+    compile group: 'org.apache.commons', name: 'commons-configuration2', version: '2.2'
+
+    iamWar group: "org.ow2.proactive", name: "iam", version: "${schedulingVersion}", ext: "war"
+}
+
+task copyIamWar(type: Copy) {
+
+    from configurations.iamWar
+    into file("${project(':').projectDir}/dist/boot")
+
+    rename ('iam-(.*).war', 'iam.war')
+}
+
+compileJava.dependsOn copyIamWar

--- a/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarter.java
+++ b/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarter.java
@@ -36,6 +36,8 @@ import org.apache.log4j.Logger;
 import org.ow2.proactive.boot.microservices.util.IAMConfiguration;
 import org.ow2.proactive.resourcemanager.utils.OperatingSystem;
 
+import org.apache.commons.configuration2.ex.ConfigurationException;
+
 
 public class IAMStarter {
 
@@ -61,7 +63,7 @@ public class IAMStarter {
      *  Start IAM microservice
      */
     public static Process start(String paHome, String bootMicroservicesPath, String bootConfigurationPath)
-            throws InterruptedException, IOException, ExecutionException {
+            throws InterruptedException, IOException, ExecutionException, ConfigurationException {
 
         if (!started) {
             LOGGER.info("Starting IAM microservice...");
@@ -165,14 +167,15 @@ public class IAMStarter {
     /**
      * Load IAM configuration
      */
-    private static void loadIAMConfiguration(String bootConfigurationPath) {
+    private static void loadIAMConfiguration(String bootConfigurationPath) throws ConfigurationException {
 
         File configFile = new File(bootConfigurationPath + SEPARATOR + IAMConfiguration.PROPERTIES_FILE);
 
-        if (configFile.exists()) {
-            config = IAMConfiguration.loadConfig(configFile);
-        } else {
+        if (!configFile.exists()) {
             throw new IAMStarterException("IAM configuration not found in : " + configFile.getAbsolutePath());
         }
+
+        config = IAMConfiguration.loadConfig(configFile);
+
     }
 }

--- a/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarter.java
+++ b/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarter.java
@@ -33,7 +33,6 @@ import java.util.concurrent.*;
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.log4j.Logger;
-
 import org.ow2.proactive.boot.microservices.util.IAMConfiguration;
 import org.ow2.proactive.resourcemanager.utils.OperatingSystem;
 
@@ -126,10 +125,10 @@ public class IAMStarter {
 
         String javaCmd = null;
 
-        if (OS.equals(OperatingSystem.UNIX)) {
+        if (OperatingSystem.getOperatingSystem(OS).equals(OperatingSystem.UNIX)) {
             javaCmd = "java";
 
-        } else if (OS.equals(OperatingSystem.WINDOWS)) {
+        } else if (OperatingSystem.getOperatingSystem(OS).equals(OperatingSystem.WINDOWS)) {
             javaCmd = "java.exe";
         }
 

--- a/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarter.java
+++ b/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarter.java
@@ -1,0 +1,179 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.boot.microservices;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.log4j.Logger;
+
+import org.ow2.proactive.boot.microservices.util.IAMConfiguration;
+import org.ow2.proactive.resourcemanager.utils.OperatingSystem;
+
+
+public class IAMStarter {
+
+    private static final Logger LOGGER = Logger.getLogger(IAMStarter.class);
+
+    private static final String OS = System.getProperty("os.name");
+
+    private static final String SEPARATOR = File.separator;
+
+    private static Configuration config = new BaseConfiguration();
+
+    private static Process process;
+
+    private static List<String> command = new ArrayList<>();
+
+    private static boolean started = false;
+
+    private IAMStarter() {
+
+    }
+
+    /**
+     *  Start IAM microservice
+     */
+    public static Process start(String paHome, String bootMicroservicesPath, String bootConfigurationPath)
+            throws InterruptedException, IOException, ExecutionException {
+
+        if (!started) {
+            LOGGER.info("Starting IAM microservice...");
+
+            // load IAM configuration
+            loadIAMConfiguration(bootConfigurationPath);
+
+            // build java command to launch IAM
+            buildJavaCommand(paHome);
+
+            // find IAM war archive path
+            buildMicroservicePath(bootMicroservicesPath);
+
+            // execute IAM as a separate JAva process
+            ProcessBuilder processBuilder = new ProcessBuilder(command);
+            processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+            process = processBuilder.start();
+            LOGGER.info(streamOutput(process.getInputStream()));
+
+            started = true;
+        }
+        return process;
+    }
+
+    /**
+     * Stream microservice output (using an executor) to check that it starts properly
+     */
+    private static String streamOutput(InputStream inputStream) throws InterruptedException, ExecutionException {
+
+        // Stream microservice output
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<String> future = executor.submit((Callable) () -> {
+
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
+                String line;
+
+                while ((line = br.readLine()) != null) {
+                    if (line.contains(config.getString(IAMConfiguration.READY_MARKER))) {
+                        break;
+                    }
+                }
+            }
+            return "IAM Microservice started";
+        });
+
+        // Check for timeout
+        try {
+            return future.get(config.getInt(IAMConfiguration.STARTUP_TIMEOUT), TimeUnit.SECONDS);
+        } catch (TimeoutException toe) {
+            return "IAM Microservice timed out to start. See the logs for the details.";
+        } finally {
+            executor.shutdownNow();
+            future.cancel(true);
+        }
+    }
+
+    /**
+     * Prepare java command with jvm args
+     */
+    private static void buildJavaCommand(String paHome) {
+
+        String javaCmd = null;
+
+        if (OS.equals(OperatingSystem.UNIX)) {
+            javaCmd = "java";
+
+        } else if (OS.equals(OperatingSystem.WINDOWS)) {
+            javaCmd = "java.exe";
+        }
+
+        String javaPath = paHome + SEPARATOR + "jre" + SEPARATOR + "bin" + SEPARATOR + javaCmd;
+
+        if (new File(javaPath).exists()) {
+            command.add(javaPath);
+        } else {
+            command.add(javaCmd);
+        }
+
+        command.add("-Dpa.scheduler.home=" + paHome);
+
+        command.add("-jar");
+
+        command.addAll(config.getList(String.class, IAMConfiguration.JVM_ARGS));
+    }
+
+    /**
+     * Check the microservice executable war
+     */
+    private static void buildMicroservicePath(String bootMicroservicesPath) {
+
+        String microserviceFile = bootMicroservicesPath + SEPARATOR + config.getString(IAMConfiguration.ARCHIVE_NAME);
+
+        if (new File(microserviceFile).exists()) {
+            command.add(microserviceFile);
+
+        } else {
+            throw new IAMStarterException("IAM microservice is not deployed in: " + bootMicroservicesPath);
+        }
+    }
+
+    /**
+     * Load IAM configuration
+     */
+    private static void loadIAMConfiguration(String bootConfigurationPath) {
+
+        File configFile = new File(bootConfigurationPath + SEPARATOR + IAMConfiguration.PROPERTIES_FILE);
+
+        if (configFile.exists()) {
+            config = IAMConfiguration.loadConfig(configFile);
+        } else {
+            throw new IAMStarterException("IAM configuration not found in : " + configFile.getAbsolutePath());
+        }
+    }
+}

--- a/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarterException.java
+++ b/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/IAMStarterException.java
@@ -1,0 +1,33 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.boot.microservices;
+
+class IAMStarterException extends RuntimeException {
+
+    public IAMStarterException(String message) {
+        super(message);
+    }
+}

--- a/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/util/IAMConfiguration.java
+++ b/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/util/IAMConfiguration.java
@@ -57,7 +57,7 @@ public class IAMConfiguration {
 
     }
 
-    public static Configuration loadConfig(File configFile) {
+    public static Configuration loadConfig(File configFile) throws ConfigurationException {
 
         Configuration config = new BaseConfiguration();
 
@@ -72,12 +72,7 @@ public class IAMConfiguration {
 
         builder.configure(propertyParameters);
 
-        try {
-            config = builder.getConfiguration();
-
-        } catch (ConfigurationException cex) {
-            LOGGER.error("loading of IAM configuration failed");
-        }
+        config = builder.getConfiguration();
 
         return config;
     }

--- a/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/util/IAMConfiguration.java
+++ b/boot-microservices/src/main/java/org/ow2/proactive/boot/microservices/util/IAMConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.boot.microservices.util;
+
+import java.io.File;
+
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.builder.fluent.PropertiesBuilderParameters;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
+import org.apache.commons.configuration2.convert.ListDelimiterHandler;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.log4j.Logger;
+
+
+public class IAMConfiguration {
+
+    public static final String PROPERTIES_FILE = "iam.properties";
+
+    public static final String ARCHIVE_NAME = "iam.archive.name";
+
+    public static final String STARTUP_TIMEOUT = "iam.startup.timeout";
+
+    public static final String READY_MARKER = "iam.ready.marker";
+
+    public static final String JVM_ARGS = "iam.jvm.args";
+
+    private static final Logger LOGGER = Logger.getLogger(IAMConfiguration.class);
+
+    private IAMConfiguration() {
+
+    }
+
+    public static Configuration loadConfig(File configFile) {
+
+        Configuration config = new BaseConfiguration();
+
+        ListDelimiterHandler delimiter = new DefaultListDelimiterHandler(',');
+
+        PropertiesBuilderParameters propertyParameters = new Parameters().properties();
+        propertyParameters.setFile(configFile);
+        propertyParameters.setThrowExceptionOnMissing(true);
+        propertyParameters.setListDelimiterHandler(delimiter);
+
+        FileBasedConfigurationBuilder<PropertiesConfiguration> builder = new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class);
+
+        builder.configure(propertyParameters);
+
+        try {
+            config = builder.getConfiguration();
+
+        } catch (ConfigurationException cex) {
+            LOGGER.error("loading of IAM configuration failed");
+        }
+
+        return config;
+    }
+}

--- a/config/boot/iam.properties
+++ b/config/boot/iam.properties
@@ -1,0 +1,4 @@
+iam.archive.name = iam.war
+iam.startup.timeout = 180
+iam.ready.marker = Ready to process requests
+iam.jvm.args = -Xmx2048M

--- a/config/boot/iam.properties
+++ b/config/boot/iam.properties
@@ -1,4 +1,5 @@
-iam.archive.name = iam.war
-iam.startup.timeout = 180
-iam.ready.marker = Ready to process requests
-iam.jvm.args = -Xmx2048M
+## Properties needed by IAMStarter in the boot-microservices module
+iam.archive.name=iam.war
+iam.startup.timeout=180
+iam.ready.marker=Ready to process requests
+iam.jvm.args=-Xmx2048M

--- a/config/log/server.properties
+++ b/config/log/server.properties
@@ -24,6 +24,7 @@ log4j.logger.org.ow2.proactive.scheduler.util.console=INFO, CONSOLE
 log4j.logger.org.ow2.proactive.scheduler.util.SchedulerStarter=INFO, CONSOLE
 log4j.logger.org.ow2.proactive.scheduler.util.WarWrapper=INFO, CONSOLE
 log4j.logger.org.ow2.proactive.utils.JettyStarter=INFO, CONSOLE
+log4j.logger.org.ow2.proactive.boot.microservices.IAMStarter=INFO, CONSOLE
 
 # Logs from REST server
 log4j.logger.org.ow2.proactive_grid_cloud_portal=INFO

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -96,7 +96,7 @@ pa.scheduler.startscripts.paths=tools/LoadPackages.groovy
 # Path to boot (early starting) microservices
 pa.boot.microservices.path=dist/boot/
 
-Path to boot (early starting) microservices
+#Path to boot (early starting) microservices
 pa.boot.configuration.path=config/boot/
 
 #-------------------------------------------------------

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -94,10 +94,10 @@ pa.scheduler.core.listener.threadnumber=5
 pa.scheduler.startscripts.paths=tools/LoadPackages.groovy
 
 # Path to boot (early starting) microservices
-pa.boot.microservices.path= dist/boot/
+pa.boot.microservices.path=dist/boot/
 
 Path to boot (early starting) microservices
-pa.boot.configuration.path= config/boot/
+pa.boot.configuration.path=config/boot/
 
 #-------------------------------------------------------
 #----------------   JOBS PROPERTIES   ------------------

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -93,6 +93,12 @@ pa.scheduler.core.listener.threadnumber=5
 # List of the scripts paths to execute at scheduler start. Paths are separated by a ';'.
 pa.scheduler.startscripts.paths=tools/LoadPackages.groovy
 
+# Path to boot (early starting) microservices
+pa.boot.microservices.path= dist/boot/
+
+Path to boot (early starting) microservices
+pa.boot.configuration.path= config/boot/
+
 #-------------------------------------------------------
 #----------------   JOBS PROPERTIES   ------------------
 #-------------------------------------------------------

--- a/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
@@ -142,13 +142,13 @@ public class RestFuncTHelper {
 
         // Connect a scheduler client
         SchedulerAuthenticationInterface schedAuth = SchedulerConnection.waitAndJoin(url,
-                                                                                     TimeUnit.SECONDS.toMillis(120));
+                                                                                     TimeUnit.SECONDS.toMillis(240));
         schedulerPublicKey = schedAuth.getPublicKey();
         Credentials schedCred = RestFuncTUtils.createCredentials("admin", "admin", schedulerPublicKey);
         scheduler = schedAuth.login(schedCred);
 
         // Connect a rm client
-        RMAuthentication rmAuth = RMConnection.waitAndJoin(url, TimeUnit.SECONDS.toMillis(120));
+        RMAuthentication rmAuth = RMConnection.waitAndJoin(url, TimeUnit.SECONDS.toMillis(240));
         Credentials rmCredentials = getRmCredentials();
         rm = rmAuth.login(rmCredentials);
 

--- a/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
@@ -80,6 +80,8 @@ public class RestFuncTHelper {
     public static final String RM_CRED_RELATIVE_PATH = "config" + File.separator + "authentication" + File.separator +
                                                        "rm.cred";
 
+    private static final int SCHEDULER_CONNECTION_TIMEOUT = 240;
+
     private static String restServerUrl;
 
     private static String restfulSchedulerUrl;
@@ -142,13 +144,13 @@ public class RestFuncTHelper {
 
         // Connect a scheduler client
         SchedulerAuthenticationInterface schedAuth = SchedulerConnection.waitAndJoin(url,
-                                                                                     TimeUnit.SECONDS.toMillis(240));
+                                                                                     TimeUnit.SECONDS.toMillis(SCHEDULER_CONNECTION_TIMEOUT));
         schedulerPublicKey = schedAuth.getPublicKey();
         Credentials schedCred = RestFuncTUtils.createCredentials("admin", "admin", schedulerPublicKey);
         scheduler = schedAuth.login(schedCred);
 
         // Connect a rm client
-        RMAuthentication rmAuth = RMConnection.waitAndJoin(url, TimeUnit.SECONDS.toMillis(240));
+        RMAuthentication rmAuth = RMConnection.waitAndJoin(url, TimeUnit.SECONDS.toMillis(SCHEDULER_CONNECTION_TIMEOUT));
         Credentials rmCredentials = getRmCredentials();
         rm = rmAuth.login(rmCredentials);
 

--- a/rest/rest-server/src/test/java/functionaltests/utils/RestFuncTUtils.java
+++ b/rest/rest-server/src/test/java/functionaltests/utils/RestFuncTUtils.java
@@ -49,11 +49,10 @@ public class RestFuncTUtils {
     }
 
     public static void destroy(Process process) throws Exception {
-        process.destroy();
         close(process.getOutputStream());
         close(process.getInputStream());
         close(process.getErrorStream());
-        process.waitFor();
+        process.destroyForcibly();
         System.out.println(String.format("Process ended with exit code %d. ", process.exitValue()));
     }
 

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/OperatingSystem.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/OperatingSystem.java
@@ -55,7 +55,7 @@ public enum OperatingSystem {
         if ("LINUX".equals(desc) || "UNIX".equals(desc)) {
             return OperatingSystem.UNIX;
         }
-        if ("WINDOWS".equals(desc)) {
+        if (desc.contains("WINDOWS")) {
             return OperatingSystem.WINDOWS;
         }
         if ("CYGWIN".equals(desc)) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -137,6 +137,14 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** List of the scripts paths to execute at scheduler start. Paths are separated by a ';'. */
     SCHEDULER_STARTSCRIPTS_PATHS("pa.scheduler.startscripts.paths", PropertyType.LIST),
 
+    /** Path to boot (early starting) microservices (e.g., configuration and iam micro-services). */
+    SCHEDULER_BOOT_MICROSERVICES_PATH("pa.boot.microservices.path", PropertyType.STRING),
+
+    /** Path to boot microservices configuration. */
+    SCHEDULER_BOOT_CONFIGURATION_PATH("pa.boot.configuration.path", PropertyType.STRING),
+
+    /* ***************************************************************** */
+
     /* ***************************************************************** */
     /* ********************** AUTHENTICATION PROPERTIES **************** */
     /* ***************************************************************** */

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     compile project(':scheduler:scheduler-node')
     compile project(':rm:rm-server')
     compile project(':rm:rm-client')
-    //compile project(':rest:rest-server')
     compile project(':boot-microservices')
 
     testCompile "com.google.jimfs:jimfs:1.1"

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -31,9 +31,8 @@ dependencies {
     compile project(':scheduler:scheduler-node')
     compile project(':rm:rm-server')
     compile project(':rm:rm-client')
-
-
-
+    //compile project(':rest:rest-server')
+    compile project(':boot-microservices')
 
     testCompile "com.google.jimfs:jimfs:1.1"
     testCompile "org.objectweb.proactive:programming-extension-pnp:${programmingVersion}"

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -52,6 +52,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import org.objectweb.proactive.core.ProActiveException;
@@ -224,7 +226,7 @@ public class SchedulerStarter {
      *  Launch boot (i.e., early-starting) microservices (notably, IAM microservice)
      *
      */
-    private static void startBootMicroservices() throws IOException, InterruptedException, ExecutionException {
+    private static void startBootMicroservices() throws IOException, InterruptedException, ExecutionException, ConfigurationException {
 
         // Do nothing if PA_home or the boot microservices path is not specified
         if (!(PASchedulerProperties.SCHEDULER_BOOT_MICROSERVICES_PATH.isSet() &&
@@ -415,8 +417,9 @@ public class SchedulerStarter {
                 //Shutting down boot microservices (notably the IAM microservice)
                 LOGGER.info("Stopping boot microservices...");
 
-                for (Process process : bootMicroservicesProcesses)
+                for (Process process : bootMicroservicesProcesses){
                     process.destroyForcibly();
+                }
 
                 LOGGER.info("Shutting down...");
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,3 +26,4 @@ include 'rest:rest-client'
 include 'rest:rest-smartproxy'
 
 include 'war-wrapper'
+include 'boot-microservices'

--- a/war-wrapper/build.gradle
+++ b/war-wrapper/build.gradle
@@ -12,6 +12,7 @@ configurations {
 
 task deleteConfigFiles(type: Delete){
     delete 'build/classes/main/config'
+    delete 'build/classes/main/dist'
 }
 
 task copyConfigFiles(type: Copy) {
@@ -19,8 +20,13 @@ task copyConfigFiles(type: Copy) {
     into 'build/classes/main/config'
 }
 
+task copyDistFiles(type: Copy) {
+    from project(':').files('dist/boot')
+    into 'build/classes/main/dist/boot'
+}
+
 copyConfigFiles.dependsOn deleteConfigFiles
-test.dependsOn copyConfigFiles
+test.dependsOn copyConfigFiles, copyDistFiles
 
 dependencies {
 
@@ -51,6 +57,10 @@ war {
 
         into('WEB-INF/classes/dist/lib') {
             from { configurations.providedCompile}
+        }
+
+        into('WEB-INF/classes/dist/boot') {
+            from project(':').files('dist/boot', '*')
         }
 
         manifest {

--- a/war-wrapper/build.gradle
+++ b/war-wrapper/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '1.7.0RC4'
     testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '1.7.0RC4'
 
+    testCompile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.1'
+
 }
 
 sourceSets {


### PR DESCRIPTION
A new Java module called 'boot-microservices' is added. It contains a class called 'IAMStarter', which starts the IAM microservice. This class is early executed by the 'SchedulerStarter' class, i.e., before starting core ProActive components.

- IAM log is generated under $PA_Home/logs/iam.log (similar to exisiting microservices).
- The IAM process is properly killed when PA is shut down.
- IAMStarter requires the 'iam.war' file to be added under the 'dist/boot' directory. This is done when building the scheduling project (boot-microservices/build.gradle contains a task downloadFile), and during the release (for the distribution).
- The 'iam.war' file is the outcome of the iam project (https://github.com/ow2-proactive/iam).

Fixed issues:
- IAM log is generated under $PA_Home/logs/iam.log (similar to exisiting microservices)
- Java command (in IAMStarter) is portable and can be  executed in Linux and Windows
- iam.war is downloaded properly as a dependency of the 'boot-microservices' module
- iam.war do not contain duplicate dependencies, neither an embedded war archive

