### PR TITLE
Use RSA instead of DSA to prevent errors on recent JDK updates

### DIFF
--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2.java
@@ -122,7 +122,9 @@ public class TestSSHInfrastructureV2 extends RMFunctionalTest {
 
         sshd = SshServer.setUpDefaultServer();
 
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
+        SimpleGeneratorHostKeyProvider keyProvider = new SimpleGeneratorHostKeyProvider();
+        keyProvider.setAlgorithm("RSA");
+        sshd.setKeyPairProvider(keyProvider);
 
         List<NamedFactory<UserAuth>> userAuthFactories = new ArrayList<>(1);
         userAuthFactories.add(new UserAuthPasswordFactory());


### PR DESCRIPTION
Will stabilize SSH functional tests described in #3218 