### PR TITLE
Allow timeout on Authentication.isActivated

### DIFF
--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/Authentication.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/Authentication.java
@@ -32,6 +32,7 @@ import javax.management.JMException;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.jmx.naming.JMXTransportProtocol;
 
@@ -50,7 +51,7 @@ public interface Authentication extends Loggable, Serializable {
      * 
      * @return true if it is activated.
      */
-    boolean isActivated();
+    BooleanWrapper isActivated();
 
     /**
      * Request this Authentication's public key for credentials encryption

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/AuthenticationImpl.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/AuthenticationImpl.java
@@ -41,8 +41,10 @@ import javax.security.auth.login.LoginException;
 import org.objectweb.proactive.Body;
 import org.objectweb.proactive.RunActive;
 import org.objectweb.proactive.Service;
+import org.objectweb.proactive.annotation.ImmediateService;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.core.body.request.Request;
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.authentication.crypto.Credentials;
 
@@ -56,7 +58,7 @@ import org.ow2.proactive.authentication.crypto.Credentials;
 public abstract class AuthenticationImpl implements Authentication, RunActive {
 
     /** Activation is used to control authentication during scheduling initialization */
-    private boolean activated = false;
+    private volatile boolean activated = false;
 
     /**
      * Defines login method
@@ -205,8 +207,9 @@ public abstract class AuthenticationImpl implements Authentication, RunActive {
     /**
      * @see org.ow2.proactive.authentication.Authentication#isActivated()
      */
-    public boolean isActivated() {
-        return activated;
+    @ImmediateService
+    public BooleanWrapper isActivated() {
+        return new BooleanWrapper(activated);
     }
 
     /**


### PR DESCRIPTION
The previous implementation used a ProActive synchronous call (primitive boolean return value) which can block indefinitely. This could cause random freeze of a windows agent trying to contact the RM (the precise reason why the method never return is still uncertain).

This modification allow to not wait more than the expected timeout, allowing retries on windows agents.

An immediate service call is also added to try to avoid the root cause of the issue.