### PR TITLE
FIX CPU overhead due to log event processor issue

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchFileAppender.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchFileAppender.java
@@ -89,11 +89,15 @@ public class AsynchFileAppender extends FileAppender {
 
     private void logEventProcessor() {
         while (Thread.currentThread().isAlive()) {
+            ApplicableEvent queuedEvent;
             try {
-                ApplicableEvent queuedEvent = queue.peek();
+                queuedEvent = queue.peek();
                 if (queuedEvent != null) {
                     queuedEvent.apply();
                     queue.take();
+                } else {
+                    // Workaround to avoid CPU overhead
+                    Thread.sleep(10);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
In this PR, we apply @fviale's workaround for CPU overhead due to relentless log event processor implementation.

**NOTE** This is mainly a temporary fix until @Mykhailenko's return.