### PR TITLE
Re-registed node in TopologyManager

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1184,6 +1184,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
             internalSetFree(node);
         }
 
+        if (RMCore.topologyManager != null) {
+            RMCore.topologyManager.addNode(node.getNode());
+        }
         node.getNodeSource().setNodeAvailable(node);
     }
 


### PR DESCRIPTION
 - when a node is reconnecting from down state, register it again in the topology manager to prevent topology information loss.