### PR TITLE
feat: add workflow variable type `PA:CREDENTIAL`

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -1999,17 +1999,23 @@ public interface SchedulerRestInterface {
             UnknownTaskRestException, PermissionRestException;
 
     /**
-     * Validates a job.
-     * 
+     * Validates a job
+     *
+     * @param sessionId
+     *            user session id used to connect to scheduler
+     * @param pathSegment
+     *            variables of the workflow
      * @param multipart
      *            a HTTP multipart form which contains the job-descriptor
      * @return the result of job validation
+     * @throws NotConnectedRestException
      */
     @POST
     @Path("{path:validate}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces("application/json")
-    JobValidationData validate(@PathParam("path") PathSegment pathSegment, MultipartFormDataInput multipart);
+    JobValidationData validate(@HeaderParam("sessionid") String sessionId, @PathParam("path") PathSegment pathSegment,
+            MultipartFormDataInput multipart) throws NotConnectedRestException;
 
     /**
      * Validates a workflow taken from a given URL

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
@@ -193,7 +193,8 @@ public interface StudioInterface {
     @Path("{path:validate}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces("application/json")
-    JobValidationData validate(@PathParam("path") PathSegment pathSegment, MultipartFormDataInput multipart);
+    JobValidationData validate(@HeaderParam("sessionid") String sessionId, @PathParam("path") PathSegment pathSegment,
+            MultipartFormDataInput multipart) throws NotConnectedRestException;
 
     /**
      * Submits a job to the scheduler

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -3304,7 +3304,10 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             throws NotConnectedRestException {
         File tmpFile = null;
         try {
-            Scheduler scheduler = checkAccess(sessionId);
+            Scheduler scheduler = null;
+            if (sessionId != null) {
+                scheduler = checkAccess(sessionId);
+            }
             Map<String, List<InputPart>> formDataMap = multipart.getFormDataMap();
             String name = formDataMap.keySet().iterator().next();
             InputPart part1 = formDataMap.get(name).get(0);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
@@ -114,7 +114,7 @@ public class WorkflowSubmitter {
 
     private Job createJobObject(File jobFile, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
             throws JobCreationException {
-        return JobFactory.getFactory().createJob(jobFile.getAbsolutePath(), jobVariables, jobGenericInfos);
+        return JobFactory.getFactory().createJob(jobFile.getAbsolutePath(), jobVariables, jobGenericInfos, scheduler);
     }
 
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/util/ValidationUtil.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/util/ValidationUtil.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobVariable;
@@ -83,15 +84,17 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobValidationData;
 
 public class ValidationUtil {
 
-    public static JobValidationData validateJobDescriptor(File jobDescFile, Map<String, String> jobVariables) {
-        return validateJob(jobDescFile.getAbsolutePath(), jobVariables);
+    public static JobValidationData validateJobDescriptor(File jobDescFile, Map<String, String> jobVariables,
+            Scheduler scheduler) {
+        return validateJob(jobDescFile.getAbsolutePath(), jobVariables, scheduler);
     }
 
-    public static JobValidationData validateJob(String jobFilePath, Map<String, String> jobVariables) {
+    public static JobValidationData validateJob(String jobFilePath, Map<String, String> jobVariables,
+            Scheduler scheduler) {
         JobValidationData data = new JobValidationData();
         try {
             JobFactory factory = JobFactory.getFactory();
-            Job job = factory.createJob(jobFilePath, jobVariables, null);
+            Job job = factory.createJob(jobFilePath, jobVariables, null, scheduler);
 
             if (job instanceof TaskFlowJob) {
                 validateJob((TaskFlowJob) job, data);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -323,8 +323,10 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public JobValidationData validate(@PathParam("path") PathSegment pathSegment, MultipartFormDataInput multipart) {
-        return scheduler().validate(pathSegment, multipart);
+    public JobValidationData validate(@HeaderParam("sessionid") String sessionId,
+            @PathParam("path") PathSegment pathSegment, MultipartFormDataInput multipart)
+            throws NotConnectedRestException {
+        return scheduler().validate(sessionId, pathSegment, multipart);
     }
 
     @Override

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobFactory.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.job.Job;
 
@@ -136,6 +137,18 @@ public abstract class JobFactory {
      */
     public abstract Job createJob(String filePath, Map<String, String> variables, Map<String, String> genericInfos)
             throws JobCreationException;
+
+    /**
+     * Creates a job using the given job descriptor with the scheduler instance for validating jobs.
+     * @param filePath the path to an XML job descriptor
+     * @param variables map of job submission variables
+     * @param genericInfos map of job submission generic infos
+     * @param scheduler the scheduler instance with access of third-party credentials for validating jobs
+     * @return a Job instance created with the given XML file
+     * @throws JobCreationException if an exception occurred during job creation
+     */
+    public abstract Job createJob(String filePath, Map<String, String> variables, Map<String, String> genericInfos,
+            Scheduler scheduler) throws JobCreationException;
 
     /**
      * Creates a job using the given job descriptor.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobFactory.java
@@ -179,4 +179,7 @@ public abstract class JobFactory {
     public abstract Job createJob(InputStream workflowStream, Map<String, String> variables,
             Map<String, String> genericInfos) throws JobCreationException;
 
+    public abstract Job createJob(InputStream workflowStream, Map<String, String> variables,
+            Map<String, String> genericInfos, Scheduler scheduler) throws JobCreationException;
+
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -192,8 +192,14 @@ public class StaxJobFactory extends JobFactory {
     @Override
     public Job createJob(InputStream workflowStream, Map<String, String> replacementVariables,
             Map<String, String> replacementGenericInfos) throws JobCreationException {
+        return createJob(workflowStream, replacementVariables, replacementGenericInfos, null);
+    }
+
+    @Override
+    public Job createJob(InputStream workflowStream, Map<String, String> replacementVariables,
+            Map<String, String> replacementGenericInfos, Scheduler scheduler) throws JobCreationException {
         try {
-            return createJobFromInputStream(workflowStream, replacementVariables, replacementGenericInfos, null);
+            return createJobFromInputStream(workflowStream, replacementVariables, replacementGenericInfos, scheduler);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -283,7 +289,6 @@ public class StaxJobFactory extends JobFactory {
      */
     private TaskFlowJob validate(TaskFlowJob job, Scheduler scheduler)
             throws VerifierConfigurationException, JobCreationException {
-
         Map<String, JobValidatorService> factories;
         try {
             factories = JobValidatorRegistry.getInstance().getRegisteredFactories();

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -54,6 +54,7 @@ import javax.xml.stream.events.XMLEvent;
 import org.apache.log4j.Logger;
 import org.iso_relax.verifier.VerifierConfigurationException;
 import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
+import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.exception.JobValidationException;
 import org.ow2.proactive.scheduler.common.job.Job;
@@ -146,7 +147,19 @@ public class StaxJobFactory extends JobFactory {
     public Job createJob(String filePath, Map<String, String> replacementVariables,
             Map<String, String> replacementGenericInfos) throws JobCreationException {
         try {
-            return createJob(new File(filePath), replacementVariables, replacementGenericInfos);
+            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, null);
+        } catch (JobCreationException jce) {
+            throw jce;
+        } catch (Exception e) {
+            throw new JobCreationException(e);
+        }
+    }
+
+    @Override
+    public Job createJob(String filePath, Map<String, String> replacementVariables,
+            Map<String, String> replacementGenericInfos, Scheduler scheduler) throws JobCreationException {
+        try {
+            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, scheduler);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -163,7 +176,7 @@ public class StaxJobFactory extends JobFactory {
     public Job createJob(URI filePath, Map<String, String> replacementVariables,
             Map<String, String> replacementGenericInfos) throws JobCreationException {
         try {
-            return createJob(new File(filePath), replacementVariables, replacementGenericInfos);
+            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, null);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -180,7 +193,7 @@ public class StaxJobFactory extends JobFactory {
     public Job createJob(InputStream workflowStream, Map<String, String> replacementVariables,
             Map<String, String> replacementGenericInfos) throws JobCreationException {
         try {
-            return createJobFromInputStream(workflowStream, replacementVariables, replacementGenericInfos);
+            return createJobFromInputStream(workflowStream, replacementVariables, replacementGenericInfos, null);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -189,14 +202,14 @@ public class StaxJobFactory extends JobFactory {
     }
 
     private Job createJob(File file, Map<String, String> replacementVariables,
-            Map<String, String> replacementGenericInfos) throws JobCreationException {
+            Map<String, String> replacementGenericInfos, Scheduler scheduler) throws JobCreationException {
         try {
             if (!file.exists()) {
                 throw new FileNotFoundException("This file has not been found: " + file.getAbsolutePath());
             }
             relativePathRoot = file.getParentFile().getAbsolutePath();
             try (InputStream inputStream = new FileInputStream(file)) {
-                return createJobFromInputStream(inputStream, replacementVariables, replacementGenericInfos);
+                return createJobFromInputStream(inputStream, replacementVariables, replacementGenericInfos, scheduler);
             }
         } catch (JobCreationException jce) {
             jce.pushTag(XMLTags.JOB.getXMLName());
@@ -207,7 +220,7 @@ public class StaxJobFactory extends JobFactory {
     }
 
     private Job createJobFromInputStream(InputStream jobInputStream, Map<String, String> replacementVariables,
-            Map<String, String> replacementGenericInfos)
+            Map<String, String> replacementGenericInfos, Scheduler scheduler)
             throws JobCreationException, VerifierConfigurationException, IOException, XMLStreamException {
         long t0 = System.currentTimeMillis();
         byte[] bytes = ValidationUtil.getInputStreamBytes(jobInputStream);
@@ -227,7 +240,7 @@ public class StaxJobFactory extends JobFactory {
 
         makeDependences(job, dependencies);
         long t4 = System.currentTimeMillis();
-        validate((TaskFlowJob) job);
+        validate((TaskFlowJob) job, scheduler);
         long t5 = System.currentTimeMillis();
         long d1 = t1 - t0;
         long d2 = t2 - t1;
@@ -268,7 +281,8 @@ public class StaxJobFactory extends JobFactory {
     /*
      * Validate the given job descriptor
      */
-    private TaskFlowJob validate(TaskFlowJob job) throws VerifierConfigurationException, JobCreationException {
+    private TaskFlowJob validate(TaskFlowJob job, Scheduler scheduler)
+            throws VerifierConfigurationException, JobCreationException {
 
         Map<String, JobValidatorService> factories;
         try {
@@ -282,7 +296,7 @@ public class StaxJobFactory extends JobFactory {
         try {
 
             for (JobValidatorService factory : factories.values()) {
-                updatedJob = factory.validateJob(updatedJob);
+                updatedJob = factory.validateJob(updatedJob, scheduler);
             }
         } catch (JobValidationException e) {
             throw e;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/JobValidatorService.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/JobValidatorService.java
@@ -59,6 +59,18 @@ public interface JobValidatorService {
      * @return if the validator eventually made some modifications to the job, return a new version
      * @throws JobValidationException if the job is not valid
      */
+    TaskFlowJob validateJob(TaskFlowJob job) throws JobValidationException;
+
+    /**
+     * Validate a job object which may contain PA:CREDENTIAL variables, after the job has been parsed by the scheduler.
+     *
+     * Example of use: variable model validation.
+     *
+     * @param job job object to validate
+     * @param scheduler scheduler instance which can give the access to the third-party credentials
+     * @return if the validator eventually made some modifications to the job, return a new version
+     * @throws JobValidationException if the job is not valid
+     */
     TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler) throws JobValidationException;
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/JobValidatorService.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/JobValidatorService.java
@@ -27,6 +27,7 @@ package org.ow2.proactive.scheduler.common.job.factories.spi;
 
 import java.io.InputStream;
 
+import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.exception.JobValidationException;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 
@@ -58,6 +59,6 @@ public interface JobValidatorService {
      * @return if the validator eventually made some modifications to the job, return a new version
      * @throws JobValidationException if the job is not valid
      */
-    TaskFlowJob validateJob(TaskFlowJob job) throws JobValidationException;
+    TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler) throws JobValidationException;
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
@@ -27,6 +27,7 @@ package org.ow2.proactive.scheduler.common.job.factories.spi.model;
 
 import java.io.InputStream;
 
+import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.exception.JobValidationException;
 import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
@@ -51,16 +52,16 @@ public class DefaultModelJobValidatorServiceProvider implements JobValidatorServ
     }
 
     @Override
-    public TaskFlowJob validateJob(TaskFlowJob job) throws JobValidationException {
+    public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler) throws JobValidationException {
 
-        ModelValidatorContext context = new ModelValidatorContext(job);
+        ModelValidatorContext context = new ModelValidatorContext(job, scheduler);
 
         for (JobVariable jobVariable : job.getVariables().values()) {
             checkVariableFormat(null, jobVariable, context);
             context.updateJobWithContext(job);
         }
         for (Task task : job.getTasks()) {
-            context = new ModelValidatorContext(task);
+            context = new ModelValidatorContext(task, scheduler);
             for (TaskVariable taskVariable : task.getVariables().values()) {
                 checkVariableFormat(task, taskVariable, context);
                 context.updateTaskWithContext(task);

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
@@ -52,6 +52,11 @@ public class DefaultModelJobValidatorServiceProvider implements JobValidatorServ
     }
 
     @Override
+    public TaskFlowJob validateJob(TaskFlowJob job) throws JobValidationException {
+        return validateJob(job, null);
+    }
+
+    @Override
     public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler) throws JobValidationException {
 
         ModelValidatorContext context = new ModelValidatorContext(job, scheduler);

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/ModelValidatorContext.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/ModelValidatorContext.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.utils.RestrictedMethodResolver;
@@ -47,33 +48,38 @@ public class ModelValidatorContext {
 
     private final StandardEvaluationContext spelContext;
 
+    private final Scheduler scheduler;
+
     // container for job and task variables
     private SpELVariables spELVariables;
 
-    public ModelValidatorContext(StandardEvaluationContext context) {
+    public ModelValidatorContext(StandardEvaluationContext context, Scheduler scheduler) {
         this.spelContext = context;
-
+        this.scheduler = scheduler;
     }
 
-    private ModelValidatorContext(Map<String, Serializable> variablesValues) {
+    private ModelValidatorContext(Map<String, Serializable> variablesValues, Scheduler scheduler) {
         spELVariables = new SpELVariables(variablesValues);
         spelContext = new StandardEvaluationContext(spELVariables);
         spelContext.setTypeLocator(new RestrictedTypeLocator());
         spelContext.setMethodResolvers(Collections.singletonList(new RestrictedMethodResolver()));
         spelContext.addPropertyAccessor(new RestrictedPropertyAccessor());
+        this.scheduler = scheduler;
     }
 
-    public ModelValidatorContext(Task task) {
+    public ModelValidatorContext(Task task, Scheduler scheduler) {
         this(task.getVariables().values().stream().collect(HashMap<String, Serializable>::new,
                                                            (m, v) -> m.put(v.getName(), v.getValue()),
-                                                           HashMap<String, Serializable>::putAll));
+                                                           HashMap<String, Serializable>::putAll),
+             scheduler);
 
     }
 
-    public ModelValidatorContext(TaskFlowJob job) {
+    public ModelValidatorContext(TaskFlowJob job, Scheduler scheduler) {
         this(job.getVariables().values().stream().collect(HashMap<String, Serializable>::new,
                                                           (m, v) -> m.put(v.getName(), v.getValue()),
-                                                          HashMap<String, Serializable>::putAll));
+                                                          HashMap<String, Serializable>::putAll),
+             scheduler);
 
     }
 
@@ -83,6 +89,10 @@ public class ModelValidatorContext {
 
     public SpELVariables getSpELVariables() {
         return spELVariables;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/CredentialParserValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/CredentialParserValidator.java
@@ -1,0 +1,54 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.spi.model.factory;
+
+import org.ow2.proactive.scheduler.common.job.factories.spi.model.converter.Converter;
+import org.ow2.proactive.scheduler.common.job.factories.spi.model.converter.IdentityConverter;
+import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.ModelSyntaxException;
+import org.ow2.proactive.scheduler.common.job.factories.spi.model.validator.CredentialValidator;
+import org.ow2.proactive.scheduler.common.job.factories.spi.model.validator.Validator;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 27/08/19
+ */
+public class CredentialParserValidator extends BaseParserValidator<String> {
+    public CredentialParserValidator(String model) throws ModelSyntaxException {
+        super(model, ModelType.CREDENTIAL);
+    }
+
+    @Override
+    protected Converter<String> createConverter(String model) throws ModelSyntaxException {
+        return new IdentityConverter();
+    }
+
+    @Override
+    protected Validator<String> createValidator(String model, Converter<String> converter) throws ModelSyntaxException {
+        return new CredentialValidator();
+    }
+
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ModelType.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ModelType.java
@@ -52,7 +52,8 @@ public enum ModelType {
     SPEL(SPELParserValidator.class, String.class),
     URI(URIParserValidator.class, URI.class),
     URL(URLParserValidator.class, URL.class),
-    HIDDEN(HiddenParserValidator.class, String.class);
+    HIDDEN(HiddenParserValidator.class, String.class),
+    CREDENTIAL(CredentialParserValidator.class, String.class);
 
     // The parser validator of the model type
     private Class typeParserValidator;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
@@ -25,6 +25,10 @@
  */
 package org.ow2.proactive.scheduler.common.job.factories.spi.model.validator;
 
+import java.util.Set;
+
+import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
+import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.ModelValidatorContext;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.ValidationException;
 
@@ -36,7 +40,16 @@ import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.Val
 public class CredentialValidator implements Validator<String> {
     @Override
     public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
-        // TODO if parameterValue not exists in 3rd-party credentials, throw ValidationException
+        // if parameterValue not exists in 3rd-party credentials, throw ValidationException
+        try {
+            Set<String> credentialKeys = context.getScheduler().thirdPartyCredentialsKeySet();
+            if (!credentialKeys.contains(parameterValue)) {
+                throw new ValidationException("Expected value should exist in the third-party credentials.");
+            }
+        } catch (NotConnectedException | PermissionException e) {
+            e.printStackTrace(); //TODO
+            throw new ValidationException("Exception during getting the third-party credentials.", e);
+        }
         return parameterValue;
     }
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
@@ -27,6 +27,7 @@ package org.ow2.proactive.scheduler.common.job.factories.spi.model.validator;
 
 import java.util.Set;
 
+import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.ModelValidatorContext;
@@ -38,8 +39,18 @@ import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.Val
  * @since 27/08/19
  */
 public class CredentialValidator implements Validator<String> {
+    private static final Logger logger = Logger.getLogger(CredentialValidator.class);
+
     @Override
     public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+        if (context == null || context.getScheduler() == null) {
+            // Sometimes the workflow is submitted without scheduler instance (e.g., submitted from catalog).
+            // In this case, we don't have the access of the third-party credentials, so the validity check is passed.
+            logger.warn(String.format("Can't check the validity of the variable value, because missing the access to the scheduler third-party credentials",
+                                      parameterValue));
+            return parameterValue;
+        }
+
         // if parameterValue not exists in 3rd-party credentials, throw ValidationException
         try {
             Set<String> credentialKeys = context.getScheduler().thirdPartyCredentialsKeySet();

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
@@ -44,10 +44,10 @@ public class CredentialValidator implements Validator<String> {
     @Override
     public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
         if (context == null || context.getScheduler() == null) {
-            // Sometimes the workflow is submitted without scheduler instance (e.g., submitted from catalog).
+            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog).
             // In this case, we don't have the access of the third-party credentials, so the validity check is passed.
-            logger.warn(String.format("Can't check the validity of the variable value, because missing the access to the scheduler third-party credentials",
-                                      parameterValue));
+            logger.debug(String.format("Can't check the validity of the variable value, because missing the access to the scheduler third-party credentials",
+                                       parameterValue));
             return parameterValue;
         }
 
@@ -55,10 +55,12 @@ public class CredentialValidator implements Validator<String> {
         try {
             Set<String> credentialKeys = context.getScheduler().thirdPartyCredentialsKeySet();
             if (!credentialKeys.contains(parameterValue)) {
-                throw new ValidationException("Expected value should exist in the third-party credentials.");
+                throw new ValidationException(String.format("Could not find the key named [%s] in the third-party credentials. Please add it into the scheduler third-party credentials or change the variable value to a valid key.",
+                                                            parameterValue));
             }
         } catch (NotConnectedException | PermissionException e) {
-            throw new ValidationException("Exception during getting the third-party credentials.", e);
+            throw new ValidationException("Could not read third party-credentials from the scheduler, make sure you are connected and you have permission rights to read third-party credentials.",
+                                          e);
         }
         return parameterValue;
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
@@ -1,0 +1,43 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.spi.model.validator;
+
+import org.ow2.proactive.scheduler.common.job.factories.spi.model.ModelValidatorContext;
+import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.ValidationException;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 27/08/19
+ */
+public class CredentialValidator implements Validator<String> {
+    @Override
+    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+        // TODO if parameterValue not exists in 3rd-party credentials, throw ValidationException
+        return parameterValue;
+    }
+
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
@@ -47,7 +47,6 @@ public class CredentialValidator implements Validator<String> {
                 throw new ValidationException("Expected value should exist in the third-party credentials.");
             }
         } catch (NotConnectedException | PermissionException e) {
-            e.printStackTrace(); //TODO
             throw new ValidationException("Exception during getting the third-party credentials.", e);
         }
         return parameterValue;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/stax/StaxJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/stax/StaxJobValidatorServiceProvider.java
@@ -76,6 +76,12 @@ public class StaxJobValidatorServiceProvider implements JobValidatorService {
     }
 
     @Override
+    public TaskFlowJob validateJob(TaskFlowJob job) throws JobValidationException {
+        // validate any job
+        return job;
+    }
+
+    @Override
     public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler) throws JobValidationException {
         // validate any job
         return job;

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/stax/StaxJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/stax/StaxJobValidatorServiceProvider.java
@@ -34,6 +34,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
 
+import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.exception.JobValidationException;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
 import org.ow2.proactive.scheduler.common.job.factories.Schemas;
@@ -75,7 +76,7 @@ public class StaxJobValidatorServiceProvider implements JobValidatorService {
     }
 
     @Override
-    public TaskFlowJob validateJob(TaskFlowJob job) throws JobValidationException {
+    public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler) throws JobValidationException {
         // validate any job
         return job;
     }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProviderTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProviderTest.java
@@ -59,69 +59,69 @@ public class DefaultModelJobValidatorServiceProviderTest {
 
     @Test
     public void testValidateJobWithJobModelVariableOK() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN));
+        factory.validateJob(createJobWithJobModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithJobModelVariableKO() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN));
+        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
     }
 
     @Test
     public void testValidateJobWithJobModelVariableEmptyModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", "  "));
+        factory.validateJob(createJobWithJobModelVariable("blabla", "  "), null);
     }
 
     @Test
     public void testValidateJobWithJobModelVariableUnknownModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", "UNKNOWN"));
+        factory.validateJob(createJobWithJobModelVariable("blabla", "UNKNOWN"), null);
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithJobModelVariableValidPrefixButUnknownModel()
             throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"));
+        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"), null);
     }
 
     @Test
     public void testValidateJobWithSpelModelVariablesOK() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithSpelJobModelVariablesOK());
+        factory.validateJob(createJobWithSpelJobModelVariablesOK(), null);
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithSpelModelVariablesKO() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithSpelJobModelVariablesKO());
+        factory.validateJob(createJobWithSpelJobModelVariablesKO(), null);
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithSpelModelVariablesUnauthorizedType() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithSpelJobModelVariablesUnauthorizedType());
+        factory.validateJob(createJobWithSpelJobModelVariablesUnauthorizedType(), null);
     }
 
     @Test
     public void testValidateJobWithTaskModelVariableOK() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN));
+        factory.validateJob(createJobWithTaskModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithTaskModelVariableKO() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN));
+        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
     }
 
     @Test
     public void testValidateJobWithTaskModelVariableEmptyModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", "  "));
+        factory.validateJob(createJobWithTaskModelVariable("blabla", "  "), null);
     }
 
     @Test
     public void testValidateJobWithTaskModelVariableUnknownModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", "UNKNOWN"));
+        factory.validateJob(createJobWithTaskModelVariable("blabla", "UNKNOWN"), null);
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithTaskModelVariableValidPrefixButUnknownModel()
             throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"));
+        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"), null);
     }
 
     private TaskFlowJob createJobWithJobModelVariable(String value, String model) throws UserException {

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProviderTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProviderTest.java
@@ -59,69 +59,69 @@ public class DefaultModelJobValidatorServiceProviderTest {
 
     @Test
     public void testValidateJobWithJobModelVariableOK() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
+        factory.validateJob(createJobWithJobModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN));
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithJobModelVariableKO() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
+        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN));
     }
 
     @Test
     public void testValidateJobWithJobModelVariableEmptyModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", "  "), null);
+        factory.validateJob(createJobWithJobModelVariable("blabla", "  "));
     }
 
     @Test
     public void testValidateJobWithJobModelVariableUnknownModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", "UNKNOWN"), null);
+        factory.validateJob(createJobWithJobModelVariable("blabla", "UNKNOWN"));
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithJobModelVariableValidPrefixButUnknownModel()
             throws UserException, JobValidationException {
-        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"), null);
+        factory.validateJob(createJobWithJobModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"));
     }
 
     @Test
     public void testValidateJobWithSpelModelVariablesOK() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithSpelJobModelVariablesOK(), null);
+        factory.validateJob(createJobWithSpelJobModelVariablesOK());
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithSpelModelVariablesKO() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithSpelJobModelVariablesKO(), null);
+        factory.validateJob(createJobWithSpelJobModelVariablesKO());
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithSpelModelVariablesUnauthorizedType() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithSpelJobModelVariablesUnauthorizedType(), null);
+        factory.validateJob(createJobWithSpelJobModelVariablesUnauthorizedType());
     }
 
     @Test
     public void testValidateJobWithTaskModelVariableOK() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
+        factory.validateJob(createJobWithTaskModelVariable("true", ModelValidator.PREFIX + ModelType.BOOLEAN));
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithTaskModelVariableKO() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN), null);
+        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + ModelType.BOOLEAN));
     }
 
     @Test
     public void testValidateJobWithTaskModelVariableEmptyModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", "  "), null);
+        factory.validateJob(createJobWithTaskModelVariable("blabla", "  "));
     }
 
     @Test
     public void testValidateJobWithTaskModelVariableUnknownModel() throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", "UNKNOWN"), null);
+        factory.validateJob(createJobWithTaskModelVariable("blabla", "UNKNOWN"));
     }
 
     @Test(expected = JobValidationException.class)
     public void testValidateJobWithTaskModelVariableValidPrefixButUnknownModel()
             throws UserException, JobValidationException {
-        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"), null);
+        factory.validateJob(createJobWithTaskModelVariable("blabla", ModelValidator.PREFIX + "UNKNOWN"));
     }
 
     private TaskFlowJob createJobWithJobModelVariable(String value, String model) throws UserException {

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidatorTest.java
@@ -63,91 +63,91 @@ public class SpelValidatorTest {
     public void testSpelOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'");
         String value = "MyString";
-        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context)));
+        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context, null)));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelKO() throws ValidationException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'");
         String value = "MyString123";
-        validator.validate(value, new ModelValidatorContext(context));
+        validator.validate(value, new ModelValidatorContext(context, null));
     }
 
     @Test
     public void testSpelMathOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.Math).random() instanceof T(Double)");
         String value = "true";
-        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context)));
+        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context, null)));
     }
 
     @Test
     public void testSpelXmlOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(javax.xml.parsers.DocumentBuilderFactory).newInstance().newDocumentBuilder().parse(new org.xml.sax.InputSource(new java.io.StringReader('<employee id=\"101\"><name>toto</name><title>tata</title></employee>'))).getElementsByTagName('name').item(0).getTextContent() instanceof T(String)");
         String value = "toto";
-        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context)));
+        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context, null)));
     }
 
     @Test
     public void testSpelJSONOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("new org.codehaus.jackson.map.ObjectMapper().readTree('{\"var\": \"value\"}').get('var').getTextValue() instanceof T(String)");
         String value = "value";
-        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context)));
+        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context, null)));
     }
 
     @Test
     public void testSpelJSONOK2() throws ValidationException {
         SpelValidator validator = new SpelValidator("new org.json.simple.parser.JSONParser().parse('{\"var\": \"value\"}').get('var').toString() instanceof T(String)");
         String value = "value";
-        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context)));
+        Assert.assertEquals(value, validator.validate(value, new ModelValidatorContext(context, null)));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType() throws ValidationException {
         SpelValidator validator = new SpelValidator("new x.y.z.Object().toString() instanceof T(String)");
         String value = "value";
-        validator.validate(value, new ModelValidatorContext(context));
+        validator.validate(value, new ModelValidatorContext(context, null));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType2() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.Runtime).getRuntime().exec('hostname').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, new ModelValidatorContext(context));
+        validator.validate(value, new ModelValidatorContext(context, null));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType3() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.System).getenv('HOME').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, new ModelValidatorContext(context));
+        validator.validate(value, new ModelValidatorContext(context, null));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType4() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(org.apache.commons.lang3.time.DateUtils).toCalendar('01/01/2000') instanceof T(Date)");
         String value = "true";
-        validator.validate(value, new ModelValidatorContext(context));
+        validator.validate(value, new ModelValidatorContext(context, null));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedMethod() throws ValidationException {
         SpelValidator validator = new SpelValidator("(new java.lang.String()).getClass().forName('java.lang.Runtime').getDeclaredMethod('getRuntime').invoke(null).exec('hostname').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, new ModelValidatorContext(context));
+        validator.validate(value, new ModelValidatorContext(context, null));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedAttribute() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.String).class.forName('java.lang.Runtime').getDeclaredMethod('getRuntime').invoke(null).exec('hostname').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, new ModelValidatorContext(context));
+        validator.validate(value, new ModelValidatorContext(context, null));
     }
 
     @Test
     public void testSpelOKUpdateJobVariable() throws ValidationException, UserException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String):false");
         String value = "MyString";
-        ModelValidatorContext context = new ModelValidatorContext(createJob());
+        ModelValidatorContext context = new ModelValidatorContext(createJob(), null);
         Assert.assertEquals(value, validator.validate(value, context));
         Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var1"));
     }
@@ -156,7 +156,7 @@ public class SpelValidatorTest {
     public void testSpelKOUpdateJobVariable() throws ValidationException, UserException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String):false");
         String value = "MyString123";
-        ModelValidatorContext context = new ModelValidatorContext(createJob());
+        ModelValidatorContext context = new ModelValidatorContext(createJob(), null);
         try {
             validator.validate(value, context);
             Assert.fail();
@@ -170,7 +170,7 @@ public class SpelValidatorTest {
     public void testSpelOKUpdateJobVariableWhenEmptyOK() throws ValidationException, UserException {
         SpelValidator validator = new SpelValidator("#value == 'MyString' ? (variables['var4'] == null ? (variables['var4'] = 'toto1') instanceof T(String) : true) : false");
         String value = "MyString";
-        ModelValidatorContext context = new ModelValidatorContext(createJob());
+        ModelValidatorContext context = new ModelValidatorContext(createJob(), null);
         Assert.assertEquals(value, validator.validate(value, context));
         Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var4"));
     }
@@ -179,7 +179,7 @@ public class SpelValidatorTest {
     public void testSpelOKUpdateJobVariableWhenEmptyKO() throws ValidationException, UserException {
         SpelValidator validator = new SpelValidator("#value == 'MyString' ? (variables['var2'] == null ? (variables['var2'] = 'toto1') instanceof T(String) : true) : false");
         String value = "MyString";
-        ModelValidatorContext context = new ModelValidatorContext(createJob());
+        ModelValidatorContext context = new ModelValidatorContext(createJob(), null);
         Assert.assertEquals(value, validator.validate(value, context));
         Assert.assertEquals("value2", context.getSpELVariables().getVariables().get("var2"));
     }
@@ -188,7 +188,7 @@ public class SpelValidatorTest {
     public void testSpelOKUpdateTaskVariable() throws ValidationException, UserException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String) : false");
         String value = "MyString";
-        ModelValidatorContext context = new ModelValidatorContext(createTask());
+        ModelValidatorContext context = new ModelValidatorContext(createTask(), null);
         Assert.assertEquals(value, validator.validate(value, context));
         Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var1"));
     }
@@ -197,7 +197,7 @@ public class SpelValidatorTest {
     public void testSpelKOUpdateTaskVariable() throws ValidationException, UserException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String) : false");
         String value = "MyString123";
-        ModelValidatorContext context = new ModelValidatorContext(createTask());
+        ModelValidatorContext context = new ModelValidatorContext(createTask(), null);
         try {
             validator.validate(value, context);
             Assert.fail();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -455,7 +455,8 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
         final String jobContent = getJobContent(currentJobId);
         final Job job = JobFactory.getFactory().createJob(IOUtils.toInputStream(jobContent, Charset.forName("UTF-8")),
                                                           jobVariables,
-                                                          jobGenericInfos);
+                                                          jobGenericInfos,
+                                                          this);
         return submit(job);
     }
 


### PR DESCRIPTION
Add a workflow variable type `PA:CREDENTIAL`. 
This variable type uses _Scheduler Third-Party Credentials_ to store credentials which can be later accessed through its key (e.g. `credentials.get(variables.get("VAR_KEY")`).

The variable value is required to be a **key** which exists in the _Scheduler Third-Party Credentials_.

Note, the workflow validate request is not always sending from the clients which has the access of _Scheduler Third-Party Credentials_, for example, the client "catalog". In such case, the variable validity check is skipped.