### PR TITLE
Housekeeping performance, memory leaks and hsldb

### DIFF
--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -94,6 +94,8 @@ public enum WebProperties implements PACommonProperties {
 
     JETTY_LOG_FILE("jetty.log.file", PropertyType.STRING),
 
+    JETTY_LOG_RETAIN_DAYS("jetty.log.retain.days", PropertyType.INTEGER, "5"),
+
     /** session cleaning period in seconds **/
     SESSION_CLEANING_PERIOD("session.cleaning.period", PropertyType.INTEGER, "300"),
 

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -6,6 +6,10 @@
 # Scheduler home directory (this default value should be proper in most cases)
 pa.scheduler.home=.
 
+# HSQLDB location, use this property to store the database in a different folder than scheduler_home/data/db
+# you can use an absolute location or a relative location from scheduler home
+# pa.hsqldb.location=data/db
+
 # Scheduler rest url. If not defined, it is set automatically when starting the server.
 # When the server has a public endpoint, different from the hostname available on the machine, this property should be used to correctly set the url
 #pa.scheduler.rest.url=

--- a/config/web/settings.ini
+++ b/config/web/settings.ini
@@ -97,7 +97,11 @@ war.wrapper.context.root=/
 #### Job Planner REST URL
 jp.url=http://localhost:8080/job-planner/planned_jobs
 
+# path to the jetty log file
 jetty.log.file=./logs/jetty-yyyy_mm_dd.request.log
+
+# retention period (days) for jetty logs
+jetty.log.retain.days=5
 
 # session cleaning period in seconds, default to 5 minutes
 session.cleaning.period=300

--- a/rest/rest-api/build.gradle
+++ b/rest/rest-api/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    compile 'org.jboss.resteasy:resteasy-jackson-provider:3.0.17.Final'
-    compile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.17.Final'
+    compile 'org.jboss.resteasy:resteasy-jackson-provider:3.0.19.Final'
+    compile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.19.Final'
     compile "org.objectweb.proactive:programming-util:${programmingVersion}"
     compile project(':scheduler:scheduler-api')
 }

--- a/rest/rest-server/build.gradle
+++ b/rest/rest-server/build.gradle
@@ -26,8 +26,8 @@ miredot {
 }
 
 dependencies {
-    compile 'org.jboss.resteasy:resteasy-jackson-provider:3.0.17.Final'
-    compile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.17.Final'
+    compile 'org.jboss.resteasy:resteasy-jackson-provider:3.0.19.Final'
+    compile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.19.Final'
 
     compile 'org.rrd4j:rrd4j:2.2.1'
     compile 'net.sf.dozer:dozer:5.5.1'
@@ -51,7 +51,7 @@ dependencies {
     testCompile functionalTestDependencies
 
     testCompile 'org.apache.httpcomponents:httpmime:4.5.2'
-    testCompile 'org.jboss.resteasy:tjws:3.0.13.Final'
+    testCompile 'org.jboss.resteasy:tjws:3.0.19.Final'
 
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.eclipse.jetty:jetty-client:9.2.24.v20180105'

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -2276,6 +2276,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                     // clean the temporary file
                     FileUtils.deleteQuietly(tmpJobFile);
                 }
+                if (multipart != null) {
+                    multipart.close();
+                }
             }
         } catch (IOException e) {
             throw new IOException("I/O Error: " + e.getMessage(), e);
@@ -2399,50 +2402,57 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     public boolean pushFile(@HeaderParam("sessionid") String sessionId, @PathParam("spaceName") String spaceName,
             @PathParam("filePath") String filePath, MultipartFormDataInput multipart)
             throws IOException, NotConnectedRestException, PermissionRestException {
-        checkAccess(sessionId, "pushFile");
+        try {
+            checkAccess(sessionId, "pushFile");
 
-        Session session = dataspaceRestApi.checkSessionValidity(sessionId);
+            Session session = dataspaceRestApi.checkSessionValidity(sessionId);
 
-        Map<String, List<InputPart>> formDataMap = multipart.getFormDataMap();
+            Map<String, List<InputPart>> formDataMap = multipart.getFormDataMap();
 
-        List<InputPart> fNL = formDataMap.get("fileName");
-        if ((fNL == null) || (fNL.isEmpty())) {
-            throw new IllegalArgumentException("Illegal multipart argument definition (fileName), received " + fNL);
+            List<InputPart> fNL = formDataMap.get("fileName");
+            if ((fNL == null) || (fNL.isEmpty())) {
+                throw new IllegalArgumentException("Illegal multipart argument definition (fileName), received " + fNL);
+            }
+            String fileName = fNL.get(0).getBody(String.class, null);
+
+            List<InputPart> fCL = formDataMap.get("fileContent");
+            if ((fCL == null) || (fCL.isEmpty())) {
+                throw new IllegalArgumentException("Illegal multipart argument definition (fileContent), received " +
+                                                   fCL);
+            }
+            InputStream fileContent = fCL.get(0).getBody(InputStream.class, null);
+
+            if (fileName == null) {
+                throw new IllegalArgumentException("Wrong file name : " + fileName);
+            }
+
+            filePath = normalizeFilePath(filePath, fileName);
+
+            FileObject destfo = dataspaceRestApi.resolveFile(session, spaceName, filePath);
+
+            URL targetUrl = destfo.getURL();
+            logger.info("[pushFile] pushing file to " + targetUrl);
+
+            if (!destfo.isWriteable()) {
+                RuntimeException ex = new IllegalArgumentException("File " + filePath + " is not writable in space " +
+                                                                   spaceName);
+                logger.error(ex);
+                throw ex;
+            }
+            if (destfo.exists()) {
+                destfo.delete();
+            }
+            // used to create the necessary directories if needed
+            destfo.createFile();
+
+            dataspaceRestApi.writeFile(fileContent, destfo, null);
+
+            return true;
+        } finally {
+            if (multipart != null) {
+                multipart.close();
+            }
         }
-        String fileName = fNL.get(0).getBody(String.class, null);
-
-        List<InputPart> fCL = formDataMap.get("fileContent");
-        if ((fCL == null) || (fCL.isEmpty())) {
-            throw new IllegalArgumentException("Illegal multipart argument definition (fileContent), received " + fCL);
-        }
-        InputStream fileContent = fCL.get(0).getBody(InputStream.class, null);
-
-        if (fileName == null) {
-            throw new IllegalArgumentException("Wrong file name : " + fileName);
-        }
-
-        filePath = normalizeFilePath(filePath, fileName);
-
-        FileObject destfo = dataspaceRestApi.resolveFile(session, spaceName, filePath);
-
-        URL targetUrl = destfo.getURL();
-        logger.info("[pushFile] pushing file to " + targetUrl);
-
-        if (!destfo.isWriteable()) {
-            RuntimeException ex = new IllegalArgumentException("File " + filePath + " is not writable in space " +
-                                                               spaceName);
-            logger.error(ex);
-            throw ex;
-        }
-        if (destfo.exists()) {
-            destfo.delete();
-        }
-        // used to create the necessary directories if needed
-        destfo.createFile();
-
-        dataspaceRestApi.writeFile(fileContent, destfo, null);
-
-        return true;
     }
 
     /**
@@ -3275,6 +3285,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         } finally {
             if (tmpFile != null) {
                 FileUtils.deleteQuietly(tmpFile);
+            }
+            if (multipart != null) {
+                multipart.close();
             }
         }
     }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -281,40 +281,45 @@ public class StudioRest implements StudioInterface {
     @Override
     public String createClass(@HeaderParam("sessionid") String sessionId, MultipartFormDataInput input)
             throws NotConnectedRestException, IOException {
+        try {
+            String userName = getUserName(sessionId);
+            File classesDir = new File(getFileStorageSupport().getWorkflowsDir(userName), "classes");
 
-        String userName = getUserName(sessionId);
-        File classesDir = new File(getFileStorageSupport().getWorkflowsDir(userName), "classes");
-
-        if (!classesDir.exists()) {
-            logger.info("Creating dir " + classesDir.getAbsolutePath());
-            classesDir.mkdirs();
-        }
-
-        String fileName = "";
-
-        Map<String, List<InputPart>> uploadForm = input.getFormDataMap();
-        String name = uploadForm.keySet().iterator().next();
-        List<InputPart> inputParts = uploadForm.get(name);
-
-        for (InputPart inputPart : inputParts) {
-
-            try {
-                //convert the uploaded file to inputstream
-                InputStream inputStream = inputPart.getBody(InputStream.class, null);
-                byte[] bytes = IOUtils.toByteArray(inputStream);
-
-                //constructs upload file path
-                fileName = classesDir.getAbsolutePath() + File.separator + name;
-
-                FileUtils.writeByteArrayToFile(new File(fileName), bytes);
-            } catch (IOException e) {
-                logger.warn("Could not read input part", e);
-                throw e;
+            if (!classesDir.exists()) {
+                logger.info("Creating dir " + classesDir.getAbsolutePath());
+                classesDir.mkdirs();
             }
 
-        }
+            String fileName = "";
 
-        return fileName;
+            Map<String, List<InputPart>> uploadForm = input.getFormDataMap();
+            String name = uploadForm.keySet().iterator().next();
+            List<InputPart> inputParts = uploadForm.get(name);
+
+            for (InputPart inputPart : inputParts) {
+
+                try {
+                    //convert the uploaded file to inputstream
+                    InputStream inputStream = inputPart.getBody(InputStream.class, null);
+                    byte[] bytes = IOUtils.toByteArray(inputStream);
+
+                    //constructs upload file path
+                    fileName = classesDir.getAbsolutePath() + File.separator + name;
+
+                    FileUtils.writeByteArrayToFile(new File(fileName), bytes);
+                } catch (IOException e) {
+                    logger.warn("Could not read input part", e);
+                    throw e;
+                }
+
+            }
+
+            return fileName;
+        } finally {
+            if (input != null) {
+                input.close();
+            }
+        }
     }
 
     @Override

--- a/rm/rm-server/build.gradle
+++ b/rm/rm-server/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     testCompile 'org.apache.sshd:sshd-core:1.7.0'
 
-    runtime 'org.hsqldb:hsqldb:2.4.0'
+    runtime 'org.hsqldb:hsqldb:2.4.1'
 
     runtime "org.objectweb.proactive:programming-extension-pnp:${programmingVersion}"
     runtime "org.objectweb.proactive:programming-extension-pnpssl:${programmingVersion}"

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -313,6 +313,9 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Scheduler home directory */
     SCHEDULER_HOME("pa.scheduler.home", PropertyType.STRING),
 
+    /** Hsqldb catalog location, use this property to store the hsqldb database in a different folder than scheduler_home/data/db */
+    HSQLDB_LOCATION("pa.hsqldb.location", PropertyType.STRING),
+
     /**
      * Scheduler rest url
      */

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
@@ -132,6 +132,11 @@ public class JobInfoImpl implements JobInfo {
     public JobInfoImpl() {
     }
 
+    public JobInfoImpl(JobId jobId, String owner) {
+        this.jobId = jobId;
+        this.owner = owner;
+    }
+
     /*
      * Copy constructor is used to pass job information to the event listener
      * (SchedulerStateUpdate)

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     testCompile 'org.apache.sshd:sshd-core:0.14.0'
 
 
-    runtime 'org.hsqldb:hsqldb:2.4.0'
+    runtime 'org.hsqldb:hsqldb:2.4.1'
 
     runtime "org.objectweb.proactive:programming-extension-pnp:${programmingVersion}"
     runtime "org.objectweb.proactive:programming-extension-pnpssl:${programmingVersion}"

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -973,6 +973,7 @@ class LiveJobs {
             job.terminate();
             jlogger.debug(job.getId(), "terminated");
             terminationData.addJobToTerminate(job.getId());
+            jobs.remove(job.getId());
         }
 
         task.setTaskResult(result);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -1123,7 +1123,18 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
 
     @Override
     public synchronized void jobStateUpdated(String owner, NotificationData<JobInfo> notification) {
+        if (notification.getEventType().equals(SchedulerEvent.JOB_REMOVE_FINISHED)) {
+            // removing jobs from the global list : this job is no more managed
+            sState.removeFinished(notification.getData().getJobId());
+            jobsMap.remove(notification.getData().getJobId());
+            finishedJobsLRUCache.remove(notification.getData().getJobId());
+            jobs.remove(notification.getData().getJobId());
+            logger.debug("HOUSEKEEPING removed the finished job " + notification.getData().getJobId() +
+                         " from the SchedulerFrontEndState");
+            return;
+        }
         ClientJobState js = getClientJobState(notification.getData().getJobId());
+
         boolean withAttachment = false;
         if (js != null) {
             synchronized (js) {
@@ -1151,15 +1162,6 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
                         // set this job finished, user can get its result
                         jobs.remove(notification.getData().getJobId()).setFinished(true);
                         withAttachment = true;
-                        break;
-                    case JOB_REMOVE_FINISHED:
-                        // removing jobs from the global list : this job is no more managed
-                        sState.removeFinished(js);
-                        jobsMap.remove(js.getId());
-                        finishedJobsLRUCache.remove(js.getId());
-                        jobs.remove(notification.getData().getJobId());
-                        logger.debug("HOUSEKEEPING removed the finished job " + js.getId() +
-                                     " from the SchedulerFrontEndState");
                         break;
                     default:
                         logger.warn("**WARNING** - Unconsistent update type received from Scheduler Core : " +

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerHsqldbStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerHsqldbStarter.java
@@ -70,7 +70,17 @@ public class SchedulerHsqldbStarter {
         String databaseFileName = "database.properties";
         String schedulerConfigurationFolderName = "config";
 
-        Path schedulerDbPath = Paths.get(schedulerHome, "data", "db");
+        Path schedulerDbPath;
+
+        if (PASchedulerProperties.HSQLDB_LOCATION.isSet()) {
+            if (Paths.get(PASchedulerProperties.HSQLDB_LOCATION.getValueAsString()).isAbsolute()) {
+                schedulerDbPath = Paths.get(PASchedulerProperties.HSQLDB_LOCATION.getValueAsString());
+            } else {
+                schedulerDbPath = Paths.get(schedulerHome, PASchedulerProperties.HSQLDB_LOCATION.getValueAsString());
+            }
+        } else {
+            schedulerDbPath = Paths.get(schedulerHome, "data", "db");
+        }
 
         hibernateRmConfiguration = Paths.get(schedulerHome, schedulerConfigurationFolderName, "rm", databaseFileName);
         hibernateSchedulerConfiguration = Paths.get(schedulerHome,

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
@@ -130,7 +130,7 @@ public class JettyStarter {
                     requestLog.setExtended(false);
                     requestLog.setLogTimeZone("GMT");
                     requestLog.setLogLatency(true);
-                    requestLog.setRetainDays(90);
+                    requestLog.setRetainDays(WebProperties.JETTY_LOG_RETAIN_DAYS.getValueAsInt());
 
                     RequestLogHandler requestLogHandler = new RequestLogHandler();
                     requestLogHandler.setRequestLog(requestLog);


### PR DESCRIPTION
 - Improve housekeeping time by reducing the number of requests to the database
 - a memory leak was found in LiveJobs (missing jobs.remove() call when a job is finished normally)
 - upgrade hsqldb to version 2.4.1 (this version makes is handling lobs file better)
 - upgrade rest easy to 3.0.19  (second memory leak due to deleteOnExit calls)
 - avoid using deleteOnExit for rrdj temp files (third memory leak)
 - added a property to let admins configure the location of the HSQL database (default to data/db, but can now even use absolute paths)
 - added a property to configure jetty log files retention period