### PR TITLE
fix for #3251 When removing a job, "precious logs" produced by the job are not removed

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/TaskLoggerRelativePathGenerator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/TaskLoggerRelativePathGenerator.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.scheduler.common.util;
 
+import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 
 
@@ -40,6 +41,24 @@ public class TaskLoggerRelativePathGenerator {
     public TaskLoggerRelativePathGenerator(TaskId taskId) {
         this.fileName = LOG_FILE_PREFIX + "-" + taskId.getJobId() + "-" + taskId.value() + ".log";
         this.relativePath = taskId.getJobId().toString() + "/" + fileName;
+    }
+
+    /**
+     * Return an include pattern to find all log files associated with the given job id
+     * @param jobId id of a job
+     * @return an include pattern;
+     */
+    public static String getIncludePatternForAllLogFiles(JobId jobId) {
+        return jobId.toString() + "/" + LOG_FILE_PREFIX + "-" + jobId.toString() + "-*.log";
+    }
+
+    /**
+     * Return the containing folder of log files for a given job id
+     * @param jobId id of the job associated with logs
+     * @return a containing folder relative path
+     */
+    public static String getContainingFolderForLogFiles(JobId jobId) {
+        return jobId.toString();
     }
 
     public String getRelativePath() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/SchedulerFactory.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/SchedulerFactory.java
@@ -228,11 +228,11 @@ public class SchedulerFactory {
             // creating the scheduler
             // if this fails then it will not continue.
             logger.debug("Creating scheduler frontend...");
-            PAActiveObject.newActive(SchedulerFrontend.class.getName(), new Object[] { rmURL, policyFullClassName });
+            PAActiveObject.newActive(SchedulerFrontend.class, new Object[] { rmURL, policyFullClassName });
 
             //ready
             logger.debug("Scheduler is now ready to be started!");
-            ServerJobAndTaskLogs.configure();
+            ServerJobAndTaskLogs.getInstance().configure();
         } catch (Exception e) {
             logger.error(e);
             e.printStackTrace();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobRemoveHandler.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobRemoveHandler.java
@@ -98,7 +98,7 @@ public class JobRemoveHandler implements Callable<Boolean> {
 
             boolean removeFromDb = PASchedulerProperties.JOB_REMOVE_FROM_DB.getValueAsBoolean();
 
-            dbManager.removeJob(jobId, jobs.get(0).getRemovedTime(), removeFromDb);
+            dbManager.removeJob(jobId, job.getRemovedTime(), removeFromDb);
 
             ServerJobAndTaskLogs.getInstance().remove(jobId, job.getOwner());
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -332,6 +332,8 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
 
             this.spacesSupport = infrastructure.getSpacesSupport();
 
+            ServerJobAndTaskLogs.getInstance().setSpacesSupport(this.spacesSupport);
+
             this.corePublicKey = Credentials.getPublicKey(PASchedulerProperties.getAbsolutePath(PASchedulerProperties.SCHEDULER_AUTH_PUBKEY_PATH.getValueAsString()));
             this.schedulingService = new SchedulingService(infrastructure,
                                                            frontendState,
@@ -1235,7 +1237,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
                                        frontendState.getIdentifiedJob(id),
                                        YOU_DO_NOT_HAVE_PERMISSIONS_TO_GET_THE_LOGS_OF_THIS_JOB);
 
-        return ServerJobAndTaskLogs.getJobLog(JobIdImpl.makeJobId(jobId), frontendState.getJobTasks(id));
+        return ServerJobAndTaskLogs.getInstance().getJobLog(JobIdImpl.makeJobId(jobId), frontendState.getJobTasks(id));
     }
 
     @Override
@@ -1250,7 +1252,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
 
         for (TaskId taskId : frontendState.getJobTasks(id)) {
             if (taskId.getReadableName().equals(taskName)) {
-                return ServerJobAndTaskLogs.getTaskLog(taskId);
+                return ServerJobAndTaskLogs.getInstance().getTaskLog(taskId);
             }
         }
 
@@ -1271,7 +1273,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
             tasksIds.add(taskState.getId());
         }
 
-        return ServerJobAndTaskLogs.getJobLog(id, tasksIds);
+        return ServerJobAndTaskLogs.getInstance().getJobLog(id, tasksIds);
     }
 
     /**

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerSpacesSupport.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerSpacesSupport.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.extensions.dataspaces.api.DataSpacesFileObject;
 import org.objectweb.proactive.extensions.dataspaces.api.PADataSpaces;
@@ -65,7 +66,7 @@ public class SchedulerSpacesSupport {
      * @return the list of uris of the userspace
      */
     public List<String> getUserSpaceURIs(String username) {
-        DataSpacesFileObject o = this.userGlobalSpaces.get(username);
+        DataSpacesFileObject o = getUserSpace(username);
         if (o != null) {
             return o.getAllRealURIs();
         }
@@ -84,6 +85,8 @@ public class SchedulerSpacesSupport {
      * @return the default userspace of an identified user
      */
     public DataSpacesFileObject getUserSpace(String username) {
+        Validate.notBlank(username);
+        registerUserSpace(username);
         return this.userGlobalSpaces.get(username);
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -1117,7 +1117,6 @@ public class SchedulingService {
             List<Long> longList = new ArrayList<>(jobIdList.size());
             for (JobId jobId : jobIdList) {
                 TerminationData terminationData = jobs.removeJob(jobId);
-                ServerJobAndTaskLogs.remove(jobId);
                 submitTerminationDataHandler(terminationData);
             }
             List<InternalJob> jobsFromDB;
@@ -1136,6 +1135,7 @@ public class SchedulingService {
                                                                                 new JobInfoImpl((JobInfoImpl) job.getJobInfo())));
                     getListener().jobUpdatedFullData(job);
                     longList.add(job.getId().longValue());
+                    ServerJobAndTaskLogs.getInstance().remove(job.getId(), job.getOwner());
                     logger.info("HOUSEKEEPING sent JOB_REMOVE_FINISHED notification for job " + job.getId());
                 }
             }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
@@ -27,7 +27,6 @@ package org.ow2.proactive.scheduler.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
@@ -229,7 +228,7 @@ public class ServerJobAndTaskLogs {
     }
 
     private static class LazyHolder {
-        static final ServerJobAndTaskLogs INSTANCE = new ServerJobAndTaskLogs();
+        private static final ServerJobAndTaskLogs INSTANCE = new ServerJobAndTaskLogs();
     }
 
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
@@ -27,11 +27,18 @@ package org.ow2.proactive.scheduler.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.log4j.Logger;
+import org.objectweb.proactive.extensions.dataspaces.api.DataSpacesFileObject;
+import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
+import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.task.TaskId;
+import org.ow2.proactive.scheduler.common.util.TaskLoggerRelativePathGenerator;
+import org.ow2.proactive.scheduler.core.SchedulerSpacesSupport;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.utils.FileUtils;
 import org.ow2.proactive.utils.appenders.FileAppender;
@@ -41,7 +48,13 @@ public class ServerJobAndTaskLogs {
 
     private static final Logger logger = Logger.getLogger(ServerJobAndTaskLogs.class);
 
-    public static void configure() {
+    private SchedulerSpacesSupport spacesSupport = null;
+
+    public static ServerJobAndTaskLogs getInstance() {
+        return LazyHolder.INSTANCE;
+    }
+
+    public void configure() {
         if (logsLocationIsSet()) {
             if (isCleanStart()) {
                 removeLogsDirectory();
@@ -52,12 +65,16 @@ public class ServerJobAndTaskLogs {
         }
     }
 
-    public static String getTaskLog(TaskId id) {
+    public void setSpacesSupport(SchedulerSpacesSupport spacesSupport) {
+        this.spacesSupport = spacesSupport;
+    }
+
+    public String getTaskLog(TaskId id) {
         String result = readLog(TaskLogger.getTaskLogRelativePath(id));
         return result != null ? result : "Cannot retrieve logs for task " + id;
     }
 
-    public static String getJobLog(JobId jobId, Set<TaskId> tasks) {
+    public String getJobLog(JobId jobId, Set<TaskId> tasks) {
         String jobLog = readLog(JobLogger.getJobLogRelativePath(jobId));
         if (jobLog == null) {
             return "Cannot retrieve logs for job " + jobId;
@@ -74,12 +91,55 @@ public class ServerJobAndTaskLogs {
 
     }
 
-    public static void remove(JobId jobId) {
+    public void remove(JobId jobId, String jobOwner) {
         removeFolderLog(jobId.value());
         removeVisualizationFile(jobId.value());
+        removePreciousLogs(jobId, jobOwner);
     }
 
-    private static void removeFolderLog(String path) {
+    private void removePreciousLogs(JobId jobId, String jobOwner) {
+        if (spacesSupport == null) {
+            logger.warn("DataSpaces not initialized, cannot remove precious logs for job " + jobId);
+            return;
+        }
+        try {
+            Validate.notBlank(jobOwner);
+            DataSpacesFileObject userspace = spacesSupport.getUserSpace(jobOwner);
+            Validate.notNull(userspace,
+                             "Cannot find user space for user " + jobOwner +
+                                        ". User spaces are probably not configured properly.");
+            deleteAllLogFiles(jobId, userspace);
+            deleteLogsFolderIfEmpty(jobId, userspace);
+
+        } catch (Exception e) {
+            logger.warn("Exception occurred when trying to remove precious logs for job " + jobId);
+        }
+    }
+
+    private void deleteAllLogFiles(JobId jobId, DataSpacesFileObject userspace) throws FileSystemException {
+        userspace.refresh();
+        for (DataSpacesFileObject logFileObject : userspace.findFiles(new FileSelector(TaskLoggerRelativePathGenerator.getIncludePatternForAllLogFiles(jobId)))) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Deleting file : " + logFileObject.getRealURI());
+            }
+            logFileObject.delete();
+        }
+    }
+
+    private void deleteLogsFolderIfEmpty(JobId jobId, DataSpacesFileObject userspace) throws FileSystemException {
+        DataSpacesFileObject logsFolder = userspace.resolveFile(TaskLoggerRelativePathGenerator.getContainingFolderForLogFiles(jobId));
+        if (logsFolder != null) {
+            logsFolder.refresh();
+            if (logsFolder.getChildren().isEmpty()) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Deleting empty folder : " + logsFolder.getRealURI());
+                }
+                logsFolder.delete();
+            }
+        }
+    }
+
+    private void removeFolderLog(String path) {
         if (logsLocationIsSet()) {
             String logsLocation = getLogsLocation();
             File logFolder = new File(logsLocation, path);
@@ -102,26 +162,26 @@ public class ServerJobAndTaskLogs {
      * Remove visualization file created by rest server (if present)
      * see org.ow2.proactive_grid_cloud_portal.studio.StudioRest.updateVisualization
      */
-    private static void removeVisualizationFile(String jobId) {
+    private void removeVisualizationFile(String jobId) {
         File visualizationFile = new File(System.getProperty("java.io.tmpdir") + File.separator + "job_" + jobId +
                                           ".zip.html");
         org.apache.commons.io.FileUtils.deleteQuietly(visualizationFile);
     }
 
-    private static boolean logsLocationIsSet() {
+    private boolean logsLocationIsSet() {
         return PASchedulerProperties.SCHEDULER_JOB_LOGS_LOCATION.isSet();
     }
 
     // public for testing
-    public static String getLogsLocation() {
+    public String getLogsLocation() {
         return PASchedulerProperties.getAbsolutePath(PASchedulerProperties.SCHEDULER_JOB_LOGS_LOCATION.getValueAsString());
     }
 
-    private static boolean isCleanStart() {
+    private boolean isCleanStart() {
         return PASchedulerProperties.SCHEDULER_DB_HIBERNATE_DROPDB.getValueAsBoolean();
     }
 
-    private static String readLog(String filename) {
+    private String readLog(String filename) {
         String result = null;
         for (String suffix : new String[] { ".1", "" }) {
             String contents = readFile(new File(getLogsLocation(), filename + suffix));
@@ -136,7 +196,7 @@ public class ServerJobAndTaskLogs {
         return result;
     }
 
-    private static String readFile(File file) {
+    private String readFile(File file) {
         if (file.exists()) {
             try {
                 return org.apache.commons.io.FileUtils.readFileToString(file);
@@ -147,25 +207,29 @@ public class ServerJobAndTaskLogs {
         return null;
     }
 
-    static void removeLogsDirectory() {
+    void removeLogsDirectory() {
         String logsLocation = getLogsLocation();
         logger.info("Removing logs " + logsLocation);
         FileUtils.removeDir(new File(logsLocation));
     }
 
-    private static void addNewFileAppenderToLoggerFor(Class<?> cls) {
+    private void addNewFileAppenderToLoggerFor(Class<?> cls) {
         Logger jobLogger = Logger.getLogger(cls);
         FileAppender appender = createFileAppender();
         jobLogger.addAppender(appender);
     }
 
-    private static FileAppender createFileAppender() {
+    private FileAppender createFileAppender() {
         FileAppender appender = new FileAppender();
         if (PASchedulerProperties.SCHEDULER_JOB_LOGS_MAX_SIZE.isSet()) {
             appender.setMaxFileSize(PASchedulerProperties.SCHEDULER_JOB_LOGS_MAX_SIZE.getValueAsString());
         }
         appender.setFilesLocation(getLogsLocation());
         return appender;
+    }
+
+    private static class LazyHolder {
+        static final ServerJobAndTaskLogs INSTANCE = new ServerJobAndTaskLogs();
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/log/TestJobServerLogs.java
@@ -83,7 +83,7 @@ public class TestJobServerLogs extends SchedulerFunctionalTestNoRestart {
 
     private final String SCRIPT_OUTPUT = "SCRIPT_OUTPUT_" + Math.random();
 
-    private String logsLocation = ServerJobAndTaskLogs.getLogsLocation();
+    private String logsLocation = ServerJobAndTaskLogs.getInstance().getLogsLocation();
 
     private SimpleDateFormat simpleDateFormat = new SimpleDateFormat("kk:mm:ss:SSS");
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogsTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogsTest.java
@@ -68,7 +68,7 @@ public class ServerJobAndTaskLogsTest extends ProActiveTestClean {
         // set a very small limit so that only 1 line would fit
         PASchedulerProperties.SCHEDULER_JOB_LOGS_MAX_SIZE.updateProperty("10");
 
-        ServerJobAndTaskLogs.configure();
+        ServerJobAndTaskLogs.getInstance().configure();
 
         jobLogger = JobLogger.getInstance();
         Logger.getLogger(JobLogger.class).setLevel(Level.INFO);
@@ -100,19 +100,20 @@ public class ServerJobAndTaskLogsTest extends ProActiveTestClean {
         jobLogger.info(jobId, "second job log");
         taskLogger.info(taskId, "second task log");
 
-        assertTrue(new File(ServerJobAndTaskLogs.getLogsLocation(), JobLogger.getJobLogRelativePath(jobId)).exists());
-        assertTrue(new File(ServerJobAndTaskLogs.getLogsLocation(),
+        assertTrue(new File(ServerJobAndTaskLogs.getInstance().getLogsLocation(),
+                            JobLogger.getJobLogRelativePath(jobId)).exists());
+        assertTrue(new File(ServerJobAndTaskLogs.getInstance().getLogsLocation(),
                             JobLogger.getJobLogRelativePath(jobId) + ".1").exists());
-        assertTrue(new File(ServerJobAndTaskLogs.getLogsLocation(),
+        assertTrue(new File(ServerJobAndTaskLogs.getInstance().getLogsLocation(),
                             TaskLogger.getTaskLogRelativePath(taskId)).exists());
-        assertTrue(new File(ServerJobAndTaskLogs.getLogsLocation(),
+        assertTrue(new File(ServerJobAndTaskLogs.getInstance().getLogsLocation(),
                             TaskLogger.getTaskLogRelativePath(taskId) + ".1").exists());
 
-        assertEquals(4, new File(ServerJobAndTaskLogs.getLogsLocation() + "/" + jobId).list().length);
+        assertEquals(4, new File(ServerJobAndTaskLogs.getInstance().getLogsLocation() + "/" + jobId).list().length);
 
-        ServerJobAndTaskLogs.remove(jobId);
+        ServerJobAndTaskLogs.getInstance().remove(jobId, "test");
 
-        assertEquals(0, new File(ServerJobAndTaskLogs.getLogsLocation()).list().length);
+        assertEquals(0, new File(ServerJobAndTaskLogs.getInstance().getLogsLocation()).list().length);
     }
 
     @Test
@@ -124,25 +125,25 @@ public class ServerJobAndTaskLogsTest extends ProActiveTestClean {
 
         assertEquals(1, fakeSchedulerHome.getRoot().list().length);
 
-        ServerJobAndTaskLogs.removeLogsDirectory();
+        ServerJobAndTaskLogs.getInstance().removeLogsDirectory();
 
         assertEquals(0, fakeSchedulerHome.getRoot().list().length);
     }
 
     private void checkContains(JobId jobId, TaskId taskId, String word) {
-        assertThat(ServerJobAndTaskLogs.getJobLog(jobId, Collections.singleton(taskId)),
+        assertThat(ServerJobAndTaskLogs.getInstance().getJobLog(jobId, Collections.singleton(taskId)),
                    containsString(word + " job log"));
-        assertThat(ServerJobAndTaskLogs.getJobLog(jobId, Collections.singleton(taskId)),
+        assertThat(ServerJobAndTaskLogs.getInstance().getJobLog(jobId, Collections.singleton(taskId)),
                    containsString(word + " task log"));
-        assertThat(ServerJobAndTaskLogs.getTaskLog(taskId), containsString(word + " task log"));
+        assertThat(ServerJobAndTaskLogs.getInstance().getTaskLog(taskId), containsString(word + " task log"));
     }
 
     private void checkDoesNotContain(JobId jobId, TaskId taskId, String word) {
-        assertThat(ServerJobAndTaskLogs.getJobLog(jobId, Collections.singleton(taskId)),
+        assertThat(ServerJobAndTaskLogs.getInstance().getJobLog(jobId, Collections.singleton(taskId)),
                    not(containsString(word + " job log")));
-        assertThat(ServerJobAndTaskLogs.getJobLog(jobId, Collections.singleton(taskId)),
+        assertThat(ServerJobAndTaskLogs.getInstance().getJobLog(jobId, Collections.singleton(taskId)),
                    not(containsString(word + " task log")));
-        assertThat(ServerJobAndTaskLogs.getTaskLog(taskId), not(containsString(word + " task log")));
+        assertThat(ServerJobAndTaskLogs.getInstance().getTaskLog(taskId), not(containsString(word + " task log")));
     }
 
 }


### PR DESCRIPTION

 - move TaskLoggerRelativePathGenerator to scheduler-api project
 - initialize ServerJobAndTaskLogs with a helper class used to acces data spaces.
 - in ServerJobAndTaskLogs delete all precious log files associated with a job, using data space api and include pattern
 - in JobRemoveHandler log exceptions in case an exception occurs (exceptions were never printed to Scheduler.log before)
 - TestPreciousLogs : verify that precious logs are removed after jobs are deleted.