### PR TITLE
Reduce scheduler and node log space

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ configure(javaSubprojects) {
 
     dependencies {
         compile 'log4j:log4j:1.2.17'
+        compile 'log4j:apache-log4j-extras:1.2.17'
         compile 'com.google.guava:guava:19.0'
 
         runtime 'org.slf4j:slf4j-log4j12:1.7.12'

--- a/config/log/node.properties
+++ b/config/log/node.properties
@@ -17,10 +17,15 @@ log4j.logger.org.eclipse.jetty=WARN
 node.name=UNSET
 
 # File appender
-log4j.appender.NODE=org.apache.log4j.RollingFileAppender
+
+log4j.appender.NODE=org.apache.log4j.rolling.RollingFileAppender
 log4j.appender.NODE.File=${proactive.home}/logs/Node-${node.name}.log
-log4j.appender.NODE.MaxFileSize=10MB
-log4j.appender.NODE.MaxBackupIndex=10
+log4j.appender.NODE.RollingPolicy=org.apache.log4j.rolling.FixedWindowRollingPolicy  
+log4j.appender.NODE.RollingPolicy.maxIndex=10
+log4j.appender.NODE.TriggeringPolicy=org.apache.log4j.rolling.SizeBasedTriggeringPolicy  
+log4j.appender.NODE.TriggeringPolicy.MaxFileSize=10000000
+log4j.appender.NODE.RollingPolicy.FileNamePattern=${proactive.home}/logs/Node-${node.name}.log.%i.zip
+log4j.appender.NODE.RollingPolicy.ActiveFileName=${proactive.home}/logs/Node-${node.name}.log
 log4j.appender.NODE.layout=org.apache.log4j.PatternLayout
 log4j.appender.NODE.layout.ConversionPattern=[%d{ISO8601} %10.10t %-5p] [%X{job.id}t%X{task.id}] [NODE.%C{1}.%M] %m%n
 

--- a/config/log/server.properties
+++ b/config/log/server.properties
@@ -16,6 +16,9 @@ log4j.logger.org.ow2.proactive.resourcemanager.core.jmx=INFO
 log4j.logger.org.ow2.proactive.resourcemanager.db=INFO
 log4j.logger.org.ow2.proactive.scheduler.common.job.Job=FATAL
 
+# uncomment the following line in order to display the job contents at submission
+# log4j.logger.org.ow2.proactive.scheduler.util.JobLogger=TRACE
+
 
 # To debug selection script caching
 # log4j.logger.org.ow2.proactive.resourcemanager.selection.statistics=TRACE
@@ -47,10 +50,14 @@ log4j.logger.org.jboss.resteasy.resteasy_jaxrs.i18n=ERROR
 log4j.logger.org.ow2.proactive.scheduler.synchronization=DEBUG
 
 # SCHEDULER file appender
-log4j.appender.SCHEDULER=org.apache.log4j.RollingFileAppender
+log4j.appender.SCHEDULER=org.apache.log4j.rolling.RollingFileAppender
 log4j.appender.SCHEDULER.File=${pa.scheduler.home}/logs/Scheduler.log
-log4j.appender.SCHEDULER.MaxFileSize=100MB
-log4j.appender.SCHEDULER.MaxBackupIndex=10
+log4j.appender.SCHEDULER.RollingPolicy=org.apache.log4j.rolling.FixedWindowRollingPolicy  
+log4j.appender.SCHEDULER.RollingPolicy.maxIndex=10
+log4j.appender.SCHEDULER.TriggeringPolicy=org.apache.log4j.rolling.SizeBasedTriggeringPolicy  
+log4j.appender.SCHEDULER.TriggeringPolicy.MaxFileSize=100000000
+log4j.appender.SCHEDULER.RollingPolicy.FileNamePattern=${pa.scheduler.home}/logs/Scheduler.log.%i.zip
+log4j.appender.SCHEDULER.RollingPolicy.ActiveFileName=${pa.scheduler.home}/logs/Scheduler.log
 log4j.appender.SCHEDULER.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.SCHEDULER.layout.ConversionPattern=[%d{ISO8601} %10.10t %-5p %30.30c{1.}] %m%n
 

--- a/rm/rm-node/src/main/resources/config/log/node.properties
+++ b/rm/rm-node/src/main/resources/config/log/node.properties
@@ -16,10 +16,14 @@ log4j.logger.org.eclipse.jetty=WARN
 node.name=UNSET
 
 # File appender
-log4j.appender.NODE=org.apache.log4j.RollingFileAppender
+log4j.appender.NODE=org.apache.log4j.rolling.RollingFileAppender
 log4j.appender.NODE.File=logs/Node-${node.name}.log
-log4j.appender.NODE.MaxFileSize=10MB
-log4j.appender.NODE.MaxBackupIndex=10
+log4j.appender.NODE.RollingPolicy=org.apache.log4j.rolling.FixedWindowRollingPolicy  
+log4j.appender.NODE.RollingPolicy.maxIndex=10
+log4j.appender.NODE.TriggeringPolicy=org.apache.log4j.rolling.SizeBasedTriggeringPolicy  
+log4j.appender.NODE.TriggeringPolicy.MaxFileSize=10000000
+log4j.appender.NODE.RollingPolicy.FileNamePattern=logs/Node-${node.name}.log.%i.zip
+log4j.appender.NODE.RollingPolicy.ActiveFileName=logs/Node-${node.name}.log
 log4j.appender.NODE.layout=org.apache.log4j.PatternLayout
 log4j.appender.NODE.layout.ConversionPattern=[%d{ISO8601} %-5p] [NODE.%C{1}.%M] %m%n
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -515,11 +515,14 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         usersUpdated(new NotificationData<UserIdentification>(SchedulerEvent.USERS_UPDATE, ident));
         jlogger.info(job.getId(),
                      "submitted: name '" + job.getName() + "', tasks '" + job.getTotalNumberOfTasks() + "', owner '" +
+
                                   job.getOwner() + "'");
-        try {
-            jlogger.info(job.getId(), job.display());
-        } catch (Exception e) {
-            jlogger.error(job.getId(), "Error while displaying the job :", e);
+        if (jlogger.isTraceEnabled()) {
+            try {
+                jlogger.trace(job.getId(), job.display());
+            } catch (Exception e) {
+                jlogger.error(job.getId(), "Error while displaying the job :", e);
+            }
         }
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/JobLogger.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/JobLogger.java
@@ -58,6 +58,20 @@ public class JobLogger {
         MDC.remove(FileAppender.FILE_NAME);
     }
 
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    public void trace(JobId id, String message) {
+        updateMdcWithTaskLogFilename(id);
+        logger.trace(PREFIX + id + " " + message);
+        MDC.remove(FileAppender.FILE_NAME);
+    }
+
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
     public void warn(JobId id, String message) {
         updateMdcWithTaskLogFilename(id);
         logger.warn(PREFIX + id + " " + message);


### PR DESCRIPTION
Scheduler and node logs can take a big amount of space on disk, the purpose of this change is to reduce this space.

 - Display JobContent at TRACE level: currently, the content of all jobs appear in the logs, it used to be mandatory for debugging, but recent developments now allow to export an already submitted job and see its content (with instanciated variables). In case of debugging, it's possible to enable the job logger in trace mode to output the job content.

 - use log4j extra to compress log files: log4j extra library allows to automatically compress log files when a size-based rolling is executed. As log compression rate is very high, this converts a 100MB file to 10MB.