### PR TITLE
SchedulerStateRest:submitFromUrl, Allow submission from non-http url

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -106,6 +106,8 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.util.WorkflowVariablesTrans
 import org.ow2.proactive_grid_cloud_portal.webapp.DateFormatter;
 import org.ow2.proactive_grid_cloud_portal.webapp.PortalConfiguration;
 
+import com.google.common.base.Charsets;
+
 
 /**
  * This class exposes the Scheduler as a RESTful service.
@@ -3488,8 +3490,13 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             throws JobCreationRestException, IOException {
         if (StringUtils.isBlank(workflowUrl))
             throw new JobCreationRestException("Cannot create workflow without url");
-        HttpResourceDownloader httpResourceDownloader = HttpResourceDownloader.getInstance();
-        return httpResourceDownloader.getResource(sessionId, workflowUrl, String.class);
+        if (workflowUrl.startsWith("http")) {
+            HttpResourceDownloader httpResourceDownloader = HttpResourceDownloader.getInstance();
+            return httpResourceDownloader.getResource(sessionId, workflowUrl, String.class);
+        } else {
+            URL nonHttpURL = new URL(workflowUrl);
+            return IOUtils.toString(nonHttpURL.openStream(), Charsets.UTF_8);
+        }
     }
 
     protected static Map<String, String> createSortableTaskAttrMap() {


### PR DESCRIPTION
submitFromUrl method only supported http(s) urls, which is a non-necessary limitation.
This change allows using other kind of urls (ftp, file, etc), by simply using url.openStream()