### PR TITLE
Rename REPLICATION column to REPLICATE in order to support SQLServer.

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -1077,7 +1077,7 @@ public class TaskData {
         this.iteration = iteration;
     }
 
-    @Column(name = "REPLICATION")
+    @Column(name = "REPLICATE")
     public int getReplication() {
         return replication;
     }


### PR DESCRIPTION
'REPLICATION' is a reserved keyword in SQLServer.

This fixes #3320