### PR TITLE
Catch Throwable in SchedulerStateRecoverHelp

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -118,7 +118,7 @@ public class SchedulerStateRecoverHelper {
                     job.setNumberOfPendingTasks(job.getNumberOfPendingTasks() + job.getNumberOfRunningTasks());
                     job.setNumberOfRunningTasks(0);
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 logger.error("Failed to recover job " + job.getId() + " " + job.getName() +
                              " job might be in a inconsistent state", e);
                 jobLogger.error(job.getId(), "Failed to recover job, job might be in an inconsistent state", e);


### PR DESCRIPTION
SchedulerStateRecoverHelp can throw StackOverflowError which does not belong to Exception. If this error is not catched properly, the scheduler fails to start at all without possible recovery. By catching Throwable, we allow the scheduler to recover by cancelling the problematic job(s).