### PR TITLE
Fix node source status change propagation

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1431,30 +1431,36 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
      */
     @Override
     public BooleanWrapper deployNodeSource(String nodeSourceName) {
-
         logger.info("Deploy node source " + nodeSourceName + REQUESTED_BY_STRING + this.caller.getName());
-
         if (!this.deployedNodeSources.containsKey(nodeSourceName)) {
-
             NodeSourceDescriptor nodeSourceDescriptor = this.getDefinedNodeSourceDescriptorOrFail(nodeSourceName);
+            this.updateNodeSourceDescriptorWithStatusAndPersist(nodeSourceDescriptor, NodeSourceStatus.NODES_DEPLOYED);
+            deployNodeSourceOrFail(nodeSourceName, nodeSourceDescriptor);
+        } else {
+            logger.debug("Node source " + nodeSourceName + " is already deployed");
+        }
+        return new BooleanWrapper(true);
+    }
 
+    private void deployNodeSourceOrFail(String nodeSourceName, NodeSourceDescriptor nodeSourceDescriptor) {
+        try {
             NodeSource nodeSourceToDeploy = this.createNodeSourceInstance(nodeSourceDescriptor);
             NodeSourcePolicy nodeSourcePolicyStub = this.createNodeSourcePolicyActivity(nodeSourceDescriptor,
                                                                                         nodeSourceToDeploy);
             NodeSource nodeSourceStub = this.createNodeSourceActivity(nodeSourceName, nodeSourceToDeploy);
-
             this.configureDeployedNodeSource(nodeSourceName,
                                              nodeSourceDescriptor,
                                              nodeSourceStub,
                                              nodeSourcePolicyStub);
-
-            this.updateNodeSourceDescriptorWithStatusAndPersist(nodeSourceDescriptor, NodeSourceStatus.NODES_DEPLOYED);
             this.deployedNodeSources.put(nodeSourceName, nodeSourceStub);
             this.emitNodeSourceEvent(nodeSourceStub, RMEventType.NODESOURCE_CREATED);
             logger.info(NODE_SOURCE_STRING + nodeSourceName + " has been successfully deployed");
+        } catch (RuntimeException e) {
+            this.updateNodeSourceDescriptorWithStatusAndPersist(nodeSourceDescriptor,
+                                                                NodeSourceStatus.NODES_UNDEPLOYED);
+            logger.error(NODE_SOURCE_STRING + nodeSourceName + " failed to be deployed", e);
+            throw e;
         }
-
-        return new BooleanWrapper(true);
     }
 
     private void configureDeployedNodeSource(String nodeSourceName, NodeSourceDescriptor nodeSourceDescriptor,
@@ -1499,22 +1505,19 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     }
 
     private NodeSource createNodeSourceActivity(String nodeSourceName, NodeSource nodeSourceToDeploy) {
-
         try {
             nodeSourceToDeploy = PAActiveObject.turnActive(nodeSourceToDeploy, this.nodeRM);
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-            throw new RuntimeException("Cannot create node source activity " + nodeSourceName, e);
+            String errorMessage = "Failed to create node source activity " + nodeSourceName;
+            logger.error(errorMessage, e);
+            throw new RuntimeException(errorMessage, e);
         }
-
         return nodeSourceToDeploy;
     }
 
     private void updateNodeSourceDescriptorWithStatusAndPersist(NodeSourceDescriptor descriptor,
             NodeSourceStatus status) {
-
         descriptor.setStatus(status);
-
         persistNodeSourceWithNewDescriptor(descriptor);
     }
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1455,7 +1455,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             this.deployedNodeSources.put(nodeSourceName, nodeSourceStub);
             this.emitNodeSourceEvent(nodeSourceStub, RMEventType.NODESOURCE_CREATED);
             logger.info(NODE_SOURCE_STRING + nodeSourceName + " has been successfully deployed");
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             this.updateNodeSourceDescriptorWithStatusAndPersist(nodeSourceDescriptor,
                                                                 NodeSourceStatus.NODES_UNDEPLOYED);
             logger.error(NODE_SOURCE_STRING + nodeSourceName + " failed to be deployed", e);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1437,7 +1437,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             this.updateNodeSourceDescriptorWithStatusAndPersist(nodeSourceDescriptor, NodeSourceStatus.NODES_DEPLOYED);
             deployNodeSourceOrFail(nodeSourceName, nodeSourceDescriptor);
         } else {
-            logger.debug("Node source " + nodeSourceName + " is already deployed");
+            logger.debug(NODE_SOURCE_STRING + nodeSourceName + " is already deployed");
         }
         return new BooleanWrapper(true);
     }


### PR DESCRIPTION
- in commit #3317, node source status update from UNDEPLOYED to DEPLOYED was move to after the node source activity was created. This creates inconsistencies between the node source status that is in the NodeSource activity and the one that is in the RMCore activity.
- the fix is to perform the update before the node source activity is created (like before commit #3317), but to rollback the update if an exception occurs in the creation of the node source activity. This also fix the bug fixed by commit #3317 and leaves the failed deployed node source as undeployed.