### PR TITLE
register resteasy gzip encoding in all resteasy client usages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -367,7 +367,7 @@ class CustomCreateStartScripts extends CreateStartScripts {
         generator.mainClassName = getMainClassName()
 
         if (getApplicationName().equals("proactive-server")) {
-            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8", "-Xms4g"]
+            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8", "-Dresteasy.allowGzip=true", "-Xms4g"]
         } else {
             generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8"]
         }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
@@ -50,6 +50,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.ow2.proactive.authentication.ConnectionInfo;
 import org.ow2.proactive.http.HttpClientBuilder;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
@@ -59,6 +60,7 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive.scheduler.rest.ISchedulerClient;
 import org.ow2.proactive.scheduler.rest.SchedulerClient;
 import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
+import org.ow2.proactive_grid_cloud_portal.scheduler.client.SchedulerRestClient;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
@@ -73,6 +75,8 @@ public class DataSpaceClient implements IDataSpaceClient {
     private String sessionId;
 
     private ClientHttpEngine httpEngine;
+
+    private ResteasyProviderFactory providerFactory;
 
     private ISchedulerClient schedulerClient;
 
@@ -90,6 +94,8 @@ public class DataSpaceClient implements IDataSpaceClient {
                                                                                              .isInsecure())
                                                                              .useSystemProperties()
                                                                              .build());
+        this.providerFactory = ResteasyProviderFactory.getInstance();
+        SchedulerRestClient.registerGzipEncoding(providerFactory);
         this.restDataspaceUrl = restDataspaceUrl(restServerUrl);
         this.sessionId = client.getSession();
         if (log.isDebugEnabled()) {
@@ -113,7 +119,9 @@ public class DataSpaceClient implements IDataSpaceClient {
         }
 
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(destination.getDataspace().value());
-        ResteasyClient client = new ResteasyClientBuilder().httpEngine(httpEngine).build();
+        ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
+                                                           .httpEngine(httpEngine)
+                                                           .build();
         ResteasyWebTarget target = client.target(uriTmpl.toString()).path(destination.getPath());
         Response response = null;
         try {
@@ -153,7 +161,9 @@ public class DataSpaceClient implements IDataSpaceClient {
         }
 
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(source.getDataspace().value());
-        ResteasyClient client = new ResteasyClientBuilder().httpEngine(httpEngine).build();
+        ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
+                                                           .httpEngine(httpEngine)
+                                                           .build();
         ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath());
 
         Response response = null;
@@ -194,7 +204,9 @@ public class DataSpaceClient implements IDataSpaceClient {
         }
 
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(source.getDataspace().value());
-        ResteasyClient client = new ResteasyClientBuilder().httpEngine(httpEngine).build();
+        ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
+                                                           .httpEngine(httpEngine)
+                                                           .build();
         ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath());
 
         List<String> includes = source.getIncludes();
@@ -254,7 +266,9 @@ public class DataSpaceClient implements IDataSpaceClient {
     @Override
     public ListFile list(IRemoteSource source) throws NotConnectedException, PermissionException {
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(source.getDataspace().value());
-        ResteasyClient client = new ResteasyClientBuilder().httpEngine(httpEngine).build();
+        ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
+                                                           .httpEngine(httpEngine)
+                                                           .build();
         ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath()).queryParam("comp", "list");
 
         List<String> includes = source.getIncludes();
@@ -291,7 +305,9 @@ public class DataSpaceClient implements IDataSpaceClient {
         }
 
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(source.getDataspace().value());
-        ResteasyClient client = new ResteasyClientBuilder().httpEngine(httpEngine).build();
+        ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
+                                                           .httpEngine(httpEngine)
+                                                           .build();
         ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath());
 
         List<String> includes = source.getIncludes();
@@ -336,7 +352,9 @@ public class DataSpaceClient implements IDataSpaceClient {
     @Override
     public Map<String, String> metadata(IRemoteSource source) throws NotConnectedException, PermissionException {
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(source.getDataspace().value());
-        ResteasyClient client = new ResteasyClientBuilder().httpEngine(httpEngine).build();
+        ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
+                                                           .httpEngine(httpEngine)
+                                                           .build();
         ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath());
         Response response = null;
         try {

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/HttpResourceDownloader.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/HttpResourceDownloader.java
@@ -38,9 +38,11 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.ow2.proactive.http.HttpClientBuilder;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.web.WebProperties;
+import org.ow2.proactive_grid_cloud_portal.scheduler.client.SchedulerRestClient;
 
 
 public class HttpResourceDownloader {
@@ -65,7 +67,11 @@ public class HttpResourceDownloader {
                                                                                             .useSystemProperties()
                                                                                             .build());
 
-        ResteasyClientBuilder clientBuilder = new ResteasyClientBuilder().httpEngine(engine);
+        ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
+        SchedulerRestClient.registerGzipEncoding(providerFactory);
+
+        ResteasyClientBuilder clientBuilder = new ResteasyClientBuilder().providerFactory(providerFactory)
+                                                                         .httpEngine(engine);
 
         if (WebProperties.WEB_HTTPS_TRUSTSTORE.isSet() && WebProperties.WEB_HTTPS_TRUSTSTORE_PASSWORD.isSet()) {
             String trustStorePath = null;

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -67,6 +67,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.objectweb.proactive.ActiveObjectCreationException;
 import org.objectweb.proactive.api.PAActiveObject;
 import org.objectweb.proactive.api.PAFuture;
@@ -96,6 +97,7 @@ import org.ow2.proactive_grid_cloud_portal.common.SessionStore;
 import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
 import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
 import org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl;
+import org.ow2.proactive_grid_cloud_portal.scheduler.client.SchedulerRestClient;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.*;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventNotification;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.eventing.EventSubscription;
@@ -2325,7 +2327,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
         Response response = null;
         try {
-            ResteasyClient client = new ResteasyClientBuilder().build();
+            ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
+            SchedulerRestClient.registerGzipEncoding(providerFactory);
+            ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory).build();
             ResteasyWebTarget target = client.target(PortalConfiguration.JOBPLANNER_URL.getValueAsString());
             response = target.request()
                              .header("sessionid", sessionId)

--- a/rest/rest-server/src/main/webapp/META-INF/services/javax.ws.rs.ext.Providers
+++ b/rest/rest-server/src/main/webapp/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,3 +1,0 @@
-org.jboss.resteasy.plugins.interceptors.encoding.AcceptEncodingGZIPFilter
-org.jboss.resteasy.plugins.interceptors.encoding.GZIPDecodingInterceptor
-org.jboss.resteasy.plugins.interceptors.encoding.GZIPEncodingInterceptor

--- a/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
@@ -104,6 +104,7 @@ public class RestFuncTHelper {
         String javaPath = RestFuncTUtils.getJavaPathFromSystemProperties();
         cmd.add(javaPath);
         cmd.add("-Djava.security.manager");
+        cmd.add("-Dresteasy.allowGzip=true");
         cmd.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() + toPath(serverJavaPolicy));
 
         cmd.add(CentralPAPropertyRepository.PA_HOME.getCmdLine() + getSchedHome());

--- a/rm/rm-server/src/test/java/functionaltests/utils/TestRM.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/TestRM.java
@@ -88,6 +88,7 @@ public class TestRM {
         List<String> commandLine = new ArrayList<>();
         commandLine.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
         commandLine.add("-Djava.security.manager");
+        commandLine.add("-Dresteasy.allowGzip=true");
 
         String proactiveHome = CentralPAPropertyRepository.PA_HOME.getValue();
         if (!CentralPAPropertyRepository.PA_HOME.isSet()) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/TestScheduler.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/TestScheduler.java
@@ -83,6 +83,7 @@ public class TestScheduler {
         List<String> commandLine = new ArrayList<>();
         commandLine.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
         commandLine.add("-Djava.security.manager");
+        commandLine.add("-Dresteasy.allowGzip=true");
         commandLine.add("-Dfile.encoding=" + System.getProperty("file.encoding"));
         // commandLine.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
 


### PR DESCRIPTION
without gzip encoding enabled resteasy clients fail to handle endpoint which request gzip compression.