### PR TITLE
Support Oracle DB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,9 +142,9 @@ configure(javaSubprojects) {
         testCompile 'com.jayway.awaitility:awaitility:1.6.0'
         testCompile 'org.apache.commons:commons-lang3:3.4'
 
-        compile 'org.postgresql:postgresql:42.0.0'
-        compile 'mysql:mysql-connector-java:8.0.11'
-
+        testCompile 'org.postgresql:postgresql:42.0.0'
+        testCompile 'mysql:mysql-connector-java:8.0.11'
+        testCompile 'com.microsoft.sqlserver:mssql-jdbc:7.1.2.jre8-preview'
 
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ configure(javaSubprojects) {
         testCompile 'org.apache.commons:commons-lang3:3.4'
 
         compile 'org.postgresql:postgresql:42.0.0'
-        compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.11'
+        compile 'mysql:mysql-connector-java:8.0.11'
 
 
     }

--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,11 @@ configure(javaSubprojects) {
         testCompile 'ObjectFaker:ObjectFaker:0.1'
         testCompile 'com.jayway.awaitility:awaitility:1.6.0'
         testCompile 'org.apache.commons:commons-lang3:3.4'
+
+        compile 'org.postgresql:postgresql:42.0.0'
+        compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.11'
+
+
     }
 
     test {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/NodeSourceData.java
@@ -120,7 +120,7 @@ public class NodeSourceData implements Serializable {
     }
 
     @Column(length = Integer.MAX_VALUE)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getInfrastructureType() {
         return infrastructureType;
     }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
@@ -584,7 +584,7 @@ public abstract class SelectionManager {
                         logger.error("Error while executing node script and waiting for the result on " + nodeURL, e);
                         throw e;
                     } finally {
-                        SelectionManager.this.rmcore.unlockNodes(Collections.singleton(nodeURL));
+                        SelectionManager.this.rmcore.unlockNodes(Collections.singleton(nodeURL)).getBooleanValue();
                     }
                 }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobContent.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobContent.java
@@ -59,7 +59,7 @@ import org.ow2.proactive.scheduler.util.ByteCompressionUtils;
 @NamedQueries({ @NamedQuery(name = "deleteJobContentInBulk", query = "delete from JobContent where id in :jobIdList"),
                 @NamedQuery(name = "loadJobContent", query = "from JobContent as content where content.jobId = :id"),
                 @NamedQuery(name = "countJobContent", query = "select count (*) from JobContent") })
-@Table(name = "JOB_CONTENT", indexes = { @Index(name = "INITIAL_JOB_INDEX", columnList = "JOB_ID") })
+@Table(name = "JOB_CONTENT")
 public class JobContent implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(JobContent.class);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -396,7 +396,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "INPUT_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getInputSpace() {
         return inputSpace;
     }
@@ -407,7 +407,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "OUT_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getOutputSpace() {
         return outputSpace;
     }
@@ -418,7 +418,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "GLOBAL_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getGlobalSpace() {
         return globalSpace;
     }
@@ -429,7 +429,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "USER_SPACE", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getUserSpace() {
         return userSpace;
     }
@@ -440,7 +440,7 @@ public class JobData implements Serializable {
 
     @Lob
     @Column(name = "DESCRIPTION", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getDescription() {
         return description;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobDataVariable.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobDataVariable.java
@@ -34,7 +34,7 @@ import org.ow2.proactive.scheduler.common.job.JobVariable;
 @NamedQueries({ @NamedQuery(name = "deleteJobDataVariable", query = "delete from JobDataVariable where jobData.id = :jobId"),
                 @NamedQuery(name = "deleteJobDataVariableInBulk", query = "delete from JobDataVariable where jobData.id in :jobIdList"),
                 @NamedQuery(name = "countJobDataVariable", query = "select count (*) from JobDataVariable") })
-@Table(name = "JOB_DATA_VARIABLE")
+@Table(name = "JOB_DATA_VARIABLE", indexes = { @Index(name = "JOB_DATA_VARIABLE_JOB_ID", columnList = "JOB_ID") })
 public class JobDataVariable {
 
     private long id;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -628,7 +628,12 @@ public class SchedulerDBManager {
     }
 
     private void removeJobScripts(Session session, long jobId) {
+        // This query competes with "deleteJobData" query.
+        // So Oracle 12c can stuck in deadlock.
+        // It is definitely something to improve.
+        // For now, we added "additionalDelayRandomized" in TransactionHelper.
         session.getNamedQuery("updateTaskDataJobScripts").setParameter("jobId", jobId).executeUpdate();
+
         session.getNamedQuery("deleteScriptData").setParameter("jobId", jobId).executeUpdate();
         session.getNamedQuery("deleteSelectionScriptData").setParameter("jobId", jobId).executeUpdate();
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ScriptData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ScriptData.java
@@ -50,6 +50,9 @@ import org.ow2.proactive.scripting.SimpleScript;
                 @NamedQuery(name = "deleteScriptDataInBulk", query = "delete from ScriptData where taskData.id.jobId in :jobIdList"),
                 @NamedQuery(name = "countScriptData", query = "select count (*) from ScriptData") })
 @BatchSize(size = 100)
+@Table(name = "SCRIPT_DATA", indexes = { @Index(name = "SCRIPT_DATA_JOB_ID", columnList = "JOB_ID"),
+                                         @Index(name = "SCRIPT_DATA_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
+                                         @Index(name = "SCRIPT_DATA_TASK_ID", columnList = "TASK_ID") })
 public class ScriptData {
 
     private long id;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectionScriptData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectionScriptData.java
@@ -47,6 +47,7 @@ import org.ow2.proactive.scripting.SelectionScript;
                 @NamedQuery(name = "deleteSelectionScriptDataInBulk", query = "delete from SelectionScriptData where taskData.id.jobId in :jobIdList"),
                 @NamedQuery(name = "countSelectionScriptData", query = "select count (*) from SelectionScriptData") })
 @Table(name = "SELECTION_SCRIPT_DATA", indexes = { @Index(name = "SELECTION_SCRIPT_DATA_JOB_ID", columnList = "JOB_ID"),
+                                                   @Index(name = "SELECTION_SCRIPT_DATA_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
                                                    @Index(name = "SELECTION_SCRIPT_DATA_TASK_ID", columnList = "TASK_ID") })
 @BatchSize(size = 100)
 public class SelectionScriptData {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectionScriptData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectionScriptData.java
@@ -46,9 +46,9 @@ import org.ow2.proactive.scripting.SelectionScript;
 @NamedQueries({ @NamedQuery(name = "deleteSelectionScriptData", query = "delete from SelectionScriptData where taskData.id.jobId = :jobId"),
                 @NamedQuery(name = "deleteSelectionScriptDataInBulk", query = "delete from SelectionScriptData where taskData.id.jobId in :jobIdList"),
                 @NamedQuery(name = "countSelectionScriptData", query = "select count (*) from SelectionScriptData") })
-@Table(name = "SELECTION_SCRIPT_DATA", indexes = { @Index(name = "SELECTION_SCRIPT_DATA_JOB_ID", columnList = "JOB_ID"),
-                                                   @Index(name = "SELECTION_SCRIPT_DATA_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
-                                                   @Index(name = "SELECTION_SCRIPT_DATA_TASK_ID", columnList = "TASK_ID") })
+@Table(name = "SELECTION_SCRIPT_DATA", indexes = { @Index(name = "SSD_DATA_JOB_ID", columnList = "JOB_ID"),
+                                                   @Index(name = "SSD_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
+                                                   @Index(name = "SSD_TASK_ID", columnList = "TASK_ID") })
 @BatchSize(size = 100)
 public class SelectionScriptData {
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectorData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectorData.java
@@ -43,9 +43,9 @@ import org.ow2.proactive.scheduler.core.db.types.PatternType;
 @NamedQueries({ @NamedQuery(name = "deleteSelectorData", query = "delete from SelectorData where taskData.id.jobId = :jobId"),
                 @NamedQuery(name = "deleteSelectorDataInBulk", query = "delete from SelectorData where taskData.id.jobId in :jobIdList"),
                 @NamedQuery(name = "countSelectorData", query = "select count (*) from SelectorData") })
-@Table(name = "DS_SELECTOR_DATA", indexes = { @Index(name = "DS_SELECTOR_DATA_JOB_ID", columnList = "JOB_ID"),
-                                              @Index(name = "DS_SELECTOR_DATA_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
-                                              @Index(name = "DS_SELECTOR_DATA_TASK_ID", columnList = "TASK_ID") })
+@Table(name = "DS_SELECTOR_DATA", indexes = { @Index(name = "DS_JOB_ID", columnList = "JOB_ID"),
+                                              @Index(name = "DS_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
+                                              @Index(name = "DS_TASK_ID", columnList = "TASK_ID") })
 public class SelectorData {
 
     private static final String INPUT_TYPE = "input";

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectorData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectorData.java
@@ -44,6 +44,7 @@ import org.ow2.proactive.scheduler.core.db.types.PatternType;
                 @NamedQuery(name = "deleteSelectorDataInBulk", query = "delete from SelectorData where taskData.id.jobId in :jobIdList"),
                 @NamedQuery(name = "countSelectorData", query = "select count (*) from SelectorData") })
 @Table(name = "DS_SELECTOR_DATA", indexes = { @Index(name = "DS_SELECTOR_DATA_JOB_ID", columnList = "JOB_ID"),
+                                              @Index(name = "DS_SELECTOR_DATA_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
                                               @Index(name = "DS_SELECTOR_DATA_TASK_ID", columnList = "TASK_ID") })
 public class SelectorData {
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -767,6 +767,7 @@ public class TaskData {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "TASK_DATA_DEPENDENCIES", joinColumns = { @JoinColumn(name = "JOB_ID", referencedColumnName = "TASK_ID_JOB"),
                                                                       @JoinColumn(name = "TASK_ID", referencedColumnName = "TASK_ID_TASK") }, indexes = { @Index(name = "TASK_DATA_DEP_JOB_ID", columnList = "JOB_ID"),
+                                                                                                                                                          @Index(name = "TASK_DATA_DEP_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
                                                                                                                                                           @Index(name = "TASK_DATA_DEP_TASK_ID", columnList = "TASK_ID"), })
     @BatchSize(size = 100)
     public List<DBTaskId> getDependentTasks() {
@@ -780,6 +781,7 @@ public class TaskData {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "TASK_DATA_JOINED_BRANCHES", joinColumns = { @JoinColumn(name = "JOB_ID", referencedColumnName = "TASK_ID_JOB"),
                                                                          @JoinColumn(name = "TASK_ID", referencedColumnName = "TASK_ID_TASK") }, indexes = { @Index(name = "TASK_DATA_JB_JOB_ID", columnList = "JOB_ID"),
+                                                                                                                                                             @Index(name = "TASK_DATA_JB_TASK_ID_JOB_ID", columnList = "TASK_ID,JOB_ID"),
                                                                                                                                                              @Index(name = "TASK_DATA_JB_TASK_ID", columnList = "TASK_ID"), })
     @BatchSize(size = 100)
     public List<DBTaskId> getJoinedBranches() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -902,7 +902,7 @@ public class TaskData {
 
     @Lob
     @Column(name = "DESCRIPTION", length = Integer.MAX_VALUE, updatable = false)
-    @Type(type = "org.hibernate.type.TextType")
+    @Type(type = "org.hibernate.type.MaterializedClobType")
     public String getDescription() {
         return description;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
@@ -177,7 +177,7 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BinaryType")
+    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_VALUE", length = Integer.MAX_VALUE)
     public byte[] getSerializedValue() {
         return serializedValue;
@@ -188,7 +188,7 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BinaryType")
+    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_EXCEPTION", length = Integer.MAX_VALUE)
     public byte[] getSerializedException() {
         return serializedException;
@@ -227,7 +227,7 @@ public class TaskResultData {
         this.propagatedVariables = executionVariables;
     }
 
-    @Column(name = "RAW", nullable = true)
+    @Column(name = "IS_RAW", nullable = true)
     public Boolean isRaw() {
         if (isRaw == null) {
             return false;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskResultData.java
@@ -177,7 +177,6 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_VALUE", length = Integer.MAX_VALUE)
     public byte[] getSerializedValue() {
         return serializedValue;
@@ -188,7 +187,6 @@ public class TaskResultData {
     }
 
     @Lob
-    @Type(type = "org.hibernate.type.BlobType")
     @Column(name = "RESULT_EXCEPTION", length = Integer.MAX_VALUE)
     public byte[] getSerializedException() {
         return serializedException;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/HsqldbServer.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/HsqldbServer.java
@@ -83,6 +83,8 @@ public class HsqldbServer extends AbstractIdleService {
     // this property is not a common HSQLDB property but a custom one to configure catalog options
     protected static final String PROP_HSQLDB_SERVER_CATALOGS_OPTION_LINE = "server.catalogs.option_line";
 
+    public static final String HSQLDB = "hsqldb";
+
     /*
      * Instance variables.
      */
@@ -125,7 +127,7 @@ public class HsqldbServer extends AbstractIdleService {
 
         String connectionUrl = hibernateProperties.getProperty(PROP_HIBERNATE_CONNECTION_URL);
 
-        if (connectionUrl.toLowerCase().contains("hsqldb")) {
+        if (connectionUrl.toLowerCase().contains(HSQLDB)) {
 
             String catalogLocation = identifyCatalogLocationFromConnectionUrl(connectionUrl);
             String catalogName = identifyCatalogNameFromConnectionUrl(connectionUrl);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
@@ -28,6 +28,7 @@ package functionaltests.db.schedulerdb;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Vector;
 
@@ -271,8 +272,8 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
                 Assert.assertEquals("Unexpected tasks number", tasksNumber, state.getTasks().size());
                 Assert.assertEquals(JobType.TASKSFLOW, state.getType());
                 Assert.assertEquals(DEFAULT_USER_NAME, state.getOwner());
-                Assert.assertEquals(job.getDescription(), state.getDescription());
-                Assert.assertEquals(job.getProjectName(), state.getProjectName());
+                Assert.assertEquals(job.getDescription(), Objects.toString(state.getDescription(), ""));
+                Assert.assertEquals(job.getProjectName(), Objects.toString(state.getProjectName(), ""));
                 Assert.assertEquals(job.getInputSpace(), state.getInputSpace());
                 Assert.assertEquals(job.getOutputSpace(), state.getOutputSpace());
                 Assert.assertEquals(job.getOnTaskErrorProperty().getValue(), state.getOnTaskErrorProperty().getValue());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDbManagerRecoveryTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDbManagerRecoveryTest.java
@@ -45,6 +45,7 @@ import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
+import org.ow2.proactive.scheduler.util.HsqldbServer;
 import org.ow2.tests.ProActiveTest;
 
 import functionaltests.utils.Jobs;
@@ -205,10 +206,12 @@ public class SchedulerDbManagerRecoveryTest extends ProActiveTest {
                                                                                        configureFilename)
                                                                           .toURI()));
 
-        String jdbcUrl = "jdbc:hsqldb:file:" + dbFolder.getRoot().getAbsolutePath() +
-                         ";create=true;hsqldb.tx=mvcc;hsqldb.write_delay=false";
+        if (config.getProperty("hibernate.connection.url").contains(HsqldbServer.HSQLDB)) {
+            String jdbcUrl = "jdbc:hsqldb:file:" + dbFolder.getRoot().getAbsolutePath() +
+                             ";create=true;hsqldb.tx=mvcc;hsqldb.write_delay=false";
 
-        config.setProperty("hibernate.connection.url", jdbcUrl);
+            config.setProperty("hibernate.connection.url", jdbcUrl);
+        }
 
         return new SchedulerDBManager(config, wipeOnStartup);
     }


### PR DESCRIPTION
Several changes in order to adapt to Oracle DB:

- all fields with `@Type(type = "org.hibernate.type.TextType")  ` should be changed to  `@Type(type = "org.hibernate.type.MaterializedClobType")  `
- if class has 2 fields with `@Type(type = "org.hibernate.type.BinaryType")  ` then they should be changed to  `@Type(type = "org.hibernate.type.BlobType")  ` 
- Column cannot be called `RAW` - it is reserved work in Oracle.