### PR TITLE
Allow configuration of a global domain name

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -290,6 +290,9 @@ pa.scheduler.auth.privkey.path=config/authentication/keys/priv.key
 # Path to the public key file which is used to encrypt credentials for authentication
 pa.scheduler.auth.pubkey.path=config/authentication/keys/pub.key
 
+# Uncomment the following line to configure a global domain for scheduler users in active directory environments
+# pa.scheduler.auth.global.domain=mydomain
+
 # LDAP Authentication configuration file path, used to set LDAP configuration properties
 # If this file path is relative, the path is evaluated from the Scheduler dir (ie application's root dir)
 # with the variable defined below : pa.scheduler.home.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -154,6 +154,9 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** path to the public key file which is used to encrypt credentials for authentication */
     SCHEDULER_AUTH_PUBKEY_PATH("pa.scheduler.auth.pubkey.path", PropertyType.STRING, "config/authentication/keys/pub.key"),
 
+    /** a domain name (windows active directory) which can be configured globally at the scheduler level **/
+    SCHEDULER_AUTH_GLOBAL_DOMAIN("pa.scheduler.auth.global.domain", PropertyType.STRING),
+
     /** 
      * LDAP Authentication configuration file path, used to set LDAP configuration properties
      * If this file path is relative, the path is evaluated from the Scheduler dir (ie application's root dir)

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/TimedDoTaskAction.java
@@ -162,6 +162,11 @@ public class TimedDoTaskAction implements CallableWithTimeoutAction<Void> {
     private void createAndSetCredentials() throws KeyException, NoSuchAlgorithmException {
         CredData decryptedUserCredentials = job.getCredentials().decrypt(corePrivateKey);
 
+        if (PASchedulerProperties.SCHEDULER_AUTH_GLOBAL_DOMAIN.isSet() &&
+            decryptedUserCredentials.getDomain() == null) {
+            decryptedUserCredentials.setDomain(PASchedulerProperties.SCHEDULER_AUTH_GLOBAL_DOMAIN.getValueAsString());
+        }
+
         enrichWithThirdPartyCredentials(decryptedUserCredentials);
 
         PublicKey nodePublicKey = launcher.generatePublicKey();


### PR DESCRIPTION
For active directory domains, it is convenient to allow the possibility to configure globally at the scheduler level the default domain for users.
This change adds a dedicated property, whenever a task is deployed this domain name is automatically added in the task credentials (which is used by runasme)