### PR TITLE
Manually fix the serialver to exclude last digit of ProActive version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 #Tue, 18 Sep 2018 13:12:49 +0200
 programmingVersion=8.4.0-SNAPSHOT
 schedulingVersion=8.4.0-SNAPSHOT
-schedulingSerialver=83L
+schedulingSerialver=84L

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 #Tue, 18 Sep 2018 13:12:49 +0200
 programmingVersion=8.4.0-SNAPSHOT
 schedulingVersion=8.4.0-SNAPSHOT
-schedulingSerialver=840L
+schedulingSerialver=83L


### PR DESCRIPTION
- The release process mistakenly included the maintenance version in the serial version UIDs. We fix this by applying manually the correct serial version UID, which will be then increased by the automated version increase process for the future releases.