### PR TITLE
Install tools needed by the scripts automatically

### DIFF
--- a/tools/install_base.sh
+++ b/tools/install_base.sh
@@ -205,6 +205,45 @@ config/web/truststore
     cd "$OLD_PWD"
 }
 
+install_binaries()
+{
+    if ! which rsync > /dev/null 2>&1; then
+        echo "rsync is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+           $PKG_TOOL -y install rsync
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+
+    if ! which zip > /dev/null 2>&1; then
+        echo "zip is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+           $PKG_TOOL -y install zip
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+
+    if ! which unzip > /dev/null 2>&1; then
+        echo "unzip is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+           $PKG_TOOL -y install unzip
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+
+    if ! which git > /dev/null 2>&1; then
+        echo "Git is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+            $PKG_TOOL -y install git
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+}
+
 initial_commit()
 {
     OLD_PWD=$(pwd)
@@ -242,16 +281,8 @@ if [ ! -f "$INSTALL_PADIR/jre/bin/java" ]; then
     fi
 fi
 
-if ! which git > /dev/null 2>&1; then
-     echo "Git is not installed on this computer and is required by the ProActive installation."
-     if confirm "Do you want to install it? [Y/n] " ; then
-         if [[ "$OS" == "RedHat" ]]; then
-            $PKG_TOOL -y install git
-         elif [[ "$OS" == "Debian" ]]; then
-            $PKG_TOOL -y install git
-         fi
-     fi
-fi
+install_binaries
+
 
 # stopping service
 

--- a/tools/patch_git_prior_8_4.sh
+++ b/tools/patch_git_prior_8_4.sh
@@ -95,6 +95,45 @@ copy_configs()
     cd "$OLD_PWD"
 }
 
+install_binaries()
+{
+    if ! which rsync > /dev/null 2>&1; then
+        echo "rsync is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+           $PKG_TOOL -y install rsync
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+
+    if ! which zip > /dev/null 2>&1; then
+        echo "zip is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+           $PKG_TOOL -y install zip
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+
+    if ! which unzip > /dev/null 2>&1; then
+        echo "unzip is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+           $PKG_TOOL -y install unzip
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+
+    if ! which git > /dev/null 2>&1; then
+        echo "Git is not installed on this computer and is required by the ProActive installation."
+        if confirm "Do you want to install it? [Y/n] " ; then
+            $PKG_TOOL -y install git
+        else
+           echo "Installation aborted."; exit 1 ;
+        fi
+    fi
+}
+
 echo "This command will patch the ProActive installation in $PA_DIR using the unmodified same version package in $ORIGINAL_DIR. The original configuration files and git history are stored in an archive file for backup purpose."
 if confirm "Proceed? [Y/n] "; then
 
@@ -105,6 +144,8 @@ if confirm "Proceed? [Y/n] "; then
     echo " 3) make sure all file belong to the correct user and not to root"
     echo ""
     echo "Beginning the patch procedure..."
+
+    install_binaries
 
     OLD_PWD=$(pwd)
 


### PR DESCRIPTION
The installation script needs a few system tools (rsync, zip, unzip, git) which are not always installed by default.

This change asks the user to confirm that these tools will be installed