### PR TITLE
Add Scheduler Vars replacement in job parsing

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -78,6 +78,7 @@ import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.ow2.proactive.scheduler.common.task.flow.FlowBlock;
 import org.ow2.proactive.scheduler.common.task.flow.FlowScript;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.ow2.proactive.scheduler.task.SchedulerVars;
 import org.ow2.proactive.scripting.ForkEnvironmentScript;
 import org.ow2.proactive.scripting.Script;
 import org.ow2.proactive.scripting.SelectionScript;
@@ -101,6 +102,10 @@ public class StaxJobFactory extends JobFactory {
     public static final Logger logger = Logger.getLogger(StaxJobFactory.class);
 
     private static final String FILE_ENCODING = PASchedulerProperties.FILE_ENCODING.getValueAsString();
+
+    private static final String PA_CATALOG_REST_URL = PASchedulerProperties.CATALOG_REST_URL.getValueAsString();
+
+    private static final String PA_SCHEDULER_REST_URL = PASchedulerProperties.SCHEDULER_REST_URL.getValueAsString();
 
     public static final String MSG_UNABLE_TO_INSTANCIATE_JOB_VALIDATION_FACTORIES = "Unable to instanciate job validation factories";
 
@@ -1730,10 +1735,18 @@ public class StaxJobFactory extends JobFactory {
      * @throws JobCreationException if a Variable has not been found
      */
     private String replace(String str, Map<String, String> variables) throws JobCreationException {
+
+        // Include System Variables
         Map<String, String> replacements = new HashMap<>();
         for (Map.Entry<Object, Object> o : System.getProperties().entrySet()) {
             replacements.put(o.getKey().toString(), o.getValue().toString());
         }
+
+        // Include useful "global" scheduler variables
+        replacements.put(SchedulerVars.PA_CATALOG_REST_URL.toString(), PA_CATALOG_REST_URL);
+        replacements.put(SchedulerVars.PA_SCHEDULER_REST_URL.toString(), PA_SCHEDULER_REST_URL);
+
+        // Include given variables if any
         if (variables != null) {
             replacements.putAll(variables);
         }


### PR DESCRIPTION
In this PR, we apply variable substitution for SchedulerVars : `PA_SCHEDULER_REST_URL` and `PA_CATALOG_REST_URL` during job parsing.

The main goal behind this is to allow referencing Catalog objects with relative Scheduler Catalog URL links.

Therefore, from now on, a task implementation that uses a catalog script by reference will have the following URL:
`${PA_CATALOG_REST_URL}`/buckets/scripts/my_script`