### PR TITLE
Avoid deadlocks and heavy CPU usage

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchChachedFileAppender.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchChachedFileAppender.java
@@ -46,7 +46,8 @@ public class AsynchChachedFileAppender extends AsynchFileAppender {
             appenderCache.computeIfAbsent(cacheKey, this::createAppender);
             queue.put(new ApplicableEvent(cacheKey, event));
         } catch (InterruptedException e) {
-            LOGGER.warn("Queue put is interrupted.");
+            LOGGER.warn("Interrupted append on " + cacheKey);
+            Thread.currentThread().interrupt();
         } finally {
             isAppending.unlock();
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchFileAppender.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchFileAppender.java
@@ -64,7 +64,8 @@ public class AsynchFileAppender extends FileAppender {
             isAppending.lock();
             queue.put(new ApplicableEvent(cacheKey, event));
         } catch (InterruptedException e) {
-            LOGGER.debug("Append interrupted: " + e);
+            LOGGER.warn("Interrupted append on " + cacheKey);
+            Thread.currentThread().interrupt();
         } finally {
             isAppending.unlock();
         }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchFileAppender.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchFileAppender.java
@@ -29,8 +29,9 @@ import static org.ow2.proactive.resourcemanager.core.properties.PAResourceManage
 import static org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties.LOG4J_ASYNC_APPENDER_FLUSH_TIMOUT;
 
 import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.log4j.*;
 import org.apache.log4j.spi.LoggingEvent;
@@ -40,7 +41,14 @@ public class AsynchFileAppender extends FileAppender {
 
     private static final Logger LOGGER = Logger.getLogger(AsynchFileAppender.class);
 
-    final BlockingQueue<ApplicableEvent> queue = new LinkedBlockingQueue<>(LOG4J_ASYNC_APPENDER_BUFFER_SIZE.getValueAsInt());
+    final BlockingQueue<ApplicableEvent> queue = new ArrayBlockingQueue<>(LOG4J_ASYNC_APPENDER_BUFFER_SIZE.getValueAsInt(),
+                                                                          true);
+
+    protected ReentrantReadWriteLock preventConcurrentAppendClose = new ReentrantReadWriteLock();
+
+    protected ReentrantReadWriteLock.ReadLock isAppending = preventConcurrentAppendClose.readLock();
+
+    protected ReentrantReadWriteLock.WriteLock isClosing = preventConcurrentAppendClose.writeLock();
 
     public AsynchFileAppender() {
         super();
@@ -52,18 +60,24 @@ public class AsynchFileAppender extends FileAppender {
 
     // non blocking
     public void append(String cacheKey, LoggingEvent event) {
-        synchronized (queue) {
-            try {
-                queue.put(new ApplicableEvent(cacheKey, event));
-            } catch (InterruptedException e) {
-                LOGGER.debug("Append interrupted: " + e);
-            }
+        try {
+            isAppending.lock();
+            queue.put(new ApplicableEvent(cacheKey, event));
+        } catch (InterruptedException e) {
+            LOGGER.debug("Append interrupted: " + e);
+        } finally {
+            isAppending.unlock();
         }
     }
 
     @Override
     public void close() {
-        flush();
+        try {
+            isClosing.lock();
+            flush();
+        } finally {
+            isClosing.unlock();
+        }
     }
 
     // blocking
@@ -94,6 +108,9 @@ public class AsynchFileAppender extends FileAppender {
                 if (queuedEvent != null) {
                     queuedEvent.apply();
                     queue.take();
+                } else {
+                    // Workaround to avoid CPU overhead
+                    Thread.sleep(10);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogs.java
@@ -252,8 +252,13 @@ public class ServerJobAndTaskLogs {
     void removeLogsDirectory() {
         String logsLocation = getLogsLocation();
         logger.info("Removing logs " + logsLocation);
-        FileUtils.removeDir(new File(logsLocation));
-        // this code breaks the tests
+
+        boolean folderRemoved = org.apache.commons.io.FileUtils.deleteQuietly(new File(logsLocation));
+        if (!folderRemoved) {
+            logger.error("Could not remove logs folder");
+        }
+
+        // infinite remove retries breaks the tests
         //        try {
         //            while (!org.apache.commons.io.FileUtils.deleteQuietly(new File(logsLocation))) {
         //                logger.warn("Could not delete folder " + logsLocation + " retrying");

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogsTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/util/ServerJobAndTaskLogsTest.java
@@ -150,6 +150,10 @@ public class ServerJobAndTaskLogsTest extends ProActiveTestClean {
         System.out.println(fakeSchedulerHome);
         assertEquals(1, fakeSchedulerHome.list().length);
 
+        // avoid keeping a handle on the files
+        jobLogger.close(jobId);
+        taskLogger.close(taskId);
+
         ServerJobAndTaskLogs.getInstance().removeLogsDirectory();
 
         assertEquals(0, fakeSchedulerHome.list().length);


### PR DESCRIPTION
 - use read/write locks instead of synchronized
 - use Thread.sleep to avoid aggressive loop
 - use ArrayBlockingQueue instead of LinkedBlockingQueue (minor)
 - use fairness to respect FIFO thread access to the queue.