### PR TITLE
FIX incorrect job visualization

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
@@ -80,9 +80,9 @@ public class WorkflowSubmitter {
             JobId jobId = scheduler.submit(job);
             // Create Job's SVG visualization file
             String visualization = job.getVisualization();
+            File visualizationFile = new File(PortalConfiguration.jobIdToPath(jobId.value()) + ".html");
+            Files.deleteIfExists(visualizationFile.toPath());
             if (visualization != null && !visualization.isEmpty()) {
-                File visualizationFile = new File(PortalConfiguration.jobIdToPath(jobId.value()) + ".html");
-                Files.deleteIfExists(visualizationFile.toPath());
                 FileUtils.write(new File(visualizationFile.getAbsolutePath()),
                                 job.getVisualization(),
                                 Charset.forName(FILE_ENCODING));


### PR DESCRIPTION
In this PR, we fix a bug that shows incorrect job visualization in case the latter doesn't have visualization metadata and eventually there was another job with the same id in a different scheduler database that had a visu.