### PR TITLE
fix submitFromUrl

### DIFF
--- a/rest/rest-server/src/main/webapp/WEB-INF/web.xml
+++ b/rest/rest-server/src/main/webapp/WEB-INF/web.xml
@@ -21,6 +21,12 @@
         <param-value>500000000</param-value>
     </context-param>
     <context-param>
+        <!-- This context parameter is added because of stricter request matching rules introduced in resteasy 3.0.25
+         The parameter allows backward compatibility-->
+        <param-name>resteasy.loose.step2.request.matching</param-name>
+        <param-value>true</param-value>
+    </context-param>
+    <context-param>
         <param-name>resteasy.resources</param-name>
         <param-value>
             org.ow2.proactive_grid_cloud_portal.scheduler.SchedulerStateRest,org.ow2.proactive_grid_cloud_portal.studio.StudioRest,org.ow2.proactive_grid_cloud_portal.rm.RMRest,org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl

--- a/rest/rest-server/src/test/java/functionaltests/AbstractRestFuncTestCase.java
+++ b/rest/rest-server/src/test/java/functionaltests/AbstractRestFuncTestCase.java
@@ -25,10 +25,12 @@
  */
 package functionaltests;
 
+import java.nio.charset.Charset;
 import java.security.Policy;
 
 import javax.ws.rs.core.MediaType;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -118,6 +120,14 @@ public abstract class AbstractRestFuncTestCase {
     }
 
     protected void assertHttpStatusOK(HttpResponse response) {
+        if (getStatusCode(response) != STATUS_OK) {
+            try {
+                System.out.println("Unexpected status response");
+                System.out.println(IOUtils.toString(response.getEntity().getContent(), Charset.defaultCharset()));
+            } catch (Exception e) {
+                //ignored
+            }
+        }
         assertEquals(STATUS_OK, getStatusCode(response));
     }
 

--- a/rest/rest-server/src/test/java/functionaltests/RestSchedulerJobTaskTest.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestSchedulerJobTaskTest.java
@@ -151,6 +151,19 @@ public class RestSchedulerJobTaskTest extends AbstractRestFuncTestCase {
     }
 
     @Test
+    public void testSubmitFromUrl() throws Exception {
+        String schedulerUrl = getResourceUrl("jobs");
+        HttpPost httpPost = new HttpPost(schedulerUrl);
+        setSessionHeader(httpPost);
+        File jobFile = RestFuncTHelper.getDefaultJobXmlfile();
+        httpPost.setHeader("link", jobFile.toURI().toURL().toExternalForm());
+        HttpResponse response = executeUriRequest(httpPost);
+        assertHttpStatusOK(response);
+        JSONObject jsonObj = toJsonObject(response);
+        assertNotNull(jsonObj.get("id").toString());
+    }
+
+    @Test
     public void testUrlMatrixParamsShouldReplaceJobVariables() throws Exception {
         File jobFile = new File(RestSchedulerJobTaskTest.class.getResource("config/job_matrix_params.xml").toURI());
 


### PR DESCRIPTION
 - enable resteasy.loose.step2.request.matching which provides backward compatibility due to stricter request matching introduced in resteasy 3.0.25
 - add functional test for subbmitFromUrl