### PR TITLE
Do not use updateJobAndTasksState method so often

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -147,7 +147,7 @@ class LiveJobs {
                     InternalJob job = jobData.job;
                     if (job.getStatus() == JobStatus.PAUSED) {
                         job.setUnPause();
-                        dbManager.updateJobAndTasksState(job);
+                        dbManager.unpauseJobAndTasks(job);
                         updateJobInSchedulerState(job, SchedulerEvent.JOB_RESUMED);
                     }
                 } finally {
@@ -219,7 +219,7 @@ class LiveJobs {
 
             setJobStatusToInErrorIfNotPaused(job);
 
-            dbManager.updateJobAndTasksState(job);
+            dbManager.updateJobAndRestartAllInErrorTasks(job);
             updateJobInSchedulerState(job, SchedulerEvent.JOB_RESTARTED_FROM_ERROR);
 
             return Boolean.TRUE;
@@ -239,7 +239,7 @@ class LiveJobs {
 
             if (!updatedTasks.isEmpty()) {
                 jlogger.info(jobId, "has just been resumed.");
-                dbManager.updateJobAndTasksState(job);
+                dbManager.unpauseJobAndTasks(job);
                 updateTasksInSchedulerState(job, updatedTasks);
             }
 
@@ -264,7 +264,7 @@ class LiveJobs {
 
             if (!updatedTasks.isEmpty()) {
                 jlogger.info(jobId, "has just been paused.");
-                dbManager.updateJobAndTasksState(job);
+                dbManager.pauseJobAndTasks(job);
                 updateTasksInSchedulerState(job, updatedTasks);
             }
 
@@ -681,7 +681,7 @@ class LiveJobs {
 
         task.setInErrorTime(task.getStartTime() + taskDuration);
 
-        dbManager.updateJobAndTasksState(job);
+        dbManager.updateJobAndTaskState(job, task);
 
         updateTaskPausedOnerrorState(job, task.getId());
         updateJobInSchedulerState(job, SchedulerEvent.JOB_IN_ERROR);
@@ -773,7 +773,6 @@ class LiveJobs {
             InternalTask task = jobData.job.getTask(taskName);
             tlogger.info(task.getId(), "restarting in-error task " + task.getId());
             jobData.job.restartInErrorTask(task);
-            dbManager.updateJobAndTasksState(jobData.job);
             updateJobInSchedulerState(jobData.job, SchedulerEvent.JOB_RESTARTED_FROM_ERROR);
         } finally {
             jobData.unlock();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -131,6 +131,25 @@ import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
                                                                              "task.finishedTime = :finishedTime, " +
                                                                              "task.executionDuration = :executionDuration " +
                                                                              "where task.id = :taskId"),
+                @NamedQuery(name = "pauseTasks", query = "update TaskData task set task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.PAUSED " +
+                                                         "where task.id.jobId = :jobId " +
+                                                         "and task.taskStatus <> org.ow2.proactive.scheduler.common.task.TaskStatus.FINISHED " +
+                                                         "and task.taskStatus <> org.ow2.proactive.scheduler.common.task.TaskStatus.RUNNING " +
+                                                         "and task.taskStatus <> org.ow2.proactive.scheduler.common.task.TaskStatus.SKIPPED " +
+                                                         "and task.taskStatus <> org.ow2.proactive.scheduler.common.task.TaskStatus.FAULTY " +
+                                                         "and task.taskStatus <> org.ow2.proactive.scheduler.common.task.TaskStatus.IN_ERROR "),
+                @NamedQuery(name = "unpausePendingTasks", query = "update TaskData task set task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.SUBMITTED " +
+                                                                  "where task.id.jobId = :jobId"),
+                @NamedQuery(name = "unpauseTasks", query = "update TaskData task set task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.PENDING " +
+                                                           "where task.id.jobId = :jobId " +
+                                                           "and task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.FINISHED " +
+                                                           "and task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.RUNNING " +
+                                                           "and task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.SKIPPED " +
+                                                           "and task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.FAULTY " +
+                                                           "and task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.IN_ERROR "),
+                @NamedQuery(name = "restartAllInErrorTasks", query = "update TaskData task set task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.PENDING " +
+                                                                     "where task.id.jobId = :jobId " +
+                                                                     "and task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.IN_ERROR "),
                 @NamedQuery(name = "updateTaskDataJobScripts", query = "update TaskData set envScript = null, preScript = null, postScript = null,flowScript = null," +
                                                                        "cleanScript = null  where id.jobId = :jobId"),
                 @NamedQuery(name = "updateTaskDataJobScriptsInBulk", query = "update TaskData set envScript = null, preScript = null, postScript = null,flowScript = null," +


### PR DESCRIPTION
_updateJobAndTasksState_ method sends N+1 requests, where N is number of tasks in the job.
So of course, this method it pretty heavy. However, in most of the cases, we can avoid of using it.  