### PR TITLE
Modify NodeSource shutdown

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1660,10 +1660,10 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             this.deployedNodeSources.size() == 0) {
             finalizeShutdown();
         } else {
-            for (Entry<String, NodeSource> entry : this.deployedNodeSources.entrySet()) {
-                removeAllNodes(entry.getKey(), preempt, true);
-                entry.getValue().shutdown(caller);
-            }
+            this.deployedNodeSources.forEach((nodeSourceName, nodeSource) -> {
+                removeAllNodes(nodeSourceName, preempt, true);
+                nodeSource.shutdown(this.caller);
+            });
             waitForAllNodeSourcesToBeShutdown();
             finalizeShutdown();
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -761,7 +761,6 @@ public class NodeSource implements InitActive, RunActive {
 
         this.activePolicy.shutdown(initiator);
         this.infrastructureManager.internalShutDown();
-        this.rmcore.disconnect(Client.getId(PAActiveObject.getStubOnThis()));
         this.finishNodeSourceShutdown(initiator);
     }
 
@@ -769,6 +768,7 @@ public class NodeSource implements InitActive, RunActive {
      * Terminates a node source active object when the policy is shutdown. 
      */
     public void finishNodeSourceShutdown(Client initiator) {
+        this.rmcore.disconnect(Client.getId(PAActiveObject.getStubOnThis()));
         PAActiveObject.terminateActiveObject(false);
     }
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -659,10 +659,6 @@ public class NodeSource implements InitActive, RunActive {
             }
         }
 
-        if (this.toShutdown && this.nodes.size() == 0) {
-            this.shutdownNodeSourceServices(initiator);
-        }
-
         return new BooleanWrapper(true);
     }
 
@@ -765,6 +761,7 @@ public class NodeSource implements InitActive, RunActive {
 
         this.activePolicy.shutdown(initiator);
         this.infrastructureManager.internalShutDown();
+        this.finishNodeSourceShutdown(initiator);
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -761,6 +761,7 @@ public class NodeSource implements InitActive, RunActive {
 
         this.activePolicy.shutdown(initiator);
         this.infrastructureManager.internalShutDown();
+        this.rmcore.disconnect(Client.getId(PAActiveObject.getStubOnThis()));
         this.finishNodeSourceShutdown(initiator);
     }
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/NodeSourcePolicy.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/NodeSourcePolicy.java
@@ -63,6 +63,8 @@ public abstract class NodeSourcePolicy implements NodeSourcePlugin {
 
     private AtomicInteger handledNodes;
 
+    private RMCore rmCore;
+
     /** Node source of the policy */
     protected NodeSource nodeSource;
 
@@ -122,9 +124,7 @@ public abstract class NodeSourcePolicy implements NodeSourcePlugin {
      * Shutdown the policy
      */
     public void shutdown(Client initiator) {
-        RMCore rmCoreStub = this.nodeSource.getRMCore();
-        this.nodeSource.finishNodeSourceShutdown(initiator);
-        rmCoreStub.disconnect(Client.getId(PAActiveObject.getStubOnThis()));
+        this.rmCore.disconnect(Client.getId(PAActiveObject.getStubOnThis()));
         PAActiveObject.terminateActiveObject(false);
     }
 
@@ -140,6 +140,7 @@ public abstract class NodeSourcePolicy implements NodeSourcePlugin {
      */
     public void setNodeSource(NodeSource nodeSource) {
         this.nodeSource = nodeSource;
+        this.rmCore = this.nodeSource.getRMCore();
         Thread.currentThread().setName("Node Source Policy \"" + nodeSource.getName() + "\"");
     }
 


### PR DESCRIPTION
- remove callback from node source to node source policy shutdown, as it is suspected to be source of deadlock in the RM shutdown, instead the shutdown is asynchronously triggered from the node source and the node source active object is terminated just after.
- modify NodeSourcePolicy so that it does not require a stub reference at shutdown time
- remove the conditional trigger for NodeSource shutdown in the NodeSource#removeNode method. We could not identify a need for it to be triggered there.
- rename variables in RMCore#shutdown to better identify node source and node source name