### PR TITLE
allow text areas as input fields in node sources

### DIFF
--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/Configurable.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/Configurable.java
@@ -65,6 +65,11 @@ public @interface Configurable {
     boolean fileBrowser() default false;
 
     /**
+     * Field is a multiline text area.
+     */
+    boolean textArea() default false;
+
+    /**
      * Dynamic fields can be edited while the node source is deployed.
      */
     boolean dynamic() default false;

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/ConfigurableAdapter.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/ConfigurableAdapter.java
@@ -52,6 +52,7 @@ public class ConfigurableAdapter extends XmlAdapter<ConfigurableWrapper, Configu
         CREDENTIAL("credential"),
         PASSWORD("password"),
         FILEBROWSER("fileBrowser"),
+        TEXTAREA("textArea"),
         NONE("none");
 
         private String name;
@@ -97,6 +98,8 @@ public class ConfigurableAdapter extends XmlAdapter<ConfigurableWrapper, Configu
             type = ConfigurableValues.PASSWORD;
         } else if (arg0.fileBrowser()) {
             type = ConfigurableValues.FILEBROWSER;
+        } else if (arg0.textArea()) {
+            type = ConfigurableValues.TEXTAREA;
         } else {
             type = ConfigurableValues.NONE;
         }
@@ -105,7 +108,7 @@ public class ConfigurableAdapter extends XmlAdapter<ConfigurableWrapper, Configu
     }
 
     @Override
-    public Configurable unmarshal(ConfigurableWrapper arg0) throws Exception {
+    public Configurable unmarshal(final ConfigurableWrapper arg0) throws Exception {
 
         if (arg0 == null || arg0.type == null)
             return null;
@@ -135,6 +138,11 @@ public class ConfigurableAdapter extends XmlAdapter<ConfigurableWrapper, Configu
             @Override
             public boolean fileBrowser() {
                 return arg0.type == ConfigurableValues.FILEBROWSER;
+            }
+
+            @Override
+            public boolean textArea() {
+                return arg0.type == ConfigurableValues.TEXTAREA;
             }
 
             @Override


### PR DESCRIPTION
This modif will allow to use text areas as input fields when defining a node source.
Yet to be coupled with modifications to `scheduling-portal` and `[enterprise-]node-source-addons`