### PR TITLE
ProActive examples script inside OpenShift

### DIFF
--- a/tools/LoadPackages.groovy
+++ b/tools/LoadPackages.groovy
@@ -30,7 +30,7 @@ class LoadPackages {
         this.TOOLS_DIR = new File(this.SCHEDULER_HOME, "tools")
 
         // Deduced variables
-        this.EXAMPLES_DIR_PATH = this.EXAMPLES_ZIP_PATH.substring(0, this.EXAMPLES_ZIP_PATH.lastIndexOf("."))
+        this.EXAMPLES_DIR_PATH = this.SCHEDULER_HOME + "/samples/workflows/proactive-examples"
 
         // Create a new instance of the package loader
         File load_package_script = new File(this.TOOLS_DIR, this.LOAD_PACKAGE_SCRIPT_NAME)


### PR DESCRIPTION
- Change the workflows extraction path from the proactive-examples.zip. The reason is that it makes it much easier with OpenShift to handle such directory structure. OpenShift gives read access to every folder, when one creates a volume, then the container has write access to that directory. In the case of the proactive-examples script, it checks whether the samples/proactive-examples directory is already existing. Creating a volume with OpenShift can make the samples/proactive-examples directory writeable but then this directory already exists, so the script exits. To avoid that, this PR switches the samples/proactive-examples directory with samples/workflows/proactive-examples, that way one can create samples/workflows as a volume inside OpenShift. Having the samples/workflows volumes allows to extract the proactive-examples script its workflows into that. Now the proactive-exmaples script is changed to create a subfolder in samples/workflows/proactive-examples. This sub-folder will not be existing at startup, but will have write access -> so the roactive-examples script will work inside OpenShift