### PR TITLE
Support Oracle DB 

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -120,7 +120,7 @@ public class NodeSourceData implements Serializable {
     }
 
     @Column(length = Integer.MAX_VALUE)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getInfrastructureType() {
         return infrastructureType;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -372,7 +372,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "INPUT_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getInputSpace() {
         return inputSpace;
     }
@@ -383,7 +383,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "OUT_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getOutputSpace() {
         return outputSpace;
     }
@@ -394,7 +394,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "GLOBAL_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getGlobalSpace() {
         return globalSpace;
     }
@@ -405,7 +405,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "USER_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getUserSpace() {
         return userSpace;
     }
@@ -416,7 +416,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "DESCRIPTION", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getDescription() {
         return description;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -902,7 +902,7 @@ public class TaskData {
 
     @Lob
     @Column(name = "DESCRIPTION", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getDescription() {
         return description;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
@@ -177,7 +177,7 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BinaryType")
+    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_VALUE", length = Integer.MAX_VALUE)
     public byte[] getSerializedValue() {
         return serializedValue;
@@ -188,7 +188,7 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BinaryType")
+    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_EXCEPTION", length = Integer.MAX_VALUE)
     public byte[] getSerializedException() {
         return serializedException;
@@ -227,7 +227,7 @@ public class TaskResultData {
         this.propagatedVariables = executionVariables;
     }
 
-    @Column(name = "RAW", nullable = true)
+    @Column(name = "IS_RAW", nullable = true)
     public Boolean isRaw() {
         if (isRaw == null) {
             return false;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
@@ -177,7 +177,6 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_VALUE", length = Integer.MAX_VALUE)
     public byte[] getSerializedValue() {
         return serializedValue;
@@ -188,7 +187,6 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_EXCEPTION", length = Integer.MAX_VALUE)
     public byte[] getSerializedException() {
         return serializedException;


### PR DESCRIPTION
Several changes in order to adapt to Oracle DB:

- all fields with `@Type(type = "org.hibernate.type.TextType")  ` should be changed to  `@Type(type = "org.hibernate.type.MaterializedClobType")  `
- if class has 2 fields with `@Type(type = "org.hibernate.type.BinaryType")  ` then they should be changed to  `@Type(type = "org.hibernate.type.BlobType")  ` 
- Column cannot be called `RAW` - it is reserved work in Oracle.