### PR TITLE
Add node to topology manager during recovery

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/NodesRecoveryManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/NodesRecoveryManager.java
@@ -200,6 +200,11 @@ public class NodesRecoveryManager {
         RMNode rmNode = nodeSource.internalAddNodeAfterRecovery(node, rmNodeData);
         this.rmCore.registerAvailableNode(rmNode);
         if (node != null) {
+            try {
+                RMCore.topologyManager.addNode(rmNode.getNode());
+            } catch (Exception e) {
+                logger.error("Error occurred when adding recovered node to the topology", e);
+            }
             this.nodesLockRestorationManager.handle(rmNode, rmNodeData.getProvider());
         } else {
             this.triggerDownNodeHookIfNecessary(nodeSource, rmNodeData, nodeUrl, previousState);


### PR DESCRIPTION
A node recovered from the database was not added to the topology manager.

Because of this, multi-node selection could not work for recovered nodes and warning messages were appearing in the logs.