### PR TITLE
Fix binding replacement used to compute digest in selection script

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/ScriptExecutor.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/ScriptExecutor.java
@@ -90,8 +90,8 @@ public class ScriptExecutor implements Callable<Node> {
 
                 logger.info(rmnode.getNodeURL() + " : " + script.hashCode() + " executing");
                 try {
-                    ScriptResult<Boolean> scriptResult = rmnode.executeScript(script, criteria.getBindings());
                     atLeastOneScriptExecuted = true;
+                    ScriptResult<Boolean> scriptResult = rmnode.executeScript(script, criteria.getBindings());
 
                     // processing the results
                     if (!MOP.isReifiedObject(scriptResult) && scriptResult.getException() != null) {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbablisticSelectionManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbablisticSelectionManager.java
@@ -277,7 +277,13 @@ public class ProbablisticSelectionManager extends SelectionManager {
         String scriptContent = script.getScript();
         if (bindings != null) {
             for (Map.Entry<String, Serializable> entry : bindings.entrySet()) {
-                scriptContent = scriptContent.replace(entry.getKey(), entry.getValue().toString());
+                String reservedKeyword = entry.getKey();
+                Serializable binding = entry.getValue();
+                if (binding instanceof Map) {
+                    scriptContent = replaceBindingKeysByTheirValue(scriptContent, (Map<String, Serializable>) binding);
+                } else {
+                    scriptContent = scriptContent.replace(reservedKeyword, binding.toString());
+                }
             }
         }
         try {
@@ -290,6 +296,13 @@ public class ProbablisticSelectionManager extends SelectionManager {
                         System.lineSeparator() + script.toString(), e);
             return script;
         }
+    }
+
+    private String replaceBindingKeysByTheirValue(String scriptContent, Map<String, Serializable> binding) {
+        for (Map.Entry<String, Serializable> variableMapping : binding.entrySet()) {
+            scriptContent = scriptContent.replace(variableMapping.getKey(), variableMapping.getValue().toString());
+        }
+        return scriptContent;
     }
 
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbablisticSelectionManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbablisticSelectionManager.java
@@ -282,7 +282,9 @@ public class ProbablisticSelectionManager extends SelectionManager {
                 if (binding instanceof Map) {
                     scriptContent = replaceBindingKeysByTheirValue(scriptContent, (Map<String, Serializable>) binding);
                 } else {
-                    scriptContent = scriptContent.replace(reservedKeyword, binding.toString());
+                    if (binding != null) {
+                        scriptContent = scriptContent.replace(reservedKeyword, binding.toString());
+                    }
                 }
             }
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbablisticSelectionManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbablisticSelectionManager.java
@@ -302,7 +302,10 @@ public class ProbablisticSelectionManager extends SelectionManager {
 
     private String replaceBindingKeysByTheirValue(String scriptContent, Map<String, Serializable> binding) {
         for (Map.Entry<String, Serializable> variableMapping : binding.entrySet()) {
-            scriptContent = scriptContent.replace(variableMapping.getKey(), variableMapping.getValue().toString());
+            Serializable bindingValue = variableMapping.getValue();
+            if (bindingValue != null) {
+                scriptContent = scriptContent.replace(variableMapping.getKey(), bindingValue.toString());
+            }
         }
         return scriptContent;
     }

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbabilisticSelectionManagerTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/selection/statistics/ProbabilisticSelectionManagerTest.java
@@ -252,12 +252,11 @@ public class ProbabilisticSelectionManagerTest {
         ManagerObjects managerObjects = new ManagerObjects(1).invoke();
         SelectionManager selectionManager = managerObjects.getSelectionManager();
         ArrayList<RMNode> freeNodes = managerObjects.getFreeNodes();
-        Map<String, Serializable> bindings = Collections.singletonMap("TOTO", (Serializable) "value");
+
         selectionManager.processScriptResult(script,
                                              Collections.singletonMap("TOTO", (Serializable) "value"),
                                              new ScriptResult<>(true),
                                              freeNodes.get(0));
-
         Assert.assertTrue(selectionManager.isPassed(script,
                                                     Collections.singletonMap("TOTO", (Serializable) "value"),
                                                     freeNodes.get(0)));


### PR DESCRIPTION
- in selection script, change the way the bindings are replaced in the script to compute the digest of the script. The issue was that the reserved proactive keyword were replaced by the in-extension map of all bindings, resulting in scripts whose digest change from one job to another, even if the selection script did not change itself. The fix for this problem is to not replace the proactive keyword by the full map (if the considered binding is a map, otherwise, the behavior is not changed), but to replace the key of the binding used in the script by its value. This is enough to identify that a script did not change and does not need to be re-executed.