### PR TITLE
Fix serialVersionUID for ExecuterInformationData

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
@@ -43,6 +43,8 @@ import org.ow2.proactive.utils.NodeSet;
  */
 public class ExecuterInformationData implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger logger = Logger.getLogger(ExecuterInformationData.class);
 
     private long taskId;


### PR DESCRIPTION
 - as this class is stored in the database. Setting the versionuid to a fixed value prevents issues when upgrading the scheduler version.
 - this class is rarely changed, but in case it is changed in the future a more permanent solution will have to be found (for example creating a dedicated table).