### PR TITLE
Force usage of the system console when initializing the proactive-cli

### DIFF
--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/EntryPoint.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/EntryPoint.java
@@ -46,9 +46,6 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.ow2.proactive_grid_cloud_portal.cli.cmd.AbstractLoginCommand;
 import org.ow2.proactive_grid_cloud_portal.cli.cmd.Command;
 import org.ow2.proactive_grid_cloud_portal.cli.console.AbstractDevice;
-import org.ow2.proactive_grid_cloud_portal.cli.console.JLineDevice;
-
-import com.google.common.collect.ObjectArrays;
 
 
 public abstract class EntryPoint {
@@ -139,13 +136,8 @@ public abstract class EntryPoint {
     }
 
     protected static CommandFactory getCommandFactory(ApplicationContext currentContext) throws IOException {
-        CommandFactory commandFactory;
-        AbstractDevice console;
-        commandFactory = getCommandFactory();
-        console = AbstractDevice.getConsole(AbstractDevice.JLINE);
-        ((JLineDevice) console).setCommands(ObjectArrays.concat(commandFactory.supportedCommandEntries(),
-                                                                CommandSet.INTERACTIVE_COMMANDS,
-                                                                CommandSet.Entry.class));
+        CommandFactory commandFactory = getCommandFactory();
+        AbstractDevice console = AbstractDevice.getConsole(AbstractDevice.STANDARD);
         currentContext.setDevice(console);
         return commandFactory;
     }

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/EntryPoint.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/EntryPoint.java
@@ -186,6 +186,8 @@ public abstract class EntryPoint {
                 }
 
                 if (isDebugModeEnabled) {
+                    // when debug mode is enabled we display extra info
+                    // like the java stacktrace when possible
                     if (cause instanceof CLIException && ((CLIException) cause).stackTrace() != null) {
                         writer.printf("%nStack trace: %s%n", ((CLIException) cause).stackTrace());
                     } else {

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/EntryPoint.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/EntryPoint.java
@@ -176,22 +176,24 @@ public abstract class EntryPoint {
 
     private void writeError(ApplicationContext currentContext, String errorMsg, Throwable cause,
             boolean isDebugModeEnabled) {
-        PrintWriter writer = new PrintWriter(currentContext.getDevice().getWriter(), true);
-        writer.printf("%s", errorMsg);
 
-        if (cause != null) {
-            if (cause.getMessage() != null) {
-                writer.printf("%n%nError message: %s%n", cause.getMessage());
-            }
+        try (PrintWriter writer = new PrintWriter(currentContext.getDevice().getWriter(), true)) {
+            writer.printf("%s", errorMsg);
 
-            if (isDebugModeEnabled) {
-                if (cause instanceof CLIException && ((CLIException) cause).stackTrace() != null) {
-                    writer.printf("%nStack trace: %s%n", ((CLIException) cause).stackTrace());
-                } else {
-                    writer.printf("%nStack trace: %s%n", getStackTraceAsString(cause));
+            if (cause != null) {
+                if (cause.getMessage() != null) {
+                    writer.printf("%n%nError message: %s%n", cause.getMessage());
                 }
-            } else {
-                writeDebugModeUsageWithBreakEndLine(currentContext);
+
+                if (isDebugModeEnabled) {
+                    if (cause instanceof CLIException && ((CLIException) cause).stackTrace() != null) {
+                        writer.printf("%nStack trace: %s%n", ((CLIException) cause).stackTrace());
+                    } else {
+                        writer.printf("%nStack trace: %s%n", getStackTraceAsString(cause));
+                    }
+                } else {
+                    writeDebugModeUsageWithBreakEndLine(currentContext);
+                }
             }
         }
     }

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/AbstractIModeCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/AbstractIModeCommand.java
@@ -56,6 +56,7 @@ public abstract class AbstractIModeCommand extends AbstractCommand implements Co
         CommandFactory commandFactory = CommandFactory.getCommandFactory(CommandFactory.Type.ALL);
         AbstractDevice console = null;
         try {
+            // force the console to JLine to provide commands completion and suggestions
             console = AbstractDevice.getConsole(AbstractDevice.JLINE);
             ((JLineDevice) console).setCommands(ObjectArrays.concat(commandFactory.supportedCommandEntries(),
                                                                     CommandSet.INTERACTIVE_COMMANDS,

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/AbstractIModeCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/AbstractIModeCommand.java
@@ -61,7 +61,7 @@ public abstract class AbstractIModeCommand extends AbstractCommand implements Co
                                                                     CommandSet.INTERACTIVE_COMMANDS,
                                                                     CommandSet.Entry.class));
         } catch (IOException e) {
-            e.printStackTrace();
+            handleError("An error occurred while initializing the console:", e, currentContext);
         }
         currentContext.setDevice(console);
         currentContext.setProperty(IMODE, true);
@@ -81,7 +81,7 @@ public abstract class AbstractIModeCommand extends AbstractCommand implements Co
                 }
                 engine.eval(command);
             } catch (ScriptException se) {
-                handleError(String.format("An error occurred while executing the script:"), se, currentContext);
+                handleError("An error occurred while executing the script:", se, currentContext);
             }
         }
     }

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/AbstractIModeCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/AbstractIModeCommand.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive_grid_cloud_portal.cli.cmd;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
@@ -33,6 +34,12 @@ import javax.script.ScriptException;
 
 import org.ow2.proactive_grid_cloud_portal.cli.ApplicationContext;
 import org.ow2.proactive_grid_cloud_portal.cli.CLIException;
+import org.ow2.proactive_grid_cloud_portal.cli.CommandFactory;
+import org.ow2.proactive_grid_cloud_portal.cli.CommandSet;
+import org.ow2.proactive_grid_cloud_portal.cli.console.AbstractDevice;
+import org.ow2.proactive_grid_cloud_portal.cli.console.JLineDevice;
+
+import com.google.common.collect.ObjectArrays;
 
 
 public abstract class AbstractIModeCommand extends AbstractCommand implements Command {
@@ -46,6 +53,17 @@ public abstract class AbstractIModeCommand extends AbstractCommand implements Co
 
     @Override
     public void execute(ApplicationContext currentContext) throws CLIException {
+        CommandFactory commandFactory = CommandFactory.getCommandFactory(CommandFactory.Type.ALL);
+        AbstractDevice console = null;
+        try {
+            console = AbstractDevice.getConsole(AbstractDevice.JLINE);
+            ((JLineDevice) console).setCommands(ObjectArrays.concat(commandFactory.supportedCommandEntries(),
+                                                                    CommandSet.INTERACTIVE_COMMANDS,
+                                                                    CommandSet.Entry.class));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        currentContext.setDevice(console);
         currentContext.setProperty(IMODE, true);
         ScriptEngine engine = currentContext.getEngine();
         try {

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/console/AbstractDevice.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/console/AbstractDevice.java
@@ -31,7 +31,7 @@ import java.io.Writer;
 
 public abstract class AbstractDevice {
 
-    public static final short STARDARD = 1;
+    public static final short STANDARD = 1;
 
     public static final short JLINE = 2;
 
@@ -53,7 +53,7 @@ public abstract class AbstractDevice {
 
     public static AbstractDevice getConsole(int type) throws IOException {
         switch (type) {
-            case STARDARD:
+            case STANDARD:
                 return (System.console() != null) ? new ConsoleDevice(System.console())
                                                   : new CharacterDevice(System.in, System.out);
             case JLINE:


### PR DESCRIPTION
This is intended to avoid JLine errors if the proactive-client command is sent to the background (e.g `nohup ./proactive-client -lj &`)
Minor refactor over the naming of the SYSTEM console