### PR TITLE
Add ImmediateService to pauseJob and resumeJob

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -1118,6 +1118,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
      * {@inheritDoc}
      */
     @Override
+    @ImmediateService
     public boolean pauseJob(String jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return this.pauseJob(JobIdImpl.makeJobId(jobId));
     }
@@ -1144,6 +1145,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
      * {@inheritDoc}
      */
     @Override
+    @ImmediateService
     public boolean resumeJob(String jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return this.resumeJob(JobIdImpl.makeJobId(jobId));
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -1048,6 +1048,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
      * {@inheritDoc}
      */
     @Override
+    @ImmediateService
     public boolean pauseJob(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         frontendState.checkPermissions("pauseJob",
                                        frontendState.getIdentifiedJob(jobId),
@@ -1059,6 +1060,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
      * {@inheritDoc}
      */
     @Override
+    @ImmediateService
     public boolean resumeJob(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         frontendState.checkPermissions("resumeJob",
                                        frontendState.getIdentifiedJob(jobId),


### PR DESCRIPTION
To un-freeze scheduler portal I have added ImmediateService annotations to SchedulerFrontend. 
However, it will still be frozen for user session who initiated pauseJob/resumeJob.

https://trello.com/c/az1qdOa9/3718-server-performance-other-benchmarks-un-freeze-scheduling-portal-when-pausejob-resumejob-is-called