### PR TITLE
Make RestartAllInErrorTasks immediate

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -1130,6 +1130,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
     }
 
     @Override
+    @ImmediateService
     public boolean restartAllInErrorTasks(String jobId)
             throws NotConnectedException, UnknownJobException, PermissionException {
         final JobId jobIdObject = JobIdImpl.makeJobId(jobId);
@@ -1444,6 +1445,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
     }
 
     @Override
+    @ImmediateService
     public Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
             throws NotConnectedException, PermissionException {


### PR DESCRIPTION
When user clicks "Restart All In-Error tasks", it blocks SchedulerFrontend for all users. ImmediateService annotation unblocks frontend for all other users.

Also client periodically pulls `getTaskStates`method which also was blocking all users for long time.