### PR TITLE
Handle gracefully the case where the scheduling loop cannot load a task definition

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -83,6 +83,8 @@ class LiveJobs {
 
     private static final TaskResultCreator taskResultCreator = TaskResultCreator.getInstance();
 
+    public static String KILL_TASK_DEFAULT_MESSAGE = "The task has been manually killed.";
+
     public static class JobData {
 
         final InternalJob job;
@@ -873,6 +875,11 @@ class LiveJobs {
     }
 
     TerminationData killTask(JobId jobId, String taskName) throws UnknownJobException, UnknownTaskException {
+        return this.killTask(jobId, taskName, KILL_TASK_DEFAULT_MESSAGE);
+    }
+
+    TerminationData killTask(JobId jobId, String taskName, String message)
+            throws UnknownJobException, UnknownTaskException {
         JobData jobData = lockJob(jobId);
         if (jobData == null) {
             throw new UnknownJobException(jobId);
@@ -893,9 +900,8 @@ class LiveJobs {
             TaskResultImpl taskResult = taskResultCreator.getTaskResult(dbManager,
                                                                         jobData.job,
                                                                         task,
-                                                                        new TaskAbortedException("The task has been manually killed."),
-                                                                        new SimpleTaskLogs("",
-                                                                                           "The task has been manually killed."));
+                                                                        new TaskAbortedException(message),
+                                                                        new SimpleTaskLogs("", message));
 
             TerminationData terminationData = createAndFillTerminationData(taskResult,
                                                                            taskData,
@@ -907,7 +913,7 @@ class LiveJobs {
                        terminationData,
                        task,
                        taskResult,
-                       "The task has been manually killed. " + "You also ask to cancel the job in such a situation!",
+                       message + " The job was configured to be cancelled automatically in this situation.",
                        JobStatus.CANCELED);
             } else {
                 terminateTask(jobData, task, true, taskResult, terminationData);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -618,13 +618,18 @@ public class SchedulingService {
     }
 
     public boolean killTask(final JobId jobId, final String taskName) throws UnknownJobException, UnknownTaskException {
+        return killTask(jobId, taskName, LiveJobs.KILL_TASK_DEFAULT_MESSAGE);
+    }
+
+    public boolean killTask(final JobId jobId, final String taskName, final String message)
+            throws UnknownJobException, UnknownTaskException {
         try {
             if (status.isUnusable()) {
                 return false;
             }
 
             return infrastructure.getClientOperationsThreadPool().submit(() -> {
-                TerminationData terminationData = jobs.killTask(jobId, taskName);
+                TerminationData terminationData = jobs.killTask(jobId, taskName, message);
                 boolean taskKilled = terminationData.taskTerminated(jobId, taskName);
                 submitTerminationDataHandler(terminationData);
                 wakeUpSchedulingThread();


### PR DESCRIPTION
Even if this happens very rarely, when the scheduling loop cannot load a task definition from the database, the scheduler will be completely unable to schedule new tasks afterwards (it keeps on retrying to load the task).

This change kills the incriminating task, with a comprehensive error message.

Example of such error:
org.hibernate.ObjectNotFoundException: No row with the given identifier exists: [org.ow2.proactive.scheduler.core.db.ScriptData#359]
	at org.hibernate.boot.internal.StandardEntityNotFoundDelegate.handleEntityNotFound(StandardEntityNotFoundDelegate.java:28)
	at org.hibernate.proxy.AbstractLazyInitializer.checkTargetState(AbstractLazyInitializer.java:236)
	at org.hibernate.proxy.AbstractLazyInitializer.initialize(AbstractLazyInitializer.java:158)
	at org.hibernate.proxy.AbstractLazyInitializer.getImplementation(AbstractLazyInitializer.java:260)
	at org.hibernate.proxy.pojo.javassist.JavassistLazyInitializer.invoke(JavassistLazyInitializer.java:68)
	at org.ow2.proactive.scheduler.core.db.ScriptData_$$_jvstbf1_8.createSimpleScript(ScriptData_$$_jvstbf1_8.java)
	at org.ow2.proactive.scheduler.core.db.TaskData.createExecutableContainer(TaskData.java:399)
	at org.ow2.proactive.scheduler.core.db.SchedulerDBManager.loadExecutableContainer(SchedulerDBManager.java:1650)
	... 12 more