### PR TITLE
Move NodesHouseKeepingPropertiesTest to regression tests

### DIFF
--- a/rm/rm-server/src/test/java/functionaltests/RegressionTestSuite.java
+++ b/rm/rm-server/src/test/java/functionaltests/RegressionTestSuite.java
@@ -28,6 +28,7 @@ package functionaltests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import functionaltests.housekeeping.NodesHouseKeepingPropertiesTest;
 import functionaltests.nodesource.TestLocalInfrastructureCronPolicy;
 import functionaltests.nodesource.TestLocalInfrastructureTimeSlotPolicy;
 import functionaltests.nodesource.TestSSHInfrastructureV2RestartDownNodesPolicy;
@@ -43,7 +44,8 @@ import functionaltests.selectionscript.SelectionScriptTimeOutTest;
 @Suite.SuiteClasses({ NonBlockingCoreTest.class, TestNSNodesPermissions.class, SelectionScriptTimeOutTest.class,
                       RecoverLocalInfrastructureTest.class, RecoverSSHInfrastructureV2Test.class,
                       TestLocalInfrastructureCronPolicy.class, TestLocalInfrastructureTimeSlotPolicy.class,
-                      TestSSHInfrastructureV2RestartDownNodesPolicy.class, NodesRecoveryPropertyTest.class })
+                      TestSSHInfrastructureV2RestartDownNodesPolicy.class, NodesRecoveryPropertyTest.class,
+                      NodesHouseKeepingPropertiesTest.class })
 
 /**
  * @author ActiveEon Team

--- a/rm/rm-server/src/test/java/functionaltests/StandardTestSuite.java
+++ b/rm/rm-server/src/test/java/functionaltests/StandardTestSuite.java
@@ -37,7 +37,6 @@ import functionaltests.db.NodeSourcesTest;
 import functionaltests.db.RMDBManagerBufferTest;
 import functionaltests.db.RMDBManagerTest;
 import functionaltests.execremote.TestExecRemote;
-import functionaltests.housekeeping.NodesHouseKeepingPropertiesTest;
 import functionaltests.jmx.RMProxyUserInterfaceTest;
 import functionaltests.jmx.ResourceManagerJMXTest;
 import functionaltests.jmx.account.AddGetDownRemoveTest;
@@ -85,7 +84,7 @@ import functionaltests.topology.SelectionTest;
                       SelectionWithSeveralScriptsTest.class, SelectionWithSeveralScriptsTest2.class,
                       StaticSelectionScriptTest.class, UnauthorizedSelectionScriptTest.class, LocalSelectionTest.class,
                       SelectionTest.class, SSHInfrastructureV2LifecycleTest.class, TestSSHInfrastructureV2.class,
-                      LocalInfrastructureLifecycleTest.class, NodesHouseKeepingPropertiesTest.class })
+                      LocalInfrastructureLifecycleTest.class })
 
 /**
  * @author ActiveEon Team


### PR DESCRIPTION
- after some time of stability, this test is moved to regression tests as it plays with the resource manager properties and requires testing based on timeouts