### PR TITLE
CheckEligibleTaskDescriptorScript: verify if the script content can be accessed

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/Script.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/Script.java
@@ -278,10 +278,31 @@ public abstract class Script<E> implements Serializable {
             ScriptContentAndEngineName fetchedInformation = null;
             try {
                 fetchedInformation = getScriptContentAndEngineName();
+                return fetchedInformation.getScriptContent();
             } catch (Exception e) {
                 logger.trace("Could not fetch script at " + url, e);
+                return null;
             }
+        }
+        return script;
+    }
+
+    /**
+     * If the script is defined by an url, in fetchImmediately=false mode, retrieve and return the script content from the url.
+     *
+     * The script internal definition will not be modified, thus allowing fetching again the url prior to execution.
+     *
+     * Otherwise, return the inline script definition
+     *
+     * @return the script.
+     * @throws IOException when the script cannot be accessed
+     */
+    public String fetchScriptWithExceptionHandling() throws IOException {
+        if (script == null && url != null) {
+            ScriptContentAndEngineName fetchedInformation = null;
+            fetchedInformation = getScriptContentAndEngineName();
             return fetchedInformation.getScriptContent();
+
         }
         return script;
     }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/InProcessTaskExecutor.java
@@ -210,7 +210,15 @@ public class InProcessTaskExecutor implements TaskExecutor {
             path = path + "." + extension;
         }
 
-        String code = script.fetchScript().trim();
+        String fetchedScript = null;
+
+        try {
+            fetchedScript = script.fetchScriptWithExceptionHandling();
+        } catch (IOException e) {
+            throw new TaskException("Error fetching script from url " + script.getScriptUrl(), e);
+        }
+
+        String code = fetchedScript.trim();
 
         Path p = Paths.get(path);
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/CheckEligibleTaskDescriptorScript.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/CheckEligibleTaskDescriptorScript.java
@@ -96,6 +96,11 @@ public class CheckEligibleTaskDescriptorScript {
 
         String scriptContent = script.fetchScript();
 
+        if (scriptContent == null) {
+            // script could not be fetched, it may be because the script is stored in the catalog and the catalog is not started yet
+            return true;
+        }
+
         return (scriptContent != null) && (scriptContent.contains(SchedulerConstants.SCHEDULER_CLIENT_BINDING_NAME) ||
                                            scriptContent.contains(SchedulerConstants.DS_GLOBAL_API_BINDING_NAME) ||
                                            scriptContent.contains(SchedulerConstants.DS_USER_API_BINDING_NAME));


### PR DESCRIPTION
 When the script is defined as a reference to the catalog, it might not be available on scheduler startup until the catalog is started.
 Accordingly, the task must be delayed for execution until then.

 Additionally, in InProcessTaskExecutor a proper task error message must be displayed if the script to be saved cannot be accessed.