### PR TITLE
Fix deadlock in LocalInfrastrucure by writing protected variables in separate threads only.

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
@@ -365,26 +365,26 @@ public class LocalInfrastructure extends InfrastructureManager {
     }
 
     private void increaseNumberOfHandledNodesWithLockAndPersist(final int additionalNumberOfNodes) {
-        setPersistedInfraVariable((PersistedInfraVariablesHandler<Void>) () -> {
+        setPersistedInfraVariable(() -> {
             int updated = (int) this.persistedInfraVariables.get(NB_HANDLED_NODES_KEY) + additionalNumberOfNodes;
             this.persistedInfraVariables.put(NB_HANDLED_NODES_KEY, updated);
-            return null;
+            return updated;
         });
     }
 
     private void incrementNumberOfAcquiredNodesWithLockAndPersist() {
-        setPersistedInfraVariable((PersistedInfraVariablesHandler<Void>) () -> {
+        setPersistedInfraVariable(() -> {
             int updated = (int) this.persistedInfraVariables.get(NB_ACQUIRED_NODES_KEY) + 1;
             this.persistedInfraVariables.put(NB_ACQUIRED_NODES_KEY, updated);
-            return null;
+            return updated;
         });
     }
 
     private void incrementNumberOfLostNodesWithLockAndPersist() {
-        setPersistedInfraVariable((PersistedInfraVariablesHandler<Void>) () -> {
+        setPersistedInfraVariable(() -> {
             int updated = (int) this.persistedInfraVariables.get(NB_LOST_NODES_KEY) + 1;
             this.persistedInfraVariables.put(NB_LOST_NODES_KEY, updated);
-            return null;
+            return updated;
         });
     }
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.security.KeyException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,7 +86,7 @@ public class LocalInfrastructure extends InfrastructureManager {
     /**
      * A map containing process executors, associated with their corresponding deployment node urls.
      */
-    private transient Map<ProcessExecutor, List<String>> processExecutors = new ConcurrentHashMap<>();
+    private transient ConcurrentHashMap<ProcessExecutor, List<String>> processExecutors = new ConcurrentHashMap<>();
 
     @Override
     public String getDescription() {
@@ -119,19 +120,23 @@ public class LocalInfrastructure extends InfrastructureManager {
 
     @Override
     public void acquireNode() {
-        startNodes(1);
+        if (maxNodes - getNumberOfAcquiredNodesWithLock() > 0) {
+            startNodes(1);
+        }
     }
 
     @Override
     public void acquireNodes(int n, Map<String, ?> nodeConfiguration) {
-        if (n > 0) {
+        if (n > 0 && (maxNodes - getNumberOfAcquiredNodesWithLock() - n) >= 0) {
             startNodes(n);
         }
     }
 
-    private void startNodes(final int n) {
-        increaseNumberOfHandledNodesWithLockAndPersist(n);
-        this.nodeSource.executeInParallel(() -> LocalInfrastructure.this.startNodeProcess(n));
+    private void startNodes(final int numberOfNodes) {
+        this.nodeSource.executeInParallel(() -> {
+            increaseNumberOfHandledNodesWithLockAndPersist(numberOfNodes);
+            LocalInfrastructure.this.startNodeProcess(numberOfNodes);
+        });
     }
 
     private void startNodeProcess(int numberOfNodes) {
@@ -219,53 +224,8 @@ public class LocalInfrastructure extends InfrastructureManager {
             String mess = "Cannot launch rm node " + baseNodeName + lf + Throwables.getStackTraceAsString(e);
             multipleDeclareDeployingNodeLost(depNodeURLs, mess);
             if (processExecutor != null) {
-                cleanProcess(processExecutor);
-            }
-            return;
-        }
-
-        // watching process
-        int threshold = 10;
-        while (!allNodesAcquiredOrLost()) {
-            if (processExecutor.isProcessFinished()) {
-                int exit = processExecutor.getExitCode();
-                if (exit != 0) {
-                    String lf = System.lineSeparator();
-                    String message = "RMNode exit code == " + exit + lf;
-                    message += "Command: " + obfuscatedCmd + lf;
-                    String out = Joiner.on('\n').join(processExecutor.getOutput());
-                    String err = Joiner.on('\n').join(processExecutor.getErrorOutput());
-                    message += "stdout: " + out + lf + "stderr: " + err;
-                    multipleDeclareDeployingNodeLost(depNodeURLs, message);
-                }
-            } else {
-                logger.debug("Waiting for nodes " + baseNodeName + " acquisition");
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                logger.warn("Interrupted while waiting for local process status", e);
-                threshold--;
-                if (threshold <= 0) {
-                    break;
-                }
-            }
-        }
-
-        logger.debug("Local Infrastructure manager exits watching loop for nodes " + baseNodeName);
-        logNodeOutput(baseNodeName + " stdout: ", processExecutor.getOutput());
-        logNodeOutput(baseNodeName + " stderr: ", processExecutor.getErrorOutput());
-
-        if (allNodesLost(numberOfNodes)) {
-            // clean up the process
-            cleanProcess(processExecutor);
-        }
-    }
-
-    private void logNodeOutput(final String prefix, List<String> nodeOutputLines) {
-        if (nodeOutputLines != null) {
-            for (String processOutputLine : nodeOutputLines) {
-                logger.debug(prefix + processOutputLine);
+                processExecutor.killProcess();
+                this.processExecutors.remove(processExecutor);
             }
         }
     }
@@ -285,22 +245,6 @@ public class LocalInfrastructure extends InfrastructureManager {
                                                 this.nodeTimeout);
             String st = Throwables.getStackTraceAsString(e);
             super.declareDeployingNodeLost(url, message + lf + st);
-        }
-    }
-
-    private boolean allNodesAcquiredOrLost() {
-        return (getNumberOfAcquiredNodesWithLock() +
-                getNumberOfLostNodesWithLock()) >= getNumberOfHandledNodesWithLock();
-    }
-
-    private boolean allNodesLost(int numberOfNodes) {
-        return getNumberOfLostNodesWithLock() >= numberOfNodes;
-    }
-
-    private void cleanProcess(ProcessExecutor processExecutor) {
-        if (processExecutor != null) {
-            processExecutor.killProcess();
-            this.processExecutors.remove(processExecutor);
         }
     }
 
@@ -350,18 +294,12 @@ public class LocalInfrastructure extends InfrastructureManager {
     public void removeNode(Node node) throws RMException {
         logger.debug("A node is removed " + node.getNodeInformation().getURL() + " from " +
                      this.getClass().getSimpleName());
-        removeAcquiredNodesAndShutDownIfNeeded();
+        removeNodeAndShutdownProcessIfNeeded(node.getNodeInformation().getURL());
     }
 
     @Override
     public void notifyDownNode(String nodeName, String nodeUrl, Node node) {
-        logger.debug("A down node is removed: " + nodeUrl + " from " + this.getClass().getSimpleName());
-        removeAcquiredNodesAndShutDownIfNeeded();
-    }
-
-    @Override
-    public void onDownNodeReconnection(Node node) {
-        incrementNumberOfAcquiredNodesWithLockAndPersist();
+        logger.debug("A down node is detected: " + nodeUrl + " from " + this.getClass().getSimpleName());
     }
 
     @Override
@@ -389,22 +327,49 @@ public class LocalInfrastructure extends InfrastructureManager {
         this.persistedInfraVariables.put(LAST_NODE_STARTED_INDEX_KEY, 0);
     }
 
-    private void removeAcquiredNodesAndShutDownIfNeeded() {
-        int remainingNodesCount = decrementAndGetNumberOfAcquiredNodesWithLockAndPersist();
-        // if there is no remaining node, kill the JVM process
-        if (remainingNodesCount == 0) {
-            shutDown();
+    private void removeNodeAndShutdownProcessIfNeeded(String nodeUrl) {
+
+        // Update handle & acquire/lost nodes persistent counters
+        decrementNumberOfHandledNodesWithLockAndPersist();
+        if (nodeSource.getNodeInDeployingOrLostNodes(nodeUrl) == null) {
+            decrementNumberOfLostNodesWithLockAndPersist();
+        } else {
+            decrementNumberOfAcquiredNodesWithLockAndPersist();
+        }
+
+        // Delete the process if it doesn't have remaining node
+        Iterator<Map.Entry<ProcessExecutor, List<String>>> processIterator = processExecutors.entrySet().iterator();
+        while (processIterator.hasNext()) {
+            Map.Entry<ProcessExecutor, List<String>> processExecutor = processIterator.next();
+            if (processExecutor.getValue().contains(nodeUrl)) {
+                processExecutor.getValue().remove(nodeUrl);
+                // if there is no remaining node, kill the JVM process
+                if (processExecutor.getValue().isEmpty()) {
+                    if (processExecutor.getKey() != null) {
+                        processExecutor.getKey().killProcess();
+                    }
+                    processIterator.remove();
+                }
+            }
         }
     }
 
     // Below are wrapper methods around the runtime variables map
 
+    private int getNumberOfHandledNodesWithLock() {
+        return getPersistedInfraVariable(() -> (int) this.persistedInfraVariables.get(NB_HANDLED_NODES_KEY));
+    }
+
     private int getNumberOfAcquiredNodesWithLock() {
         return getPersistedInfraVariable(() -> (int) this.persistedInfraVariables.get(NB_ACQUIRED_NODES_KEY));
     }
 
-    private int getNumberOfLostNodesWithLock() {
-        return getPersistedInfraVariable(() -> (int) this.persistedInfraVariables.get(NB_LOST_NODES_KEY));
+    private void increaseNumberOfHandledNodesWithLockAndPersist(final int additionalNumberOfNodes) {
+        setPersistedInfraVariable((PersistedInfraVariablesHandler<Void>) () -> {
+            int updated = (int) this.persistedInfraVariables.get(NB_HANDLED_NODES_KEY) + additionalNumberOfNodes;
+            this.persistedInfraVariables.put(NB_HANDLED_NODES_KEY, updated);
+            return null;
+        });
     }
 
     private void incrementNumberOfAcquiredNodesWithLockAndPersist() {
@@ -423,23 +388,27 @@ public class LocalInfrastructure extends InfrastructureManager {
         });
     }
 
-    private int decrementAndGetNumberOfAcquiredNodesWithLockAndPersist() {
-        return setPersistedInfraVariable(() -> {
+    private void decrementNumberOfHandledNodesWithLockAndPersist() {
+        setPersistedInfraVariable(() -> {
+            int updated = (int) this.persistedInfraVariables.get(NB_HANDLED_NODES_KEY) - 1;
+            this.persistedInfraVariables.put(NB_HANDLED_NODES_KEY, updated);
+            return updated;
+        });
+    }
+
+    private void decrementNumberOfAcquiredNodesWithLockAndPersist() {
+        setPersistedInfraVariable(() -> {
             int updated = (int) this.persistedInfraVariables.get(NB_ACQUIRED_NODES_KEY) - 1;
             this.persistedInfraVariables.put(NB_ACQUIRED_NODES_KEY, updated);
             return updated;
         });
     }
 
-    private int getNumberOfHandledNodesWithLock() {
-        return getPersistedInfraVariable(() -> (int) this.persistedInfraVariables.get(NB_HANDLED_NODES_KEY));
-    }
-
-    private void increaseNumberOfHandledNodesWithLockAndPersist(final int additionalNumberOfNodes) {
-        setPersistedInfraVariable((PersistedInfraVariablesHandler<Void>) () -> {
-            int updated = (int) this.persistedInfraVariables.get(NB_HANDLED_NODES_KEY) + additionalNumberOfNodes;
-            this.persistedInfraVariables.put(NB_HANDLED_NODES_KEY, updated);
-            return null;
+    private void decrementNumberOfLostNodesWithLockAndPersist() {
+        setPersistedInfraVariable(() -> {
+            int updated = (int) this.persistedInfraVariables.get(NB_LOST_NODES_KEY) - 1;
+            this.persistedInfraVariables.put(NB_LOST_NODES_KEY, updated);
+            return updated;
         });
     }
 
@@ -455,5 +424,4 @@ public class LocalInfrastructure extends InfrastructureManager {
         return getPersistedInfraVariable(() -> (int) this.persistedInfraVariables.get(NB_HANDLED_NODES_KEY) -
                                                (int) this.persistedInfraVariables.get(NB_ACQUIRED_NODES_KEY));
     }
-
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/LocalInfrastructure.java
@@ -126,9 +126,9 @@ public class LocalInfrastructure extends InfrastructureManager {
     }
 
     @Override
-    public void acquireNodes(int n, Map<String, ?> nodeConfiguration) {
-        if (n > 0 && (maxNodes - getNumberOfAcquiredNodesWithLock() - n) >= 0) {
-            startNodes(n);
+    public void acquireNodes(int numberOfNodes, Map<String, ?> nodeConfiguration) {
+        if (numberOfNodes > 0 && (maxNodes - getNumberOfAcquiredNodesWithLock() - numberOfNodes) >= 0) {
+            startNodes(numberOfNodes);
         }
     }
 


### PR DESCRIPTION
This also makes the infrastructure more clean and robust:
 - Do not acquire more than maxNodes nodes
 - Do not manually check the status of deployment processes
 - Delete processes when removing latest node
 - Use concurrent hashmap to safely manipulate 'nodes to processes' mapping
 - Decrement all appropriate counters when deleting a node
 - Do not mess with down nodes detection: do not touch acquiredNode counter!
 - Reorder, simplify and add some wrapper methods
 - Remove unused methods and dead code