### PR TITLE
Fix RM shutdown

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -419,7 +419,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                 @Override
                 public void run() {
                     if (!toShutDown) {
-                        rmcoreStub.shutdown(true);
+                        PAFuture.waitFor(rmcoreStub.shutdown(true),
+                                         PAResourceManagerProperties.RM_SHUTDOWN_TIMEOUT.getValueAsInt() * 1000);
                     }
                 }
             });
@@ -1691,7 +1692,6 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         try {
             return PAActiveObject.pingActiveObject(entry.getValue());
         } catch (Exception e) {
-            logger.warn("", e);
             return false;
         }
     }


### PR DESCRIPTION
- in commit e079ea1d785f78f523bf9dfb0e9e29b6807eca9c, we oversimplified the shutdown of the RM such that the shutdown hook was finished before cleaning up the nodes (because it was making unwaited asynchronous calls). This commit rehabilitates waiting for the shutdown hook to be completed before exiting, with a configurable timeout.