### PR TITLE
feat: task retry delay

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
@@ -361,6 +361,7 @@ public abstract class Job extends CommonAttribute {
                                    lineWithQuotes("ProjectName", projectName),
                                    line("onTaskError", onTaskError),
                                    line("restartTaskOnError", restartTaskOnError),
+                                   line("taskRetryDelay", taskRetryDelay),
                                    line("maxNumberOfExecution",
                                         maxNumberOfExecution,
                                         () -> maxNumberOfExecution.getValue().getIntegerValue()),

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
@@ -198,6 +198,9 @@ public class Job2XMLTransformer {
         if (job.getRestartTaskOnErrorProperty().isSet()) {
             setAttribute(rootJob, XMLAttributes.COMMON_RESTART_TASK_ON_ERROR, job.getRestartTaskOnError().toString());
         }
+        if (job.getTaskRetryDelayProperty().isSet()) {
+            setAttribute(rootJob, XMLAttributes.COMMON_TASK_RETRY_DELAY, formatDate(job.getTaskRetryDelay()));
+        }
 
         // *** elements ***
 
@@ -445,6 +448,9 @@ public class Job2XMLTransformer {
         setAttribute(taskE, XMLAttributes.COMMON_NAME, task.getName(), true);
         if (task.getRestartTaskOnErrorProperty().isSet()) {
             setAttribute(taskE, XMLAttributes.COMMON_RESTART_TASK_ON_ERROR, task.getRestartTaskOnError().toString());
+        }
+        if (task.getTaskRetryDelayProperty().isSet()) {
+            setAttribute(taskE, XMLAttributes.COMMON_TASK_RETRY_DELAY, formatDate(task.getTaskRetryDelay()));
         }
 
         // *** task attributes ***

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobComparator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobComparator.java
@@ -145,6 +145,11 @@ public class JobComparator {
             return false;
         }
 
+        if (attrib1.getTaskRetryDelay() != attrib2.getTaskRetryDelay()) {
+            stack.push(" taskRetryDelay ");
+            return false;
+        }
+
         stack.push(" genericInformation ");
         if (!isEqualMap(attrib1.getGenericInformation(), attrib2.getGenericInformation())) {
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -469,7 +469,9 @@ public class StaxJobFactory extends JobFactory {
                 job.setProjectName(commonPropertiesHolder.getProjectName());
                 job.setOnTaskError(commonPropertiesHolder.getOnTaskErrorProperty().getValue());
                 job.setRestartTaskOnError(commonPropertiesHolder.getRestartTaskOnError());
-                job.setTaskRetryDelay(commonPropertiesHolder.getTaskRetryDelay());
+                if (commonPropertiesHolder.getTaskRetryDelayProperty().isSet()) {
+                    job.setTaskRetryDelay(commonPropertiesHolder.getTaskRetryDelay());
+                }
                 job.setMaxNumberOfExecution(commonPropertiesHolder.getMaxNumberOfExecution());
                 job.setGenericInformation(commonPropertiesHolder.getGenericInformation());
                 job.setUnresolvedGenericInformation(commonPropertiesHolder.getUnresolvedGenericInformation());

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -469,6 +469,7 @@ public class StaxJobFactory extends JobFactory {
                 job.setProjectName(commonPropertiesHolder.getProjectName());
                 job.setOnTaskError(commonPropertiesHolder.getOnTaskErrorProperty().getValue());
                 job.setRestartTaskOnError(commonPropertiesHolder.getRestartTaskOnError());
+                job.setTaskRetryDelay(commonPropertiesHolder.getTaskRetryDelay());
                 job.setMaxNumberOfExecution(commonPropertiesHolder.getMaxNumberOfExecution());
                 job.setGenericInformation(commonPropertiesHolder.getGenericInformation());
                 job.setUnresolvedGenericInformation(commonPropertiesHolder.getUnresolvedGenericInformation());
@@ -519,6 +520,9 @@ public class StaxJobFactory extends JobFactory {
             } else if (XMLAttributes.COMMON_RESTART_TASK_ON_ERROR.matches(attributeName)) {
                 commonPropertiesHolder.setRestartTaskOnError(RestartMode.getMode(replace(attributeValue,
                                                                                          commonPropertiesHolder.getVariablesAsReplacementMap())));
+            } else if (XMLAttributes.COMMON_TASK_RETRY_DELAY.matches(attributeName)) {
+                commonPropertiesHolder.setTaskRetryDelay(Tools.formatDate(replace(attributeValue,
+                                                                                  commonPropertiesHolder.getVariablesAsReplacementMap())));
             } else if (XMLAttributes.COMMON_ON_TASK_ERROR.matches(attributeName)) {
                 commonPropertiesHolder.setOnTaskError(OnTaskError.getInstance(replace(attributeValue,
                                                                                       commonPropertiesHolder.getVariablesAsReplacementMap())));
@@ -940,6 +944,9 @@ public class StaxJobFactory extends JobFactory {
                 } else if (XMLAttributes.COMMON_RESTART_TASK_ON_ERROR.matches(attributeName)) {
                     tmpTask.setRestartTaskOnError(RestartMode.getMode(replace(attributeValue,
                                                                               tmpTask.getVariablesOverriden(job))));
+                } else if (XMLAttributes.COMMON_TASK_RETRY_DELAY.matches(attributeName)) {
+                    tmpTask.setTaskRetryDelay(Tools.formatDate(replace(attributeValue,
+                                                                       tmpTask.getVariablesOverriden(job))));
                 } else if (XMLAttributes.COMMON_MAX_NUMBER_OF_EXECUTION.matches(attributeName)) {
                     tmpTask.setMaxNumberOfExecution(Integer.parseInt(replace(attributeValue,
                                                                              tmpTask.getVariablesOverriden(job))));
@@ -1897,6 +1904,7 @@ public class StaxJobFactory extends JobFactory {
             logger.debug("priority: " + job.getPriority());
             logger.debug("onTaskError: " + job.getOnTaskErrorProperty().getValue().toString());
             logger.debug("restartTaskOnError: " + job.getRestartTaskOnError());
+            logger.debug("TaskRetryDelay: " + job.getTaskRetryDelay());
             logger.debug("maxNumberOfExecution: " + job.getMaxNumberOfExecution());
             logger.debug("inputSpace: " + job.getInputSpace());
             logger.debug("outputSpace: " + job.getOutputSpace());
@@ -1917,6 +1925,7 @@ public class StaxJobFactory extends JobFactory {
                 logger.debug("preciousResult: " + t.isPreciousResult());
                 logger.debug("preciousLogs: " + t.isPreciousLogs());
                 logger.debug("restartTaskOnError: " + t.getRestartTaskOnError());
+                logger.debug("taskRetryDelay: " + t.getTaskRetryDelay());
                 logger.debug("maxNumberOfExecution: " + t.getMaxNumberOfExecution());
                 logger.debug("walltime: " + t.getWallTime());
                 logger.debug("selectionScripts: " + t.getSelectionScripts());

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/XMLAttributes.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/XMLAttributes.java
@@ -47,6 +47,7 @@ public enum XMLAttributes {
     COMMON_MAX_NUMBER_OF_EXECUTION("maxNumberOfExecution"),
     COMMON_NAME("name"),
     COMMON_RESTART_TASK_ON_ERROR("restartTaskOnError"),
+    COMMON_TASK_RETRY_DELAY("taskRetryDelay"),
     COMMON_VALUE("value"),
 
     // VARIABLE

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
@@ -37,6 +37,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.scheduler.common.task.util.IntegerWrapper;
+import org.ow2.proactive.scheduler.common.task.util.LongWrapper;
 import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
 
 
@@ -61,6 +62,9 @@ public abstract class CommonAttribute implements Serializable {
      * You can override this property inside each task.
      */
     protected UpdatableProperties<RestartMode> restartTaskOnError = new UpdatableProperties<RestartMode>(RestartMode.ANYWHERE);
+
+    /** Specify how long to wait before restart the task if an error occurred. */
+    protected UpdatableProperties<LongWrapper> taskRetryDelay = new UpdatableProperties<LongWrapper>(new LongWrapper(-1l));
 
     /**
      * The maximum number of execution for a task (default 1).
@@ -97,6 +101,32 @@ public abstract class CommonAttribute implements Serializable {
      */
     public UpdatableProperties<OnTaskError> getOnTaskErrorProperty() {
         return this.onTaskError;
+    }
+
+    /**
+     * Get how long to wait before restart the task if an error occurred.
+     *
+     * @return delay to restart a task in error
+     */
+    public Long getTaskRetryDelay() {
+        return taskRetryDelay.getValue().getLongValue();
+    }
+
+    /**
+     * Get taskRetryDelay UpdatableProperties
+     * @return taskRetryDelay UpdatableProperties
+     */
+    public UpdatableProperties<LongWrapper> getTaskRetryDelayProperty() {
+        return this.taskRetryDelay;
+    }
+
+    /**
+     * Set how long to wait before restart the task if an error occurred.
+     *
+     * @param taskRetryDelay delay to restart a task in error
+     */
+    public void setTaskRetryDelay(long taskRetryDelay) {
+        this.taskRetryDelay.setValue(new LongWrapper(taskRetryDelay));
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
@@ -54,6 +54,9 @@ public abstract class CommonAttribute implements Serializable {
     /** The key for specifying start at time as generic information */
     public static final String GENERIC_INFO_START_AT_KEY = "START_AT";
 
+    /** The default value of defining how long to wait before restart task in error (zero or negative value means restart immediately) */
+    public static final Long DEFAULT_TASK_RETRY_DELAY = -1l;
+
     /**
      * Define where will a task be restarted if an error occurred (default is ANYWHERE).
      * <p>
@@ -64,7 +67,7 @@ public abstract class CommonAttribute implements Serializable {
     protected UpdatableProperties<RestartMode> restartTaskOnError = new UpdatableProperties<RestartMode>(RestartMode.ANYWHERE);
 
     /** Specify how long to wait before restart the task if an error occurred. */
-    protected UpdatableProperties<LongWrapper> taskRetryDelay = new UpdatableProperties<LongWrapper>(new LongWrapper(-1l));
+    protected UpdatableProperties<LongWrapper> taskRetryDelay = new UpdatableProperties<LongWrapper>(new LongWrapper(DEFAULT_TASK_RETRY_DELAY));
 
     /**
      * The maximum number of execution for a task (default 1).

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Task.java
@@ -751,6 +751,7 @@ public abstract class Task extends CommonAttribute {
         return "Task '" + name + "' : " + System.lineSeparator() +
                addIndent(Stream.of(lineWithQuotes("Description", description),
                                    line("restartTaskOnError", restartTaskOnError),
+                                   line("taskRetryDelay", taskRetryDelay),
                                    line("onTaskError", onTaskError),
                                    line("maxNumberOfExecution",
                                         maxNumberOfExecution,

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/util/LongWrapper.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/util/LongWrapper.java
@@ -1,0 +1,94 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.task.util;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.objectweb.proactive.annotation.PublicAPI;
+
+
+/**
+ * LongWrapper is the Scheduler Wrapper object for Long.
+ * It is mostly used for Hibernate when using Long with parametric type.
+ *
+ * @author The ProActive Team
+ * @since ProActive Scheduling 0.9.1
+ */
+@PublicAPI
+@XmlAccessorType(XmlAccessType.FIELD)
+public class LongWrapper implements Serializable {
+
+    @XmlValue
+    private Long value;
+
+    /**
+     * Create a new instance of LongWrapper.
+     *
+     * @param value the Long value of this wrapper.
+     */
+    public LongWrapper(Long value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the Long value.
+     *
+     * @return the Long value.
+     */
+    public Long getLongValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof LongWrapper))
+            return false;
+        LongWrapper other = (LongWrapper) obj;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
+    }
+}

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rnc
@@ -43,7 +43,7 @@ onTaskError_j = ## Defines the base task error behavior. Cancel job, suspend tas
     attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_j = ## For each task, where does the task restart if an error occurred ? (default=anywhere)
     attribute restartTaskOnError {restartTaskType | variableRefType}
-taskRetryDelay_j = ## For each task, specifies how long to wait before restart the task if an error occurred.
+taskRetryDelay_j = ## For each task, it specifies how long to wait before restarting the task if an error occurred.
     attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_j = ## Maximum number of execution for each task (default=1)
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}
@@ -121,7 +121,7 @@ onTaskError_t = ## Defines the base task error behavior. Cancel job, suspend tas
    attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_t = ## Where does the task restart if an error occurred ?
     attribute restartTaskOnError {restartTaskType}
-taskRetryDelay_t = ## Specifies how long to wait before restart the task if an error occurred.
+taskRetryDelay_t = ## This parameter specifies how long to wait before restarting the task if an error occurred.
     attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_t = ## Maximum number of execution for this task
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rnc
@@ -12,7 +12,8 @@ job = ## Definition of a job for the scheduler
         jobName,
         priority?, 
         onTaskError_j?,
-        restartTaskOnError_j?, 
+        restartTaskOnError_j?,
+        taskRetryDelay_j?,
         numberOfExecution_j?, 
         genericInformation?, 
         inputSpace?, 
@@ -42,6 +43,8 @@ onTaskError_j = ## Defines the base task error behavior. Cancel job, suspend tas
     attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_j = ## For each task, where does the task restart if an error occurred ? (default=anywhere)
     attribute restartTaskOnError {restartTaskType | variableRefType}
+taskRetryDelay_j = ## For each task, specifies how long to wait before restart the task if an error occurred.
+    attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_j = ## Maximum number of execution for each task (default=1)
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}
 pathElement = ## Path element (one pathElement for each classpath entry)
@@ -69,6 +72,7 @@ task = ## A task is the smallest computation unit for the scheduler
         nodesNumber_t?,
         onTaskError_t?,
         restartTaskOnError_t?,
+        taskRetryDelay_t?,
         numberOfExecution_t?,
         fork?,
         runAsMe?,
@@ -112,11 +116,13 @@ nodesNumber_t = ## number of cores needed for the task (identifier)
 taskDescription = ## Textual description of this task
     element description { text }
 walltime = ## Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')
-	attribute walltime { walltimePattern | variableRefType}
+	attribute walltime { durationPattern | variableRefType}
 onTaskError_t = ## Defines the base task error behavior. Cancel job, suspend task, pause job and continue job execution are possible settings. The onTaskError behavior is triggered on task failure, not node failure. (default=continue job execution)
    attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_t = ## Where does the task restart if an error occurred ?
     attribute restartTaskOnError {restartTaskType}
+taskRetryDelay_t = ## Specifies how long to wait before restart the task if an error occurred.
+    attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_t = ## Maximum number of execution for this task
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}
 preciousResult = ## Do we keep the result among the job results  
@@ -282,7 +288,7 @@ onErrorTaskType = 'cancelJob' | 'suspendTask' | 'pauseJob' |  'continueJobExecut
 inaccessModeType = 'transferFromInputSpace' | 'transferFromOutputSpace' | 'transferFromGlobalSpace' | 'transferFromUserSpace' | 'cacheFromInputSpace' | 'cacheFromOutputSpace' | 'cacheFromGlobalSpace' | 'cacheFromUserSpace' | 'none' | variableRefType
 outaccessModeType = 'transferToOutputSpace' | 'transferToGlobalSpace' | 'transferToUserSpace' | 'none' | variableRefType
 classPattern = xsd:string { pattern="([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*" }
-walltimePattern = xsd:string { pattern="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}" }
+durationPattern = xsd:string { pattern="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}" }
 variableRefType = xsd:string { pattern="$\{[A-Za-z0-9._]+\}" }
 inexcludePattern = xsd:string { pattern=".+(,.+)*" }
 controlFlowAction = 'goto' | 'replicate' | 'continue'

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rng
@@ -130,7 +130,7 @@
   </define>
   <define name="taskRetryDelay_j">
     <attribute name="taskRetryDelay">
-      <doc:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <doc:documentation>For each task, it specifies how long to wait before restarting the task if an error occurred.</doc:documentation>
       <choice>
         <ref name="durationPattern"/>
         <ref name="variableRefType"/>
@@ -376,7 +376,7 @@
   </define>
   <define name="taskRetryDelay_t">
     <attribute name="taskRetryDelay">
-      <doc:documentation>Specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <doc:documentation>This parameter specifies how long to wait before restarting the task if an error occurred.</doc:documentation>
       <choice>
         <ref name="durationPattern"/>
         <ref name="variableRefType"/>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.rng
@@ -23,6 +23,9 @@
         <ref name="restartTaskOnError_j"/>
       </optional>
       <optional>
+        <ref name="taskRetryDelay_j"/>
+      </optional>
+      <optional>
         <ref name="numberOfExecution_j"/>
       </optional>
       <optional>
@@ -125,6 +128,15 @@
       </choice>
     </attribute>
   </define>
+  <define name="taskRetryDelay_j">
+    <attribute name="taskRetryDelay">
+      <doc:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <choice>
+        <ref name="durationPattern"/>
+        <ref name="variableRefType"/>
+      </choice>
+    </attribute>
+  </define>
   <define name="numberOfExecution_j">
     <attribute name="maxNumberOfExecution">
       <doc:documentation>Maximum number of execution for each task (default=1)</doc:documentation>
@@ -202,6 +214,9 @@
       </optional>
       <optional>
         <ref name="restartTaskOnError_t"/>
+      </optional>
+      <optional>
+        <ref name="taskRetryDelay_t"/>
       </optional>
       <optional>
         <ref name="numberOfExecution_t"/>
@@ -339,7 +354,7 @@
     <attribute name="walltime">
       <doc:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</doc:documentation>
       <choice>
-        <ref name="walltimePattern"/>
+        <ref name="durationPattern"/>
         <ref name="variableRefType"/>
       </choice>
     </attribute>
@@ -357,6 +372,15 @@
     <attribute name="restartTaskOnError">
       <doc:documentation>Where does the task restart if an error occurred ?</doc:documentation>
       <ref name="restartTaskType"/>
+    </attribute>
+  </define>
+  <define name="taskRetryDelay_t">
+    <attribute name="taskRetryDelay">
+      <doc:documentation>Specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <choice>
+        <ref name="durationPattern"/>
+        <ref name="variableRefType"/>
+      </choice>
     </attribute>
   </define>
   <define name="numberOfExecution_t">
@@ -1013,7 +1037,7 @@
       <param name="pattern">([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*</param>
     </data>
   </define>
-  <define name="walltimePattern">
+  <define name="durationPattern">
     <data type="string">
       <param name="pattern">[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}</param>
     </data>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.xsd
@@ -44,7 +44,7 @@
       </xs:attribute>
       <xs:attribute name="taskRetryDelay">
         <xs:annotation>
-          <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+          <xs:documentation>For each task, it specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
@@ -162,7 +162,7 @@
   <xs:attributeGroup name="taskRetryDelay_j">
     <xs:attribute name="taskRetryDelay" use="required">
       <xs:annotation>
-        <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+        <xs:documentation>For each task, it specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
         <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
@@ -293,7 +293,7 @@
           </xs:attribute>
           <xs:attribute name="taskRetryDelay">
             <xs:annotation>
-              <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+              <xs:documentation>This parameter specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
             </xs:annotation>
             <xs:simpleType>
               <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
@@ -478,7 +478,7 @@
   <xs:attributeGroup name="taskRetryDelay_t">
     <xs:attribute name="taskRetryDelay" use="required">
       <xs:annotation>
-        <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+        <xs:documentation>This parameter specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
         <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/3.12/schedulerjob.xsd
@@ -42,6 +42,14 @@
           <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
         </xs:simpleType>
       </xs:attribute>
+      <xs:attribute name="taskRetryDelay">
+        <xs:annotation>
+          <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
       <xs:attribute name="maxNumberOfExecution">
         <xs:annotation>
           <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
@@ -148,6 +156,16 @@
       </xs:annotation>
       <xs:simpleType>
         <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="taskRetryDelay_j">
+    <xs:attribute name="taskRetryDelay" use="required">
+      <xs:annotation>
+        <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
       </xs:simpleType>
     </xs:attribute>
   </xs:attributeGroup>
@@ -273,6 +291,14 @@
               <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="taskRetryDelay">
+            <xs:annotation>
+              <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
           <xs:attribute name="maxNumberOfExecution">
             <xs:annotation>
               <xs:documentation>Maximum number of execution for this task</xs:documentation>
@@ -302,7 +328,7 @@
               <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</xs:documentation>
             </xs:annotation>
             <xs:simpleType>
-              <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+              <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
             </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="preciousResult">
@@ -428,7 +454,7 @@
         <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
-        <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+        <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
       </xs:simpleType>
     </xs:attribute>
   </xs:attributeGroup>
@@ -447,6 +473,16 @@
       <xs:annotation>
         <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
       </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="taskRetryDelay_t">
+    <xs:attribute name="taskRetryDelay" use="required">
+      <xs:annotation>
+        <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
+      </xs:simpleType>
     </xs:attribute>
   </xs:attributeGroup>
   <xs:attributeGroup name="numberOfExecution_t">
@@ -1318,7 +1354,7 @@
       <xs:pattern value="([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="walltimePattern">
+  <xs:simpleType name="durationPattern">
     <xs:restriction base="xs:string">
       <xs:pattern value="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}"/>
     </xs:restriction>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rnc
@@ -43,7 +43,7 @@ onTaskError_j = ## Defines the base task error behavior. Cancel job, suspend tas
     attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_j = ## For each task, where does the task restart if an error occurred ? (default=anywhere)
     attribute restartTaskOnError {restartTaskType | variableRefType}
-taskRetryDelay_j = ## For each task, specifies how long to wait before restart the task if an error occurred.
+taskRetryDelay_j = ## For each task, it specifies how long to wait before restarting the task if an error occurred.
     attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_j = ## Maximum number of execution for each task (default=1)
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}
@@ -121,7 +121,7 @@ onTaskError_t = ## Defines the base task error behavior. Cancel job, suspend tas
    attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_t = ## Where does the task restart if an error occurred ?
     attribute restartTaskOnError {restartTaskType}
-taskRetryDelay_t = ## Specifies how long to wait before restart the task if an error occurred.
+taskRetryDelay_t = ## This parameter specifies how long to wait before restarting the task if an error occurred.
     attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_t = ## Maximum number of execution for this task
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rnc
@@ -12,7 +12,8 @@ job = ## Definition of a job for the scheduler
         jobName,
         priority?, 
         onTaskError_j?,
-        restartTaskOnError_j?, 
+        restartTaskOnError_j?,
+        taskRetryDelay_j?,
         numberOfExecution_j?, 
         genericInformation?, 
         inputSpace?, 
@@ -42,6 +43,8 @@ onTaskError_j = ## Defines the base task error behavior. Cancel job, suspend tas
     attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_j = ## For each task, where does the task restart if an error occurred ? (default=anywhere)
     attribute restartTaskOnError {restartTaskType | variableRefType}
+taskRetryDelay_j = ## For each task, specifies how long to wait before restart the task if an error occurred.
+    attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_j = ## Maximum number of execution for each task (default=1)
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}
 pathElement = ## Path element (one pathElement for each classpath entry)
@@ -69,6 +72,7 @@ task = ## A task is the smallest computation unit for the scheduler
         nodesNumber_t?,
         onTaskError_t?,
         restartTaskOnError_t?,
+        taskRetryDelay_t?,
         numberOfExecution_t?,
         fork?,
         runAsMe?,
@@ -112,11 +116,13 @@ nodesNumber_t = ## number of cores needed for the task (identifier)
 taskDescription = ## Textual description of this task
     element description { text }
 walltime = ## Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')
-	attribute walltime { walltimePattern | variableRefType}
+	attribute walltime { durationPattern | variableRefType}
 onTaskError_t = ## Defines the base task error behavior. Cancel job, suspend task, pause job and continue job execution are possible settings. The onTaskError behavior is triggered on task failure, not node failure. (default=continue job execution)
    attribute onTaskError {onErrorTaskType | variableRefType}
 restartTaskOnError_t = ## Where does the task restart if an error occurred ?
     attribute restartTaskOnError {restartTaskType}
+taskRetryDelay_t = ## Specifies how long to wait before restart the task if an error occurred.
+    attribute taskRetryDelay {durationPattern | variableRefType}
 numberOfExecution_t = ## Maximum number of execution for this task
     attribute maxNumberOfExecution {xsd:nonNegativeInteger | variableRefType}
 preciousResult = ## Do we keep the result among the job results  
@@ -282,7 +288,7 @@ onErrorTaskType = 'cancelJob' | 'suspendTask' | 'pauseJob' |  'continueJobExecut
 inaccessModeType = 'transferFromInputSpace' | 'transferFromOutputSpace' | 'transferFromGlobalSpace' | 'transferFromUserSpace' | 'cacheFromInputSpace' | 'cacheFromOutputSpace' | 'cacheFromGlobalSpace' | 'cacheFromUserSpace' | 'none' | variableRefType
 outaccessModeType = 'transferToOutputSpace' | 'transferToGlobalSpace' | 'transferToUserSpace' | 'none' | variableRefType
 classPattern = xsd:string { pattern="([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*" }
-walltimePattern = xsd:string { pattern="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}" }
+durationPattern = xsd:string { pattern="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}" }
 variableRefType = xsd:string { pattern="$\{[A-Za-z0-9._]+\}" }
 inexcludePattern = xsd:string { pattern=".+(,.+)*" }
 controlFlowAction = 'goto' | 'replicate' | 'continue'

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
@@ -130,7 +130,7 @@
   </define>
   <define name="taskRetryDelay_j">
     <attribute name="taskRetryDelay">
-      <doc:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <doc:documentation>For each task, it specifies how long to wait before restarting the task if an error occurred.</doc:documentation>
       <choice>
         <ref name="durationPattern"/>
         <ref name="variableRefType"/>
@@ -376,7 +376,7 @@
   </define>
   <define name="taskRetryDelay_t">
     <attribute name="taskRetryDelay">
-      <doc:documentation>Specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <doc:documentation>This parameter specifies how long to wait before restarting the task if an error occurred.</doc:documentation>
       <choice>
         <ref name="durationPattern"/>
         <ref name="variableRefType"/>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.rng
@@ -23,6 +23,9 @@
         <ref name="restartTaskOnError_j"/>
       </optional>
       <optional>
+        <ref name="taskRetryDelay_j"/>
+      </optional>
+      <optional>
         <ref name="numberOfExecution_j"/>
       </optional>
       <optional>
@@ -125,6 +128,15 @@
       </choice>
     </attribute>
   </define>
+  <define name="taskRetryDelay_j">
+    <attribute name="taskRetryDelay">
+      <doc:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <choice>
+        <ref name="durationPattern"/>
+        <ref name="variableRefType"/>
+      </choice>
+    </attribute>
+  </define>
   <define name="numberOfExecution_j">
     <attribute name="maxNumberOfExecution">
       <doc:documentation>Maximum number of execution for each task (default=1)</doc:documentation>
@@ -202,6 +214,9 @@
       </optional>
       <optional>
         <ref name="restartTaskOnError_t"/>
+      </optional>
+      <optional>
+        <ref name="taskRetryDelay_t"/>
       </optional>
       <optional>
         <ref name="numberOfExecution_t"/>
@@ -339,7 +354,7 @@
     <attribute name="walltime">
       <doc:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</doc:documentation>
       <choice>
-        <ref name="walltimePattern"/>
+        <ref name="durationPattern"/>
         <ref name="variableRefType"/>
       </choice>
     </attribute>
@@ -357,6 +372,15 @@
     <attribute name="restartTaskOnError">
       <doc:documentation>Where does the task restart if an error occurred ?</doc:documentation>
       <ref name="restartTaskType"/>
+    </attribute>
+  </define>
+  <define name="taskRetryDelay_t">
+    <attribute name="taskRetryDelay">
+      <doc:documentation>Specifies how long to wait before restart the task if an error occurred.</doc:documentation>
+      <choice>
+        <ref name="durationPattern"/>
+        <ref name="variableRefType"/>
+      </choice>
     </attribute>
   </define>
   <define name="numberOfExecution_t">
@@ -1013,7 +1037,7 @@
       <param name="pattern">([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*</param>
     </data>
   </define>
-  <define name="walltimePattern">
+  <define name="durationPattern">
     <data type="string">
       <param name="pattern">[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}</param>
     </data>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd
@@ -44,7 +44,7 @@
       </xs:attribute>
       <xs:attribute name="taskRetryDelay">
         <xs:annotation>
-          <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+          <xs:documentation>For each task, it specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
@@ -162,7 +162,7 @@
   <xs:attributeGroup name="taskRetryDelay_j">
     <xs:attribute name="taskRetryDelay" use="required">
       <xs:annotation>
-        <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+        <xs:documentation>For each task, it specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
         <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
@@ -293,7 +293,7 @@
           </xs:attribute>
           <xs:attribute name="taskRetryDelay">
             <xs:annotation>
-              <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+              <xs:documentation>This parameter specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
             </xs:annotation>
             <xs:simpleType>
               <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
@@ -478,7 +478,7 @@
   <xs:attributeGroup name="taskRetryDelay_t">
     <xs:attribute name="taskRetryDelay" use="required">
       <xs:annotation>
-        <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+        <xs:documentation>This parameter specifies how long to wait before restarting the task if an error occurred.</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
         <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd
@@ -42,6 +42,14 @@
           <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
         </xs:simpleType>
       </xs:attribute>
+      <xs:attribute name="taskRetryDelay">
+        <xs:annotation>
+          <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
+        </xs:simpleType>
+      </xs:attribute>
       <xs:attribute name="maxNumberOfExecution">
         <xs:annotation>
           <xs:documentation>Maximum number of execution for each task (default=1)</xs:documentation>
@@ -148,6 +156,16 @@
       </xs:annotation>
       <xs:simpleType>
         <xs:union memberTypes="jd:restartTaskType jd:variableRefType"/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="taskRetryDelay_j">
+    <xs:attribute name="taskRetryDelay" use="required">
+      <xs:annotation>
+        <xs:documentation>For each task, specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
       </xs:simpleType>
     </xs:attribute>
   </xs:attributeGroup>
@@ -273,6 +291,14 @@
               <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="taskRetryDelay">
+            <xs:annotation>
+              <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+              <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
+            </xs:simpleType>
+          </xs:attribute>
           <xs:attribute name="maxNumberOfExecution">
             <xs:annotation>
               <xs:documentation>Maximum number of execution for this task</xs:documentation>
@@ -302,7 +328,7 @@
               <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</xs:documentation>
             </xs:annotation>
             <xs:simpleType>
-              <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+              <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
             </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="preciousResult">
@@ -428,7 +454,7 @@
         <xs:documentation>Defines walltime - maximum execution time of the task. (patterns are 'ss' OR 'mm:ss' OR 'hh:mm:ss')</xs:documentation>
       </xs:annotation>
       <xs:simpleType>
-        <xs:union memberTypes="jd:walltimePattern jd:variableRefType"/>
+        <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
       </xs:simpleType>
     </xs:attribute>
   </xs:attributeGroup>
@@ -447,6 +473,16 @@
       <xs:annotation>
         <xs:documentation>Where does the task restart if an error occurred ?</xs:documentation>
       </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="taskRetryDelay_t">
+    <xs:attribute name="taskRetryDelay" use="required">
+      <xs:annotation>
+        <xs:documentation>Specifies how long to wait before restart the task if an error occurred.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:union memberTypes="jd:durationPattern jd:variableRefType"/>
+      </xs:simpleType>
     </xs:attribute>
   </xs:attributeGroup>
   <xs:attributeGroup name="numberOfExecution_t">
@@ -1318,7 +1354,7 @@
       <xs:pattern value="([A-Za-z_$][A-Za-z_0-9$]*\.)*[A-Za-z_$][A-Za-z_0-9$]*"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="walltimePattern">
+  <xs:simpleType name="durationPattern">
     <xs:restriction base="xs:string">
       <xs:pattern value="[0-9]*[1-9][0-9]*(:[0-5][0-9]){0,2}"/>
     </xs:restriction>

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -695,7 +695,9 @@ public class TaskData {
         internalTask.setRunAsMe(isRunAsMe());
         internalTask.setFork(isForkTask());
         internalTask.setWallTime(getWallTime());
-        internalTask.setTaskRetryDelay(getRetryDelay());
+        if (getRetryDelay() != null) {
+            internalTask.setTaskRetryDelay(getRetryDelay());
+        }
         internalTask.setMaxNumberOfExecution(getMaxNumberOfExecution());
         internalTask.setNumberOfExecutionLeft(getNumberOfExecutionLeft());
         internalTask.setNumberOfExecutionOnFailureLeft(getNumberOfExecutionOnFailureLeft());
@@ -1234,7 +1236,9 @@ public class TaskData {
         taskState.setIterationIndex(getIteration());
         taskState.setReplicationIndex(getReplication());
         taskState.setMaxNumberOfExecution(getMaxNumberOfExecution());
-        taskState.setTaskRetryDelay(getRetryDelay());
+        if (getRetryDelay() != null) {
+            taskState.setTaskRetryDelay(getRetryDelay());
+        }
         taskState.setParallelEnvironment(getParallelEnvironment());
         taskState.setGenericInformation(getGenericInformation());
         taskState.setVariables(variablesToTaskVariables());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -257,6 +257,8 @@ public class TaskData {
 
     private long wallTime;
 
+    private Long retryDelay;
+
     private int iteration;
 
     private int replication;
@@ -534,6 +536,7 @@ public class TaskData {
         taskData.setRunAsMe(task.isRunAsMe());
         taskData.setWallTime(task.getWallTime());
         taskData.setOnTaskErrorString(task.getOnTaskErrorProperty().getValue());
+        taskData.setRetryDelay(task.getTaskRetryDelay());
         taskData.setMaxNumberOfExecution(task.getMaxNumberOfExecution());
         taskData.setJobData(jobRuntimeData);
         taskData.setNumberOfExecutionOnFailureLeft(PASchedulerProperties.NUMBER_OF_EXECUTION_ON_FAILURE.getValueAsInt());
@@ -690,11 +693,14 @@ public class TaskData {
         internalTask.setPreciousLogs(isPreciousLogs());
         internalTask.setPreciousResult(isPreciousResult());
         internalTask.setRunAsMe(isRunAsMe());
+        internalTask.setFork(isForkTask());
         internalTask.setWallTime(getWallTime());
+        internalTask.setTaskRetryDelay(getRetryDelay());
         internalTask.setMaxNumberOfExecution(getMaxNumberOfExecution());
         internalTask.setNumberOfExecutionLeft(getNumberOfExecutionLeft());
         internalTask.setNumberOfExecutionOnFailureLeft(getNumberOfExecutionOnFailureLeft());
         internalTask.setRestartTaskOnError(getRestartMode());
+
         internalTask.setFlowBlock(getFlowBlock());
         internalTask.setIterationIndex(getIteration());
         internalTask.setReplicationIndex(getReplication());
@@ -1004,6 +1010,15 @@ public class TaskData {
         this.startTime = startTime;
     }
 
+    @Column(name = "RETRY_DELAY")
+    public Long getRetryDelay() {
+        return retryDelay;
+    }
+
+    public void setRetryDelay(Long retryDelay) {
+        this.retryDelay = retryDelay;
+    }
+
     @Column(name = "FINISH_TIME")
     public long getFinishedTime() {
         return finishedTime;
@@ -1219,6 +1234,7 @@ public class TaskData {
         taskState.setIterationIndex(getIteration());
         taskState.setReplicationIndex(getReplication());
         taskState.setMaxNumberOfExecution(getMaxNumberOfExecution());
+        taskState.setTaskRetryDelay(getRetryDelay());
         taskState.setParallelEnvironment(getParallelEnvironment());
         taskState.setGenericInformation(getGenericInformation());
         taskState.setVariables(variablesToTaskVariables());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
@@ -51,7 +51,6 @@ import org.ow2.proactive.scheduler.common.task.ScriptTask;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
 import org.ow2.proactive.scheduler.core.OnErrorPolicyInterpreter;
-import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
 import org.ow2.proactive.scheduler.task.internal.InternalForkedScriptTask;
 import org.ow2.proactive.scheduler.task.internal.InternalScriptTask;
@@ -399,6 +398,13 @@ public class InternalJobFactory {
         } else {
             taskToSet.setRestartTaskOnError(userJob.getRestartTaskOnError());
         }
+
+        if (task.getTaskRetryDelayProperty().isSet()) {
+            taskToSet.setTaskRetryDelay(task.getTaskRetryDelay());
+        } else {
+            taskToSet.setTaskRetryDelay(userJob.getTaskRetryDelay());
+        }
+
         if (task.getMaxNumberOfExecutionProperty().isSet()) {
             taskToSet.setMaxNumberOfExecution(task.getMaxNumberOfExecution());
         } else {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
@@ -401,7 +401,7 @@ public class InternalJobFactory {
 
         if (task.getTaskRetryDelayProperty().isSet()) {
             taskToSet.setTaskRetryDelay(task.getTaskRetryDelay());
-        } else {
+        } else if (userJob.getTaskRetryDelayProperty().isSet()) {
             taskToSet.setTaskRetryDelay(userJob.getTaskRetryDelay());
         }
 


### PR DESCRIPTION
Add the property `taskRetryDelay` to allow users to specify a static delay before restarting a task in error.

The property can be configured both for the job and the task. The task value overwrites the job value if configured.

The property is nullable, when it's null, the previous retry mechanism (retry delay augment with the number of retry times) is taken.