### PR TITLE
Add fixed serial uid to NodeSet

### DIFF
--- a/rm/rm-client/src/main/java/org/ow2/proactive/utils/NodeSet.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/utils/NodeSet.java
@@ -53,6 +53,8 @@ import org.objectweb.proactive.core.node.Node;
 @PublicAPI
 public class NodeSet extends ArrayList<Node> {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * extra nodes
      */


### PR DESCRIPTION
As NodeSet is stored inside the scheduler database, a fixed serialuid on the class is needed to keep the database when upgrading the scheduler server version.