### PR TITLE
Make task pagination O(1) complex

### DIFF
--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -1273,7 +1273,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
             List<TaskState> taskStates = restApi().getJobTaskStatesPaginated(sid, jobId, offset, limit)
                                                   .getList()
                                                   .stream()
-                                                  .map(taskStateData -> taskState(taskStateData))
+                                                  .map(DataUtility::taskState)
                                                   .collect(Collectors.toList());
             taskStatesPage = new TaskStatesPage();
             taskStatesPage.setSize(limit);

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -61,6 +61,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -101,6 +102,7 @@ import org.ow2.proactive.scheduler.common.job.factories.Job2XMLTransformer;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.usage.JobUsage;
 import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.job.SchedulerUserInfo;
@@ -1261,6 +1263,25 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         } catch (PermissionRestException e) {
             throw new PermissionException("Session " + sid + " doesnt have permission");
         }
+    }
+
+    @Override
+    public TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        TaskStatesPage taskStatesPage = null;
+        try {
+            List<TaskState> taskStates = restApi().getJobTaskStatesPaginated(sid, jobId, offset, limit)
+                                                  .getList()
+                                                  .stream()
+                                                  .map(taskStateData -> taskState(taskStateData))
+                                                  .collect(Collectors.toList());
+            taskStatesPage = new TaskStatesPage();
+            taskStatesPage.setSize(limit);
+            taskStatesPage.setTaskStates(taskStates);
+        } catch (Exception e) {
+            throwUJEOrNCEOrPE(e);
+        }
+        return taskStatesPage;
     }
 
     @Override

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -1270,13 +1270,14 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
             throws NotConnectedException, UnknownJobException, PermissionException {
         TaskStatesPage taskStatesPage = null;
         try {
+            final int size = restApi().getJobTaskStates(sid, jobId).getList().size();
             List<TaskState> taskStates = restApi().getJobTaskStatesPaginated(sid, jobId, offset, limit)
                                                   .getList()
                                                   .stream()
                                                   .map(DataUtility::taskState)
                                                   .collect(Collectors.toList());
             taskStatesPage = new TaskStatesPage();
-            taskStatesPage.setSize(limit);
+            taskStatesPage.setSize(size);
             taskStatesPage.setTaskStates(taskStates);
         } catch (Exception e) {
             throwUJEOrNCEOrPE(e);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -1199,11 +1199,10 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         if (limit == -1)
             limit = TASKS_PAGE_SIZE;
         try {
-            Scheduler s = checkAccess(sessionId, "jobs/" + jobId + "/taskstates/paginated");
-            JobState jobState = s.getJobState(jobId);
-            TaskStatesPage page = jobState.getTasksPaginated(offset, limit);
+            Scheduler scheduler = checkAccess(sessionId, "jobs/" + jobId + "/taskstates/paginated");
+            TaskStatesPage page = scheduler.getTaskPaginated(jobId, offset, limit);
             List<TaskStateData> tasks = map(page.getTaskStates(), TaskStateData.class);
-            return new RestPage<TaskStateData>(tasks, page.getSize());
+            return new RestPage<>(tasks, page.getSize());
         } catch (PermissionException e) {
             throw new PermissionRestException(e);
         } catch (UnknownJobException e) {

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestPaginationTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestPaginationTest.java
@@ -102,7 +102,7 @@ public class SchedulerStateRestPaginationTest extends RestTestServer {
     public void testGetJobTaskStatesPaginated() throws Throwable {
 
         JobState job = newMockedJob(jobIdStr, nbTasks);
-        when(mockOfScheduler.getJobState(jobIdStr)).thenReturn(job);
+        when(mockOfScheduler.getTaskPaginated(jobIdStr, 0, nbTasks)).thenReturn(job.getTasksPaginated(0, nbTasks));
 
         List<TaskStateData> res = restInterface.getJobTaskStatesPaginated(sessionId, jobIdStr, 0, nbTasks).getList();
 

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestPaginationTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestPaginationTest.java
@@ -102,7 +102,17 @@ public class SchedulerStateRestPaginationTest extends RestTestServer {
     public void testGetJobTaskStatesPaginated() throws Throwable {
 
         JobState job = newMockedJob(jobIdStr, nbTasks);
-        when(mockOfScheduler.getTaskPaginated(jobIdStr, 0, nbTasks)).thenReturn(job.getTasksPaginated(0, nbTasks));
+
+        List<TaskState> dumbList = new ArrayList<TaskState>(nbTasks);
+        for (int i = 0; i < nbTasks; i++) {
+            TaskState mockedTask = mock(TaskState.class);
+            TaskId mockedTaskId = mock(TaskId.class);
+            when(mockedTaskId.getReadableName()).thenReturn(generateReadableName(jobIdStr, i, nbTasks));
+            when(mockedTask.getId()).thenReturn(mockedTaskId);
+            dumbList.add(mockedTask);
+        }
+
+        when(mockOfScheduler.getTaskPaginated(jobIdStr, 0, nbTasks)).thenReturn(new TaskStatesPage(dumbList, nbTasks));
 
         List<TaskStateData> res = restInterface.getJobTaskStatesPaginated(sessionId, jobIdStr, 0, nbTasks).getList();
 

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestTaskCentricTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestTaskCentricTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.ow2.proactive_grid_cloud_portal.scheduler.RestTestUtils.newTaskState;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +43,7 @@ import org.ow2.proactive.scheduler.common.SortSpecifierContainer;
 import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
 import org.ow2.proactive_grid_cloud_portal.RestTestServer;
 import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
@@ -280,7 +282,13 @@ public class SchedulerStateRestTaskCentricTest extends RestTestServer {
         int nbTasks = 50;
         String jobIdStr = "1";
         JobState job = RestTestUtils.newMockedJob(jobIdStr, null, nbTasks);
-        when(mockOfScheduler.getTaskPaginated(jobIdStr, 0, nbTasks)).thenReturn(job.getTasksPaginated(0, nbTasks));
+
+        List<TaskState> dumbList = new ArrayList<TaskState>(nbTasks);
+        for (int i = 0; i < nbTasks; i++) {
+            dumbList.add(newTaskState(jobIdStr, null, i, nbTasks));
+        }
+
+        when(mockOfScheduler.getTaskPaginated(jobIdStr, 0, nbTasks)).thenReturn(new TaskStatesPage(dumbList, nbTasks));
 
         List<TaskStateData> res = restInterface.getJobTaskStatesPaginated(sessionId, jobIdStr, 0, nbTasks).getList();
 

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestTaskCentricTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestTaskCentricTest.java
@@ -280,7 +280,7 @@ public class SchedulerStateRestTaskCentricTest extends RestTestServer {
         int nbTasks = 50;
         String jobIdStr = "1";
         JobState job = RestTestUtils.newMockedJob(jobIdStr, null, nbTasks);
-        when(mockOfScheduler.getJobState(jobIdStr)).thenReturn(job);
+        when(mockOfScheduler.getTaskPaginated(jobIdStr, 0, nbTasks)).thenReturn(job.getTasksPaginated(0, nbTasks));
 
         List<TaskStateData> res = restInterface.getJobTaskStatesPaginated(sessionId, jobIdStr, 0, nbTasks).getList();
 

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -61,6 +61,7 @@ import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputSelector;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputSelector;
 import org.ow2.proactive.scheduler.rest.DisconnectionAwareSchedulerEventListener;
@@ -680,6 +681,12 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     @Override
     public Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException {
         return ((ISchedulerClient) _getScheduler()).getSchedulerProperties();
+    }
+
+    @Override
+    public TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        return _getScheduler().getTaskPaginated(jobId, offset, limit);
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -48,6 +48,7 @@ import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.usage.SchedulerUsage;
 import org.ow2.proactive.scheduler.common.util.logforwarder.AppenderProvider;
 import org.ow2.proactive.scheduler.common.util.logforwarder.LogForwardingService;
@@ -1521,5 +1522,22 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @return scheduler properties
      */
     Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException;
+
+    /**
+     * Return the page of tasks of the given job.<br>
+     *
+     * @param jobId the job on which to get the state.
+     * @param offset the starting index of the sublist of tasks to get
+     * @param limit the last index (non inclusive) of the sublist of tasks to get
+     * @return the current state of the given job
+     * @throws NotConnectedException
+     *             if you are not authenticated.
+     * @throws UnknownJobException
+     *             if the job does not exist.
+     * @throws PermissionException
+     *             if you can't access to this particular job.
+     */
+    TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
+            throws NotConnectedException, UnknownJobException, PermissionException;;
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskStatesPage.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskStatesPage.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.scheduler.common.task;
 
+import java.io.Serializable;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * 
  */
 @XmlRootElement
-public class TaskStatesPage {
+public class TaskStatesPage implements Serializable {
 
     private int size;
 

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -74,6 +74,7 @@ import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.usage.JobUsage;
 import org.ow2.proactive.scheduler.common.util.logforwarder.AppenderProvider;
 import org.ow2.proactive.scheduler.job.SchedulerUserInfo;
@@ -692,6 +693,12 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     @Override
     public Map getSchedulerProperties() throws NotConnectedException, PermissionException {
         return uischeduler.getSchedulerProperties();
+    }
+
+    @Override
+    public TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        return uischeduler.getTaskPaginated(jobId, offset, limit);
     }
 
     @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -65,6 +65,7 @@ import org.ow2.proactive.scheduler.common.job.JobState;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.usage.JobUsage;
 import org.ow2.proactive.scheduler.common.util.logforwarder.AppenderProvider;
 import org.ow2.proactive.scheduler.job.SchedulerUserInfo;
@@ -790,6 +791,13 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     public Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException {
         renewSession();
         return client.getSchedulerProperties();
+    }
+
+    @Override
+    public TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        renewSession();
+        return client.getTaskPaginated(jobId, offset, limit);
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -125,6 +125,7 @@ import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
 import org.ow2.proactive.scheduler.common.usage.JobUsage;
 import org.ow2.proactive.scheduler.common.util.logforwarder.AppenderProvider;
@@ -1094,6 +1095,15 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
     @ImmediateService
     public JobState getJobState(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return frontendState.getJobState(jobId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        return frontendState.getTaskPaginated(JobIdImpl.makeJobId(jobId), offset, limit);
     }
 
     /**

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -1234,7 +1234,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
 
     synchronized TaskStatesPage getTaskPaginated(JobId jobId, int offset, int limit)
             throws UnknownJobException, NotConnectedException, PermissionException {
-        checkPermissions("getTaskPaginated",
+        checkPermissions("getJobState",
                          getIdentifiedJob(jobId),
                          YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THE_STATE_OF_THIS_JOB);
         ClientJobState jobState = jobsMap.get(jobId);

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -79,6 +79,7 @@ import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
+import org.ow2.proactive.scheduler.common.task.TaskStatesPage;
 import org.ow2.proactive.scheduler.common.task.dataspaces.InputSelector;
 import org.ow2.proactive.scheduler.common.task.dataspaces.OutputSelector;
 import org.ow2.proactive.scheduler.smartproxy.common.AbstractSmartProxy;
@@ -858,6 +859,12 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     @Override
     public Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException {
         return schedulerProxy.getSchedulerProperties();
+    }
+
+    @Override
+    public TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        return schedulerProxy.getTaskPaginated(jobId, offset, limit);
     }
 
     @Override


### PR DESCRIPTION
When user clicks on the job in scheduling-portal, portal requests server to provide "a page" of 20 tasks of this job. However, on the server side, whole job is copied, and from this job, 20 tasks are copied. So finally portal receives its 20 tasks to show. Because server copies WHOLE job (with all its tasks), complexity of this operation is linear to number of tasks in the job.

This PR will make complexity constant by copying only requested tasks.