### PR TITLE
Prevent failed node source deployment to give status DEPLOYED

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1438,8 +1438,6 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
             NodeSourceDescriptor nodeSourceDescriptor = this.getDefinedNodeSourceDescriptorOrFail(nodeSourceName);
 
-            this.updateNodeSourceDescriptorWithStatusAndPersist(nodeSourceDescriptor, NodeSourceStatus.NODES_DEPLOYED);
-
             NodeSource nodeSourceToDeploy = this.createNodeSourceInstance(nodeSourceDescriptor);
             NodeSourcePolicy nodeSourcePolicyStub = this.createNodeSourcePolicyActivity(nodeSourceDescriptor,
                                                                                         nodeSourceToDeploy);
@@ -1450,10 +1448,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                              nodeSourceStub,
                                              nodeSourcePolicyStub);
 
+            this.updateNodeSourceDescriptorWithStatusAndPersist(nodeSourceDescriptor, NodeSourceStatus.NODES_DEPLOYED);
             this.deployedNodeSources.put(nodeSourceName, nodeSourceStub);
-
             this.emitNodeSourceEvent(nodeSourceStub, RMEventType.NODESOURCE_CREATED);
-
             logger.info(NODE_SOURCE_STRING + nodeSourceName + " has been successfully deployed");
         }
 


### PR DESCRIPTION
- status DEPLOYED was advertised before the node source parameters were actually used for the deployment, so a failure in the deployment would not revert the node source status to undeployed, which was inconsistent with the portal view, and which was then preventing normal interaction with the node source.
- Fixes #3314
- Fixes ow2-proactive/scheduling-portal#480