### PR TITLE
Remove default values for Workflow project name and description

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
@@ -67,8 +67,6 @@ public abstract class Job extends CommonAttribute {
 
     private static final Logger LOGGER = Logger.getLogger(Job.class);
 
-    public static final String DEFAULT_PROJECT_NAME = "Not Assigned";
-
     public static final String JOB_DDL = "JOB_DDL";
 
     public static final String JOB_EXEC_TIME = "JOB_EXEC_TIME";
@@ -81,12 +79,12 @@ public abstract class Job extends CommonAttribute {
     /**
      * Short description of this job
      */
-    protected String description = "No description";
+    protected String description = "";
 
     /**
      * Project name for this job
      */
-    protected String projectName = DEFAULT_PROJECT_NAME;
+    protected String projectName = "";
 
     /**
      * Job priority

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
@@ -180,7 +180,7 @@ public class Job2XMLTransformer {
                                                      " http://www.activeeon.com/public_content/schemas/proactive/jobdescriptor/" +
                                                      Schemas.SCHEMA_LATEST.getVersion() + "/schedulerjob.xsd");
 
-        if (!Job.DEFAULT_PROJECT_NAME.equals(job.getProjectName())) {
+        if (!job.getProjectName().isEmpty()) {
             setAttribute(rootJob, XMLAttributes.JOB_PROJECT_NAME, job.getProjectName(), true);
         }
         setAttribute(rootJob, XMLAttributes.JOB_PRIORITY, job.getPriority().toString());

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestJobFactory.java
@@ -271,7 +271,7 @@ public class TestJobFactory {
         log("Test Job MULTI_NODES");
         TaskFlowJob mnJob = getJob(jobMultiNodesDescriptor, impl, scriptFolder);
         //Check job properties
-        assertEquals("No description", mnJob.getDescription());
+        assertEquals("", mnJob.getDescription());
         assertEquals("job_multiNodes", mnJob.getName());
         assertEquals(JobPriority.LOW, mnJob.getPriority());
         assertEquals(OnTaskError.NONE, mnJob.getOnTaskErrorProperty().getValue());


### PR DESCRIPTION
- use the empty string as default values instead of having a descriptive information inside the default value.