### PR TITLE
Fix reconnection to null

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2125,7 +2125,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             return;
         }
 
-        if (!clients.containsKey(owner.getId())) {
+        if ((!clients.containsKey(owner.getId()) && owner != localClient)) {
             logger.warn(nodeUrl + " cannot set busy as the client disconnected " + owner);
             throw new NotConnectedException("Client " + owner + " is not connected to the resource manager");
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2366,10 +2366,12 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         // return false for non connected clients
         // it should be verified by checkPermissionsMethod but it returns true for
         // local active objects
-
-        // caller == localClient added, because otherwise whatever exception thrown from main scheduler loop
-        // will cause reconnection to RM.
-        return new BooleanWrapper(!toShutDown && (clients.containsKey(caller.getId()) || caller == localClient));
+        String methodName = PAActiveObject.getContext().getCurrentRequest().getMethodName();
+        final Client sourceBodyCaller = checkMethodCallPermission(methodName,
+                                                                  PAActiveObject.getContext()
+                                                                                .getCurrentRequest()
+                                                                                .getSourceBodyID());
+        return new BooleanWrapper(!toShutDown && clients.containsKey(sourceBodyCaller.getId()));
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2125,7 +2125,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             return;
         }
 
-        if ((!clients.containsKey(owner.getId()) && owner != localClient)) {
+        if (!clients.containsKey(owner.getId()) && owner != localClient) {
             logger.warn(nodeUrl + " cannot set busy as the client disconnected " + owner);
             throw new NotConnectedException("Client " + owner + " is not connected to the resource manager");
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2366,11 +2366,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         // return false for non connected clients
         // it should be verified by checkPermissionsMethod but it returns true for
         // local active objects
-        String methodName = PAActiveObject.getContext().getCurrentRequest().getMethodName();
-        final Client sourceBodyCaller = checkMethodCallPermission(methodName,
-                                                                  PAActiveObject.getContext()
-                                                                                .getCurrentRequest()
-                                                                                .getSourceBodyID());
+        final Request currentRequest = PAActiveObject.getContext().getCurrentRequest();
+        String methodName = currentRequest.getMethodName();
+        final Client sourceBodyCaller = checkMethodCallPermission(methodName, currentRequest.getSourceBodyID());
         return new BooleanWrapper(!toShutDown && clients.containsKey(sourceBodyCaller.getId()));
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
@@ -124,6 +124,7 @@ import functionaltests.policy.ram.TestRamPolicy;
 import functionaltests.rm.TestNodeDiesAtSchedulerRestart;
 import functionaltests.rm.TestRMProxy;
 import functionaltests.rm.TestRMProxyRebind;
+import functionaltests.rm.TestRMReconnectionWhileRunning;
 import functionaltests.rm.nodesource.TestJobNodeAccessToken;
 import functionaltests.runasme.TestRunAsMeLinuxKey;
 import functionaltests.runasme.TestRunAsMeLinuxNone;
@@ -205,7 +206,7 @@ import functionaltests.workflow.variables.Test_SCHEDULING_2034;
                       JettyStarterTest.class, TestXMLTransformer.class, TagTest.class,
 
                       // RM proxy tests
-                      TestRMProxy.class, TestRMProxyRebind.class,
+                      TestRMProxy.class, TestRMProxyRebind.class, TestRMReconnectionWhileRunning.class,
 
                       // Tests without scheduler restart
                       AuthenticationTest.class, ComplexTypeArgsTest.class, SchedulerJMXTest.class,

--- a/scheduler/scheduler-server/src/test/java/functionaltests/rm/TestRMReconnectionWhileRunning.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/rm/TestRMReconnectionWhileRunning.java
@@ -119,7 +119,11 @@ public class TestRMReconnectionWhileRunning extends MultipleRMTBase {
                                                       .size();
         int attemptsThatDidNotCauseReconnection = LogProcessor.linesThatMatch("Do not reconnect to the RM as connection is active for ")
                                                               .size();
-        int actualNumberOfReconnections = numberOfAttemptsToReconnect - attemptsThatDidNotCauseReconnection;
+
+        // we print 'do not reconnect' for each user, and now we have 2 users, 'admin' and 'demo'
+        int EXP_NUMBER_OF_USERS = 2;
+        int actualNumberOfReconnections = EXP_NUMBER_OF_USERS * numberOfAttemptsToReconnect -
+                                          attemptsThatDidNotCauseReconnection;
 
         assertEquals(0, actualNumberOfReconnections);
     }


### PR DESCRIPTION
Attempt to fix: 
```
2018-09-25 07:09:14,928 /0/RM_NODE WARN      o.o.p.r.s.SelectionManager] Client "null" is not connected to the resource manager
org.ow2.proactive.resourcemanager.exception.NotConnectedException: Client "null" is not connected to the resource manager
	at org.ow2.proactive.resourcemanager.core.RMCore.setBusyNode(RMCore.java:2063)
	at sun.reflect.GeneratedMethodAccessor729.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.objectweb.proactive.core.mop.MethodCall.execute(MethodCall.java:243)
	at org.objectweb.proactive.core.body.request.RequestImpl.serveInternal(RequestImpl.java:207)
	at org.objectweb.proactive.core.body.request.RequestImpl.serve(RequestImpl.java:153)
	at org.objectweb.proactive.core.body.BodyImpl$ActiveLocalBodyStrategy.serveInternal(BodyImpl.java:561)
	at org.objectweb.proactive.core.body.BodyImpl$ActiveLocalBodyStrategy.serve(BodyImpl.java:486)
	at org.objectweb.proactive.core.body.AbstractBody.serve(AbstractBody.java:417)
	at org.objectweb.proactive.Service.serve(Service.java:119)
	at org.ow2.proactive.resourcemanager.core.RMCore.runActivity(RMCore.java:499)
	at org.objectweb.proactive.core.body.ActiveBody.run(ActiveBody.java:167)
	at java.lang.Thread.run(Thread.java:748)
	at org.ow2.proactive.resourcemanager.core.RMCore.setBusyNode([pamr://0/ActiveObject_org.ow2.proactive.resourcemanager.core.RMCore_173359a7-165f16fafce--7fff--bf68438833d05112-173359a7-165f16fafce--8000, pamr://0/RMCORE])
	at (...)(Unknown Source)
	at org.objectweb.proactive.core.body.proxy.AbstractBodyProxy.reifyAsSynchronous(AbstractBodyProxy.java:338)
	at org.objectweb.proactive.core.body.proxy.AbstractBodyProxy.invokeOnBody(AbstractBodyProxy.java:159)
	at org.objectweb.proactive.core.body.proxy.AbstractBodyProxy.reify(AbstractBodyProxy.java:113)
	at pa.stub.org.ow2.proactive.resourcemanager.core._StubRMCore.setBusyNode(_StubRMCore.java)
	at org.ow2.proactive.resourcemanager.selection.SelectionManager.doSelectNodes(SelectionManager.java:358)
	at org.ow2.proactive.resourcemanager.selection.SelectionManager.selectNodes(SelectionManager.java:214)
	at sun.reflect.GeneratedMethodAccessor723.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.objectweb.proactive.core.mop.MethodCall.execute(MethodCall.java:243)
	at org.objectweb.proactive.core.body.request.RequestImpl.serveInternal(RequestImpl.java:207)
	at org.objectweb.proactive.core.body.request.RequestImpl.serve(RequestImpl.java:153)
	at org.objectweb.proactive.core.body.BodyImpl$ActiveLocalBodyStrategy.serveInternal(BodyImpl.java:561)
	at org.objectweb.proactive.core.body.BodyImpl$ActiveLocalBodyStrategy.serve(BodyImpl.java:486)
	at org.objectweb.proactive.core.body.AbstractBody.serve(AbstractBody.java:417)
	at org.objectweb.proactive.Service.serve(Service.java:119)
	at org.objectweb.proactive.Service.blockingServeOldest(Service.java:203)
	at org.objectweb.proactive.Service.blockingServeOldest(Service.java:178)
	at org.objectweb.proactive.Service.fifoServing(Service.java:141)
	at org.objectweb.proactive.core.body.ActiveBody$FIFORunActive.runActivity(ActiveBody.java:329)
	at org.objectweb.proactive.core.body.ActiveBody.run(ActiveBody.java:167)
	at java.lang.Thread.run(Thread.java:748)
[2018-09-25 07:09:14,937 lingThread ERROR    o.o.p.s.c.SchedulingService] Unexpected exception in the scheduling thread - checking the connection to resource manager
java.lang.NullPointerException
	at sun.reflect.GeneratedMethodAccessor654.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.objectweb.proactive.core.mop.MethodCall.execute(MethodCall.java:243)
	at org.objectweb.proactive.core.body.future.FutureProxy.reify(FutureProxy.java:448)
	at pa.stub.org.ow2.proactive.utils._StubNodeSet.size(_StubNodeSet.java)
	at org.ow2.proactive.scheduler.core.SchedulingMethodImpl.getRMNodes(SchedulingMethodImpl.java:520)
	at org.ow2.proactive.scheduler.core.SchedulingMethodImpl.selectAndStartTasks(SchedulingMethodImpl.java:291)
	at org.ow2.proactive.scheduler.core.SchedulingMethodImpl.getNumberOfTaskStarted(SchedulingMethodImpl.java:215)
	at org.ow2.proactive.scheduler.core.SchedulingMethodImpl.startTasks(SchedulingMethodImpl.java:205)
	at org.ow2.proactive.scheduler.core.SchedulingMethodImpl.schedule(SchedulingMethodImpl.java:181)
	at org.ow2.proactive.scheduler.core.SchedulingThread.run(SchedulingThread.java:57)
[2018-09-25 07:09:14,937 lingThread INFO     o.o.p.s.c.SchedulingService] Automatically reconnecting to RM at url pamr://0/...
```
Sometimes setBusyNodes losts for all user connection to the RM.
