### PR TITLE
Improve Job Pausing mechanism - make it O(1)

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -264,7 +264,7 @@ class LiveJobs {
 
             if (!updatedTasks.isEmpty()) {
                 jlogger.info(jobId, "has just been paused.");
-                dbManager.updateJobAndTasksState(job);
+                dbManager.updateJobAndTasksStatuses(job, updatedTasks, TaskStatus.PAUSED);
                 updateTasksInSchedulerState(job, updatedTasks);
             }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -1225,27 +1225,23 @@ public class SchedulerDBManager {
     }
 
     public void updateJobAndTasksStatuses(final InternalJob job, final Set<TaskId> taskIds, TaskStatus taskStatus) {
-        executeReadWriteTransaction(new SessionWork<Void>() {
-            @Override
-            public Void doInTransaction(Session session) {
+        executeReadWriteTransaction((SessionWork<Void>) session -> {
 
-                updateTasksStatuses(taskIds, taskStatus, session);
+            updateTasksStatuses(taskIds, taskStatus, session);
 
-                JobInfo jobInfo = job.getJobInfo();
+            JobInfo jobInfo = job.getJobInfo();
 
-                session.getNamedQuery("updateJobAndTasksState")
-                       .setParameter("status", jobInfo.getStatus())
-                       .setParameter("numberOfFailedTasks", jobInfo.getNumberOfFailedTasks())
-                       .setParameter("numberOfFaultyTasks", jobInfo.getNumberOfFaultyTasks())
-                       .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
-                       .setParameter("inErrorTime", jobInfo.getInErrorTime())
-                       .setParameter("lastUpdatedTime", new Date().getTime())
-                       .setParameter("jobId", jobId(job))
-                       .executeUpdate();
+            session.getNamedQuery("updateJobAndTasksState")
+                   .setParameter("status", jobInfo.getStatus())
+                   .setParameter("numberOfFailedTasks", jobInfo.getNumberOfFailedTasks())
+                   .setParameter("numberOfFaultyTasks", jobInfo.getNumberOfFaultyTasks())
+                   .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
+                   .setParameter("inErrorTime", jobInfo.getInErrorTime())
+                   .setParameter("lastUpdatedTime", new Date().getTime())
+                   .setParameter("jobId", jobId(job))
+                   .executeUpdate();
 
-                return null;
-            }
-
+            return null;
         });
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -1278,8 +1278,9 @@ public class SchedulerDBManager {
 
     private int updateTasksStatuses(final Set<TaskId> taskIds, final TaskStatus taskStatus, Session session) {
         return session.getNamedQuery("updateTaskStatus")
-                      .setParameterList("taskIds", taskIds)
                       .setParameter("taskStatus", taskStatus)
+                      .setParameterList("taskIds",
+                                        taskIds.stream().map(SchedulerDBManager::taskId).collect(Collectors.toList()))
                       .executeUpdate();
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -1224,6 +1224,31 @@ public class SchedulerDBManager {
         });
     }
 
+    public void updateJobAndTasksStatuses(final InternalJob job, final Set<TaskId> taskIds, TaskStatus taskStatus) {
+        executeReadWriteTransaction(new SessionWork<Void>() {
+            @Override
+            public Void doInTransaction(Session session) {
+
+                updateTasksStatuses(taskIds, taskStatus, session);
+
+                JobInfo jobInfo = job.getJobInfo();
+
+                session.getNamedQuery("updateJobAndTasksState")
+                       .setParameter("status", jobInfo.getStatus())
+                       .setParameter("numberOfFailedTasks", jobInfo.getNumberOfFailedTasks())
+                       .setParameter("numberOfFaultyTasks", jobInfo.getNumberOfFaultyTasks())
+                       .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
+                       .setParameter("inErrorTime", jobInfo.getInErrorTime())
+                       .setParameter("lastUpdatedTime", new Date().getTime())
+                       .setParameter("jobId", jobId(job))
+                       .executeUpdate();
+
+                return null;
+            }
+
+        });
+    }
+
     public void updateTaskSchedulingTime(final InternalJob job, final long scheduledTime) {
         executeReadWriteTransaction(new SessionWork<Void>() {
             @Override
@@ -1249,6 +1274,13 @@ public class SchedulerDBManager {
             }
 
         });
+    }
+
+    private int updateTasksStatuses(final Set<TaskId> taskIds, final TaskStatus taskStatus, Session session) {
+        return session.getNamedQuery("updateTaskStatus")
+                      .setParameterList("taskIds", taskIds)
+                      .setParameter("taskStatus", taskStatus)
+                      .executeUpdate();
     }
 
     private int updateTaskData(final TaskState task, Session session) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -125,6 +125,8 @@ import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
                                                              "task.numberOfExecutionOnFailureLeft = :numberOfExecutionOnFailureLeft, " +
                                                              "task.inErrorTime = :inErrorTime " +
                                                              "where task.id = :taskId"),
+                @NamedQuery(name = "updateTaskStatus", query = "update TaskData task set task.taskStatus = :taskStatus " +
+                                                               "where task.id in (:taskIds)"),
                 @NamedQuery(name = "updateTaskDataAfterJobFinished", query = "update TaskData task set task.taskStatus = :taskStatus, " +
                                                                              "task.numberOfExecutionLeft = :numberOfExecutionLeft, " +
                                                                              "task.numberOfExecutionOnFailureLeft = :numberOfExecutionOnFailureLeft, " +


### PR DESCRIPTION
When we pause job with N tasks, we actually send one request to update job, and N requests - for each of the tasks. 
Here I add specific method to update tasks' statuses. Thus we send one request for job, and one for all its tasks.