### PR TITLE
Include java security policy in node.jar

### DIFF
--- a/config/log/scriptengines.properties
+++ b/config/log/scriptengines.properties
@@ -1,5 +1,7 @@
 log4j.rootLogger=INFO, CONSOLE
 
+log4j.logger.org.eclipse.jetty=WARN
+
 # Console appender
 log4j.logger.jsr223.docker.compose.utils.DockerComposePropertyLoader=INFO, CONSOLE
 log4j.logger.jsr223.perl.utils.PerlPropertyLoader=INFO, CONSOLE

--- a/scheduler/scheduler-node/build.gradle
+++ b/scheduler/scheduler-node/build.gradle
@@ -52,6 +52,15 @@ ext.oneJarManifest = manifest {
     attributes 'One-Jar-Expand': 'lib,binlib,main' // expand jars for subprocesses (forked tasks)
 }
 
+task cleanPolicy(type: Delete) {
+    delete 'src/main/resources/security.java.policy-client'
+}
+
+task copyPolicy(type: Copy){
+    from '../../config/security.java.policy-client'
+    into 'src/main/resources'
+}
+
 task standaloneJar(type: OneJar) {
     logging.captureStandardOutput LogLevel.INFO
     mainClass = 'org.ow2.proactive.resourcemanager.utils.RMNodeStarter'
@@ -59,7 +68,13 @@ task standaloneJar(type: OneJar) {
     additionalDir = file('src/main/resources')
     manifest = oneJarManifest
 }
+
+copyPolicy.dependsOn cleanPolicy
+
+standaloneJar.dependsOn copyPolicy
+
 build.dependsOn standaloneJar
+
 artifacts {
     archives standaloneJar
 }

--- a/scheduler/scheduler-node/build.gradle
+++ b/scheduler/scheduler-node/build.gradle
@@ -52,15 +52,6 @@ ext.oneJarManifest = manifest {
     attributes 'One-Jar-Expand': 'lib,binlib,main' // expand jars for subprocesses (forked tasks)
 }
 
-task cleanPolicy(type: Delete) {
-    delete 'src/main/resources/security.java.policy-client'
-}
-
-task copyPolicy(type: Copy){
-    from '../../config/security.java.policy-client'
-    into 'src/main/resources'
-}
-
 task standaloneJar(type: OneJar) {
     logging.captureStandardOutput LogLevel.INFO
     mainClass = 'org.ow2.proactive.resourcemanager.utils.RMNodeStarter'
@@ -68,10 +59,6 @@ task standaloneJar(type: OneJar) {
     additionalDir = file('src/main/resources')
     manifest = oneJarManifest
 }
-
-copyPolicy.dependsOn cleanPolicy
-
-standaloneJar.dependsOn copyPolicy
 
 build.dependsOn standaloneJar
 

--- a/scheduler/scheduler-node/build.gradle
+++ b/scheduler/scheduler-node/build.gradle
@@ -59,9 +59,7 @@ task standaloneJar(type: OneJar) {
     additionalDir = file('src/main/resources')
     manifest = oneJarManifest
 }
-
 build.dependsOn standaloneJar
-
 artifacts {
     archives standaloneJar
 }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ExecuteForkedTaskInsideNewJvm.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ExecuteForkedTaskInsideNewJvm.java
@@ -103,9 +103,7 @@ public class ExecuteForkedTaskInsideNewJvm {
             System.exit(-1);
         }
 
-        System.setProperty("java.security.policy",
-                           ExecuteForkedTaskInsideNewJvm.class.getResource("/" + JAVA_SECURITY_POLICY_FILE).toString());
-        Policy.getPolicy().refresh();
+        setSecurityPolicy();
 
         ExecuteForkedTaskInsideNewJvm instance = ExecuteForkedTaskInsideNewJvm.getInstance();
 
@@ -113,6 +111,12 @@ public class ExecuteForkedTaskInsideNewJvm {
 
         // Call to System.exit is necessary at this point (when the task is finished normally) as the forked JVM can keep alive non-daemon threads
         System.exit(0);
+    }
+
+    private static void setSecurityPolicy() {
+        System.setProperty("java.security.policy",
+                           ExecuteForkedTaskInsideNewJvm.class.getResource("/" + JAVA_SECURITY_POLICY_FILE).toString());
+        Policy.getPolicy().refresh();
     }
 
     private void fromForkedJVM(String contextPath) {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ExecuteForkedTaskInsideNewJvm.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ExecuteForkedTaskInsideNewJvm.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
 import java.io.*;
+import java.security.Policy;
 
 import org.apache.commons.io.FileUtils;
 import org.ow2.proactive.scheduler.task.TaskResultImpl;
@@ -34,6 +35,8 @@ import org.ow2.proactive.scheduler.task.executors.InProcessTaskExecutor;
 
 
 public class ExecuteForkedTaskInsideNewJvm {
+
+    private static final String JAVA_SECURITY_POLICY_FILE = "security.java.policy-client";
 
     public static final int MAX_CONTEXT_WAIT = 6000;
 
@@ -99,6 +102,10 @@ public class ExecuteForkedTaskInsideNewJvm {
             System.err.println("Path to serialized task context is expected");
             System.exit(-1);
         }
+
+        System.setProperty("java.security.policy",
+                           ExecuteForkedTaskInsideNewJvm.class.getResource("/" + JAVA_SECURITY_POLICY_FILE).toString());
+        Policy.getPolicy().refresh();
 
         ExecuteForkedTaskInsideNewJvm instance = ExecuteForkedTaskInsideNewJvm.getInstance();
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -51,10 +51,11 @@ import com.google.common.base.Strings;
 
 
 public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
-    private final static String javaHomePostfixJavaExecutable = File.separatorChar + "bin" + File.separatorChar +
-                                                                "java";
 
     private static final Logger logger = Logger.getLogger(ForkedJvmTaskExecutionCommandCreator.class);
+
+    private static final String JAVA_HOME_POSTFIX_JAVA_EXECUTABLE = File.separatorChar + "bin" + File.separatorChar +
+                                                                    "java";
 
     private static final String JAVA_SECURITY_POLICY_FILE = "security.java.policy-client";
 
@@ -142,7 +143,7 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
 
         List<String> javaCommand = new ArrayList<>(prefixes.size() + 3 + jvmArguments.size() + 2);
         javaCommand.addAll(prefixes);
-        javaCommand.add(javaHome + javaHomePostfixJavaExecutable);
+        javaCommand.add(javaHome + JAVA_HOME_POSTFIX_JAVA_EXECUTABLE);
 
         javaCommand.add("-cp");
         javaCommand.add(classpath.toString());

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -94,16 +94,6 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
         // if they are running in a forked task or not
         jvmArguments.add(PASchedulerProperties.TASK_FORK.getCmdLine() + "true");
 
-        if (CentralPAPropertyRepository.JAVA_SECURITY_POLICY.isSet()) {
-            if (ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + JAVA_SECURITY_POLICY_FILE) != null) {
-                jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() +
-                                 ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + JAVA_SECURITY_POLICY_FILE)
-                                                                           .toString());
-            } else {
-                jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() +
-                                 jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getValue()));
-            }
-        }
         // The following code forwards the PAMR configuration the forked JVM. Though the general use-case involves to
         // write a custom fork environment script to configure properly the properties, this avoids a common misconfiguration issues.
         forwardProActiveProperties(jvmArguments,

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -95,9 +95,14 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
         jvmArguments.add(PASchedulerProperties.TASK_FORK.getCmdLine() + "true");
 
         if (CentralPAPropertyRepository.JAVA_SECURITY_POLICY.isSet()) {
-            jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() +
-                             ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + JAVA_SECURITY_POLICY_FILE)
-                                                                       .toString());
+            if (ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + JAVA_SECURITY_POLICY_FILE) != null) {
+                jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() +
+                                 ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + JAVA_SECURITY_POLICY_FILE)
+                                                                           .toString());
+            } else {
+                jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() +
+                                 jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getValue()));
+            }
         }
         // The following code forwards the PAMR configuration the forked JVM. Though the general use-case involves to
         // write a custom fork environment script to configure properly the properties, this avoids a common misconfiguration issues.

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -57,8 +57,6 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
     private static final String JAVA_HOME_POSTFIX_JAVA_EXECUTABLE = File.separatorChar + "bin" + File.separatorChar +
                                                                     "java";
 
-    private static final String JAVA_SECURITY_POLICY_FILE = "security.java.policy-client";
-
     private final TaskContextVariableExtractor taskContextVariableExtractor = new TaskContextVariableExtractor();
 
     private final JavaPrefixCommandExtractor javaPrefixCommandExtractor = new JavaPrefixCommandExtractor();

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -28,7 +28,6 @@ package org.ow2.proactive.scheduler.task.executors.forked.env;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +55,8 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
                                                                 "java";
 
     private static final Logger logger = Logger.getLogger(ForkedJvmTaskExecutionCommandCreator.class);
+
+    private static final String SECURITY_POLICY_FILE_NAME = "security.java.policy-client";
 
     private final TaskContextVariableExtractor taskContextVariableExtractor = new TaskContextVariableExtractor();
 
@@ -96,9 +97,11 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
             jvmArguments.add(CentralPAPropertyRepository.PA_CONFIGURATION_FILE.getCmdLine() +
                              CentralPAPropertyRepository.PA_CONFIGURATION_FILE.getValue());
         }
+
         if (CentralPAPropertyRepository.JAVA_SECURITY_POLICY.isSet()) {
-            jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() +
-                             CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getValue());
+            jvmArguments.add("-Djava.security.policy=" +
+                             ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + SECURITY_POLICY_FILE_NAME)
+                                                                       .toString());
         }
         // The following code forwards the PAMR configuration the forked JVM. Though the general use-case involves to
         // write a custom fork environment script to configure properly the properties, this avoids a common misconfiguration issues.

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedJvmTaskExecutionCommandCreator.java
@@ -56,7 +56,7 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
 
     private static final Logger logger = Logger.getLogger(ForkedJvmTaskExecutionCommandCreator.class);
 
-    private static final String SECURITY_POLICY_FILE_NAME = "security.java.policy-client";
+    private static final String JAVA_SECURITY_POLICY_FILE = "security.java.policy-client";
 
     private final TaskContextVariableExtractor taskContextVariableExtractor = new TaskContextVariableExtractor();
 
@@ -93,14 +93,9 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
         // if they are running in a forked task or not
         jvmArguments.add(PASchedulerProperties.TASK_FORK.getCmdLine() + "true");
 
-        if (CentralPAPropertyRepository.PA_CONFIGURATION_FILE.isSet()) {
-            jvmArguments.add(CentralPAPropertyRepository.PA_CONFIGURATION_FILE.getCmdLine() +
-                             CentralPAPropertyRepository.PA_CONFIGURATION_FILE.getValue());
-        }
-
         if (CentralPAPropertyRepository.JAVA_SECURITY_POLICY.isSet()) {
-            jvmArguments.add("-Djava.security.policy=" +
-                             ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + SECURITY_POLICY_FILE_NAME)
+            jvmArguments.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() +
+                             ForkedJvmTaskExecutionCommandCreator.class.getResource("/" + JAVA_SECURITY_POLICY_FILE)
                                                                        .toString());
         }
         // The following code forwards the PAMR configuration the forked JVM. Though the general use-case involves to
@@ -112,7 +107,8 @@ public class ForkedJvmTaskExecutionCommandCreator implements Serializable {
                                    PAMRConfig.PA_PAMRSSH_KEY_DIR,
                                    PAMRConfig.PA_PAMRSSH_REMOTE_ADDRESS,
                                    PAMRConfig.PA_PAMRSSH_REMOTE_USERNAME,
-                                   PAMRConfig.PA_PAMRSSH_REMOTE_PORT);
+                                   PAMRConfig.PA_PAMRSSH_REMOTE_PORT,
+                                   CentralPAPropertyRepository.PA_COMMUNICATION_PROTOCOL);
 
         configureLogging(jvmArguments, variables);
 

--- a/scheduler/scheduler-node/src/main/resources/config/log/scriptengines.properties
+++ b/scheduler/scheduler-node/src/main/resources/config/log/scriptengines.properties
@@ -1,5 +1,7 @@
 log4j.rootLogger=INFO, CONSOLE
 
+log4j.logger.org.eclipse.jetty=WARN
+
 # Console appender
 log4j.logger.jsr223.docker.compose.utils.DockerComposePropertyLoader=INFO, CONSOLE
 log4j.logger.jsr223.perl.utils.PerlPropertyLoader=INFO, CONSOLE

--- a/scheduler/scheduler-node/src/main/resources/security.java.policy-client
+++ b/scheduler/scheduler-node/src/main/resources/security.java.policy-client
@@ -1,0 +1,3 @@
+grant {
+permission java.security.AllPermission;
+};


### PR DESCRIPTION
- add security.java.policy-client as resource in node.jar
- we use this policy when we start the forked JVM that executes a task