### PR TITLE
Emmit standard node added event during node recovery

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2236,10 +2236,6 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         }
     }
 
-    public void nodeEventOnlyForStatistic(RMNodeEvent event) {
-        monitoring.nodeEventOnlyForStatistic(event);
-    }
-
     public void registerAndEmitNodeEvent(final RMNodeEvent event) {
         this.monitoring.nodeEvent(event);
     }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/NodesRecoveryManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/NodesRecoveryManager.java
@@ -146,8 +146,10 @@ public class NodesRecoveryManager {
                 recoveredEligibleNodes.add(node);
             }
             if (node != null) {
-                final RMNodeEvent event = new RMNodeEvent(RMEventType.NODE_ADDED, node.getState());
-                this.rmCore.nodeEventOnlyForStatistic(event);
+                final RMNodeEvent event = node.createNodeEvent(RMEventType.NODE_ADDED,
+                                                               null,
+                                                               node.getProvider().getName());
+                this.rmCore.registerAndEmitNodeEvent(event);
             }
         }
         this.rmCore.setEligibleNodesToRecover(recoveredEligibleNodes);


### PR DESCRIPTION
 - related to previous commit f17f633
 - in this commit, the rm statistics did receive a node event on resource manager recovery but other components of the rm did not
 - this change send a proper node added event