### PR TITLE
Fix Task can stay running forever

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -43,10 +43,14 @@ pa.scheduler.core.housekeeping.scheduledpoolnbthreads=5
 # Also used by the node to ping the scheduler after finishing a task
 pa.scheduler.core.nodepingfrequency=20
 
-# The scheduler will decide to restart a task, after a given tolerated number of failed attempts.
-# A value of zero means that the scheduler will restart a task after the first failure.
+# The scheduler will decide to restart a task, after a given tolerated number of failed attempts to ping the underlying node.
+# A value of zero means that the scheduler will restart a task after the first node ping failure.
 # Also used by a node to retry to send the result of a task to the scheduler
 pa.scheduler.core.node.ping.attempts=1
+
+# when the task launcher (component responsible to execute the task) cannot be reached but the underlying node is reachable,
+# this timeout (default 5 minutes) will ensure that the task will not remain forever in running state and will be restarted
+pa.scheduler.core.tasklauncher.ping.timeout=300000
 
 # Scheduler default policy full name
 pa.scheduler.policy=org.ow2.proactive.scheduler.policy.ExtendedSchedulerPolicy

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -82,6 +82,10 @@ public enum PASchedulerProperties implements PACommonProperties {
      * tolerated failed attempts to ping a node, before the scheduler decides to restart the task running on it */
     SCHEDULER_NODE_PING_ATTEMPTS("pa.scheduler.core.node.ping.attempts", PropertyType.INTEGER, "1"),
 
+    /** Timeout between a TaskLauncher ping failure and an actual task restart. If a TaskLauncher fails to respond to a ping but the node is still available,
+     * this timeout will make sure the task will not remain forever in running state */
+    SCHEDULER_TASKLAUNCHER_PING_TIMEOUT("pa.scheduler.core.tasklauncher.ping.timeout", PropertyType.INTEGER, "300000"),
+
     /** Number of threads used to execute client requests  */
     SCHEDULER_CLIENT_POOL_NBTHREAD("pa.scheduler.core.clientpoolnbthreads", PropertyType.INTEGER, "5"),
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/RunningTaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/RunningTaskData.java
@@ -44,7 +44,11 @@ class RunningTaskData {
 
     private final NodeSet nodes;
 
-    private int pingAttempts = 0;
+    private volatile int pingAttempts = 0;
+
+    private volatile boolean isRestarting = false;
+
+    private volatile long firstFailedPingAttemptTime = -1;
 
     RunningTaskData(InternalTask task, String user, Credentials credentials, TaskLauncher launcher) {
         this.task = task;
@@ -82,8 +86,28 @@ class RunningTaskData {
         return ++pingAttempts;
     }
 
+    public void setFirstTaskLauncherFailureTime(long time) {
+        this.firstFailedPingAttemptTime = time;
+    }
+
+    public void resetFirstTaskLauncherFailureTime() {
+        this.firstFailedPingAttemptTime = -1;
+    }
+
+    public long getFirstTaskLauncherFailureTime() {
+        return this.firstFailedPingAttemptTime;
+    }
+
     public int getPingAttempts() {
         return pingAttempts;
+    }
+
+    public boolean isRestarting() {
+        return isRestarting;
+    }
+
+    public void setRestarting(boolean restarting) {
+        isRestarting = restarting;
     }
 
     /**

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -48,6 +48,7 @@ import org.objectweb.proactive.core.process.JVMProcessImpl;
 import org.objectweb.proactive.extensions.pnp.PNPConfig;
 import org.ow2.proactive.db.SortOrder;
 import org.ow2.proactive.db.SortParameter;
+import org.ow2.proactive.resourcemanager.common.NodeState;
 import org.ow2.proactive.resourcemanager.common.event.RMEventType;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeEvent;
 import org.ow2.proactive.resourcemanager.frontend.ResourceManager;
@@ -1105,6 +1106,17 @@ public class SchedulerTHelper {
 
     public RMNodeEvent waitForNodeEvent(RMEventType nodeAdded, String nodeUrl, long timeout) throws Exception {
         return RMTHelper.waitForNodeEvent(nodeAdded, nodeUrl, timeout, getRMMonitorsHandler());
+    }
+
+    public RMNodeEvent waitUntilState(String nodeUrl, NodeState expectedState, long timeout) throws Exception {
+        RMNodeEvent event;
+        do {
+            event = RMTHelper.waitForNodeEvent(RMEventType.NODE_STATE_CHANGED,
+                                               nodeUrl,
+                                               timeout,
+                                               getRMMonitorsHandler());
+        } while (!event.getNodeState().equals(expectedState));
+        return event;
     }
 
     public RMNodeEvent waitForAnyNodeEvent(RMEventType nodeStateChanged, long timeout) throws Exception {

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/config/scheduler-nonforked-nodefailure.ini
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/config/scheduler-nonforked-nodefailure.ini
@@ -1,0 +1,17 @@
+#hibernate configuration file
+pa.scheduler.db.hibernate.configuration=scheduler/scheduler-server/src/test/resources/functionaltests/config/hibernate.cfg.xml
+#initial waiting time before restarting a task
+pa.scheduler.task.initialwaitingtime=100
+# Remove job delay (in second). (The time between getting back its result and removing it from the scheduler)
+# Set this time to 0 if you don't want the job to be remove automatically.
+pa.scheduler.core.removejobdelay=1
+# Maximum number of execution for a task in case of failure (node down)
+pa.scheduler.task.numberofexecutiononfailure=2
+# Maximum time to wait for a failed task launcher
+pa.scheduler.core.tasklauncher.ping.timeout=30000
+# Accounting refresh rate from the database in seconds
+pa.scheduler.account.refreshrate=10000000
+
+pa.scheduler.task.fork=false
+
+pa.scheduler.core.timeout=50


### PR DESCRIPTION
If a task launcher dies because the underlying node is cleaned. The task will be seen by the scheduler as running forever.

 Even if the fact that the task launcher dies is not normal, there should be a configurable timeout to control the scheduler behavior with regard to this task.

 This change is to implement a timeout for task launcher failure.
