### PR TITLE
fix task dependencies order

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -32,6 +32,7 @@ import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -119,7 +120,7 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
             int resultSize = taskDescriptor.getParents().size();
             if ((job.getType() == JobType.TASKSFLOW) && (resultSize > 0) && task.handleResultsArguments()) {
 
-                Set<TaskId> parentIds = new HashSet<>(resultSize);
+                Set<TaskId> parentIds = new LinkedHashSet<>(resultSize);
                 for (int i = 0; i < resultSize; i++) {
                     parentIds.addAll(internalTaskParentFinder.getFirstNotSkippedParentTaskIds(((EligibleTaskDescriptorImpl) taskDescriptor.getParents()
                                                                                                                                           .get(i)).getInternal()));

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -31,7 +31,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
In this PR, we fixed the task dependencies order as it is described in the doc https://www.activeeon.com/public_content/documentation/latest/user/ProActiveUserGuide.html#_task_result