### PR TITLE
RMNodeUpdater use node.jar parent directory as java process directory

### DIFF
--- a/rm/rm-node-updater/src/main/java/org/ow2/proactive/resourcemanager/updater/RMNodeUpdater.java
+++ b/rm/rm-node-updater/src/main/java/org/ow2/proactive/resourcemanager/updater/RMNodeUpdater.java
@@ -200,6 +200,7 @@ public class RMNodeUpdater extends RMNodeStarter {
             case OUT_DATED:
                 logger.info("Downloading node.jar from " + nodeJarUrl + " to " + nodeJarSaveAs);
                 File destination = new File(nodeJarSaveAs);
+                destination.mkdirs();
                 File lockFile = null;
                 FileLock lock = null;
                 FileChannel channel = null;
@@ -272,20 +273,42 @@ public class RMNodeUpdater extends RMNodeStarter {
 
     /**
      * Clean the directory used by One-Jar to expand libraries. After a node.jar update, we clean this directory to prevent jar conflicts
-     * @param jarFile name of the node jar file
+     * @param jarFilePath path to the node jar file
      */
-    private void cleanExpandDirectory(String jarFile) {
+    private void cleanExpandDirectory(String jarFilePath) {
         File directoryToClean;
+        File jarFile = new File(jarFilePath);
         String oneJarExpandDir = System.getProperty(ONEJAR_EXPAND_DIR_PROPERTY);
         if (oneJarExpandDir == null) {
             // Default scheme used by one-jar
-            String jar = new File(jarFile).getName().replaceFirst(LAST_DOT_AND_AFTER, "");
+            String jar = jarFile.getName().replaceFirst(LAST_DOT_AND_AFTER, "");
             directoryToClean = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value(), jar);
         } else {
             directoryToClean = new File(oneJarExpandDir);
         }
 
-        FileUtils.deleteQuietly(directoryToClean);
+        boolean jarFileInsideExpandDirectory = isJarFileInsideExpandDirectory(jarFile, directoryToClean);
+        try {
+            if (jarFileInsideExpandDirectory) {
+                FileUtils.moveFileToDirectory(jarFile, directoryToClean.getParentFile(), false);
+            }
+
+            FileUtils.deleteQuietly(directoryToClean);
+
+            if (jarFileInsideExpandDirectory) {
+                FileUtils.moveFileToDirectory(new File(directoryToClean.getParentFile(), jarFile.getName()),
+                                              directoryToClean,
+                                              true);
+            }
+        } catch (IOException e) {
+            logger.fatal("Error when moving node jar file to parent directory, check parent folder permissions, aborting...",
+                         e);
+            System.exit(ExitStatus.FAILED_TO_LAUNCH.exitCode);
+        }
+    }
+
+    private boolean isJarFileInsideExpandDirectory(File jarFile, File expandDirectory) {
+        return jarFile.getParentFile().getAbsoluteFile().equals(expandDirectory.getAbsoluteFile());
     }
 
     @Override
@@ -457,6 +480,8 @@ public class RMNodeUpdater extends RMNodeStarter {
         logger.info("Starting Java command: " + command);
         pb = new ProcessBuilder(command);
         pb.inheritIO();
+        File nodeJarParentFolder = (new File(jarFile)).getParentFile();
+        pb.directory(nodeJarParentFolder);
         if (pb.environment().containsKey("CLASSPATH")) {
             pb.environment().remove("CLASSPATH");
         }


### PR DESCRIPTION
This is mandatory to allow docker fork environment when using node.jar
Also: when cleaning the expand directory, detect if the node.jar is present in the same directory