### PR TITLE
fix headless exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -367,9 +367,9 @@ class CustomCreateStartScripts extends CreateStartScripts {
         generator.mainClassName = getMainClassName()
 
         if (getApplicationName().equals("proactive-server")) {
-            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8", "-Xms4g"]
+            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8", "-Xms4g", "-Djava.awt.headless=false"]
         } else {
-            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8"]
+            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8", "-Djava.awt.headless=false"]
         }
 
         generator.optsEnvironmentVar = getOptsEnvironmentVar()


### PR DESCRIPTION
A Java Headless Exception is thrown when code that is dependent on a keyboard, display, or mouse is called in an environment that does not support a keyboard, display, or mouse. A possible solution is to  run our environment with a non headless implementation, the follow property may be specified at the java command line: 

``` 
-Djava.awt.headless=false
```
We wish to be able to experiment with the passage of this option to check whether the exception is still raised or not.

https://stackoverflow.com/questions/10170609/java-headless-exception-after-setting-djava-awt-headless-true