### PR TITLE
Improvements on installation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ out
 
 /tools
 !/tools/startup.groovy
+!/tools/*.sh
 
 /TEST_SCHEDULER_DB
 /.nb-gradle/private/

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -65,6 +65,12 @@ compute-version ()
 
 }
 
+update_node_jars()
+{
+    ( cd $PA_ROOT/default && zip -f dist/lib/rm-node-*.jar config/authentication/rm.cred )
+    ( cd $PA_ROOT/default/dist && zip -f war/rest/node.jar lib/rm-node-*.jar )
+}
+
 reuse_accounts()
 {
     echo "Retrieving private/public keys from previous scheduler installation"
@@ -82,11 +88,7 @@ reuse_accounts()
         /bin/cp $OLD_PADIR/config/web/truststore $PA_ROOT/default/config/web/
     fi
 
-    # configure watcher account
-    sed "s/scheduler\.cache\.password=.*/scheduler.cache.password=/g"  -i "$PA_ROOT/default/config/web/settings.ini"
-    sed "s/^.*scheduler\.cache\.credential=.*$/scheduler.cache.credential=$(escape_rhs_sed $AUTH_ROOT/watcher.cred)/g"  -i "$PA_ROOT/default/config/web/settings.ini"
-    sed "s/rm\.cache\.password=.*/rm.cache.password=/g"  -i "$PA_ROOT/default/config/web/settings.ini"
-    sed "s/^.*rm\.cache\.credential=.*$/rm.cache.credential=$(escape_rhs_sed $AUTH_ROOT/watcher.cred)/g"  -i "$PA_ROOT/default/config/web/settings.ini"
+    update_node_jars
 }
 
 ask_admin_password()
@@ -107,6 +109,7 @@ ask_admin_password()
     done
 
 }
+
 generate_new_accounts()
 {
     # generate random password for internal scheduler accounts
@@ -136,8 +139,7 @@ generate_new_accounts()
     $PA_ROOT/default/tools/proactive-create-cred  -F $AUTH_ROOT/keys/pub.key -l rm -p "$RM_PWD" -o $AUTH_ROOT/rm.cred
     $PA_ROOT/default/tools/proactive-create-cred  -F $AUTH_ROOT/keys/pub.key -l watcher -p "$WATCHER_PWD" -o $AUTH_ROOT/watcher.cred
 
-    ( cd $PA_ROOT/default && zip -f dist/lib/rm-node-*.jar config/authentication/rm.cred )
-    ( cd $PA_ROOT/default/dist && zip -f war/rest/node.jar lib/rm-node-*.jar )
+    update_node_jars
 
     # configure watcher account
     sed "s/scheduler\.cache\.password=.*/scheduler.cache.password=/g"  -i "$PA_ROOT/default/config/web/settings.ini"
@@ -156,6 +158,60 @@ generate_new_accounts()
     $PA_ROOT/default/tools/proactive-users -D -l provider
     $PA_ROOT/default/tools/proactive-users -D -l test_executor
 
+}
+
+adding_files()
+{
+    OLD_PWD=$(pwd)
+    cd "$PA_DIR"
+    git add -A config
+
+    git add bin/proactive-server
+    git add tools/proactive-scheduler
+    git add tools/*.groovy
+
+    git add dist/war/rm/rm.conf
+    git add dist/war/scheduler/scheduler.conf
+
+    for file in $( find dist/war -name 'application.properties' ); do
+        git add "$file"
+    done
+    cd "$OLD_PWD"
+}
+
+staging_changes()
+{
+    OLD_PWD=$(pwd)
+    cd "$OLD_PADIR"
+    git add -u .
+    cd "$OLD_PWD"
+}
+
+init_and_ignores()
+{
+    OLD_PWD=$(pwd)
+    cd "$PA_DIR"
+    git init
+    git config user.email "support@activeeon.com"
+    git config user.name "proactive"
+    echo '
+config/authentication/*.cred
+config/authentication/login.cfg
+config/authentication/group.cfg
+config/authentication/keys/*.key
+config/web/keystore
+config/web/truststore
+    ' > .gitignore
+    cd "$OLD_PWD"
+}
+
+initial_commit()
+{
+    OLD_PWD=$(pwd)
+    cd "$PA_DIR"
+    git commit -m "Initial configuration files for $PA_FOLDER_NAME"
+    git tag -f -a "root" -m "Root commit"
+    cd "$OLD_PWD"
 }
 
 NEW_VERSION=$(compute-version $INSTALL_PADIR)
@@ -226,12 +282,12 @@ if [ -d "$PA_ROOT/$PA_FOLDER_NAME" ]; then
 else
     # checking the previous installation
     if [ -h "$PA_ROOT/default" ]; then
-        OLD_PADIR=$(readlink "$PA_ROOT/default")
+        OLD_PADIR=$(readlink -f "$PA_ROOT/default")
         rm -f $PA_ROOT/previous
         ln -s -f $OLD_PADIR "$PA_ROOT/previous"
         rm -f $PA_ROOT/default
     elif [ -h "$PA_ROOT/previous" ]; then
-        OLD_PADIR=$(readlink "$PA_ROOT/previous")
+        OLD_PADIR=$(readlink -f "$PA_ROOT/previous")
     fi
 fi
 
@@ -241,33 +297,46 @@ ln -s -f $PA_ROOT/$PA_FOLDER_NAME "$PA_ROOT/default"
 
 AUTH_ROOT=$PA_ROOT/default/config/authentication
 
+PA_DIR="$(readlink -f "$PA_ROOT/default")"
 
-# creation of the proactive user
+if [[ "$OLD_PADIR" == "" ]]; then
 
-read -e -p "Name of the user starting the ProActive service: " -i "proactive" USER
+    # creation of the proactive user
 
-USER=$(trim "$USER")
+    read -e -p "Name of the user starting the ProActive service: " -i "proactive" USER
 
-read -e -p "Group of the user starting the ProActive service: " -i "proactive" GROUP
+    USER=$(trim "$USER")
 
-GROUP=$(trim "$GROUP")
+    read -e -p "Group of the user starting the ProActive service: " -i "proactive" GROUP
 
-id -u "$USER" > /dev/null
+    GROUP=$(trim "$GROUP")
 
-if (( $? != 0 )); then
-    echo "The user $USER does not exist. The installation script must create this user."
-    if confirm "Proceed? [Y/n] "; then
-        if [ "$GROUP" == "$USER" ]; then
-            useradd $USER -d $PA_ROOT
+    id -u "$USER" > /dev/null
+
+    if (( $? != 0 )); then
+        echo "The user $USER does not exist. The installation script must create this user."
+        if confirm "Proceed? [Y/n] "; then
+            if [ "$GROUP" == "$USER" ]; then
+                useradd $USER -d $PA_ROOT
+            else
+                useradd $USER -d $PA_ROOT -g $GROUP
+            fi
+            passwd $USER;
         else
-            useradd $USER -d $PA_ROOT -g $GROUP
+            exit 1
         fi
-        passwd $USER;
-    else
-        exit 1
+
     fi
 
+else
+    USER="$(stat -c "%U" "$OLD_PADIR")"
+    GROUP="$(stat -c "%G" "$OLD_PADIR")"
+    echo "Previous installation belonged to user $USER with group $GROUP"
 fi
+
+init_and_ignores
+adding_files
+initial_commit
 
 chown $USER:$GROUP $PA_ROOT
 chown $USER:$GROUP $PA_ROOT/default
@@ -277,213 +346,222 @@ echo "ProActive use internal system accounts which should be modified in a produ
 
 if [[ "$OLD_PADIR" != "" ]]; then
 {
-    if confirm "Do you want to reuse accounts from the previous version $OLD_PADIR ? [Y/n]" ; then
-        reuse_accounts
-    elif confirm "Do you want to regenerate the internal accounts ? [Y/n]" ; then
-        generate_new_accounts
-    fi
+    echo "Reusing accounts from the previous version $OLD_PADIR"
+    reuse_accounts
 }
 elif confirm "Do you want to regenerate the internal accounts ? [Y/n]" ; then
     generate_new_accounts
 fi
 
-echo "ProActive can integrate with Linux PAM (Pluggable Authentication Modules) to authenticate users of the linux system."
-echo "Warning: this will add the $USER account to the linux \"shadow\" group"
-
-if confirm "Do you want to set PAM integration for ProActive scheduler? [y/N] " "n" ; then
-     sed "s/pa\.rm\.authentication\.loginMethod=.*/pa.rm.authentication.loginMethod=RMPAMLoginMethod/g"  -i "$PA_ROOT/default/config/rm/settings.ini"
-     sed "s/pa\.scheduler\.core\.authentication\.loginMethod=.*/pa.scheduler.core.authentication.loginMethod=SchedulerPAMLoginMethod/g"  -i "$PA_ROOT/default/config/scheduler/settings.ini"
-     cp $AUTH_ROOT/proactive-jpam /etc/pam.d/
-     usermod -a -G shadow $USER
-     echo "Users wil be able to authenticate to the ProActive server with their linux account credentials."
-     echo "Groups must still be configured for each user in the $AUTH_ROOT/group.cfg file."
-fi
-
-
-
-# Configuration of the service script
-
 if [ -f /etc/init.d/proactive-scheduler ] && [[ "$OLD_PADIR" != "" ]]; then
     # backup previous service file
-    cp /etc/init.d/proactive-scheduler $OLD_PADIR/config/
+    /bin/cp /etc/init.d/proactive-scheduler "$OLD_PADIR/tools/"
 fi
 
-cp $SCRIPT_DIR/proactive-scheduler /etc/init.d/
+if [[ "$OLD_PADIR" == "" ]]; then
+    echo "ProActive can integrate with Linux PAM (Pluggable Authentication Modules) to authenticate users of the linux system."
+    echo "Warning: this will add the $USER account to the linux \"shadow\" group"
 
-read -e -p "Protocol to use for accessing Web apps deployed by the proactive server: [http/https] " -i "http" PROTOCOL
+    if confirm "Do you want to set PAM integration for ProActive scheduler? [y/N] " "n" ; then
+         sed "s/pa\.rm\.authentication\.loginMethod=.*/pa.rm.authentication.loginMethod=RMPAMLoginMethod/g"  -i "$PA_ROOT/default/config/rm/settings.ini"
+         sed "s/pa\.scheduler\.core\.authentication\.loginMethod=.*/pa.scheduler.core.authentication.loginMethod=SchedulerPAMLoginMethod/g"  -i "$PA_ROOT/default/config/scheduler/settings.ini"
+         cp $AUTH_ROOT/proactive-jpam /etc/pam.d/
+         usermod -a -G shadow $USER
+         echo "Users wil be able to authenticate to the ProActive server with their linux account credentials."
+         echo "Groups must still be configured for each user in the $AUTH_ROOT/group.cfg file."
+    fi
 
-PROTOCOL=$(trim "$PROTOCOL")
+    # Configuration of the service script
 
-SELF_SIGNED=false
-if [[ "$PROTOCOL" == "https" ]]; then
-    if confirm "Do you want to use the provided self-signed certificate? [Y/n] " ; then
-        SELF_SIGNED=true
+    read -e -p "Protocol to use for accessing Web apps deployed by the proactive server: [http/https] " -i "http" PROTOCOL
+
+    PROTOCOL=$(trim "$PROTOCOL")
+
+    SELF_SIGNED=false
+    if [[ "$PROTOCOL" == "https" ]]; then
+        if confirm "Do you want to use the provided self-signed certificate? [Y/n] " ; then
+            SELF_SIGNED=true
+        else
+            echo "In order to install a signed certificate, you need to follow the manual configuration steps described in the ProActive documentation :"
+            echo "http://doc.activeeon.com/latest/admin/ProActiveAdminGuide.html#_enable_https"
+        fi
+
+    fi
+
+    if [[ "$PROTOCOL" == "https" ]]; then
+        DEFAULT_PORT=8443
     else
-        echo "In order to install a signed certificate, you need to follow the manual configuration steps described in the ProActive documentation :"
-        echo "http://doc.activeeon.com/latest/admin/ProActiveAdminGuide.html#_enable_https"
+        DEFAULT_PORT=8080
     fi
 
-fi
+    read -e -p "Port to use for accessing Web apps deployed by the proactive server: " -i "$DEFAULT_PORT" PORT
 
-if [[ "$PROTOCOL" == "https" ]]; then
-    DEFAULT_PORT=8443
-else
-    DEFAULT_PORT=8080
-fi
+    PORT=$(trim "$PORT")
 
-read -e -p "Port to use for accessing Web apps deployed by the proactive server: " -i "$DEFAULT_PORT" PORT
-
-PORT=$(trim "$PORT")
-
-HTTP_REDIRECT_PORT=8080
-if [[ "$PROTOCOL" == "https" ]]; then
-    HTTP_REDIRECT=false
-    if confirm "Do you want to redirect an http port to https? [Y/n] " ; then
-        HTTP_REDIRECT=true
-        read -e -p "Which port do you want to redirect? [8080] " -i "8080" HTTP_REDIRECT_PORT
+    HTTP_REDIRECT_PORT=8080
+    if [[ "$PROTOCOL" == "https" ]]; then
+        HTTP_REDIRECT=false
+        if confirm "Do you want to redirect an http port to https? [Y/n] " ; then
+            HTTP_REDIRECT=true
+            read -e -p "Which port do you want to redirect? [8080] " -i "8080" HTTP_REDIRECT_PORT
+        fi
     fi
-fi
 
-if [[ "$JAVA_CMD" == "" ]]; then
-   JAVA_CMD=$PA_ROOT/default/jre/bin/java
-   JAVA_HOME=$PA_ROOT/default/jre
-fi
+    if [[ "$JAVA_CMD" == "" ]]; then
+       JAVA_CMD=$PA_ROOT/default/jre/bin/java
+       JAVA_HOME=$PA_ROOT/default/jre
+    fi
 
-if [[ "$PORT" -lt "1024" ]] || [[ "$HTTP_REDIRECT_PORT" -lt "1024" ]] ; then
+    if [[ "$PORT" -lt "1024" ]] || [[ "$HTTP_REDIRECT_PORT" -lt "1024" ]] ; then
 
-    if ! which setcap > /dev/null 2>&1; then
-        echo "libcap2 is not installed on this computer and is required to start the server on a port below 1024."
-        if confirm "Do you want to install it? [Y/n] " ; then
-            if [[ "$OS" == "RedHat" ]]; then
-                $PKG_TOOL -y install libcap2
-            elif [[ "$OS" == "Debian" ]]; then
-                $PKG_TOOL -y install libcap2-bin
+        if ! which setcap > /dev/null 2>&1; then
+            echo "libcap2 is not installed on this computer and is required to start the server on a port below 1024."
+            if confirm "Do you want to install it? [Y/n] " ; then
+                if [[ "$OS" == "RedHat" ]]; then
+                    $PKG_TOOL -y install libcap2
+                elif [[ "$OS" == "Debian" ]]; then
+                    $PKG_TOOL -y install libcap2-bin
+                fi
             fi
         fi
-    fi
-    echo "Enabling priviledge to run server on port lower than 1024"
+        echo "Enabling priviledge to run server on port lower than 1024"
 
-    if [[ "$JAVA_HOME" == "" ]]; then
-        echo "Unable to locate JAVA_HOME, installation will exit."
-        exit 1
-    fi
-    echo "$JAVA_HOME/lib/amd64/jli" > /etc/ld.so.conf.d/proactive-java.conf
-    ldconfig | grep libjli
-fi
-
-
-read -e -p "Number of ProActive nodes to start on the server machine: " -i "4" NB_NODES
-NB_NODES=$(trim "$NB_NODES")
-
-echo "The ProActive server can automatically remove from its database old jobs. This feature also remove the associated job logs from the file system."
-
-if confirm "Do you want to enable automatic job/node history removal? [Y/n] " ; then
-     read -e -p "Remove history older than (in days) [30]: " -i "30" JOB_CLEANUP_DAYS
-     JOB_CLEANUP_DAYS=$(trim "$JOB_CLEANUP_DAYS")
-     JOB_CLEANUP_SECONDS=$((JOB_CLEANUP_DAYS*24*3600))
-
-     # Configure the scheduler to remove jobs
-     sed "s/pa\.scheduler\.core\.automaticremovejobdelay=.*/pa.scheduler.core.automaticremovejobdelay=$JOB_CLEANUP_SECONDS/g"  -i "$PA_ROOT/default/config/scheduler/settings.ini"
-     sed "s/pa\.scheduler\.job\.removeFromDataBase=.*/pa.scheduler.job.removeFromDataBase=true/g"  -i "$PA_ROOT/default/config/scheduler/settings.ini"
-     sed "s/^#pa\.rm\.history\.maxperiod=.*/pa.rm.history.maxperiod=$JOB_CLEANUP_SECONDS/g"  -i "$PA_ROOT/default/config/rm/settings.ini"
-
-     # Cleanup extra log files older than the given period
-     if [[ $(grep -c "$PA_ROOT/default/logs" /etc/crontab) == 0 ]]; then
-        echo "1 0   * * *   root   find $PA_ROOT/default/logs -mtime +$JOB_CLEANUP_DAYS -name '*.log' -exec rm {} \;" >> /etc/crontab
-     fi
-fi
-
-
-
-sed -e "s/^USER=.*/USER=$USER/g" -i "/etc/init.d/proactive-scheduler"
-sed -e "s/^PROTOCOL=.*/PROTOCOL=$PROTOCOL/g" -i "/etc/init.d/proactive-scheduler"
-
-if [[ "$PROTOCOL" == "https" ]]; then
-    sed -e "s/^web\.https=.*/web.https=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
-    if $SELF_SIGNED; then
-        sed -e "s/^#web\.https\.keystore=\(.*\)/web.https.keystore=\1/g" -i "$PA_ROOT/default/config/web/settings.ini"
-        sed -e "s/^#web\.https\.keystore\.password=\(.*\)/web.https.keystore.password=\1/g" -i "$PA_ROOT/default/config/web/settings.ini"
-        sed -e "s/^#web\.https\.allow_any_hostname=.*/web.https.allow_any_hostname=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
-        sed -e "s/^#web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
-        sed -e "s/^#web\.https\.allow_any_hostname=.*/web.https.allow_any_hostname=true/g" -i "$PA_ROOT/default/dist/war/rm/rm.conf"
-        sed -e "s/^#web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$PA_ROOT/default/dist/war/rm/rm.conf"
-        sed -e "s/^#web\.https\.allow_any_hostname=.*/web.https.allow_any_hostname=true/g" -i "$PA_ROOT/default/dist/war/scheduler/scheduler.conf"
-        sed -e "s/^#web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$PA_ROOT/default/dist/war/scheduler/scheduler.conf"
-    fi
-fi
-
-sed -e "s/^PORT=.*/PORT=$PORT/g" -i "/etc/init.d/proactive-scheduler"
-if [[ "$PROTOCOL" == "https" ]]; then
-    sed -e "s/^web\.https\.port=.*/web.https.port=$PORT/g" -i "$PA_ROOT/default/config/web/settings.ini"
-    if $HTTP_REDIRECT; then
-        sed -e "s/^web\.redirect_http_to_https=.*/web.redirect_http_to_https=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
-        sed -e "s/^web\.http\.port=.*/web.http.port=$HTTP_REDIRECT_PORT/g" -i "$PA_ROOT/default/config/web/settings.ini"
-    fi
-else
-    sed -e "s/^web\.http\.port=.*/web.http.port=$PORT/g" -i "$PA_ROOT/default/config/web/settings.ini"
-fi
-
-for file in $( find $PA_ROOT/default/dist/war -name 'application.properties' ); do
-    sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$file"
-    if $SELF_SIGNED; then
-        sed -e "s/web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$file"
-    fi
-done
-
-sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$PA_ROOT/default/config/web/settings.ini"
-
-sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$PA_ROOT/default/dist/war/rm/rm.conf"
-sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$PA_ROOT/default/dist/war/scheduler/scheduler.conf"
-
-sed -e "s/^NB_NODES=.*/NB_NODES=$NB_NODES/g"  -i "/etc/init.d/proactive-scheduler"
-sed -e "s/^PA_ROOT=.*/PA_ROOT=$(escape_rhs_sed "$PA_ROOT")/g" -i "/etc/init.d/proactive-scheduler"
-
-sed -e "s/^SINGLE_JVM=.*/SINGLE_JVM=true/g" -i "/etc/init.d/proactive-scheduler"
-
-echo "Here are the network interfaces available on your machine and the interface which will be automatically selected by ProActive: "
-
-
-
-# Select network interface
-
-NETWORK_OUTPUT=$( $JAVA_CMD -cp "$PA_ROOT/default/dist/lib:$PA_ROOT/default/dist/lib/*" org.objectweb.proactive.core.util.ProActiveInet )
-echo "$NETWORK_OUTPUT"
-
-
-if confirm "Do you want to change the network interface used? [y/N] " "n" ; then
-     ITF_ARRAY=( $( echo "$NETWORK_OUTPUT" | grep -e 'MAC:' | awk '{ print $1 }' ) )
-     echo "Available interfaces : " "${ITF_ARRAY[@]}"
-     ITF_SELECTED=false
-     while  ! $ITF_SELECTED ; do
-        read -e -p "Enter the interface name you want to use: " ITF_NAME
-        ITF_NAME=$(trim "$ITF_NAME")
-
-        if [[ " ${ITF_ARRAY[@]} " =~ " ${ITF_NAME} " ]]; then
-            ITF_SELECTED=true
-        else
-            echo "Interface $ITF_NAME not in the list"
+        if [[ "$JAVA_HOME" == "" ]]; then
+            echo "Unable to locate JAVA_HOME, installation will exit."
+            exit 1
         fi
-     done
-
-     echo "proactive.net.interface=$ITF_NAME" >> "$PA_ROOT/default/config/network/server.ini"
-     echo "proactive.net.interface=$ITF_NAME" >> "$PA_ROOT/default/config/network/node.ini"
-fi
+        echo "$JAVA_HOME/lib/amd64/jli" > /etc/ld.so.conf.d/proactive-java.conf
+        ldconfig | grep libjli
+    fi
 
 
-# installation of the proactive-scheduler service
+    read -e -p "Number of ProActive nodes to start on the server machine: " -i "4" NB_NODES
+    NB_NODES=$(trim "$NB_NODES")
 
-chmod 700 /etc/init.d/proactive-scheduler
+    echo "The ProActive server can automatically remove from its database old jobs. This feature also remove the associated job logs from the file system."
 
-mkdir -p /var/log/proactive
-touch /var/log/proactive/scheduler
+    if confirm "Do you want to enable automatic job/node history removal? [Y/n] " ; then
+         read -e -p "Remove history older than (in days) [30]: " -i "30" JOB_CLEANUP_DAYS
+         JOB_CLEANUP_DAYS=$(trim "$JOB_CLEANUP_DAYS")
+         JOB_CLEANUP_SECONDS=$((JOB_CLEANUP_DAYS*24*3600))
 
-chown -R $USER:$GROUP /var/log/proactive
+         # Configure the scheduler to remove jobs
+         sed "s/pa\.scheduler\.core\.automaticremovejobdelay=.*/pa.scheduler.core.automaticremovejobdelay=$JOB_CLEANUP_SECONDS/g"  -i "$PA_ROOT/default/config/scheduler/settings.ini"
+         sed "s/pa\.scheduler\.job\.removeFromDataBase=.*/pa.scheduler.job.removeFromDataBase=true/g"  -i "$PA_ROOT/default/config/scheduler/settings.ini"
+         sed "s/^#pa\.rm\.history\.maxperiod=.*/pa.rm.history.maxperiod=$JOB_CLEANUP_SECONDS/g"  -i "$PA_ROOT/default/config/rm/settings.ini"
 
-if confirm "Start the proactive-scheduler service at startup? [Y/n] " ; then
-    if [[ "$OS" == "RedHat" ]]; then
-       chkconfig proactive-scheduler on
-    elif [[ "$OS" == "Debian" ]]; then
-       update-rc.d proactive-scheduler defaults
+         # Cleanup extra log files older than the given period
+         if [[ $(grep -c "$PA_ROOT/default/logs" /etc/crontab) == 0 ]]; then
+            echo "1 0   * * *   root   find $PA_ROOT/default/logs -mtime +$JOB_CLEANUP_DAYS -name '*.log' -exec rm {} \;" >> /etc/crontab
+         fi
+    fi
+
+
+
+    sed -e "s/^USER=.*/USER=$USER/g" -i "$PA_ROOT/default/tools/proactive-scheduler"
+    sed -e "s/^PROTOCOL=.*/PROTOCOL=$PROTOCOL/g" -i "$PA_ROOT/default/tools/proactive-scheduler"
+
+    if [[ "$PROTOCOL" == "https" ]]; then
+        sed -e "s/^web\.https=.*/web.https=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
+        if $SELF_SIGNED; then
+            sed -e "s/^#web\.https\.keystore=\(.*\)/web.https.keystore=\1/g" -i "$PA_ROOT/default/config/web/settings.ini"
+            sed -e "s/^#web\.https\.keystore\.password=\(.*\)/web.https.keystore.password=\1/g" -i "$PA_ROOT/default/config/web/settings.ini"
+            sed -e "s/^#web\.https\.allow_any_hostname=.*/web.https.allow_any_hostname=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
+            sed -e "s/^#web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
+            sed -e "s/^#web\.https\.allow_any_hostname=.*/web.https.allow_any_hostname=true/g" -i "$PA_ROOT/default/dist/war/rm/rm.conf"
+            sed -e "s/^#web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$PA_ROOT/default/dist/war/rm/rm.conf"
+            sed -e "s/^#web\.https\.allow_any_hostname=.*/web.https.allow_any_hostname=true/g" -i "$PA_ROOT/default/dist/war/scheduler/scheduler.conf"
+            sed -e "s/^#web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$PA_ROOT/default/dist/war/scheduler/scheduler.conf"
+        fi
+    fi
+
+    sed -e "s/^PORT=.*/PORT=$PORT/g" -i "$PA_ROOT/default/tools/proactive-scheduler"
+    if [[ "$PROTOCOL" == "https" ]]; then
+        sed -e "s/^web\.https\.port=.*/web.https.port=$PORT/g" -i "$PA_ROOT/default/config/web/settings.ini"
+        if $HTTP_REDIRECT; then
+            sed -e "s/^web\.redirect_http_to_https=.*/web.redirect_http_to_https=true/g" -i "$PA_ROOT/default/config/web/settings.ini"
+            sed -e "s/^web\.http\.port=.*/web.http.port=$HTTP_REDIRECT_PORT/g" -i "$PA_ROOT/default/config/web/settings.ini"
+        fi
+    else
+        sed -e "s/^web\.http\.port=.*/web.http.port=$PORT/g" -i "$PA_ROOT/default/config/web/settings.ini"
+    fi
+
+    for file in $( find $PA_ROOT/default/dist/war -name 'application.properties' ); do
+        sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$file"
+        if $SELF_SIGNED; then
+            sed -e "s/web\.https\.allow_any_certificate=.*/web.https.allow_any_certificate=true/g" -i "$file"
+        fi
+    done
+
+    sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$PA_ROOT/default/config/web/settings.ini"
+
+    sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$PA_ROOT/default/dist/war/rm/rm.conf"
+    sed -e "s/$(escape_lhs_sed http://localhost:8080)/$(escape_rhs_sed ${PROTOCOL}://localhost:${PORT})/g" -i "$PA_ROOT/default/dist/war/scheduler/scheduler.conf"
+
+    sed -e "s/^NB_NODES=.*/NB_NODES=$NB_NODES/g"  -i "$PA_ROOT/default/tools/proactive-scheduler"
+    sed -e "s/^PA_ROOT=.*/PA_ROOT=$(escape_rhs_sed "$PA_ROOT")/g" -i "$PA_ROOT/default/tools/proactive-scheduler"
+
+    if [ "$NB_NODES" != "0" ]; then
+        sed -e "s/^SINGLE_JVM=.*/SINGLE_JVM=true/g" -i "$PA_ROOT/default/tools/proactive-scheduler"
+    fi
+
+    echo "Here are the network interfaces available on your machine and the interface which will be automatically selected by ProActive: "
+
+
+
+    # Select network interface
+
+    NETWORK_OUTPUT=$( $JAVA_CMD -cp "$PA_ROOT/default/dist/lib:$PA_ROOT/default/dist/lib/*" org.objectweb.proactive.core.util.ProActiveInet )
+    echo "$NETWORK_OUTPUT"
+
+
+    if confirm "Do you want to change the network interface used? [y/N] " "n" ; then
+         ITF_ARRAY=( $( echo "$NETWORK_OUTPUT" | grep -e 'MAC:' | awk '{ print $1 }' ) )
+         echo "Available interfaces : " "${ITF_ARRAY[@]}"
+         ITF_SELECTED=false
+         while  ! $ITF_SELECTED ; do
+            read -e -p "Enter the interface name you want to use: " ITF_NAME
+            ITF_NAME=$(trim "$ITF_NAME")
+
+            if [[ " ${ITF_ARRAY[@]} " =~ " ${ITF_NAME} " ]]; then
+                ITF_SELECTED=true
+            else
+                echo "Interface $ITF_NAME not in the list"
+            fi
+         done
+
+         echo "proactive.net.interface=$ITF_NAME" >> "$PA_ROOT/default/config/network/server.ini"
+         echo "proactive.net.interface=$ITF_NAME" >> "$PA_ROOT/default/config/network/node.ini"
+    fi
+
+
+    # installation of the proactive-scheduler service
+
+    cp "$PA_ROOT/default/tools/proactive-scheduler" /etc/init.d/
+
+    chmod 700 /etc/init.d/proactive-scheduler
+
+    mkdir -p /var/log/proactive
+    touch /var/log/proactive/scheduler
+
+    # configure infinite timeout and service type for systemd
+    mkdir -p /etc/systemd/system/proactive-scheduler.service.d
+    echo '
+[Service]
+Type=simple
+TimeoutSec=0
+' > /etc/systemd/system/proactive-scheduler.service.d/timeout.conf
+
+
+
+    chown -R $USER:$GROUP /var/log/proactive
+
+    if confirm "Start the proactive-scheduler service at machine startup? [Y/n] " ; then
+        if [[ "$OS" == "RedHat" ]]; then
+           chkconfig proactive-scheduler on
+        elif [[ "$OS" == "Debian" ]]; then
+           update-rc.d proactive-scheduler defaults
+        fi
     fi
 fi
 
@@ -494,71 +572,60 @@ if which git > /dev/null 2>&1; then
 
     OLD_PWD=$(pwd)
 
-    cd $PA_ROOT/default/config
-
-    # version as well the proactive-scheduler service file
-    cp /etc/init.d/proactive-scheduler .
-
-    git init
-    git config user.email "support@activeeon.com"
-    git config user.name "proactive"
-    echo '
-authentication/*.cred
-authentication/login.cfg
-authentication/group.cfg
-authentication/keys/*.key
-web/keystore
-web/truststore
-    ' > .gitignore
-    git add -A .
-    git commit -m "Initial Commit for $PA_FOLDER_NAME"
-    git tag -a "root" -m "Root commit"
-
+    cd $PA_ROOT/default/
 
     if [[ "$OLD_PADIR" != "" ]]; then
         echo ""
-        echo "Detected an existing ProActive Scheduler installation at $OLD_PADIR, porting configuration into new installation."
+        echo "Detected an existing ProActive Scheduler installation at $OLD_PADIR"
+
+        echo  "Copying addons and data files from previous installation..."
         echo ""
 
         rsync $RSYNC_PROGRESS -a $OLD_PADIR/{addons,data} $PA_ROOT/default/
 
-        OLD_PADIR_NAME="$(basename "$OLD_PADIR")"
-
-        cd $OLD_PADIR/config
-
-        # Commit uncommitted changes in the old repository
-        git add -A .
-        git commit -m "Commit all changes before switching from $OLD_PADIR_NAME to $PA_FOLDER_NAME"
-        NB_COMMITS=$(git rev-list --count HEAD)
-        NB_COMMITS=$( expr $NB_COMMITS - 1 )
-
-         cd $PA_ROOT/default/config
-
-        # Apply all commits from the previous repository to the new one
-        git remote add old-version $OLD_PADIR/config/.git
-        git fetch old-version
-
-        if [[ NB_COMMITS -gt 0 ]]; then
-            ROOT_ID=$( git rev-parse old-version/master~$NB_COMMITS)
-            MASTER_ID=$( git rev-parse old-version/master )
+        if confirm "Do you want to port all configuration changes to the new version (do not do this from a version prior to 8.4.0 before executing the patch)? [Y/n] " ; then
+            echo  "Porting configuration into new installation..."
             echo ""
-            echo "Cherry-picking all changes to new installation"
-            echo ""
-            git cherry-pick -x ${ROOT_ID}..$MASTER_ID
 
-            if (( $? != 0 )); then
+            OLD_PADIR_NAME="$(basename "$OLD_PADIR")"
+
+            cd $OLD_PADIR
+
+            # Commit uncommitted changes in the old repository
+            staging_changes
+
+            git commit -m "Commit all changes before switching from $OLD_PADIR_NAME to $PA_FOLDER_NAME"
+            NB_COMMITS=$(git rev-list --count HEAD)
+            NB_COMMITS=$( expr $NB_COMMITS - 1 )
+
+            cd $PA_ROOT/default
+
+            # Apply all commits from the previous repository to the new one
+            git remote add old-version $OLD_PADIR/.git
+            git fetch old-version
+
+            if [[ NB_COMMITS -gt 0 ]]; then
+                ROOT_ID=$( git rev-parse old-version/master~$NB_COMMITS)
+                MASTER_ID=$( git rev-parse old-version/master )
                 echo ""
-                echo "A conflict occurred, cd to $PA_ROOT/default/config and follow the instructions displayed by Git to resolve them."
-                echo "Additionnaly, if a conflict occurs on the file $PA_ROOT/default/config/proactive-scheduler,"
-                echo "you will need to manually copy the modified file after conflicts are resolved by using the command:"
-                echo "cp $PA_ROOT/default/config/proactive-scheduler /etc/init.d/"
-                CONFLICT=true
+                echo "Cherry-picking all changes to new installation"
+                echo ""
+                git cherry-pick -x ${ROOT_ID}..$MASTER_ID
+
+                if (( $? != 0 )); then
+                    echo ""
+                    echo "A conflict occurred, cd to $PA_ROOT/default/ and follow the instructions displayed by Git to resolve them."
+                    echo "Additionally, if a conflict occurs on the file $PA_ROOT/default/config/proactive-scheduler,"
+                    echo "you will need to manually copy the modified file after conflicts are resolved by using the command:"
+                    echo "cp $PA_ROOT/default/config/proactive-scheduler /etc/init.d/"
+                    CONFLICT=true
+                    read -n 1 -s -r -p "Press any key to continue"
+                fi
             fi
+
+            # copy merged changes on the service (if ever a conflict occurs, the user will have to manually copy the merge)
+            cp "$PA_ROOT/default/tools/proactive-scheduler" /etc/init.d/
         fi
-
-        # copy merged changes on the service (if ever a conflict occurs, the user will have to manually copy the merge)
-        cp proactive-scheduler /etc/init.d/
-
     fi
     cd $OLD_PWD
 else
@@ -586,9 +653,20 @@ fi
 
 chown -R $USER:$GROUP $PA_ROOT/$PA_FOLDER_NAME
 
-if confirm "Restrict the access to the ProActive installation folder to user ${USER}? [Y/n] " ; then
-    # preserve credentials access
+if confirm "Restrict the access to the ProActive installation folder to user ${USER}? [y/N] " "n" ; then
+    # preserve all access
     chmod -R go-rwx $PA_ROOT/$PA_FOLDER_NAME
+fi
+
+if confirm "Restrict the access to the configuration files containing sensitive information to user ${USER}? [Y/n] " ; then
+    # preserve credentials access
+    chmod -R go-rwx $PA_ROOT/$PA_FOLDER_NAME/config
+    chmod go-rwx $PA_ROOT/$PA_FOLDER_NAME/dist/war/scheduler/scheduler.conf
+    chmod go-rwx $PA_ROOT/$PA_FOLDER_NAME/dist/war/rm/rm.conf
+    for file in $( find $PA_ROOT/$PA_FOLDER_NAME/dist/war -name 'application.properties' ); do
+        chmod go-rwx $file
+    done
+
 fi
 
 echo "Resource Manager credentials are used by remote ProActive Agents to register to the scheduler."

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -331,7 +331,7 @@ if [[ "$OLD_PADIR" == "" ]]; then
 else
     USER="$(stat -c "%U" "$OLD_PADIR")"
     GROUP="$(stat -c "%G" "$OLD_PADIR")"
-    echo "Previous installation belonged to user $USER with group $GROUP"
+    echo "Previous installation was owned by user $USER with group $GROUP"
 fi
 
 init_and_ignores
@@ -515,7 +515,7 @@ if [[ "$OLD_PADIR" == "" ]]; then
     echo "$NETWORK_OUTPUT"
 
 
-    if confirm "Do you want to change the network interface used? [y/N] " "n" ; then
+    if confirm "Do you want to change the network interface used by the ProActive server? [y/N] " "n" ; then
          ITF_ARRAY=( $( echo "$NETWORK_OUTPUT" | grep -e 'MAC:' | awk '{ print $1 }' ) )
          echo "Available interfaces : " "${ITF_ARRAY[@]}"
          ITF_SELECTED=false
@@ -578,7 +578,7 @@ if which git > /dev/null 2>&1; then
         echo ""
         echo "Detected an existing ProActive Scheduler installation at $OLD_PADIR"
 
-        echo  "Copying addons and data files from previous installation..."
+        echo  "Copying addons and data files from the previous installation..."
         echo ""
 
         rsync $RSYNC_PROGRESS -a $OLD_PADIR/{addons,data} $PA_ROOT/default/
@@ -614,10 +614,10 @@ if which git > /dev/null 2>&1; then
 
                 if (( $? != 0 )); then
                     echo ""
-                    echo "A conflict occurred, cd to $PA_ROOT/default/ and follow the instructions displayed by Git to resolve them."
-                    echo "Additionally, if a conflict occurs on the file $PA_ROOT/default/config/proactive-scheduler,"
-                    echo "you will need to manually copy the modified file after conflicts are resolved by using the command:"
-                    echo "cp $PA_ROOT/default/config/proactive-scheduler /etc/init.d/"
+                    echo "A conflict occurred, cd to $PA_ROOT/default/ and follow the instructions displayed by Git to resolve the issues."
+                    echo "Additionally, if a conflict occurred on the file $PA_ROOT/default/tools/proactive-scheduler,"
+                    echo "you will need to manually copy the modified file after conflicts have been resolved by using the command:"
+                    echo "cp $PA_ROOT/default/tools/proactive-scheduler /etc/init.d/"
                     CONFLICT=true
                     read -n 1 -s -r -p "Press any key to continue"
                 fi

--- a/tools/patch_git_prior_8_4.sh
+++ b/tools/patch_git_prior_8_4.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+if [ "$#" -ne 2 ]; then
+    SCRIPT_NAME=`basename "$0"`
+    echo "$SCRIPT_NAME"
+    echo "Can be used to patch a ProActive installation git versioning when migrating from a version prior to 8.4.0 to 8.4.0 or above."
+    echo "You must specify a ProActive installation path and a folder containing the original extracted archive corresponding to your version"
+    echo "This command must be run as the user owning the ProActive installation directory."
+    echo ""
+    echo "The command will delete all the git history and create a new one, based on the differences between your"
+    echo "ProActive installation and the default configuration files of the same ProActive version."
+    echo ""
+    echo "Usage:"
+    echo "./patch_git_prior_8_4.sh <proactive_installation_to_patch_path> <original_extracted_archive_path>"
+    exit 1
+fi
+PA_DIR="$(readlink -f "$1")"
+ORIGINAL_DIR=$2
+PA_FOLDER_NAME="$(basename "$PA_DIR")"
+
+if [ "$(stat -c "%U" "$PA_DIR")" != "$(whoami)" ] ; then echo "Please run the patch script as the owner of $PA_DIR" ; exit 1 ; fi
+
+trim() {
+    echo "$1" | sed -e 's/^[[:space:]]*//'|sed -e 's/[[:space:]]*$//'
+}
+
+confirm() {
+    # call with a prompt string or use a default
+    read -r -e -p "${1:-Are you sure? [Y/n]} " -i "${2:-y}" yn
+    yn=${yn,,}    # tolower
+    yn=$(trim "$yn")
+    if [[ $yn =~ ^(yes|y|)$ ]]; then
+            true
+    else
+            false
+    fi
+}
+
+staging_changes()
+{
+    OLD_PWD=$(pwd)
+    cd "$PA_DIR"
+    git add -A config
+
+    git add bin/proactive-server
+    git add tools/proactive-scheduler
+    git add tools/*.groovy
+
+    git add dist/war/rm/rm.conf
+    git add dist/war/scheduler/scheduler.conf
+
+    for file in $( find dist/war -name 'application.properties' ); do
+        git add "$file"
+    done
+    cd "$OLD_PWD"
+}
+
+init_and_ignores()
+{
+    OLD_PWD=$(pwd)
+    cd "$PA_DIR"
+    git init
+    git config user.email "support@activeeon.com"
+    git config user.name "proactive"
+    echo '
+config/authentication/*.cred
+config/authentication/login.cfg
+config/authentication/group.cfg
+config/authentication/keys/*.key
+config/web/keystore
+config/web/truststore
+    ' > .gitignore
+    cd "$OLD_PWD"
+}
+
+
+copy_configs()
+{
+    ORIGIN="$1"
+    DESTINATION="$2"
+    OLD_PWD=$(pwd)
+    cd "$ORIGIN"
+    cp --parents -R -f "config" "$DESTINATION"/
+
+    for file in $( find dist/war -name 'application.properties' ); do
+        cp --parents -R -f "$file" "$DESTINATION"/
+    done
+
+
+    cp --parents -R -f dist/war/rm/rm.conf "$DESTINATION"/
+    cp --parents -R -f dist/war/scheduler/scheduler.conf "$DESTINATION"/
+    cp --parents -R -f bin/proactive-server "$DESTINATION"/
+    cp --parents -R -f tools/proactive-scheduler "$DESTINATION"/
+    cp --parents -R -f tools/*.groovy "$DESTINATION"/
+    cd "$OLD_PWD"
+}
+
+echo "This command will patch the ProActive installation in $PA_DIR using the unmodified same version package in $ORIGINAL_DIR. The original configuration files and git history are stored in an archive file for backup purpose."
+if confirm "Proceed? [Y/n] "; then
+
+    echo "Zipping current content of config folder to $(pwd)/config.zip."
+    echo "If any problem occurs, in order to restore the previous state, you must:"
+    echo " 1) unzip the config.zip file into $PA_DIR/"
+    echo " 2) delete the folder $PA_DIR/.git"
+    echo " 3) make sure all file belong to the correct user and not to root"
+    echo ""
+    echo "Beginning the patch procedure..."
+
+    OLD_PWD=$(pwd)
+
+    cd "$PA_DIR"
+
+    zip -rq config.zip "config"
+
+    echo "Removing previous git history in $PA_DIR/config"
+
+    rm -rf "$PA_DIR/config/.git"
+
+    PATCH_DIR=/tmp/pa_patch
+
+    mkdir -p "$PATCH_DIR"
+
+    cd "$PA_DIR"
+
+    copy_configs "$PA_DIR" "$PATCH_DIR"
+
+    copy_configs "$ORIGINAL_DIR" "$PA_DIR"
+
+    init_and_ignores
+
+    staging_changes
+
+    git commit -m "Initial configuration files for $PA_FOLDER_NAME"
+    git tag -f -a "root" -m "Root commit"
+
+    copy_configs "$PATCH_DIR" "$PA_DIR"
+
+    staging_changes
+
+    git commit -m "Modifications in configuration files for $PA_FOLDER_NAME"
+
+    cd "$OLD_PWD"
+
+    echo "Patch applied, you can verify the result of the patch by looking at the new git history:"
+    echo "cd $PA_DIR"
+    echo "git log"
+    echo "... you can use git show to see individual commits"
+
+fi

--- a/tools/patch_git_prior_8_4.sh
+++ b/tools/patch_git_prior_8_4.sh
@@ -4,8 +4,8 @@ if [ "$#" -ne 2 ]; then
     SCRIPT_NAME=`basename "$0"`
     echo "$SCRIPT_NAME"
     echo "Can be used to patch a ProActive installation git versioning when migrating from a version prior to 8.4.0 to 8.4.0 or above."
-    echo "You must specify a ProActive installation path and a folder containing the original extracted archive corresponding to your version"
-    echo "This command must be run as the user owning the ProActive installation directory."
+    echo "Please specify a ProActive installation path and a folder containing the original extracted archive corresponding to your version"
+    echo "This command must run as the user owning the ProActive installation directory."
     echo ""
     echo "The command will delete all the git history and create a new one, based on the differences between your"
     echo "ProActive installation and the default configuration files of the same ProActive version."
@@ -99,7 +99,7 @@ echo "This command will patch the ProActive installation in $PA_DIR using the un
 if confirm "Proceed? [Y/n] "; then
 
     echo "Zipping current content of config folder to $(pwd)/config.zip."
-    echo "If any problem occurs, in order to restore the previous state, you must:"
+    echo "If any problem occurs, in order to restore the previous state, please follow the following steps:"
     echo " 1) unzip the config.zip file into $PA_DIR/"
     echo " 2) delete the folder $PA_DIR/.git"
     echo " 3) make sure all file belong to the correct user and not to root"


### PR DESCRIPTION
 - more configuration files are now under git versionning, notably the micro-service configuration files.
 - as the git root changed from scheduler_installation/config to scheduler_installation, the new installation script cannot be used to upgrade directly a previous version of the scheduler. In order to update such an installation a patch script is available (run the patch, then run install.sh)
 - upgrading an installation made much more simple. The various configurations (https, port, etc) are not asked again, simply ported from the previous installation.
 - Fix issue on recent debian distributions for the service lifecycle (e.g. Ubuntu 18), due to systemd configuration.