### PR TITLE
Popup DME so it does not restart transaction

### DIFF
--- a/common/common-db/src/main/java/org/ow2/proactive/db/TransactionHelper.java
+++ b/common/common-db/src/main/java/org/ow2/proactive/db/TransactionHelper.java
@@ -94,7 +94,7 @@ public class TransactionHelper {
         for (int i = 0; i <= maximumNumberOfRetries; i++) {
             try {
                 return tryExecuteTransaction(sessionWork, readWriteTransaction, readOnlyEntities);
-            } catch (DatabaseManagerException e) {
+            } catch (DatabaseManagerException | IllegalArgumentException e) {
                 throw e;
             } catch (Throwable exception) {
                 lastException = exception;
@@ -126,7 +126,7 @@ public class TransactionHelper {
             session.getTransaction().commit();
 
             return result;
-        } catch (DatabaseManagerException e) {
+        } catch (DatabaseManagerException | IllegalArgumentException e) {
             throw e;
         } catch (Throwable e) {
             logger.warn("Database operation failed", e);

--- a/common/common-db/src/main/java/org/ow2/proactive/db/TransactionHelper.java
+++ b/common/common-db/src/main/java/org/ow2/proactive/db/TransactionHelper.java
@@ -126,8 +126,6 @@ public class TransactionHelper {
             session.getTransaction().commit();
 
             return result;
-        } catch (DatabaseManagerException | IllegalArgumentException e) {
-            throw e;
         } catch (Throwable e) {
             logger.warn("Database operation failed", e);
 

--- a/common/common-db/src/main/java/org/ow2/proactive/db/TransactionHelper.java
+++ b/common/common-db/src/main/java/org/ow2/proactive/db/TransactionHelper.java
@@ -94,6 +94,8 @@ public class TransactionHelper {
         for (int i = 0; i <= maximumNumberOfRetries; i++) {
             try {
                 return tryExecuteTransaction(sessionWork, readWriteTransaction, readOnlyEntities);
+            } catch (DatabaseManagerException e) {
+                throw e;
             } catch (Throwable exception) {
                 lastException = exception;
 
@@ -124,6 +126,8 @@ public class TransactionHelper {
             session.getTransaction().commit();
 
             return result;
+        } catch (DatabaseManagerException e) {
+            throw e;
         } catch (Throwable e) {
             logger.warn("Database operation failed", e);
 


### PR DESCRIPTION
TransactionHelper helper considers all exceptions as database errors. So it retries each transaction 5 times (also there are delays between transactions). However, in SchedulerDBManager we throw some exceptions,  these exceptions are business exceptions, so there is nothing to retry. Thus if TransactionHelper catches DatabaseManagerError or IllegalArgumentException, it re-throws them.