### PR TITLE
Add configurable jetty idle timeout

### DIFF
--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -68,6 +68,8 @@ public enum WebProperties implements PACommonProperties {
 
     WEB_MAX_THREADS("web.max_threads", PropertyType.INTEGER, "100"),
 
+    WEB_IDLE_TIMEOUT("web.idle_timeout", PropertyType.INTEGER, "60000"),
+
     WEB_REDIRECT_HTTP_TO_HTTPS("web.redirect_http_to_https", PropertyType.BOOLEAN, "false"),
 
     METADATA_CONTENT_TYPE("content.type", PropertyType.STRING),

--- a/config/web/settings.ini
+++ b/config/web/settings.ini
@@ -6,6 +6,9 @@ web.deploy=true
 # the maximum number of threads in Jetty for parallel request processing
 web.max_threads=100
 
+# timeout on http requests, default to 1 minute, can be increased to handle long requests
+web.idle_timeout=60000
+
 # port to use to deploy web applications
 web.http.port=8080
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
@@ -213,6 +213,7 @@ public class JettyStarter {
                                                                  new HttpConnectionFactory(secureHttpConfiguration));
             httpsConnector.setName(HTTPS_CONNECTOR_NAME);
             httpsConnector.setPort(httpsPort);
+            httpsConnector.setIdleTimeout(WebProperties.WEB_IDLE_TIMEOUT.getValueAsLong());
 
             if (redirectHttpToHttps) {
                 // The next two settings allow !403 errors to be redirected to HTTPS
@@ -228,6 +229,7 @@ public class JettyStarter {
             }
         } else {
             ServerConnector httpConnector = createHttpConnector(server, httpConfiguration, httpPort);
+            httpConnector.setIdleTimeout(WebProperties.WEB_IDLE_TIMEOUT.getValueAsLong());
             connectors = new Connector[] { httpConnector };
         }
 


### PR DESCRIPTION
Default jetty idle timeout is unsufficient for some requests (like downloading node.jar). Add an increased configurable timeout.