### PR TITLE
Storing task results in memory

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -948,6 +948,8 @@ class LiveJobs {
             terminationData.addJobToTerminate(job.getId());
         }
 
+        task.setTaskResult(result);
+
         // Update database
         if (result.getAction() != null) {
             dbManager.updateAfterWorkflowTaskFinished(job, changesInfo, result);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -29,12 +29,7 @@ import java.security.KeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.log4j.Logger;
@@ -118,28 +113,17 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
             //if job is TASKSFLOW, preparing the list of parameters for this task.
             int resultSize = taskDescriptor.getParents().size();
             if ((job.getType() == JobType.TASKSFLOW) && (resultSize > 0) && task.handleResultsArguments()) {
+                InternalTask internalTask = ((EligibleTaskDescriptorImpl) taskDescriptor).getInternal();
+                internalTask.updateParentTasksResults(schedulingService);
 
                 Set<TaskId> parentIds = new LinkedHashSet<>(resultSize);
                 for (int i = 0; i < resultSize; i++) {
-                    parentIds.addAll(internalTaskParentFinder.getFirstNotSkippedParentTaskIds(((EligibleTaskDescriptorImpl) taskDescriptor.getParents()
-                                                                                                                                          .get(i)).getInternal()));
+                    InternalTask parentTask = ((EligibleTaskDescriptorImpl) taskDescriptor.getParents()
+                                                                                          .get(i)).getInternal();
+                    parentIds.addAll(internalTaskParentFinder.getFirstNotSkippedParentTaskIds(parentTask));
                 }
 
                 params = new TaskResult[parentIds.size()];
-
-                // If parentTaskResults is null after a system failure (a very rare case)
-                if (task.getParentTasksResults() == null) {
-                    Map<TaskId, TaskResult> taskResults = new HashMap<>();
-                    // Batch fetching of parent tasks results
-                    for (List<TaskId> parentsSubList : ListUtils.partition(new ArrayList<>(parentIds),
-                                                                           PASchedulerProperties.SCHEDULER_DB_FETCH_TASK_RESULTS_BATCH_SIZE.getValueAsInt())) {
-                        taskResults.putAll(schedulingService.getInfrastructure()
-                                                            .getDBManager()
-                                                            .loadTasksResults(job.getId(), parentsSubList));
-                    }
-                    // store the parent tasks results in InternalTask for future executions.
-                    task.setParentTasksResults(taskResults);
-                }
 
                 int i = 0;
                 for (TaskId taskId : parentIds) {


### PR DESCRIPTION
When a task is finished, we associate the task result with the InternalTask
When we need to access parent task results internally for task scheduling, we use the in-memory task results and look in the database only when not available (after scheduler restart for example).