### PR TITLE
Refactor REST implementations, and exceptions

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -1351,7 +1351,7 @@ public interface SchedulerRestInterface {
      * @return the <code>jobid</code> of the newly created job
      */
     @POST
-    @Path("jobs")
+    @Path("{path:jobs}")
     @Produces("application/json")
     JobIdData submitFromUrl(@HeaderParam("sessionid") String sessionId, @HeaderParam("link") String url,
             @PathParam("path") PathSegment pathSegment, @Context UriInfo contextInfos) throws JobCreationRestException,

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -1951,12 +1951,26 @@ public interface SchedulerRestInterface {
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException,
             LogForwardingRestException, IOException;
 
+    /**
+     * number of available bytes in the stream or -1 if the stream does not
+     * exist.
+     *
+     * @param sessionId a valid session id
+     * @param jobId     the id of the job to retrieve
+     */
     @GET
     @Path("jobs/{jobid}/livelog/available")
     @Produces("application/json")
     int getLiveLogJobAvailable(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
             throws NotConnectedRestException;
 
+    /**
+     * remove the live log object.
+     *
+     * @param sessionId a valid session id
+     * @param jobId     the id of the job to retrieve
+     * @throws NotConnectedRestException
+     */
     @DELETE
     @Path("jobs/{jobid}/livelog")
     @Produces("application/json")

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -78,6 +78,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestEx
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.LogForwardingRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SchedulerRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SubmissionClosedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownJobRestException;
@@ -105,7 +106,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     RestPage<String> jobs(@HeaderParam("sessionid") String sessionId,
             @QueryParam("index") @DefaultValue("-1") int index, @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws NotConnectedRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns a subset of the scheduler state, including pending, running,
@@ -127,7 +128,7 @@ public interface SchedulerRestInterface {
     @Produces({ "application/json", "application/xml" })
     RestPage<UserJobData> jobsInfo(@HeaderParam("sessionid") String sessionId,
             @QueryParam("index") @DefaultValue("-1") int index, @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws PermissionRestException, NotConnectedRestException;
+            throws RestException;
 
     /**
      * Returns a list of jobs info corresponding to the given job IDs (in the same order)
@@ -142,8 +143,7 @@ public interface SchedulerRestInterface {
     @Path("jobsinfolist")
     @Produces({ "application/json", "application/xml" })
     List<UserJobData> jobsInfoList(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("jobsid") List<String> jobsId)
-            throws PermissionRestException, NotConnectedRestException, UnknownJobRestException;
+            @QueryParam("jobsid") List<String> jobsId) throws RestException;
 
     /**
      * Returns a map containing one entry with the revision id as key and the
@@ -178,8 +178,7 @@ public interface SchedulerRestInterface {
             @QueryParam("myjobs") @DefaultValue("false") boolean myJobs,
             @QueryParam("pending") @DefaultValue("true") boolean pending,
             @QueryParam("running") @DefaultValue("true") boolean running,
-            @QueryParam("finished") @DefaultValue("true") boolean finished)
-            throws PermissionRestException, NotConnectedRestException;
+            @QueryParam("finished") @DefaultValue("true") boolean finished) throws RestException;
 
     /**
      * Returns the revision number of the scheduler state
@@ -205,7 +204,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}")
     @Produces({ "application/json", "application/xml" })
     JobStateData listJobs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns the job result associated to the job referenced by the id
@@ -220,7 +219,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/result")
     @Produces("application/json")
     JobResultData jobResult(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, PermissionRestException, UnknownJobRestException;
+            throws RestException;
 
     /**
      * Returns the job results map associated to the job referenced by the id
@@ -235,7 +234,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/resultmap")
     @Produces("application/json")
     Map<String, String> jobResultMap(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, PermissionRestException, UnknownJobRestException;
+            throws RestException;
 
     /**
      * @param sessionId a valid session id
@@ -247,7 +246,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/resultmap")
     @Produces("application/json")
     Map<Long, Map<String, String>> jobResultMaps(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("jobsid") List<String> jobsId) throws NotConnectedRestException, PermissionRestException;
+            @QueryParam("jobsid") List<String> jobsId) throws RestException;
 
     /**
      * Returns the job info associated to the job referenced by the id
@@ -262,7 +261,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/info")
     @Produces("application/json")
     JobInfoData jobInfo(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, PermissionRestException, UnknownJobRestException;
+            throws RestException;
 
     /**
      * Returns all the task results of this job as a map whose the key is the
@@ -282,7 +281,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/result/value")
     @Produces("application/json")
     Map<String, String> jobResultValue(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, PermissionRestException, UnknownJobRestException;
+            throws RestException;
 
     /**
      * Delete a job
@@ -299,7 +298,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}")
     @Produces("application/json")
     boolean removeJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns job server logs
@@ -315,7 +314,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/log/server")
     @Produces("application/json")
     String jobServerLog(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Kill the job represented by jobId.<br>
@@ -329,8 +328,7 @@ public interface SchedulerRestInterface {
     @PUT
     @Path("jobs/{jobid}/kill")
     @Produces("application/json")
-    boolean killJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+    boolean killJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId) throws RestException;
 
     /**
      * Returns a list of the name of the tasks belonging to job
@@ -346,7 +344,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks")
     @Produces("application/json")
     RestPage<String> getTasksNames(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns a list of the name of the tasks belonging to job
@@ -367,8 +365,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     RestPage<String> getTasksNamesPaginated(@HeaderParam("sessionid") String sessionId,
             @PathParam("jobid") String jobId, @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @QueryParam("limit") @DefaultValue("-1") int limit) throws RestException;
 
     /**
      * Returns a list of the name of the tasks belonging to job
@@ -387,8 +384,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tag/{tasktag}")
     @Produces("application/json")
     RestPage<String> getJobTasksIdsByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("tasktag") String taskTag) throws RestException;
 
     /**
      * Returns a list of the name of the tasks belonging to job
@@ -414,7 +410,7 @@ public interface SchedulerRestInterface {
     RestPage<String> getJobTasksIdsByTagPaginated(@HeaderParam("sessionid") String sessionId,
             @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag,
             @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns all tasks name regarding the given parameters (decoupled from the
@@ -459,7 +455,7 @@ public interface SchedulerRestInterface {
             @QueryParam("pending") @DefaultValue("true") boolean pending,
             @QueryParam("finished") @DefaultValue("true") boolean finished,
             @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws NotConnectedRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns all tasks name regarding the given parameters (decoupled from the
@@ -507,7 +503,7 @@ public interface SchedulerRestInterface {
             @QueryParam("pending") @DefaultValue("true") boolean pending,
             @QueryParam("finished") @DefaultValue("true") boolean finished,
             @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws NotConnectedRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns a list of the tags of the tasks belonging to job
@@ -523,7 +519,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tags")
     @Produces("application/json")
     List<String> getJobTaskTags(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * Returns a list of the tags of the tasks belonging to job
@@ -541,8 +537,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tags/startsWith/{prefix}")
     @Produces("application/json")
     List<String> getJobTaskTagsPrefix(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("prefix") String prefix)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("prefix") String prefix) throws RestException;
 
     /**
      * Returns a base64 utf-8 encoded html visualization corresponding to the
@@ -576,8 +571,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/xml")
     @Produces("application/xml")
     String getJobContent(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException,
-            SubmissionClosedRestException, JobCreationRestException;
+            throws RestException;
 
     /**
      * Returns a list of taskState
@@ -594,8 +588,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/taskstates")
     @Produces("application/json")
     RestPage<TaskStateData> getJobTaskStates(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("jobid") String jobId) throws RestException;
 
     /**
      * Returns a list of taskState with pagination
@@ -617,8 +610,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     RestPage<TaskStateData> getJobTaskStatesPaginated(@HeaderParam("sessionid") String sessionId,
             @PathParam("jobid") String jobId, @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("50") int limit)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @QueryParam("limit") @DefaultValue("50") int limit) throws RestException;
 
     @GET
     @GZIP
@@ -627,8 +619,7 @@ public interface SchedulerRestInterface {
     RestPage<TaskStateData> getJobTaskStatesFilteredPaginated(@HeaderParam("sessionid") String sessionId,
             @PathParam("jobid") String jobId, @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit,
-            @QueryParam("statusFilter") @DefaultValue("") String statusFilter)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @QueryParam("statusFilter") @DefaultValue("") String statusFilter) throws RestException;
 
     /**
      * Returns a list of taskState of the tasks filtered by a given tag.
@@ -647,8 +638,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/taskstates/{tasktag}")
     @Produces("application/json")
     RestPage<TaskStateData> getJobTaskStatesByTag(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag) throws RestException;
 
     /**
      * Returns a list of taskState of the tasks filtered by a given tag and
@@ -674,7 +664,7 @@ public interface SchedulerRestInterface {
     RestPage<TaskStateData> getJobTaskStatesByTagPaginated(@HeaderParam("sessionid") String sessionId,
             @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag,
             @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("50") int limit)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     @GET
     @GZIP
@@ -683,8 +673,7 @@ public interface SchedulerRestInterface {
     RestPage<TaskStateData> getJobTaskStatesByTagByStatusPaginated(@HeaderParam("sessionid") String sessionId,
             @PathParam("jobid") String jobId, @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit, @PathParam("tasktag") String taskTag,
-            @PathParam("statusFilter") String statusFilter)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("statusFilter") String statusFilter) throws RestException;
 
     /**
      * Returns a paginated list of <code>TaskStateData</code> regarding the
@@ -731,8 +720,7 @@ public interface SchedulerRestInterface {
             @QueryParam("pending") @DefaultValue("true") boolean pending,
             @QueryParam("finished") @DefaultValue("true") boolean finished,
             @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("-1") int limit,
-            @QueryParam("sortparameters") SortSpecifierContainer sortParams)
-            throws NotConnectedRestException, PermissionRestException;
+            @QueryParam("sortparameters") SortSpecifierContainer sortParams) throws RestException;
 
     /**
      * Returns a paginated list of <code>TaskStateData</code> regarding the
@@ -782,8 +770,7 @@ public interface SchedulerRestInterface {
             @QueryParam("pending") @DefaultValue("true") boolean pending,
             @QueryParam("finished") @DefaultValue("true") boolean finished,
             @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("-1") int limit,
-            @QueryParam("sortparameters") SortSpecifierContainer sortParams)
-            throws NotConnectedRestException, PermissionRestException;
+            @QueryParam("sortparameters") SortSpecifierContainer sortParams) throws RestException;
 
     /**
      * Returns full logs generated by tasks in job.
@@ -802,8 +789,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/log/full")
     @Produces("application/json")
     InputStream jobFullLogs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @QueryParam("sessionid") String session) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException, IOException;
+            @QueryParam("sessionid") String session) throws RestException, IOException;
 
     /**
      * Returns all the logs generated by the job (either stdout and stderr)
@@ -823,9 +809,7 @@ public interface SchedulerRestInterface {
     @GZIP
     @Path("jobs/{jobid}/result/log/all")
     @Produces("application/json")
-    String jobLogs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, UnknownTaskRestException,
-            PermissionRestException;
+    String jobLogs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId) throws RestException;
 
     /**
      * Return the task state of the task <code>taskname</code> of the job
@@ -844,8 +828,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}")
     @Produces("application/json")
     TaskStateData jobTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            PermissionRestException, UnknownTaskRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Returns the value of the task result of task <code>taskName</code> of the
@@ -945,7 +928,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/results/precious/metadata")
     @Produces("application/json")
     List<String> getPreciousTaskName(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            throws RestException;
 
     /**
      * @param sessionId a valid session id
@@ -957,7 +940,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/result/precious/metadata")
     @Produces("application/json")
     Map<Long, List<String>> getPreciousTaskNames(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("jobsid") List<String> jobsId) throws NotConnectedRestException, PermissionRestException;
+            @QueryParam("jobsid") List<String> jobsId) throws RestException;
 
     /**
      * Returns the value of the task result of the task <code>taskName</code> of
@@ -1017,8 +1000,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/result")
     @Produces("application/json")
     TaskResultData taskResult(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Returns the task results of the set of task filtered by a given tag and
@@ -1037,8 +1019,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tag/{tasktag}/result")
     @Produces("application/json")
     List<TaskResultData> taskResultByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("tasktag") String taskTag) throws RestException;
 
     /**
      * Returns all the logs generated by the task (either stdout and stderr).
@@ -1059,8 +1040,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/result/log/all")
     @Produces("application/json")
     String taskLog(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Returns all the logs generated by a set of the tasks (either stdout and
@@ -1080,8 +1060,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/log/all")
     @Produces("application/json")
     String taskLogByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("tasktag") String taskTag) throws RestException;
 
     /**
      * Returns the standard error output (stderr) generated by the task
@@ -1102,8 +1081,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/result/log/err")
     @Produces("application/json")
     String taskLogErr(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Returns the list of standard error outputs (stderr) generated by a set of
@@ -1125,8 +1103,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/log/err")
     @Produces("application/json")
     String taskLogErrByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("tasktag") String taskTag) throws RestException;
 
     /**
      * Returns the standard output (stdout) generated by the task
@@ -1147,8 +1124,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/result/log/out")
     @Produces("application/json")
     String taskLogout(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Returns the standard output (stdout) generated by a set of tasks filtered
@@ -1170,8 +1146,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/log/out")
     @Produces("application/json")
     String taskLogoutByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("tasktag") String taskTag) throws RestException;
 
     /**
      * Returns full logs generated by the task from user data spaces if task was
@@ -1195,8 +1170,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     InputStream taskFullLogs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
             @PathParam("taskname") String taskname, @QueryParam("sessionid") String session)
-            throws NotConnectedRestException, UnknownJobRestException, UnknownTaskRestException,
-            PermissionRestException, IOException;
+            throws RestException, IOException;
 
     /**
      * Returns task server logs
@@ -1214,8 +1188,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/log/server")
     @Produces("application/json")
     String taskServerLog(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Returns server logs for a set of tasks filtered by a given tag.
@@ -1233,8 +1206,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/tag/{tasktag}/log/server")
     @Produces("application/json")
     String taskServerLogByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+            @PathParam("tasktag") String taskTag) throws RestException;
 
     /**
      * Pauses the job represented by jobid
@@ -1250,7 +1222,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     boolean pauseJob(@HeaderParam("sessionid")
     final String sessionId, @PathParam("jobid")
-    final String jobId) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+    final String jobId) throws RestException;
 
     /**
      * Restart all tasks in error in the job represented by jobid
@@ -1266,7 +1238,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     boolean restartAllInErrorTasks(@HeaderParam("sessionid")
     final String sessionId, @PathParam("jobid")
-    final String jobId) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+    final String jobId) throws RestException;
 
     /**
      * Resumes the job represented by jobid
@@ -1282,7 +1254,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     boolean resumeJob(@HeaderParam("sessionid")
     final String sessionId, @PathParam("jobid")
-    final String jobId) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+    final String jobId) throws RestException;
 
     /**
      * Submit job using flat command file
@@ -1306,8 +1278,7 @@ public interface SchedulerRestInterface {
     JobIdData submitFlat(@HeaderParam("sessionid") String sessionId,
             @FormParam("commandFileContent") String commandFileContent, @FormParam("jobName") String jobName,
             @FormParam("selectionScriptContent") String selectionScriptContent,
-            @FormParam("selectionScriptExtension") String selectionScriptExtension) throws NotConnectedRestException,
-            IOException, JobCreationRestException, PermissionRestException, SubmissionClosedRestException;
+            @FormParam("selectionScriptExtension") String selectionScriptExtension) throws IOException, RestException;
 
     /**
      * Submits a job to the scheduler
@@ -1347,8 +1318,7 @@ public interface SchedulerRestInterface {
     @Produces("application/json")
     JobIdData reSubmit(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
             @PathParam("path") PathSegment pathSegment, @Context UriInfo contextInfos)
-            throws JobCreationRestException, NotConnectedRestException, PermissionRestException,
-            SubmissionClosedRestException, IOException, UnknownJobRestException;
+            throws IOException, RestException;
 
     /**
      * submit a planned workflow
@@ -1465,7 +1435,7 @@ public interface SchedulerRestInterface {
     @Path("disconnect")
     @Produces("application/json")
     void disconnect(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * pauses the scheduler
@@ -1478,7 +1448,7 @@ public interface SchedulerRestInterface {
     @Path("pause")
     @Produces("application/json")
     boolean pauseScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * stops the scheduler
@@ -1491,7 +1461,7 @@ public interface SchedulerRestInterface {
     @Path("stop")
     @Produces("application/json")
     boolean stopScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * resumes the scheduler
@@ -1504,7 +1474,7 @@ public interface SchedulerRestInterface {
     @Path("resume")
     @Produces("application/json")
     boolean resumeScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * changes the priority of a job
@@ -1520,8 +1490,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/priority/byname/{name}")
     void schedulerChangeJobPriorityByName(@HeaderParam("sessionid")
     final String sessionId, @PathParam("jobid")
-    final String jobId, @PathParam("name") String priorityName) throws NotConnectedRestException,
-            UnknownJobRestException, PermissionRestException, JobAlreadyFinishedRestException;
+    final String jobId, @PathParam("name") String priorityName) throws RestException;
 
     /**
      * changes the priority of a job
@@ -1537,9 +1506,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/priority/byvalue/{value}")
     void schedulerChangeJobPriorityByValue(@HeaderParam("sessionid")
     final String sessionId, @PathParam("jobid")
-    final String jobId, @PathParam("value") String priorityValue)
-            throws NumberFormatException, NotConnectedRestException, UnknownJobRestException, PermissionRestException,
-            JobAlreadyFinishedRestException;
+    final String jobId, @PathParam("value") String priorityValue) throws RestException;
 
     /**
      * freezes the scheduler
@@ -1552,7 +1519,7 @@ public interface SchedulerRestInterface {
     @Path("freeze")
     @Produces("application/json")
     boolean freezeScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * returns the status of the scheduler
@@ -1565,7 +1532,7 @@ public interface SchedulerRestInterface {
     @Path("status")
     @Produces("application/json")
     SchedulerStatusData getSchedulerStatus(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * starts the scheduler
@@ -1578,7 +1545,7 @@ public interface SchedulerRestInterface {
     @Path("start")
     @Produces("application/json")
     boolean startScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * kills the scheduler
@@ -1591,7 +1558,7 @@ public interface SchedulerRestInterface {
     @Path("kill")
     @Produces("application/json")
     boolean killScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * shutdown the scheduler
@@ -1604,7 +1571,7 @@ public interface SchedulerRestInterface {
     @Path("shutdown")
     @Produces("application/json")
     boolean shutdownScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * Reconnect a new Resource Manager to the scheduler. Can be used if the
@@ -1620,7 +1587,7 @@ public interface SchedulerRestInterface {
     @Path("linkrm")
     @Produces("application/json")
     boolean linkRm(@HeaderParam("sessionid")
-    final String sessionId, @FormParam("rmurl") String rmURL) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId, @FormParam("rmurl") String rmURL) throws RestException;
 
     /**
      * Tests whether or not the user is connected to the ProActive Scheduler
@@ -1748,19 +1715,17 @@ public interface SchedulerRestInterface {
     @Path("users")
     @Produces("application/json")
     List<SchedulerUserData> getUsers(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     @GET
     @Path("userspace")
     @Produces("application/json")
-    List<String> userspaceURIs(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, PermissionRestException;
+    List<String> userspaceURIs(@HeaderParam("sessionid") String sessionId) throws RestException;
 
     @GET
     @Path("globalspace")
     @Produces("application/json")
-    List<String> globalspaceURIs(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, PermissionRestException;
+    List<String> globalspaceURIs(@HeaderParam("sessionid") String sessionId) throws RestException;
 
     /**
      * Users having jobs in the scheduler
@@ -1774,7 +1739,7 @@ public interface SchedulerRestInterface {
     @Path("userswithjobs")
     @Produces("application/json")
     List<SchedulerUserData> getUsersWithJobs(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * returns statistics about the scheduler
@@ -1812,7 +1777,7 @@ public interface SchedulerRestInterface {
     @Path("stats/myaccount")
     @Produces("application/json")
     Map<String, String> getStatisticsOnMyAccount(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * generates a credential file from user provided credentials
@@ -1852,8 +1817,7 @@ public interface SchedulerRestInterface {
     @Path("usage/myaccount")
     @Produces("application/json")
     List<JobUsageData> getUsageOnMyAccount(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("startdate") Date startDate, @QueryParam("enddate") Date endDate)
-            throws NotConnectedRestException, PermissionRestException;
+            @QueryParam("startdate") Date startDate, @QueryParam("enddate") Date endDate) throws RestException;
 
     /**
      * Returns details on job and task execution times for the caller's
@@ -1884,8 +1848,7 @@ public interface SchedulerRestInterface {
     @Path("usage/account")
     @Produces("application/json")
     List<JobUsageData> getUsageOnAccount(@HeaderParam("sessionid") String sessionId, @QueryParam("user") String user,
-            @QueryParam("startdate") Date startDate, @QueryParam("enddate") Date endDate)
-            throws NotConnectedRestException, PermissionRestException;
+            @QueryParam("startdate") Date startDate, @QueryParam("enddate") Date endDate) throws RestException;
 
     /**
      * Stream the output of job identified by the id <code>jobid</code> only
@@ -1939,8 +1902,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/restart")
     @Produces("application/json")
     boolean restartTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Finish a task, which is in InError state inside a job.
@@ -1953,8 +1915,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/finishInErrorTask")
     @Produces("application/json")
     boolean finishInErrorTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Restart a pause on error task within a job
@@ -1967,8 +1928,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/restartInErrorTask")
     @Produces("application/json")
     boolean restartInErrorTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Preempt a task within a job
@@ -1983,8 +1943,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/preempt")
     @Produces("application/json")
     boolean preemptTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Kill a task within a job
@@ -1997,8 +1956,7 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/tasks/{taskname}/kill")
     @Produces("application/json")
     boolean killTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException;
+            @PathParam("taskname") String taskname) throws RestException;
 
     /**
      * Validates a job
@@ -2039,19 +1997,17 @@ public interface SchedulerRestInterface {
     @POST
     @Path("/credentials/{key}")
     void putThirdPartyCredential(@HeaderParam("sessionid") String sessionId, @PathParam("key") @Encoded String key,
-            @FormParam("value") String value)
-            throws NotConnectedRestException, PermissionRestException, SchedulerRestException;
+            @FormParam("value") String value) throws RestException;
 
     @DELETE
     @Path("/credentials/{key}")
     void removeThirdPartyCredential(@HeaderParam("sessionid") String sessionId, @PathParam("key") @Encoded String key)
-            throws NotConnectedRestException, PermissionRestException, SchedulerRestException;
+            throws RestException;
 
     @GET
     @Path("/credentials/")
     @Produces("application/json")
-    Set<String> thirdPartyCredentialsKeySet(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, PermissionRestException;
+    Set<String> thirdPartyCredentialsKeySet(@HeaderParam("sessionid") String sessionId) throws RestException;
 
     /**
      * Change the START_AT generic information at job level and reset the
@@ -2070,7 +2026,7 @@ public interface SchedulerRestInterface {
     boolean changeStartAt(@HeaderParam("sessionid")
     final String sessionId, @PathParam("jobid")
     final String jobId, @PathParam("startAt")
-    final String startAt) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException;
+    final String startAt) throws RestException;
 
     /**
      * Get portal configuration properties
@@ -2078,8 +2034,7 @@ public interface SchedulerRestInterface {
     @GET
     @Path("configuration/portal")
     @Produces("application/json")
-    public Map<Object, Object> getPortalConfiguration(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, PermissionRestException;
+    public Map<Object, Object> getPortalConfiguration(@HeaderParam("sessionid") String sessionId) throws RestException;
 
     /**
      * returns scheduler properties
@@ -2092,7 +2047,7 @@ public interface SchedulerRestInterface {
     @Path("properties")
     @Produces("application/json")
     Map<String, Object> getSchedulerPropertiesFromSessionId(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException;
+    final String sessionId) throws RestException;
 
     /**
      * 
@@ -2104,6 +2059,5 @@ public interface SchedulerRestInterface {
     @Path("job/{jobid}/permission/{method}")
     @Consumes(value = MediaType.APPLICATION_JSON)
     @Produces("application/json")
-    boolean checkJobPermissionMethod(String sessionId, String jobId, String method)
-            throws NotConnectedRestException, UnknownJobRestException;
+    boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws RestException;
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -1299,10 +1299,6 @@ public interface SchedulerRestInterface {
      *            extension of the selectionscript to determine script engine
      *            ("js", "py", "rb")
      * @return Id of the submitted job
-     * @throws NotConnectedRestException
-     * @throws IOException
-     * @throws PermissionRestException
-     * @throws SubmissionClosedRestException
      */
     @POST
     @Path("submitflat")
@@ -1361,11 +1357,6 @@ public interface SchedulerRestInterface {
      * @param pathSegment path param going to be transferred to the variables
      * @param jobContentXmlString job content in xml string
      * @return true if the submission is done sucessfully, false otherwise
-     * @throws JobCreationRestException
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     * @throws SubmissionClosedRestException
-     * @throws IOException
      */
     @Consumes(MediaType.APPLICATION_JSON)
     @POST
@@ -1388,11 +1379,6 @@ public interface SchedulerRestInterface {
      * @param contextInfos
      *            the context informations (generic parameters,..)
      * @return the <code>jobid</code> of the newly created job
-     * @throws NotConnectedRestException
-     * @throws IOException
-     * @throws JobCreationRestException
-     * @throws PermissionRestException
-     * @throws SubmissionClosedRestException
      */
     @POST
     @Path("jobs")
@@ -1487,8 +1473,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("pause")
@@ -1502,8 +1486,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("stop")
@@ -1517,8 +1499,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("resume")
@@ -1535,10 +1515,6 @@ public interface SchedulerRestInterface {
      *            the job id
      * @param priorityName
      *            a string representing the name of the priority
-     * @throws NotConnectedRestException
-     * @throws org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownJobRestException
-     * @throws PermissionRestException
-     * @throws org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobAlreadyFinishedRestException
      */
     @PUT
     @Path("jobs/{jobid}/priority/byname/{name}")
@@ -1556,11 +1532,6 @@ public interface SchedulerRestInterface {
      *            the job id
      * @param priorityValue
      *            a string representing the value of the priority
-     * @throws NumberFormatException
-     * @throws NotConnectedRestException
-     * @throws org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownJobRestException
-     * @throws PermissionRestException
-     * @throws org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobAlreadyFinishedRestException
      */
     @PUT
     @Path("jobs/{jobid}/priority/byvalue/{value}")
@@ -1576,8 +1547,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("freeze")
@@ -1591,8 +1560,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return the scheduler status
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @GET
     @Path("status")
@@ -1606,8 +1573,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("start")
@@ -1621,8 +1586,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return true if success, false if not
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("kill")
@@ -1636,8 +1599,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            a valid session id
      * @return true if success, false if not
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("shutdown")
@@ -1654,8 +1615,6 @@ public interface SchedulerRestInterface {
      * @param rmURL
      *            the url of the resource manager
      * @return true if success, false otherwise.
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @POST
     @Path("linkrm")
@@ -1686,8 +1645,6 @@ public interface SchedulerRestInterface {
      * @param password
      *            password
      * @return the session id associated to the login
-     * @throws LoginException
-     * @throws SchedulerRestException
      */
     @POST
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
@@ -1707,7 +1664,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            session id identifying a session to renew.
      * @return the new session id to use.
-     * @throws SchedulerRestException
      */
     @PUT
     @Path("session")
@@ -1730,7 +1686,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            session id identifying a session to renew.
      * @return the new session id to use.
-     * @throws SchedulerRestException
      */
     @PUT
     @Path("session")
@@ -1773,9 +1728,6 @@ public interface SchedulerRestInterface {
      * field name 'credential'
      * 
      * @return the session id associated to this new connection
-     * @throws KeyException
-     * @throws LoginException
-     * @throws SchedulerRestException
      */
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -1790,8 +1742,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            the session id associated to this new connection
      * @return list of users
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @GET
     @GZIP
@@ -1818,8 +1768,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            the session id associated to this new connection
      * @return list of users
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @GET
     @GZIP
@@ -1859,8 +1807,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            the session id associated to this new connection
      * @return a string containing some data regarding the user's account
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @GET
     @Path("stats/myaccount")
@@ -1872,8 +1818,6 @@ public interface SchedulerRestInterface {
      * generates a credential file from user provided credentials
      * 
      * @return the credential file generated by the scheduler
-     * @throws SchedulerRestException
-     * @throws LoginException
      */
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -1943,6 +1887,14 @@ public interface SchedulerRestInterface {
             @QueryParam("startdate") Date startDate, @QueryParam("enddate") Date endDate)
             throws NotConnectedRestException, PermissionRestException;
 
+    /**
+     * Stream the output of job identified by the id <code>jobid</code> only
+     * stream currently available logs, call this method several times to get
+     * the complete output.
+     *
+     * @param sessionId a valid session id
+     * @param jobId     the id of the job to retrieve
+     */
     @GET
     @GZIP
     @Path("jobs/{jobid}/livelog")
@@ -1969,7 +1921,6 @@ public interface SchedulerRestInterface {
      *
      * @param sessionId a valid session id
      * @param jobId     the id of the job to retrieve
-     * @throws NotConnectedRestException
      */
     @DELETE
     @Path("jobs/{jobid}/livelog")
@@ -1977,6 +1928,13 @@ public interface SchedulerRestInterface {
     boolean deleteLiveLogJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
             throws NotConnectedRestException;
 
+    /**
+     * Restart a task within a job
+     *
+     * @param sessionId current session
+     * @param jobid     id of the job containing the task to kill
+     * @param taskname  name of the task to kill
+     */
     @PUT
     @Path("jobs/{jobid}/tasks/{taskname}/restart")
     @Produces("application/json")
@@ -1984,6 +1942,13 @@ public interface SchedulerRestInterface {
             @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
             UnknownTaskRestException, PermissionRestException;
 
+    /**
+     * Finish a task, which is in InError state inside a job.
+     *
+     * @param sessionId current session
+     * @param jobid     id of the job containing the task to finish (only when InError state)
+     * @param taskname  name of the task to finish (only when InError state)
+     */
     @PUT
     @Path("jobs/{jobid}/tasks/{taskname}/finishInErrorTask")
     @Produces("application/json")
@@ -1991,6 +1956,13 @@ public interface SchedulerRestInterface {
             @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
             UnknownTaskRestException, PermissionRestException;
 
+    /**
+     * Restart a pause on error task within a job
+     *
+     * @param sessionId current session
+     * @param jobid     id of the job containing the task to kill
+     * @param taskname  name of the task to kill
+     */
     @PUT
     @Path("jobs/{jobid}/tasks/{taskname}/restartInErrorTask")
     @Produces("application/json")
@@ -1998,6 +1970,15 @@ public interface SchedulerRestInterface {
             @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
             UnknownTaskRestException, PermissionRestException;
 
+    /**
+     * Preempt a task within a job
+     * <p>
+     * The task will be stopped and restarted later
+     *
+     * @param sessionId current session
+     * @param jobid     id of the job containing the task to preempt
+     * @param taskname  name of the task to preempt
+     */
     @PUT
     @Path("jobs/{jobid}/tasks/{taskname}/preempt")
     @Produces("application/json")
@@ -2005,6 +1986,13 @@ public interface SchedulerRestInterface {
             @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
             UnknownTaskRestException, PermissionRestException;
 
+    /**
+     * Kill a task within a job
+     *
+     * @param sessionId current session
+     * @param jobid     id of the job containing the task to kill
+     * @param taskname  name of the task to kill
+     */
     @PUT
     @Path("jobs/{jobid}/tasks/{taskname}/kill")
     @Produces("application/json")
@@ -2022,7 +2010,6 @@ public interface SchedulerRestInterface {
      * @param multipart
      *            a HTTP multipart form which contains the job-descriptor
      * @return the result of job validation
-     * @throws NotConnectedRestException
      */
     @POST
     @Path("{path:validate}")
@@ -2041,11 +2028,6 @@ public interface SchedulerRestInterface {
      * @param pathSegment
      *            variables of the workflow
      * @return the result of job validation
-     * @throws NotConnectedRestException
-     * @throws IOException
-     * @throws JobCreationRestException
-     * @throws PermissionRestException
-     * @throws SubmissionClosedRestException
      */
     @POST
     @Path("{path:validateurl}")
@@ -2081,9 +2063,6 @@ public interface SchedulerRestInterface {
      *            id of the job that needs to be updated
      * @param startAt
      *            its value should be ISO 8601 compliant
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     * @throws PermissionRestException
      */
     @PUT
     @Path("jobs/{jobid}/startat/{startAt}")
@@ -2095,10 +2074,6 @@ public interface SchedulerRestInterface {
 
     /**
      * Get portal configuration properties
-     * @param sessionId
-     * @return
-     * @throws NotConnectedRestException 
-     * @throws PermissionRestException 
      */
     @GET
     @Path("configuration/portal")
@@ -2112,8 +2087,6 @@ public interface SchedulerRestInterface {
      * @param sessionId
      *            the session id associated to this new connection
      * @return a map containing the properties
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
      */
     @GET
     @Path("properties")
@@ -2125,12 +2098,7 @@ public interface SchedulerRestInterface {
      * 
      * Check if the user has the permission to execute the method passed as argument
      * 
-     * @param sessionId
-     * @param jobId
-     * @param method
      * @return true if the user has the permission to execute the java method
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
      */
     @GET
     @Path("job/{jobid}/permission/{method}")

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/exception/RestException.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/exception/RestException.java
@@ -25,6 +25,16 @@
  */
 package org.ow2.proactive_grid_cloud_portal.scheduler.exception;
 
+import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
+import org.ow2.proactive.scheduler.common.exception.JobCreationException;
+import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
+import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.SchedulerException;
+import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
+import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
+import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
+
+
 public class RestException extends Exception {
     public RestException(String message) {
         super(message);
@@ -37,4 +47,43 @@ public class RestException extends Exception {
     public RestException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    public static RestException wrapExceptionToRest(SchedulerException schedulerException) {
+        if (schedulerException instanceof NotConnectedException) {
+            return new NotConnectedRestException(schedulerException);
+        } else if (schedulerException instanceof PermissionException) {
+            return new PermissionRestException(schedulerException);
+        } else if (schedulerException instanceof UnknownJobException) {
+            return new UnknownJobRestException(schedulerException);
+        } else if (schedulerException instanceof JobAlreadyFinishedException) {
+            return new JobAlreadyFinishedRestException(schedulerException);
+        } else if (schedulerException instanceof SubmissionClosedException) {
+            return new SubmissionClosedRestException(schedulerException);
+        } else if (schedulerException instanceof JobCreationException) {
+            return new JobCreationRestException(schedulerException);
+        } else if (schedulerException instanceof UnknownTaskException) {
+            return new UnknownTaskRestException(schedulerException);
+        }
+        return new UnknownJobRestException(schedulerException);
+    }
+
+    public static SchedulerException unwrapRestException(RestException restException) {
+        if (restException instanceof NotConnectedRestException) {
+            return new NotConnectedException(restException);
+        } else if (restException instanceof PermissionRestException) {
+            return new PermissionException(restException);
+        } else if (restException instanceof UnknownJobRestException) {
+            return new UnknownJobException(restException);
+        } else if (restException instanceof JobAlreadyFinishedRestException) {
+            return new JobAlreadyFinishedException(restException);
+        } else if (restException instanceof SubmissionClosedRestException) {
+            return new SubmissionClosedException(restException);
+        } else if (restException instanceof JobCreationRestException) {
+            return new JobCreationException(restException);
+        } else if (restException instanceof UnknownTaskRestException) {
+            return new UnknownTaskException(restException);
+        }
+        return new UnknownJobException(restException);
+    }
+
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
@@ -57,6 +57,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobValidationData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SchedulerRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SubmissionClosedRestException;
 
@@ -78,7 +79,7 @@ public interface StudioInterface {
     @PUT
     @Path("logout")
     void logout(@HeaderParam("sessionid")
-    final String sessionId) throws PermissionRestException, NotConnectedRestException;
+    final String sessionId) throws RestException;
 
     @GET
     @Path("connected")

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/InstallPackageCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/InstallPackageCommand.java
@@ -45,6 +45,7 @@ import org.ow2.proactive_grid_cloud_portal.cli.cmd.Command;
 import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
 
 
 /**
@@ -171,7 +172,7 @@ public class InstallPackageCommand extends AbstractCommand implements Command {
     }
 
     private Map<String, Object> retrieveSchedulerProperties(ApplicationContext currentContext,
-            SchedulerRestInterface scheduler) throws PermissionRestException, NotConnectedRestException {
+            SchedulerRestInterface scheduler) throws RestException {
         return scheduler.getSchedulerPropertiesFromSessionId(currentContext.getSessionId());
     }
 

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommand.java
@@ -39,6 +39,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.dto.RestMapPage;
 import org.ow2.proactive_grid_cloud_portal.scheduler.dto.UserJobData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
 
 
 public class ListJobCommand extends AbstractCommand implements Command {
@@ -85,7 +86,7 @@ public class ListJobCommand extends AbstractCommand implements Command {
     }
 
     private void printJobsList(int index, int offset, ApplicationContext currentContext)
-            throws PermissionRestException, NotConnectedRestException, IOException {
+            throws RestException, IOException {
         RestMapPage<Long, ArrayList<UserJobData>> page = currentContext.getRestClient()
                                                                        .getScheduler()
                                                                        .revisionAndJobsInfo(currentContext.getSessionId(),

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -87,6 +87,7 @@ import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
@@ -1131,53 +1132,40 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public void putThirdPartyCredential(String key, String value) throws NotConnectedException, PermissionException {
+    public void putThirdPartyCredential(String key, String value) throws SchedulerException {
         try {
             restApi().putThirdPartyCredential(sid, key, value);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
-        } catch (SchedulerRestException e) {
-            throw new RuntimeException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
     @Override
-    public Set<String> thirdPartyCredentialsKeySet() throws NotConnectedException, PermissionException {
+    public Set<String> thirdPartyCredentialsKeySet() throws SchedulerException {
         try {
             return restApi().thirdPartyCredentialsKeySet(sid);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
     @Override
-    public void removeThirdPartyCredential(String key) throws NotConnectedException, PermissionException {
+    public void removeThirdPartyCredential(String key) throws SchedulerException {
         try {
             restApi().removeThirdPartyCredential(sid, key);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
-        } catch (SchedulerRestException e) {
-            throw new RuntimeException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
     @Override
     public Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, boolean running,
-            boolean pending, boolean finished, int offset, int limit)
-            throws NotConnectedException, PermissionException {
+            boolean pending, boolean finished, int offset, int limit) throws SchedulerException {
         RestPage<TaskStateData> page = null;
         try {
             page = restApi().getTaskStates(sid, from, to, mytasks, running, pending, finished, offset, limit, null);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
         List<TaskId> lTaskIds = new ArrayList<TaskId>(page.getList().size());
         for (TaskStateData taskStateData : page.getList()) {
@@ -1193,7 +1181,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     @Override
     public Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
-            throws NotConnectedException, PermissionException {
+            throws SchedulerException {
         RestPage<TaskStateData> page = null;
         SortSpecifierContainer sortContainer = new SortSpecifierContainer(sortParams.toString());
         try {
@@ -1207,10 +1195,8 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
                                            offset,
                                            limit,
                                            sortContainer);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
         List<TaskState> lTaskStates = new ArrayList<TaskState>(page.getList().size());
         for (TaskStateData taskStateData : page.getList()) {
@@ -1220,16 +1206,12 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public JobInfo getJobInfo(String jobId) throws UnknownJobException, NotConnectedException, PermissionException {
+    public JobInfo getJobInfo(String jobId) throws SchedulerException {
         JobInfoData jobInfoData = null;
         try {
             jobInfoData = restApi().jobInfo(sid, jobId);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
-        } catch (UnknownJobRestException e) {
-            throw new UnknownJobException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
         JobInfoImpl jobInfoImpl = new JobInfoImpl();
         JobId newJobId = JobIdImpl.makeJobId(jobId);
@@ -1268,31 +1250,20 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public String getJobContent(JobId jobId) throws NotConnectedException, PermissionException, UnknownJobException,
-            JobCreationException, SubmissionClosedException {
+    public String getJobContent(JobId jobId) throws SchedulerException {
         try {
             return restApi().getJobContent(sid, jobId.value());
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (UnknownJobRestException e) {
-            throw new UnknownJobException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
-        } catch (SubmissionClosedRestException e) {
-            throw new SubmissionClosedException(e);
-        } catch (JobCreationRestException e) {
-            throw new JobCreationException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
     @Override
-    public Map<Object, Object> getPortalConfiguration() throws NotConnectedException, PermissionException {
+    public Map<Object, Object> getPortalConfiguration() throws SchedulerException {
         try {
             return restApi().getPortalConfiguration(sid);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
@@ -1317,14 +1288,12 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException {
+    public Map<String, Object> getSchedulerProperties() throws SchedulerException {
 
         try {
             return restApi().getSchedulerPropertiesFromSessionId(sid);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException("Session " + sid + " is not connected");
-        } catch (PermissionRestException e) {
-            throw new PermissionException("Session " + sid + " doesnt have permission");
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
@@ -1395,8 +1364,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
         try {
             Map<Long, Map<String, Serializable>> result = new HashMap<>();
             Map<Long, Map<String, String>> map = restApi().jobResultMaps(sid, jobsId);
@@ -1410,34 +1378,26 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
             }
 
             return result;
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
     @Override
-    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException {
         try {
             return restApi().getPreciousTaskNames(sid, jobsId);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException(e);
-        } catch (PermissionRestException e) {
-            throw new PermissionException(e);
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method)
-            throws NotConnectedException, UnknownJobException {
+    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
         try {
             return restApi().checkJobPermissionMethod(sessionId, jobId, method);
-        } catch (NotConnectedRestException e) {
-            throw new NotConnectedException("Session " + sid + " is not connected");
-        } catch (UnknownJobRestException e) {
-            throw new UnknownJobException("Job id " + jobId + " not found");
+        } catch (RestException e) {
+            throw RestException.unwrapRestException(e);
         }
     }
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -234,10 +234,11 @@ public class RMRest implements RMRestInterface {
     @Path("monitoring")
     @Produces("application/json")
     public RMStateDelta getRMStateDelta(@HeaderParam("sessionid") String sessionId,
-            @HeaderParam("clientCounter") @DefaultValue("-1") String clientCounter) throws NotConnectedException {
+            @HeaderParam("clientCounter") @DefaultValue("-1") String clientCounter)
+            throws NotConnectedException, PermissionRestException {
         checkAccess(sessionId);
         long counter = Integer.valueOf(clientCounter);
-        return RMStateCaching.getRMStateDelta(counter);
+        return orThrowRPE(RMStateCaching.getRMStateDelta(counter));
     }
 
     @Override
@@ -245,9 +246,10 @@ public class RMRest implements RMRestInterface {
     @GZIP
     @Path("monitoring/full")
     @Produces("application/json")
-    public RMStateFull getRMStateFull(@HeaderParam("sessionid") String sessionId) throws NotConnectedException {
+    public RMStateFull getRMStateFull(@HeaderParam("sessionid") String sessionId)
+            throws NotConnectedException, PermissionRestException {
         checkAccess(sessionId);
-        return RMStateCaching.getRMStateFull();
+        return orThrowRPE(RMStateCaching.getRMStateFull());
     }
 
     @Override
@@ -289,9 +291,9 @@ public class RMRest implements RMRestInterface {
     @Path("nodesource")
     @Produces("application/json")
     public List<RMNodeSourceEvent> getExistingNodeSources(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedException {
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.getExistingNodeSourcesList();
+        return orThrowRPE(rm.getExistingNodeSourcesList());
     }
 
     @Override
@@ -380,7 +382,8 @@ public class RMRest implements RMRestInterface {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
-            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException {
+            @FormParam("policyFileParameters") String[] policyFileParameters)
+            throws NotConnectedException, PermissionRestException {
 
         ResourceManager rm = checkAccess(sessionId);
         NSState nsState = new NSState();
@@ -419,16 +422,17 @@ public class RMRest implements RMRestInterface {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
-            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException {
-        return createNodeSource(sessionId,
-                                nodeSourceName,
-                                infrastructureType,
-                                infrastructureParameters,
-                                infrastructureFileParameters,
-                                policyType,
-                                policyParameters,
-                                policyFileParameters,
-                                Boolean.TRUE.toString());
+            @FormParam("policyFileParameters") String[] policyFileParameters)
+            throws NotConnectedException, PermissionRestException {
+        return orThrowRPE(createNodeSource(sessionId,
+                                           nodeSourceName,
+                                           infrastructureType,
+                                           infrastructureParameters,
+                                           infrastructureFileParameters,
+                                           policyType,
+                                           policyParameters,
+                                           policyFileParameters,
+                                           Boolean.TRUE.toString()));
     }
 
     @Deprecated
@@ -489,7 +493,7 @@ public class RMRest implements RMRestInterface {
     @Path("nodesource/deploy")
     @Produces("application/json")
     public NSState deployNodeSource(@HeaderParam("sessionid") String sessionId,
-            @FormParam("nodeSourceName") String nodeSourceName) throws NotConnectedException {
+            @FormParam("nodeSourceName") String nodeSourceName) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
         NSState nsState = new NSState();
         try {
@@ -508,7 +512,7 @@ public class RMRest implements RMRestInterface {
     @Produces("application/json")
     public NSState undeployNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName, @FormParam("preempt") boolean preempt)
-            throws NotConnectedException {
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
         NSState nsState = new NSState();
         try {
@@ -526,9 +530,9 @@ public class RMRest implements RMRestInterface {
     @Path("nodesource/pingfrequency")
     @Produces("application/json")
     public int getNodeSourcePingFrequency(@HeaderParam("sessionid") String sessionId,
-            @FormParam("sourcename") String sourceName) throws NotConnectedException {
+            @FormParam("sourcename") String sourceName) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.getNodeSourcePingFrequency(sourceName).getIntValue();
+        return orThrowRPE(rm.getNodeSourcePingFrequency(sourceName).getIntValue());
     }
 
     @Override
@@ -536,11 +540,11 @@ public class RMRest implements RMRestInterface {
     @Path("node/release")
     @Produces("application/json")
     public boolean releaseNode(@HeaderParam("sessionid") String sessionId, @FormParam("url") String url)
-            throws NodeException, NotConnectedException {
+            throws NodeException, NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
         Node n;
         n = NodeFactory.getNode(url);
-        return rm.releaseNode(n).getBooleanValue();
+        return orThrowRPE(rm.releaseNode(n).getBooleanValue());
     }
 
     @Override
@@ -548,9 +552,9 @@ public class RMRest implements RMRestInterface {
     @Path("node/remove")
     @Produces("application/json")
     public boolean removeNode(@HeaderParam("sessionid") String sessionId, @FormParam("url") String nodeUrl,
-            @FormParam("preempt") boolean preempt) throws NotConnectedException {
+            @FormParam("preempt") boolean preempt) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.removeNode(nodeUrl, preempt).getBooleanValue();
+        return orThrowRPE(rm.removeNode(nodeUrl, preempt).getBooleanValue());
     }
 
     @Override
@@ -558,9 +562,9 @@ public class RMRest implements RMRestInterface {
     @Path("nodesource/remove")
     @Produces("application/json")
     public boolean removeNodeSource(@HeaderParam("sessionid") String sessionId, @FormParam("name") String sourceName,
-            @FormParam("preempt") boolean preempt) throws NotConnectedException {
+            @FormParam("preempt") boolean preempt) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.removeNodeSource(sourceName, preempt).getBooleanValue();
+        return orThrowRPE(rm.removeNodeSource(sourceName, preempt).getBooleanValue());
     }
 
     @Override
@@ -568,9 +572,9 @@ public class RMRest implements RMRestInterface {
     @Path("node/lock")
     @Produces("application/json")
     public boolean lockNodes(@HeaderParam("sessionid") String sessionId, @FormParam("nodeurls") Set<String> nodeUrls)
-            throws NotConnectedException {
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.lockNodes(nodeUrls).getBooleanValue();
+        return orThrowRPE(rm.lockNodes(nodeUrls).getBooleanValue());
     }
 
     @Override
@@ -578,9 +582,9 @@ public class RMRest implements RMRestInterface {
     @Path("node/unlock")
     @Produces("application/json")
     public boolean unlockNodes(@HeaderParam("sessionid") String sessionId, @FormParam("nodeurls") Set<String> nodeUrls)
-            throws NotConnectedException {
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.unlockNodes(nodeUrls).getBooleanValue();
+        return orThrowRPE(rm.unlockNodes(nodeUrls).getBooleanValue());
     }
 
     @Override
@@ -592,11 +596,11 @@ public class RMRest implements RMRestInterface {
             @QueryParam("nodejmxurl") String nodeJmxUrl, @QueryParam("objectname") String objectName,
             @QueryParam("attrs") List<String> attrs)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
-            NotConnectedException, MalformedObjectNameException, NullPointerException {
+            NotConnectedException, MalformedObjectNameException, NullPointerException, PermissionRestException {
 
         // checking that still connected to the RM
         RMProxyUserInterface rmProxy = checkAccess(sessionId);
-        return rmProxy.getNodeMBeanInfo(nodeJmxUrl, objectName, attrs);
+        return orThrowRPE(rmProxy.getNodeMBeanInfo(nodeJmxUrl, objectName, attrs));
     }
 
     @Override
@@ -642,11 +646,11 @@ public class RMRest implements RMRestInterface {
             @QueryParam("nodejmxurl") String nodeJmxUrl, @QueryParam("objectname") String objectNames,
             @QueryParam("attrs") List<String> attrs)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
-            NotConnectedException, MalformedObjectNameException, NullPointerException {
+            NotConnectedException, MalformedObjectNameException, NullPointerException, PermissionRestException {
 
         // checking that still connected to the RM
         RMProxyUserInterface rmProxy = checkAccess(sessionId);
-        return rmProxy.getNodeMBeansInfo(nodeJmxUrl, objectNames, attrs);
+        return orThrowRPE(rmProxy.getNodeMBeansInfo(nodeJmxUrl, objectNames, attrs));
     }
 
     @Override
@@ -658,11 +662,12 @@ public class RMRest implements RMRestInterface {
             @QueryParam("nodejmxurl") String nodeJmxUrl, @QueryParam("objectname") String objectNames,
             @QueryParam("attrs") List<String> attrs, @QueryParam("range") String range)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
-            NotConnectedException, MalformedObjectNameException, NullPointerException, MBeanException {
+            NotConnectedException, MalformedObjectNameException, NullPointerException, MBeanException,
+            PermissionRestException {
 
         // checking that still connected to the RM
         RMProxyUserInterface rmProxy = checkAccess(sessionId);
-        return rmProxy.getNodeMBeansHistory(nodeJmxUrl, objectNames, attrs, range);
+        return orThrowRPE(rmProxy.getNodeMBeansHistory(nodeJmxUrl, objectNames, attrs, range));
     }
 
     @Override
@@ -670,18 +675,20 @@ public class RMRest implements RMRestInterface {
     @Path("shutdown")
     @Produces("application/json")
     public boolean shutdown(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("preempt") @DefaultValue("false") boolean preempt) throws NotConnectedException {
+            @QueryParam("preempt") @DefaultValue("false") boolean preempt)
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.shutdown(preempt).getBooleanValue();
+        return orThrowRPE(rm.shutdown(preempt)).getBooleanValue();
     }
 
     @Override
     @GET
     @Path("topology")
     @Produces("application/json")
-    public Topology getTopology(@HeaderParam("sessionid") String sessionId) throws NotConnectedException {
+    public Topology getTopology(@HeaderParam("sessionid") String sessionId)
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return PAFuture.getFutureValue(rm.getTopology());
+        return orThrowRPE(PAFuture.getFutureValue(rm.getTopology()));
     }
 
     @Override
@@ -692,33 +699,25 @@ public class RMRest implements RMRestInterface {
     public Collection<PluginDescriptor> getSupportedNodeSourceInfrastructures(
             @HeaderParam("sessionid") String sessionId) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        Collection<PluginDescriptor> result;
-        try {
-            result = rm.getSupportedNodeSourceInfrastructures();
-            PAFuture.getFutureValue(result);
-        } catch (SecurityException e) {
-            throw new PermissionRestException(e);
-        }
-        return result;
+        return orThrowRPE(rm.getSupportedNodeSourceInfrastructures());
     }
 
     @Override
     public Map<String, List<String>> getInfrasToPoliciesMapping(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedException {
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
 
-        Collection<PluginDescriptor> supportedInfrastructures = rm.getSupportedNodeSourceInfrastructures();
+        Collection<PluginDescriptor> supportedInfrastructures = orThrowRPE(rm.getSupportedNodeSourceInfrastructures());
 
-        Collection<PluginDescriptor> supportedPolicies = rm.getSupportedNodeSourcePolicies();
+        Collection<PluginDescriptor> supportedPolicies = orThrowRPE(rm.getSupportedNodeSourcePolicies());
 
-        Map<String, List<String>> result = rm.getInfrasToPoliciesMapping().entrySet().stream().filter(entry -> {
-            for (PluginDescriptor supportedInfrastructure : supportedInfrastructures) {
-                if (supportedInfrastructure.getPluginName().equals(entry.getKey())) {
-                    return true;
-                }
-            }
-            return false;
-        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, List<String>> result = orThrowRPE(rm.getInfrasToPoliciesMapping()).entrySet()
+                                                                                      .stream()
+                                                                                      .filter(entry -> supportedInfrastructures.stream()
+                                                                                                                               .anyMatch(infra -> infra.getPluginName()
+                                                                                                                                                       .equals(entry.getKey())))
+                                                                                      .collect(Collectors.toMap(Map.Entry::getKey,
+                                                                                                                Map.Entry::getValue));
 
         return result.entrySet().stream().map(entry -> {
             List<String> policies = entry.getValue()
@@ -730,24 +729,15 @@ public class RMRest implements RMRestInterface {
         }).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
     }
 
-    private boolean containsPlugin(String pluginName, Collection<PluginDescriptor> plugins) {
-        for (PluginDescriptor supportedPolicy : plugins) {
-            if (supportedPolicy.getPluginName().equals(pluginName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     @Override
     @GET
     @GZIP
     @Path("policies")
     @Produces("application/json")
     public Collection<PluginDescriptor> getSupportedNodeSourcePolicies(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedException {
+            throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.getSupportedNodeSourcePolicies();
+        return orThrowRPE(rm.getSupportedNodeSourcePolicies());
     }
 
     @Override
@@ -756,9 +746,9 @@ public class RMRest implements RMRestInterface {
     @Path("nodesource/configuration")
     @Produces("application/json")
     public NodeSourceConfiguration getNodeSourceConfiguration(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("nodeSourceName") String nodeSourceName) throws NotConnectedException {
+            @QueryParam("nodeSourceName") String nodeSourceName) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return rm.getNodeSourceConfiguration(nodeSourceName);
+        return orThrowRPE(rm.getNodeSourceConfiguration(nodeSourceName));
     }
 
     @Override
@@ -768,16 +758,16 @@ public class RMRest implements RMRestInterface {
     @Produces("application/json")
     public Object getMBeanInfo(@HeaderParam("sessionid") String sessionId, @PathParam("name") ObjectName name,
             @QueryParam("attr") List<String> attrs) throws InstanceNotFoundException, IntrospectionException,
-            ReflectionException, IOException, NotConnectedException {
+            ReflectionException, IOException, NotConnectedException, PermissionRestException {
         RMProxyUserInterface rm = checkAccess(sessionId);
 
         if ((attrs == null) || (attrs.size() == 0)) {
             // no attribute is requested, we return
             // the description of the mbean
-            return rm.getMBeanInfo(name);
+            return orThrowRPE(rm.getMBeanInfo(name));
 
         } else {
-            return rm.getMBeanAttributes(name, attrs.toArray(new String[attrs.size()]));
+            return orThrowRPE(rm.getMBeanAttributes(name, attrs.toArray(new String[attrs.size()])));
         }
     }
 
@@ -829,8 +819,9 @@ public class RMRest implements RMRestInterface {
     @GET
     @Path("version")
     public String getVersion() {
-        return "{ " + "\"rm\" : \"" + RMRest.class.getPackage().getSpecificationVersion() + "\", " + "\"rest\" : \"" +
-               RMRest.class.getPackage().getImplementationVersion() + "\"" + "}";
+        return String.format("{ \"rm\" : \"%s\", \"rest\" : \"%s\"}",
+                             RMRest.class.getPackage().getSpecificationVersion(),
+                             RMRest.class.getPackage().getImplementationVersion());
     }
 
     @Override
@@ -844,10 +835,10 @@ public class RMRest implements RMRestInterface {
 
         RMProxyUserInterface rm = checkAccess(sessionId);
 
-        List<ScriptResult<Object>> results = rm.executeScript(script,
-                                                              scriptEngine,
-                                                              TargetType.NODE_URL.name(),
-                                                              Collections.singleton(nodeUrl));
+        List<ScriptResult<Object>> results = orThrowRPE(rm.executeScript(script,
+                                                                         scriptEngine,
+                                                                         TargetType.NODE_URL.name(),
+                                                                         Collections.singleton(nodeUrl)));
         checkEmptyScriptResults(results);
 
         return results.get(0);
@@ -863,10 +854,10 @@ public class RMRest implements RMRestInterface {
             @FormParam("scriptEngine") String scriptEngine) throws Throwable {
         RMProxyUserInterface rm = checkAccess(sessionId);
 
-        List<ScriptResult<Object>> results = rm.executeScript(script,
-                                                              scriptEngine,
-                                                              TargetType.NODESOURCE_NAME.name(),
-                                                              Collections.singleton(nodeSource));
+        List<ScriptResult<Object>> results = orThrowRPE(rm.executeScript(script,
+                                                                         scriptEngine,
+                                                                         TargetType.NODESOURCE_NAME.name(),
+                                                                         Collections.singleton(nodeSource)));
 
         List<ScriptResult<Object>> awaitedResults = results.stream()
                                                            .map(PAFuture::getFutureValue)
@@ -888,10 +879,10 @@ public class RMRest implements RMRestInterface {
 
         RMProxyUserInterface rm = checkAccess(sessionId);
 
-        List<ScriptResult<Object>> results = rm.executeScript(script,
-                                                              scriptEngine,
-                                                              TargetType.HOSTNAME.name(),
-                                                              Collections.singleton(hostname));
+        List<ScriptResult<Object>> results = orThrowRPE(rm.executeScript(script,
+                                                                         scriptEngine,
+                                                                         TargetType.HOSTNAME.name(),
+                                                                         Collections.singleton(hostname)));
         checkEmptyScriptResults(results);
 
         return results.get(0);
@@ -918,7 +909,7 @@ public class RMRest implements RMRestInterface {
         RMProxyUserInterface rm = checkAccess(sessionId);
         String threadDump;
         try {
-            threadDump = rm.getRMThreadDump().getStringValue();
+            threadDump = orThrowRPE(rm.getRMThreadDump().getStringValue());
         } catch (Exception exception) {
             return exception.getMessage();
         }
@@ -935,7 +926,7 @@ public class RMRest implements RMRestInterface {
         RMProxyUserInterface rm = checkAccess(sessionId);
         String threadDump;
         try {
-            threadDump = rm.getNodeThreadDump(nodeUrl).getStringValue();
+            threadDump = orThrowRPE(rm.getNodeThreadDump(nodeUrl).getStringValue());
         } catch (Exception exception) {
             return exception.getMessage();
         }
@@ -1106,4 +1097,23 @@ public class RMRest implements RMRestInterface {
         }
         return mapper.readValue(jsonString, Map.class);
     }
+
+    private boolean containsPlugin(String pluginName, Collection<PluginDescriptor> plugins) {
+        for (PluginDescriptor supportedPolicy : plugins) {
+            if (supportedPolicy.getPluginName().equals(pluginName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private <T> T orThrowRPE(T future) throws PermissionRestException {
+        try {
+            PAFuture.getFutureValue(future);
+            return future;
+        } catch (SecurityException e) {
+            throw new PermissionRestException(e);
+        }
+    }
+
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -137,9 +137,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("login")
-    @Produces("application/json")
     public String rmConnect(@FormParam("username") String username, @FormParam("password") String password)
             throws KeyException, LoginException, RMException, ActiveObjectCreationException, NodeException {
 
@@ -150,9 +147,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("disconnect")
-    @Produces("application/json")
     public void rmDisconnect(@HeaderParam("sessionid") String sessionId) throws NotConnectedException {
         RMProxyUserInterface rm = checkAccess(sessionId);
         rm.disconnect();
@@ -166,10 +160,6 @@ public class RMRest implements RMRestInterface {
      * proactive_grid_cloud_portal.LoginForm)
      */
     @Override
-    @POST
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @Path("login")
-    @Produces("application/json")
     public String loginWithCredential(@MultipartForm LoginForm multipart) throws ActiveObjectCreationException,
             NodeException, KeyException, IOException, LoginException, RMException {
 
@@ -203,9 +193,6 @@ public class RMRest implements RMRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @GET
-    @Path("logins/sessionid/{sessionId}/userdata")
-    @Produces("application/json")
     public UserData getUserDataFromSessionId(@PathParam("sessionId") String sessionId) {
         if (sessionId != null && sessionStore.exists(sessionId)) {
             try {
@@ -220,19 +207,12 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @Path("state")
-    @Produces("application/json")
     public RMState getState(@HeaderParam("sessionid") String sessionId) throws NotConnectedException {
         ResourceManager rm = checkAccess(sessionId);
         return PAFuture.getFutureValue(rm.getState());
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("monitoring")
-    @Produces("application/json")
     public RMStateDelta getRMStateDelta(@HeaderParam("sessionid") String sessionId,
             @HeaderParam("clientCounter") @DefaultValue("-1") String clientCounter)
             throws NotConnectedException, PermissionRestException {
@@ -242,10 +222,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("monitoring/full")
-    @Produces("application/json")
     public RMStateFull getRMStateFull(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedException, PermissionRestException {
         checkAccess(sessionId);
@@ -253,18 +229,12 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @Path("isactive")
-    @Produces("application/json")
     public boolean isActive(@HeaderParam("sessionid") String sessionId) throws NotConnectedException {
         ResourceManager rm = checkAccess(sessionId);
         return rm.isActive().getBooleanValue();
     }
 
     @Override
-    @POST
-    @Path("node")
-    @Produces("application/json")
     public boolean addNode(@HeaderParam("sessionid") String sessionId, @FormParam("nodeurl") String url,
             @FormParam("nodesource") String nodesource) throws NotConnectedException {
         ResourceManager rm = checkAccess(sessionId);
@@ -276,9 +246,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @Path("node/isavailable")
-    @Produces("application/json")
     public boolean nodeIsAvailable(@HeaderParam("sessionid") String sessionId, @QueryParam("nodeurl") String url)
             throws NotConnectedException {
         ResourceManager rm = checkAccess(sessionId);
@@ -286,10 +253,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("nodesource")
-    @Produces("application/json")
     public List<RMNodeSourceEvent> getExistingNodeSources(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -297,9 +260,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("nodesource")
-    @Produces("application/json")
     public NSState defineNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName,
             @FormParam("infrastructureType") String infrastructureType,
@@ -335,9 +295,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @PUT
-    @Path("nodesource/edit")
-    @Produces("application/json")
     public NSState editNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName,
             @FormParam("infrastructureType") String infrastructureType,
@@ -373,9 +330,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @PUT
-    @Path("nodesource/parameter")
-    @Produces("application/json")
     public NSState updateDynamicParameters(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName,
             @FormParam("infrastructureType") String infrastructureType,
@@ -413,9 +367,6 @@ public class RMRest implements RMRestInterface {
 
     @Deprecated
     @Override
-    @POST
-    @Path("nodesource/create")
-    @Produces("application/json")
     public NSState createNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName,
             @FormParam("infrastructureType") String infrastructureType,
@@ -437,9 +388,6 @@ public class RMRest implements RMRestInterface {
 
     @Deprecated
     @Override
-    @POST
-    @Path("nodesource/create/recovery")
-    @Produces("application/json")
     public NSState createNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName,
             @FormParam("infrastructureType") String infrastructureType,
@@ -489,9 +437,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @PUT
-    @Path("nodesource/deploy")
-    @Produces("application/json")
     public NSState deployNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -507,9 +452,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @PUT
-    @Path("nodesource/undeploy")
-    @Produces("application/json")
     public NSState undeployNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName, @FormParam("preempt") boolean preempt)
             throws NotConnectedException, PermissionRestException {
@@ -526,9 +468,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("nodesource/pingfrequency")
-    @Produces("application/json")
     public int getNodeSourcePingFrequency(@HeaderParam("sessionid") String sessionId,
             @FormParam("sourcename") String sourceName) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -536,9 +475,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("node/release")
-    @Produces("application/json")
     public boolean releaseNode(@HeaderParam("sessionid") String sessionId, @FormParam("url") String url)
             throws NodeException, NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -548,9 +484,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("node/remove")
-    @Produces("application/json")
     public boolean removeNode(@HeaderParam("sessionid") String sessionId, @FormParam("url") String nodeUrl,
             @FormParam("preempt") boolean preempt) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -558,9 +491,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("nodesource/remove")
-    @Produces("application/json")
     public boolean removeNodeSource(@HeaderParam("sessionid") String sessionId, @FormParam("name") String sourceName,
             @FormParam("preempt") boolean preempt) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -568,9 +498,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("node/lock")
-    @Produces("application/json")
     public boolean lockNodes(@HeaderParam("sessionid") String sessionId, @FormParam("nodeurls") Set<String> nodeUrls)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -578,9 +505,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @Path("node/unlock")
-    @Produces("application/json")
     public boolean unlockNodes(@HeaderParam("sessionid") String sessionId, @FormParam("nodeurls") Set<String> nodeUrls)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -588,10 +512,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Produces("application/json")
-    @Path("node/mbean")
     public Object getNodeMBeanInfo(@HeaderParam("sessionid") String sessionId,
             @QueryParam("nodejmxurl") String nodeJmxUrl, @QueryParam("objectname") String objectName,
             @QueryParam("attrs") List<String> attrs)
@@ -604,10 +524,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Produces("application/json")
-    @Path("node/mbean/history")
     public String getNodeMBeanHistory(@HeaderParam("sessionid") String sessionId,
             @QueryParam("nodejmxurl") String nodeJmxUrl, @QueryParam("objectname") String objectName,
             @QueryParam("attrs") List<String> attrs, @QueryParam("range") String range)
@@ -638,10 +554,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Produces("application/json")
-    @Path("node/mbeans")
     public Object getNodeMBeansInfo(@HeaderParam("sessionid") String sessionId,
             @QueryParam("nodejmxurl") String nodeJmxUrl, @QueryParam("objectname") String objectNames,
             @QueryParam("attrs") List<String> attrs)
@@ -654,10 +566,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Produces("application/json")
-    @Path("node/mbeans/history")
     public Object getNodeMBeansHistory(@HeaderParam("sessionid") String sessionId,
             @QueryParam("nodejmxurl") String nodeJmxUrl, @QueryParam("objectname") String objectNames,
             @QueryParam("attrs") List<String> attrs, @QueryParam("range") String range)
@@ -671,9 +579,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @Path("shutdown")
-    @Produces("application/json")
     public boolean shutdown(@HeaderParam("sessionid") String sessionId,
             @QueryParam("preempt") @DefaultValue("false") boolean preempt)
             throws NotConnectedException, PermissionRestException {
@@ -682,9 +587,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @Path("topology")
-    @Produces("application/json")
     public Topology getTopology(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -692,10 +594,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("infrastructures")
-    @Produces("application/json")
     public Collection<PluginDescriptor> getSupportedNodeSourceInfrastructures(
             @HeaderParam("sessionid") String sessionId) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -730,10 +628,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("policies")
-    @Produces("application/json")
     public Collection<PluginDescriptor> getSupportedNodeSourcePolicies(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -741,10 +635,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("nodesource/configuration")
-    @Produces("application/json")
     public NodeSourceConfiguration getNodeSourceConfiguration(@HeaderParam("sessionid") String sessionId,
             @QueryParam("nodeSourceName") String nodeSourceName) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
@@ -752,10 +642,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("info/{name}")
-    @Produces("application/json")
     public Object getMBeanInfo(@HeaderParam("sessionid") String sessionId, @PathParam("name") ObjectName name,
             @QueryParam("attr") List<String> attrs) throws InstanceNotFoundException, IntrospectionException,
             ReflectionException, IOException, NotConnectedException, PermissionRestException {
@@ -772,10 +658,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @GZIP
-    @Path("info/{name}")
-    @Produces("application/json")
     public void setMBeanInfo(@HeaderParam("sessionid") String sessionId, @PathParam("name") ObjectName name,
             @QueryParam("type") String type, @QueryParam("attr") String attr, @QueryParam("value") String value)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
@@ -788,10 +670,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("stathistory")
-    @Produces("application/json")
     public String getStatHistory(@HeaderParam("sessionid") String sessionId, @QueryParam("range") String range1)
             throws ReflectionException, InterruptedException, IntrospectionException, NotConnectedException,
             InstanceNotFoundException, MalformedObjectNameException, IOException {
@@ -816,8 +694,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @Path("version")
     public String getVersion() {
         return String.format("{ \"rm\" : \"%s\", \"rest\" : \"%s\"}",
                              RMRest.class.getPackage().getSpecificationVersion(),
@@ -825,10 +701,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @GZIP
-    @Path("node/script")
-    @Produces("application/json")
     public ScriptResult<Object> executeNodeScript(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeurl") String nodeUrl, @FormParam("script") String script,
             @FormParam("scriptEngine") String scriptEngine) throws Throwable {
@@ -845,10 +717,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @GZIP
-    @Path("nodesource/script")
-    @Produces("application/json")
     public List<ScriptResult<Object>> executeNodeSourceScript(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodesource") String nodeSource, @FormParam("script") String script,
             @FormParam("scriptEngine") String scriptEngine) throws Throwable {
@@ -869,10 +737,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @POST
-    @GZIP
-    @Path("host/script")
-    @Produces("application/json")
     public ScriptResult<Object> executeHostScript(@HeaderParam("sessionid") String sessionId,
             @FormParam("host") String hostname, @FormParam("script") String script,
             @FormParam("scriptEngine") String scriptEngine) throws Throwable {
@@ -901,10 +765,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("threaddump")
-    @Produces("application/json")
     public String getRMThreadDump(@HeaderParam("sessionid") String sessionId) throws NotConnectedException {
         RMProxyUserInterface rm = checkAccess(sessionId);
         String threadDump;
@@ -917,10 +777,6 @@ public class RMRest implements RMRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("node/threaddump")
-    @Produces("application/json")
     public String getNodeThreadDump(@HeaderParam("sessionid") String sessionId, @QueryParam("nodeurl") String nodeUrl)
             throws NotConnectedException {
         RMProxyUserInterface rm = checkAccess(sessionId);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -202,13 +202,13 @@ public class RMRest implements RMRestInterface {
             throws NotConnectedException, PermissionRestException {
         checkAccess(sessionId);
         long counter = Integer.valueOf(clientCounter);
-        return orThrowRPE(RMStateCaching.getRMStateDelta(counter));
+        return orThrowRpe(RMStateCaching.getRMStateDelta(counter));
     }
 
     @Override
     public RMStateFull getRMStateFull(String sessionId) throws NotConnectedException, PermissionRestException {
         checkAccess(sessionId);
-        return orThrowRPE(RMStateCaching.getRMStateFull());
+        return orThrowRpe(RMStateCaching.getRMStateFull());
     }
 
     @Override
@@ -237,7 +237,7 @@ public class RMRest implements RMRestInterface {
     public List<RMNodeSourceEvent> getExistingNodeSources(String sessionId)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.getExistingNodeSourcesList());
+        return orThrowRpe(rm.getExistingNodeSourcesList());
     }
 
     @Override
@@ -339,7 +339,7 @@ public class RMRest implements RMRestInterface {
             String[] infrastructureParameters, String[] infrastructureFileParameters, String policyType,
             String[] policyParameters, String[] policyFileParameters)
             throws NotConnectedException, PermissionRestException {
-        return orThrowRPE(createNodeSource(sessionId,
+        return orThrowRpe(createNodeSource(sessionId,
                                            nodeSourceName,
                                            infrastructureType,
                                            infrastructureParameters,
@@ -430,7 +430,7 @@ public class RMRest implements RMRestInterface {
     public int getNodeSourcePingFrequency(String sessionId, String sourceName)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.getNodeSourcePingFrequency(sourceName).getIntValue());
+        return orThrowRpe(rm.getNodeSourcePingFrequency(sourceName).getIntValue());
     }
 
     @Override
@@ -439,35 +439,35 @@ public class RMRest implements RMRestInterface {
         ResourceManager rm = checkAccess(sessionId);
         Node n;
         n = NodeFactory.getNode(url);
-        return orThrowRPE(rm.releaseNode(n).getBooleanValue());
+        return orThrowRpe(rm.releaseNode(n).getBooleanValue());
     }
 
     @Override
     public boolean removeNode(String sessionId, String nodeUrl, boolean preempt)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.removeNode(nodeUrl, preempt).getBooleanValue());
+        return orThrowRpe(rm.removeNode(nodeUrl, preempt).getBooleanValue());
     }
 
     @Override
     public boolean removeNodeSource(String sessionId, String sourceName, boolean preempt)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.removeNodeSource(sourceName, preempt).getBooleanValue());
+        return orThrowRpe(rm.removeNodeSource(sourceName, preempt).getBooleanValue());
     }
 
     @Override
     public boolean lockNodes(String sessionId, Set<String> nodeUrls)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.lockNodes(nodeUrls).getBooleanValue());
+        return orThrowRpe(rm.lockNodes(nodeUrls).getBooleanValue());
     }
 
     @Override
     public boolean unlockNodes(String sessionId, Set<String> nodeUrls)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.unlockNodes(nodeUrls).getBooleanValue());
+        return orThrowRpe(rm.unlockNodes(nodeUrls).getBooleanValue());
     }
 
     @Override
@@ -477,7 +477,7 @@ public class RMRest implements RMRestInterface {
 
         // checking that still connected to the RM
         RMProxyUserInterface rmProxy = checkAccess(sessionId);
-        return orThrowRPE(rmProxy.getNodeMBeanInfo(nodeJmxUrl, objectName, attrs));
+        return orThrowRpe(rmProxy.getNodeMBeanInfo(nodeJmxUrl, objectName, attrs));
     }
 
     @Override
@@ -514,7 +514,7 @@ public class RMRest implements RMRestInterface {
 
         // checking that still connected to the RM
         RMProxyUserInterface rmProxy = checkAccess(sessionId);
-        return orThrowRPE(rmProxy.getNodeMBeansInfo(nodeJmxUrl, objectNames, attrs));
+        return orThrowRpe(rmProxy.getNodeMBeansInfo(nodeJmxUrl, objectNames, attrs));
     }
 
     @Override
@@ -525,26 +525,26 @@ public class RMRest implements RMRestInterface {
 
         // checking that still connected to the RM
         RMProxyUserInterface rmProxy = checkAccess(sessionId);
-        return orThrowRPE(rmProxy.getNodeMBeansHistory(nodeJmxUrl, objectNames, attrs, range));
+        return orThrowRpe(rmProxy.getNodeMBeansHistory(nodeJmxUrl, objectNames, attrs, range));
     }
 
     @Override
     public boolean shutdown(String sessionId, boolean preempt) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.shutdown(preempt)).getBooleanValue();
+        return orThrowRpe(rm.shutdown(preempt)).getBooleanValue();
     }
 
     @Override
     public Topology getTopology(String sessionId) throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(PAFuture.getFutureValue(rm.getTopology()));
+        return orThrowRpe(PAFuture.getFutureValue(rm.getTopology()));
     }
 
     @Override
     public Collection<PluginDescriptor> getSupportedNodeSourceInfrastructures(String sessionId)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.getSupportedNodeSourceInfrastructures());
+        return orThrowRpe(rm.getSupportedNodeSourceInfrastructures());
     }
 
     @Override
@@ -552,11 +552,11 @@ public class RMRest implements RMRestInterface {
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
 
-        Collection<PluginDescriptor> supportedInfrastructures = orThrowRPE(rm.getSupportedNodeSourceInfrastructures());
+        Collection<PluginDescriptor> supportedInfrastructures = orThrowRpe(rm.getSupportedNodeSourceInfrastructures());
 
-        Collection<PluginDescriptor> supportedPolicies = orThrowRPE(rm.getSupportedNodeSourcePolicies());
+        Collection<PluginDescriptor> supportedPolicies = orThrowRpe(rm.getSupportedNodeSourcePolicies());
 
-        Map<String, List<String>> result = orThrowRPE(rm.getInfrasToPoliciesMapping()).entrySet()
+        Map<String, List<String>> result = orThrowRpe(rm.getInfrasToPoliciesMapping()).entrySet()
                                                                                       .stream()
                                                                                       .filter(entry -> supportedInfrastructures.stream()
                                                                                                                                .anyMatch(infra -> infra.getPluginName()
@@ -578,14 +578,14 @@ public class RMRest implements RMRestInterface {
     public Collection<PluginDescriptor> getSupportedNodeSourcePolicies(String sessionId)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.getSupportedNodeSourcePolicies());
+        return orThrowRpe(rm.getSupportedNodeSourcePolicies());
     }
 
     @Override
     public NodeSourceConfiguration getNodeSourceConfiguration(String sessionId, String nodeSourceName)
             throws NotConnectedException, PermissionRestException {
         ResourceManager rm = checkAccess(sessionId);
-        return orThrowRPE(rm.getNodeSourceConfiguration(nodeSourceName));
+        return orThrowRpe(rm.getNodeSourceConfiguration(nodeSourceName));
     }
 
     @Override
@@ -596,10 +596,10 @@ public class RMRest implements RMRestInterface {
         if ((attrs == null) || (attrs.size() == 0)) {
             // no attribute is requested, we return
             // the description of the mbean
-            return orThrowRPE(rm.getMBeanInfo(name));
+            return orThrowRpe(rm.getMBeanInfo(name));
 
         } else {
-            return orThrowRPE(rm.getMBeanAttributes(name, attrs.toArray(new String[attrs.size()])));
+            return orThrowRpe(rm.getMBeanAttributes(name, attrs.toArray(new String[attrs.size()])));
         }
     }
 
@@ -651,7 +651,7 @@ public class RMRest implements RMRestInterface {
 
         RMProxyUserInterface rm = checkAccess(sessionId);
 
-        List<ScriptResult<Object>> results = orThrowRPE(rm.executeScript(script,
+        List<ScriptResult<Object>> results = orThrowRpe(rm.executeScript(script,
                                                                          scriptEngine,
                                                                          TargetType.NODE_URL.name(),
                                                                          Collections.singleton(nodeUrl)));
@@ -665,7 +665,7 @@ public class RMRest implements RMRestInterface {
             String scriptEngine) throws Throwable {
         RMProxyUserInterface rm = checkAccess(sessionId);
 
-        List<ScriptResult<Object>> results = orThrowRPE(rm.executeScript(script,
+        List<ScriptResult<Object>> results = orThrowRpe(rm.executeScript(script,
                                                                          scriptEngine,
                                                                          TargetType.NODESOURCE_NAME.name(),
                                                                          Collections.singleton(nodeSource)));
@@ -685,7 +685,7 @@ public class RMRest implements RMRestInterface {
 
         RMProxyUserInterface rm = checkAccess(sessionId);
 
-        List<ScriptResult<Object>> results = orThrowRPE(rm.executeScript(script,
+        List<ScriptResult<Object>> results = orThrowRpe(rm.executeScript(script,
                                                                          scriptEngine,
                                                                          TargetType.HOSTNAME.name(),
                                                                          Collections.singleton(hostname)));
@@ -711,7 +711,7 @@ public class RMRest implements RMRestInterface {
         RMProxyUserInterface rm = checkAccess(sessionId);
         String threadDump;
         try {
-            threadDump = orThrowRPE(rm.getRMThreadDump().getStringValue());
+            threadDump = orThrowRpe(rm.getRMThreadDump().getStringValue());
         } catch (Exception exception) {
             return exception.getMessage();
         }
@@ -723,7 +723,7 @@ public class RMRest implements RMRestInterface {
         RMProxyUserInterface rm = checkAccess(sessionId);
         String threadDump;
         try {
-            threadDump = orThrowRPE(rm.getNodeThreadDump(nodeUrl).getStringValue());
+            threadDump = orThrowRpe(rm.getNodeThreadDump(nodeUrl).getStringValue());
         } catch (Exception exception) {
             return exception.getMessage();
         }
@@ -904,7 +904,7 @@ public class RMRest implements RMRestInterface {
         return false;
     }
 
-    private <T> T orThrowRPE(T future) throws PermissionRestException {
+    private <T> T orThrowRpe(T future) throws PermissionRestException {
         try {
             PAFuture.getFutureValue(future);
             return future;

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
@@ -160,7 +160,8 @@ public interface RMRestInterface {
     @Path("monitoring")
     @Produces("application/json")
     RMStateDelta getRMStateDelta(@HeaderParam("sessionid") String sessionId,
-            @HeaderParam("clientCounter") @DefaultValue("-1") String clientCounter) throws NotConnectedException;
+            @HeaderParam("clientCounter") @DefaultValue("-1") String clientCounter)
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * Returns the full state of the RM, which does not include REMOVED node/nodesources
@@ -171,7 +172,8 @@ public interface RMRestInterface {
     @GZIP
     @Path("monitoring/full")
     @Produces("application/json")
-    RMStateFull getRMStateFull(@HeaderParam("sessionid") String sessionId) throws NotConnectedException;
+    RMStateFull getRMStateFull(@HeaderParam("sessionid") String sessionId)
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * Returns true if the resource manager is operational.
@@ -228,7 +230,7 @@ public interface RMRestInterface {
     @Path("nodesource")
     @Produces("application/json")
     List<RMNodeSourceEvent> getExistingNodeSources(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedException;
+            throws NotConnectedException, PermissionRestException;
 
     @POST
     @Path("nodesource")
@@ -263,7 +265,8 @@ public interface RMRestInterface {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
-            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException;
+            @FormParam("policyFileParameters") String[] policyFileParameters)
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * @deprecated  As of version 8.1, replaced by {@link #defineNodeSource(String, String, String, String[], String[],
@@ -279,7 +282,8 @@ public interface RMRestInterface {
             @FormParam("infrastructureParameters") String[] infrastructureParameters,
             @FormParam("infrastructureFileParameters") String[] infrastructureFileParameters,
             @FormParam("policyType") String policyType, @FormParam("policyParameters") String[] policyParameters,
-            @FormParam("policyFileParameters") String[] policyFileParameters) throws NotConnectedException;
+            @FormParam("policyFileParameters") String[] policyFileParameters)
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * @deprecated  As of version 8.1, replaced by {@link #defineNodeSource(String, String,String, String[], String[],
@@ -334,7 +338,7 @@ public interface RMRestInterface {
     @Path("nodesource/deploy")
     @Produces("application/json")
     NSState deployNodeSource(@HeaderParam("sessionid") String sessionId,
-            @FormParam("nodeSourceName") String nodeSourceName) throws NotConnectedException;
+            @FormParam("nodeSourceName") String nodeSourceName) throws NotConnectedException, PermissionRestException;
 
     /**
      * Remove the nodes of the node source and keep the node source undeployed
@@ -348,7 +352,7 @@ public interface RMRestInterface {
     @Produces("application/json")
     NSState undeployNodeSource(@HeaderParam("sessionid") String sessionId,
             @FormParam("nodeSourceName") String nodeSourceName, @FormParam("preempt") boolean preempt)
-            throws NotConnectedException;
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * Returns the ping frequency of a node source
@@ -361,7 +365,7 @@ public interface RMRestInterface {
     @Path("nodesource/pingfrequency")
     @Produces("application/json")
     int getNodeSourcePingFrequency(@HeaderParam("sessionid") String sessionId,
-            @FormParam("sourcename") String sourceName) throws NotConnectedException;
+            @FormParam("sourcename") String sourceName) throws NotConnectedException, PermissionRestException;
 
     /**
      * Release a node
@@ -374,7 +378,7 @@ public interface RMRestInterface {
     @Path("node/release")
     @Produces("application/json")
     boolean releaseNode(@HeaderParam("sessionid") String sessionId, @FormParam("url") String url)
-            throws NodeException, NotConnectedException;
+            throws NodeException, NotConnectedException, PermissionRestException;
 
     /**
      * Delete a node
@@ -388,7 +392,7 @@ public interface RMRestInterface {
     @Path("node/remove")
     @Produces("application/json")
     boolean removeNode(@HeaderParam("sessionid") String sessionId, @FormParam("url") String nodeUrl,
-            @FormParam("preempt") boolean preempt) throws NotConnectedException;
+            @FormParam("preempt") boolean preempt) throws NotConnectedException, PermissionRestException;
 
     /**
      * Delete a nodesource
@@ -403,7 +407,7 @@ public interface RMRestInterface {
     @Path("nodesource/remove")
     @Produces("application/json")
     boolean removeNodeSource(@HeaderParam("sessionid") String sessionId, @FormParam("name") String sourceName,
-            @FormParam("preempt") boolean preempt) throws NotConnectedException;
+            @FormParam("preempt") boolean preempt) throws NotConnectedException, PermissionRestException;
 
     /**
      * prevent other users from using a set of locked nodes
@@ -419,7 +423,7 @@ public interface RMRestInterface {
     @Path("node/lock")
     @Produces("application/json")
     boolean lockNodes(@HeaderParam("sessionid") String sessionId, @FormParam("nodeurls") Set<String> nodeUrls)
-            throws NotConnectedException;
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * allow other users to use a set of previously locked nodes
@@ -435,7 +439,7 @@ public interface RMRestInterface {
     @Path("node/unlock")
     @Produces("application/json")
     boolean unlockNodes(@HeaderParam("sessionid") String sessionId, @FormParam("nodeurls") Set<String> nodeUrls)
-            throws NotConnectedException;
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * Retrieves attributes of the specified mbean.
@@ -454,7 +458,7 @@ public interface RMRestInterface {
     Object getNodeMBeanInfo(@HeaderParam("sessionid") String sessionId, @QueryParam("nodejmxurl") String nodeJmxUrl,
             @QueryParam("objectname") String objectName, @QueryParam("attrs") List<String> attrs)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
-            NotConnectedException, MalformedObjectNameException, NullPointerException;
+            NotConnectedException, MalformedObjectNameException, NullPointerException, PermissionRestException;
 
     /**
      * Return the statistic history contained in the node RRD database,
@@ -544,7 +548,7 @@ public interface RMRestInterface {
     Object getNodeMBeansInfo(@HeaderParam("sessionid") String sessionId, @QueryParam("nodejmxurl") String nodeJmxUrl,
             @QueryParam("objectname") String objectNames, @QueryParam("attrs") List<String> attrs)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
-            NotConnectedException, MalformedObjectNameException, NullPointerException;
+            NotConnectedException, MalformedObjectNameException, NullPointerException, PermissionRestException;
 
     @GET
     @GZIP
@@ -552,9 +556,9 @@ public interface RMRestInterface {
     @Path("node/mbeans/history")
     Object getNodeMBeansHistory(@HeaderParam("sessionid") String sessionId, @QueryParam("nodejmxurl") String nodeJmxUrl,
             @QueryParam("objectname") String objectNames, @QueryParam("attrs") List<String> attrs,
-            @QueryParam("range") String range)
-            throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
-            NotConnectedException, MalformedObjectNameException, NullPointerException, MBeanException;
+            @QueryParam("range") String range) throws InstanceNotFoundException, IntrospectionException,
+            ReflectionException, IOException, NotConnectedException, MalformedObjectNameException, NullPointerException,
+            MBeanException, PermissionRestException;
 
     /**
      * Initiate the shutdowns the resource manager. During the shutdown resource
@@ -570,12 +574,14 @@ public interface RMRestInterface {
     @Path("shutdown")
     @Produces("application/json")
     boolean shutdown(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("preempt") @DefaultValue("false") boolean preempt) throws NotConnectedException;
+            @QueryParam("preempt") @DefaultValue("false") boolean preempt)
+            throws NotConnectedException, PermissionRestException;
 
     @GET
     @Path("topology")
     @Produces("application/json")
-    Topology getTopology(@HeaderParam("sessionid") String sessionId) throws NotConnectedException;
+    Topology getTopology(@HeaderParam("sessionid") String sessionId)
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * Returns the list of supported node source infrastructures descriptors.
@@ -601,7 +607,7 @@ public interface RMRestInterface {
     @Path("infrastructures/mapping")
     @Produces("application/json")
     Map<String, List<String>> getInfrasToPoliciesMapping(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedException;
+            throws NotConnectedException, PermissionRestException;
 
     /**
      * Returns the list of supported node source policies descriptors.
@@ -615,14 +621,14 @@ public interface RMRestInterface {
     @Path("policies")
     @Produces("application/json")
     Collection<PluginDescriptor> getSupportedNodeSourcePolicies(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedException;
+            throws NotConnectedException, PermissionRestException;
 
     @GET
     @GZIP
     @Path("nodesource/configuration")
     @Produces("application/json")
     NodeSourceConfiguration getNodeSourceConfiguration(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("nodeSourceName") String nodeSourceName) throws NotConnectedException;
+            @QueryParam("nodeSourceName") String nodeSourceName) throws NotConnectedException, PermissionRestException;
 
     /**
      * Returns the attributes <code>attr</code> of the mbean
@@ -643,7 +649,7 @@ public interface RMRestInterface {
     @Produces("application/json")
     Object getMBeanInfo(@HeaderParam("sessionid") String sessionId, @PathParam("name") ObjectName name,
             @QueryParam("attr") List<String> attrs) throws InstanceNotFoundException, IntrospectionException,
-            ReflectionException, IOException, NotConnectedException;
+            ReflectionException, IOException, NotConnectedException, PermissionRestException;
 
     /**
      * Set a single JMX attribute of the MBean <code>name</code>.

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRestInterface.java
@@ -401,7 +401,6 @@ public interface RMRestInterface {
      * @param sourceName a node source
      * @param preempt if true remove node source immediatly whithout waiting for nodes to be freed
      * @return true if the node is removed successfully, false or exception otherwise
-     * @throws NotConnectedException
      */
     @POST
     @Path("nodesource/remove")
@@ -417,7 +416,6 @@ public interface RMRestInterface {
      * @param nodeUrls
      *            set of node urls to lock
      * @return true when all nodes were free and have been locked
-     * @throws NotConnectedException
      */
     @POST
     @Path("node/lock")
@@ -433,7 +431,6 @@ public interface RMRestInterface {
      * @param nodeUrls
      *            set of node urls to unlock
      * @return true when all nodes were locked and have been unlocked
-     * @throws NotConnectedException
      */
     @POST
     @Path("node/unlock")
@@ -483,7 +480,6 @@ public interface RMRestInterface {
      *            <li>'M' 1 month
      *            <li>'y' 1 year</ul>
      * @return a JSON object containing a key for each source
-     * @throws NotConnectedException
      */
     @GET
     @GZIP
@@ -519,7 +515,6 @@ public interface RMRestInterface {
      *            <li>'y' 1 year</ul>
      * @return a Map where each entry containse mbean server url as key and a map of statistic values as value. Each entry has an mbean attribute as key and
      * list of its mbean values as value.
-     * @throws NotConnectedException
      */
     @GET
     @GZIP
@@ -568,7 +563,6 @@ public interface RMRestInterface {
      * @param sessionId a valid session
      * @param preempt if true shutdown immediatly whithout waiting for nodes to be freed, default value is false
      * @return true if the shutdown process is successfully triggered, runtime exception otherwise
-     * @throws NotConnectedException
      */
     @GET
     @Path("shutdown")
@@ -588,7 +582,6 @@ public interface RMRestInterface {
      *
      * @param sessionId a valid session
      * @return the list of supported node source infrastructures descriptors
-     * @throws NotConnectedException
      */
     @GET
     @GZIP
@@ -614,7 +607,6 @@ public interface RMRestInterface {
      *
      * @param sessionId a valid session
      * @return the list of supported node source policies descriptors
-     * @throws NotConnectedException
      */
     @GET
     @GZIP
@@ -637,11 +629,6 @@ public interface RMRestInterface {
      * @param name mbean's object name
      * @param attrs attributes to enumerate
      * @return returns the attributes of the mbean
-     * @throws InstanceNotFoundException
-     * @throws IntrospectionException
-     * @throws ReflectionException
-     * @throws IOException
-     * @throws NotConnectedException
      */
     @GET
     @GZIP
@@ -660,15 +647,6 @@ public interface RMRestInterface {
      * @param type      the type of the attribute to set ('integer' and 'string' are currently supported, see <code>RMProxyUserInterface</code>)
      * @param attr      the name of the attribute to set
      * @param value     the new value of the attribute (defined as a String, it is automatically converted according to <code>type</code>)
-     * @throws InstanceNotFoundException
-     * @throws IntrospectionException
-     * @throws ReflectionException
-     * @throws IOException
-     * @throws NotConnectedException
-     * @throws MBeanException
-     * @throws AttributeNotFoundException
-     * @throws InvalidAttributeValueException
-     * @throws IllegalArgumentException
      */
     @POST
     @GZIP
@@ -712,14 +690,6 @@ public interface RMRestInterface {
      *            <li>'M' 1 month
      *            <li>'y' 1 year</ul>
      * @return a JSON object containing a key for each source
-     * @throws InstanceNotFoundException
-     * @throws IntrospectionException
-     * @throws ReflectionException
-     * @throws IOException
-     * @throws MalformedObjectNameException
-     * @throws NullPointerException
-     * @throws InterruptedException
-     * @throws NotConnectedException
      */
     @GET
     @GZIP

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -719,12 +719,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @GET
-    @Path("jobs/{jobid}/xml")
-    @Produces("application/xml")
-    public String getJobContent(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException,
-            SubmissionClosedRestException, JobCreationRestException {
+    public String getJobContent(String sessionId, String jobId) throws NotConnectedRestException,
+            UnknownJobRestException, PermissionRestException, SubmissionClosedRestException, JobCreationRestException {
         try {
             Scheduler scheduler = checkAccess(sessionId, "/scheduler/jobs/" + jobId + "/xml");
             return scheduler.getJobContent(JobIdImpl.makeJobId(jobId));
@@ -741,41 +737,14 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of taskState
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the job id
-     * @return a list of task' states of the job <code>jobId</code>
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/taskstates")
-    @Produces("application/json")
-    public RestPage<TaskStateData> getJobTaskStates(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId)
+    public RestPage<TaskStateData> getJobTaskStates(String sessionId, String jobId)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         return getJobTaskStatesPaginated(sessionId, jobId, 0, TASKS_PAGE_SIZE);
     }
 
-    /**
-     * Returns a list of taskState with pagination
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the job id
-     * @param offset    the index of the first TaskState to return
-     * @param limit     the index (non inclusive) of the last TaskState to return
-     * @return a list of task' states of the job <code>jobId</code>
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/taskstates/paginated")
-    @Produces("application/json")
-    public RestPage<TaskStateData> getJobTaskStatesPaginated(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("-1") int limit)
+    public RestPage<TaskStateData> getJobTaskStatesPaginated(String sessionId, String jobId, int offset, int limit)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         if (limit == -1)
             limit = TASKS_PAGE_SIZE;
@@ -813,22 +782,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of taskState of the tasks filtered by a given tag.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the job id
-     * @param taskTag   the tag used to filter the tasks
-     * @return a list of task' states of the job <code>jobId</code> filtered by
-     * a given tag.
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/taskstates/{tasktag}")
-    @Produces("application/json")
-    public RestPage<TaskStateData> getJobTaskStatesByTag(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag)
+    public RestPage<TaskStateData> getJobTaskStatesByTag(String sessionId, String jobId, String taskTag)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/taskstates/" + taskTag);
@@ -849,14 +804,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/taskstates/{tasktag}/paginated")
-    @Produces("application/json")
-    public RestPage<TaskStateData> getJobTaskStatesByTagPaginated(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag,
-            @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
+    public RestPage<TaskStateData> getJobTaskStatesByTagPaginated(String sessionId, String jobId, String taskTag,
+            int offset, int limit) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         if (limit == -1)
             limit = TASKS_PAGE_SIZE;
         try {
@@ -875,10 +824,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    public RestPage<TaskStateData> getJobTaskStatesByTagByStatusPaginated(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("50") int limit, @PathParam("tasktag") String taskTag,
-            @PathParam("statusFilter") String statusFilter)
+    public RestPage<TaskStateData> getJobTaskStatesByTagByStatusPaginated(String sessionId, String jobId, int offset,
+            int limit, String taskTag, String statusFilter)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         if (limit == -1)
             limit = TASKS_PAGE_SIZE;
@@ -898,13 +845,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/log/full")
-    @Produces("application/json")
-    public InputStream jobFullLogs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @QueryParam("sessionid") String session) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException, IOException {
+    public InputStream jobFullLogs(String sessionId, String jobId, String session)
+            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
 
         if (sessionId == null) {
             sessionId = session;
@@ -918,7 +860,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskState> tasks = jobState.getTasks();
             List<InputStream> streams = new ArrayList<>(tasks.size());
 
-            Collections.sort(tasks, TaskState.COMPARE_BY_FINISHED_TIME_ASC);
+            tasks.sort(TaskState.COMPARE_BY_FINISHED_TIME_ASC);
 
             for (TaskState taskState : tasks) {
 
@@ -968,23 +910,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                         new TaskLoggerRelativePathGenerator(taskId).getRelativePath());
     }
 
-    /**
-     * Return the task state of the task <code>taskname</code> of the job
-     * <code>jobId</code>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskname  the name of the task
-     * @return the task state of the task <code>taskname</code> of the job
-     * <code>jobId</code>
-     */
     @Override
-    @GET
-    @Path("jobs/{jobid}/tasks/{taskname}")
-    @Produces("application/json")
-    public TaskStateData jobTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            PermissionRestException, UnknownTaskRestException {
+    public TaskStateData jobTask(String sessionId, String jobId, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, PermissionRestException, UnknownTaskRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname);
 
@@ -1006,51 +934,15 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns the value of the task result of task <code>taskName</code> of the
-     * job <code>jobId</code> <strong>the result is deserialized before sending
-     * to the client, if the class is not found the content is replaced by the
-     * string 'Unknown value type' </strong>. To get the serialized form of a
-     * given result, one has to call the following restful service
-     * jobs/{jobid}/tasks/{taskname}/result/serializedvalue
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskname  the name of the task
-     * @return the value of the task result
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result/value")
-    @Produces("*/*")
-    public Serializable valueOfTaskResult(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws Throwable {
+    public Serializable valueOfTaskResult(String sessionId, String jobId, String taskname) throws Throwable {
         Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/result/value");
         TaskResult taskResult = s.getTaskResult(jobId, taskname);
         return getTaskResultValueAsStringOrExceptionStackTrace(taskResult);
     }
 
-    /**
-     * Returns the value of the task result for a set of tasks of the job
-     * <code>jobId</code> filtered by a given tag. <strong>the result is
-     * deserialized before sending to the client, if the class is not found the
-     * content is replaced by the string 'Unknown value type' </strong>. To get
-     * the serialized form of a given result, one has to call the following
-     * restful service jobs/{jobid}/tasks/tag/{tasktag}/result/serializedvalue
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskTag   the tag used to filter the tasks.
-     * @return the value of the task result
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/value")
-    @Produces("application/json")
-    public Map<String, String> valueOfTaskResultByTag(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag) throws Throwable {
+    public Map<String, String> valueOfTaskResultByTag(String sessionId, String jobId, String taskTag) throws Throwable {
         Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag/" + taskTag + "/result/value");
         List<TaskResult> taskResults = s.getTaskResultsByTag(jobId, taskTag);
         Map<String, String> result = new HashMap<>(taskResults.size());
@@ -1085,48 +977,17 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return value;
     }
 
-    /**
-     * Returns the metadata of the task result of task <code>taskName</code> of the
-     * job <code>jobId</code>.
-     * <p>
-     * Metadata is a map containing additional information associated with a result. For example a file name if the result represents a file.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskname  the name of the task
-     * @return the metadata of the task result
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result/metadata")
-    @Produces("*/*")
-    public Map<String, String> metadataOfTaskResult(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("taskname") String taskname) throws Throwable {
+    public Map<String, String> metadataOfTaskResult(String sessionId, String jobId, String taskname) throws Throwable {
         Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/result/value");
         TaskResult taskResult = s.getTaskResult(jobId, taskname);
         taskResult = PAFuture.getFutureValue(taskResult);
         return taskResult.getMetadata();
     }
 
-    /**
-     * Returns the metadata of the task result of task <code>taskName</code> of the
-     * job <code>jobId</code>filtered by a given tag.
-     * <p>
-     * Metadata is a map containing additional information associated with a result. For example a file name if the result represents a file.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskTag   the tag used to filter the tasks.
-     * @return a map containing for each task entry, the metadata of the task result
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/metadata")
-    @Produces("application/json")
-    public Map<String, Map<String, String>> metadataOfTaskResultByTag(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag) throws Throwable {
+    public Map<String, Map<String, String>> metadataOfTaskResultByTag(String sessionId, String jobId, String taskTag)
+            throws Throwable {
         Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag" + taskTag + "/result/serializedvalue");
         List<TaskResult> trs = s.getTaskResultsByTag(jobId, taskTag);
         Map<String, Map<String, String>> result = new HashMap<>(trs.size());
@@ -1156,11 +1017,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    // request:  http://localhost:8080/rest/scheduler/jobs/result/precious/metadata?jobsid=102&jobsid=152&jobsid=162
-    // response: {"102":["Groovy_Task"],"152":["Groovy_Task","Task3"]}
     @Override
-    public Map<Long, List<String>> getPreciousTaskNames(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("jobsid") List<String> jobsId) throws NotConnectedRestException, PermissionRestException {
+    public Map<Long, List<String>> getPreciousTaskNames(String sessionId, List<String> jobsId)
+            throws NotConnectedRestException, PermissionRestException {
         Map<Long, List<String>> result = new HashMap<>();
         try {
             Scheduler scheduler = checkAccess(sessionId, "metadataOfPreciousResults");
@@ -1172,47 +1031,17 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns the value of the task result of the task <code>taskName</code> of
-     * the job <code>jobId</code> This method returns the result as a byte array
-     * whatever the result is.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskname  the name of the task
-     * @return the value of the task result as a byte array.
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result/serializedvalue")
-    @Produces("*/*")
-    public byte[] serializedValueOfTaskResult(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("taskname") String taskname) throws Throwable {
+    public byte[] serializedValueOfTaskResult(String sessionId, String jobId, String taskname) throws Throwable {
         Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/result/serializedvalue");
         TaskResult tr = s.getTaskResult(jobId, taskname);
         tr = PAFuture.getFutureValue(tr);
         return tr.getSerializedValue();
     }
 
-    /**
-     * Returns the values of a set of tasks of the job <code>jobId</code>
-     * filtered by a given tag. This method returns the result as a byte array
-     * whatever the result is.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskTag   the tag used to filter the tasks.
-     * @return the values of the set of tasks result as a byte array, indexed by
-     * the readable name of the task.
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/serializedvalue")
-    @Produces("application/json")
-    public Map<String, byte[]> serializedValueOfTaskResultByTag(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag) throws Throwable {
+    public Map<String, byte[]> serializedValueOfTaskResultByTag(String sessionId, String jobId, String taskTag)
+            throws Throwable {
         Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag" + taskTag + "/result/serializedvalue");
         List<TaskResult> trs = s.getTaskResultsByTag(jobId, taskTag);
         Map<String, byte[]> result = new HashMap<>(trs.size());
@@ -1223,23 +1052,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return result;
     }
 
-    /**
-     * Returns the task result of the task <code>taskName</code> of the job
-     * <code>jobId</code>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskname  the name of the task
-     * @return the task result of the task <code>taskName</code>
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result")
-    @Produces("application/json")
-    public TaskResultData taskResult(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public TaskResultData taskResult(String sessionId, String jobId, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/result");
             TaskResult taskResult = s.getTaskResult(jobId, taskname);
@@ -1266,22 +1081,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return mapper.map(PAFuture.getFutureValue(taskResult), TaskResultData.class);
     }
 
-    /**
-     * Returns the task results of the set of task filtered by a given tag and
-     * owned by the job <code>jobId</code>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskTag   the tag used to filter the tasks.
-     * @return the task results of the set of tasks filtered by the given tag.
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/result")
-    @Produces("application/json")
-    public List<TaskResultData> taskResultByTag(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag)
+    public List<TaskResultData> taskResultByTag(String sessionId, String jobId, String taskTag)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskTag + "/result");
@@ -1303,13 +1104,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result/log/all")
-    @Produces("application/json")
-    public String taskLog(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public String taskLog(String sessionId, String jobId, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             return retrieveTaskLogsUsingDatabase(sessionId, jobId, taskname);
         } catch (PermissionException e) {
@@ -1325,7 +1121,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
     private String retrieveTaskLogsUsingDatabase(String sessionId, String jobId, String taskName)
             throws NotConnectedRestException, UnknownJobException, UnknownTaskException, NotConnectedException,
-            PermissionException, PermissionRestException {
+            PermissionException {
         Scheduler scheduler = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskName + "/result/log/all");
         StringBuilder allLogs = new StringBuilder();
         List<TaskResult> resultList = scheduler.getTaskResultAllIncarnations(jobId, taskName);
@@ -1339,12 +1135,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/log/all")
-    @Produces("application/json")
-    public String taskLogByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
+    public String taskLogByTag(String sessionId, String jobId, String taskTag)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag/" + taskTag + "/result/log/err");
@@ -1366,13 +1157,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/result/log/all")
-    @Produces("application/json")
-    public String jobLogs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, UnknownTaskRestException,
-            PermissionRestException {
+    public String jobLogs(String sessionId, String jobId)
+            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/result/log/all");
             JobResult jobResult = s.getJobResult(jobId);
@@ -1397,13 +1183,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result/log/err")
-    @Produces("application/json")
-    public String taskLogErr(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public String taskLogErr(String sessionId, String jobId, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/result/log/err");
             StringBuilder errLogs = new StringBuilder();
@@ -1427,12 +1208,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/log/err")
-    @Produces("application/json")
-    public String taskLogErrByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
+    public String taskLogErrByTag(String sessionId, String jobId, String taskTag)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag/" + taskTag + "/result/log/err");
@@ -1454,13 +1230,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result/log/out")
-    @Produces("application/json")
-    public String taskLogout(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public String taskLogout(String sessionId, String jobId, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/result/log/out");
             StringBuilder outLogs = new StringBuilder();
@@ -1484,12 +1255,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/result/log/out")
-    @Produces("application/json")
-    public String taskLogoutByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
+    public String taskLogoutByTag(String sessionId, String jobId, String taskTag)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag/" + taskTag + "/result/log/out");
@@ -1511,12 +1277,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/result/log/full")
-    @Produces("application/json")
-    public InputStream taskFullLogs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname, @QueryParam("sessionid") String session)
+    public InputStream taskFullLogs(String sessionId, String jobId, String taskname, String session)
             throws NotConnectedRestException, UnknownJobRestException, UnknownTaskRestException,
             PermissionRestException, IOException {
         try {
@@ -1560,22 +1321,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns task server logs
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskname  the name of the task
-     * @return task traces from the scheduler and resource manager
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/{taskname}/log/server")
-    @Produces("application/json")
-    public String taskServerLog(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public String taskServerLog(String sessionId, String jobId, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/log/server");
             return s.getTaskServerLogs(jobId, taskname);
@@ -1590,21 +1338,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns server logs for a set of tasks filtered by a given tag.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @param taskTag   the tag used to filter the tasks in the job.
-     * @return task traces from the scheduler and resource manager
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/log/server")
-    @Produces("application/json")
-    public String taskServerLogByTag(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId,
-            @PathParam("tasktag") String taskTag)
+    public String taskServerLogByTag(String sessionId, String jobId, String taskTag)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag/" + taskTag + "/log/server");
@@ -1663,20 +1398,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return checkAccess(sessionId, "");
     }
 
-    /**
-     * Pauses the job represented by jobid
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @return true if success, false if not
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/pause")
-    @Produces("application/json")
-    public boolean pauseJob(@HeaderParam("sessionid")
-    final String sessionId, @PathParam("jobid")
-    final String jobId) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
+    public boolean pauseJob(String sessionId, String jobId)
+            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             final Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/pause");
             return s.pauseJob(jobId);
@@ -1689,20 +1413,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Restart all tasks in error in the job represented by jobid
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @return true if success, false if not
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/restartAllInErrorTasks")
-    @Produces("application/json")
-    public boolean restartAllInErrorTasks(@HeaderParam("sessionid")
-    final String sessionId, @PathParam("jobid")
-    final String jobId) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
+    public boolean restartAllInErrorTasks(String sessionId, String jobId)
+            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/restartAllInErrorTasks");
             return s.restartAllInErrorTasks(jobId);
@@ -1715,20 +1428,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Resumes the job represented by jobid
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @return true if success, false if not
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/resume")
-    @Produces("application/json")
-    public boolean resumeJob(@HeaderParam("sessionid")
-    final String sessionId, @PathParam("jobid")
-    final String jobId) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
+    public boolean resumeJob(String sessionId, String jobId)
+            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/resume");
             return s.resumeJob(jobId);
@@ -1741,30 +1443,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Submit job using flat command file
-     *
-     * @param sessionId                valid session id
-     * @param commandFileContent       content of a command file: endline separated native commands
-     * @param jobName                  name of the job to create
-     * @param selectionScriptContent   content of a selection script, or null
-     * @param selectionScriptExtension extension of the selectionscript to determine script engine
-     *                                 ("js", "py", "rb")
-     * @return Id of the submitted job
-     * @throws NotConnectedRestException
-     * @throws IOException
-     * @throws JobCreationRestException
-     * @throws PermissionRestException
-     * @throws SubmissionClosedRestException
-     */
     @Override
-    @POST
-    @Path("submitflat")
-    @Produces("application/json")
-    public JobIdData submitFlat(@HeaderParam("sessionid") String sessionId,
-            @FormParam("commandFileContent") String commandFileContent, @FormParam("jobName") String jobName,
-            @FormParam("selectionScriptContent") String selectionScriptContent,
-            @FormParam("selectionScriptExtension") String selectionScriptExtension) throws NotConnectedRestException,
+    public JobIdData submitFlat(String sessionId, String commandFileContent, String jobName,
+            String selectionScriptContent, String selectionScriptExtension) throws NotConnectedRestException,
             IOException, JobCreationRestException, PermissionRestException, SubmissionClosedRestException {
         Scheduler s = checkAccess(sessionId, "submitflat");
 
@@ -1824,28 +1505,10 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
     }
 
-    /**
-     * Submits a workflow to the scheduler from a workflow URL, creating hence a
-     * new job resource.
-     *
-     * @param sessionId    a valid session id
-     * @param url          url to the workflow content
-     * @param pathSegment  variables of the workflow
-     * @param contextInfos the context informations (generic parameters,..)
-     * @return the <code>jobid</code> of the newly created job
-     * @throws NotConnectedRestException
-     * @throws IOException
-     * @throws JobCreationRestException
-     * @throws PermissionRestException
-     * @throws SubmissionClosedRestException
-     */
     @Override
-    @POST
-    @Path("{path:jobs}")
-    @Produces("application/json")
-    public JobIdData submitFromUrl(@HeaderParam("sessionid") String sessionId, @HeaderParam("link") String url,
-            @PathParam("path") PathSegment pathSegment, @Context UriInfo contextInfos) throws JobCreationRestException,
-            NotConnectedRestException, PermissionRestException, SubmissionClosedRestException, IOException {
+    public JobIdData submitFromUrl(String sessionId, String url, PathSegment pathSegment, UriInfo contextInfos)
+            throws JobCreationRestException, NotConnectedRestException, PermissionRestException,
+            SubmissionClosedRestException, IOException {
         Scheduler s = checkAccess(sessionId, "jobs");
 
         File tmpWorkflowFile = null;
@@ -1876,30 +1539,10 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Submits a job to the scheduler
-     *
-     * @param sessionId
-     *            a valid session id
-     * @param pathSegment
-     *            variables of the workflow
-     * @param multipart
-     *            the form data containing : - fileName the name of the file
-     *            that will be created on the DataSpace - fileContent the
-     *            content of the file
-     * @param contextInfos
-     *            the context informations (generic parameters,..)
-     * @return the <code>jobid</code> of the newly created job
-     * @throws IOException if the job was not correctly uploaded/stored
-     */
     @Override
-    @POST
-    @Path("{path:submit}")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @Produces("application/json")
-    public JobIdData submit(@HeaderParam("sessionid") String sessionId, @PathParam("path") PathSegment pathSegment,
-            MultipartFormDataInput multipart, @Context UriInfo contextInfos) throws JobCreationRestException,
-            NotConnectedRestException, PermissionRestException, SubmissionClosedRestException, IOException {
+    public JobIdData submit(String sessionId, PathSegment pathSegment, MultipartFormDataInput multipart,
+            UriInfo contextInfos) throws JobCreationRestException, NotConnectedRestException, PermissionRestException,
+            SubmissionClosedRestException, IOException {
         try {
             Scheduler scheduler = checkAccess(sessionId, "submit");
 
@@ -1972,15 +1615,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return filePath;
     }
 
-    @Consumes(MediaType.APPLICATION_JSON)
-    @POST
-    @Path("{path:plannings}")
-    @Produces("application/json")
     @Override
-    public String submitPlannings(@HeaderParam("sessionid") String sessionId,
-            @PathParam("path") PathSegment pathSegment, Map<String, String> jobContentXmlString)
-            throws JobCreationRestException, NotConnectedRestException, PermissionRestException,
-            SubmissionClosedRestException, IOException {
+    public String submitPlannings(String sessionId, PathSegment pathSegment, Map<String, String> jobContentXmlString)
+            throws JobCreationRestException, NotConnectedRestException, IOException {
 
         checkAccess(sessionId, "plannings");
 
@@ -2057,23 +1694,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return mapper.map(newJobId, JobIdData.class);
     }
 
-    /**
-     * Pushes a file from the local file system into the given DataSpace
-     *
-     * @param sessionId a valid session id
-     * @param spaceName the name of the DataSpace
-     * @param filePath  the path inside the DataSpace where to put the file e.g.
-     *                  "/myfolder"
-     * @param multipart the form data containing : - fileName the name of the file
-     *                  that will be created on the DataSpace - fileContent the
-     *                  content of the file
-     * @return true if the transfer succeeded
-     * @see org.ow2.proactive.scheduler.common.SchedulerConstants for spaces
-     * names
-     **/
     @Override
-    public boolean pushFile(@HeaderParam("sessionid") String sessionId, @PathParam("spaceName") String spaceName,
-            @PathParam("filePath") String filePath, MultipartFormDataInput multipart)
+    public boolean pushFile(String sessionId, String spaceName, String filePath, MultipartFormDataInput multipart)
             throws IOException, NotConnectedRestException, PermissionRestException {
         try {
             checkAccess(sessionId, "pushFile");
@@ -2128,22 +1750,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Either Pulls a file from the given DataSpace to the local file system or
-     * list the content of a directory if the path refers to a directory In the
-     * case the path to a file is given, the content of this file will be
-     * returns as an input stream In the case the path to a directory is given,
-     * the input stream returned will be a text stream containing at each line
-     * the content of the directory
-     *
-     * @param sessionId a valid session id
-     * @param spaceName the name of the data space involved (GLOBAL or USER)
-     * @param filePath  the path to the file or directory whose content must be
-     *                  received
-     **/
     @Override
-    public InputStream pullFile(@HeaderParam("sessionid") String sessionId, @PathParam("spaceName") String spaceName,
-            @PathParam("filePath") String filePath)
+    public InputStream pullFile(String sessionId, String spaceName, String filePath)
             throws IOException, NotConnectedRestException, PermissionRestException {
 
         checkAccess(sessionId, "pullFile");
@@ -2184,16 +1792,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
     }
 
-    /**
-     * Deletes a file or recursively delete a directory from the given DataSpace
-     *
-     * @param sessionId a valid session id
-     * @param spaceName the name of the data space involved (GLOBAL or USER)
-     * @param filePath  the path to the file or directory which must be deleted
-     **/
     @Override
-    public boolean deleteFile(@HeaderParam("sessionid") String sessionId, @PathParam("spaceName") String spaceName,
-            @PathParam("filePath") String filePath)
+    public boolean deleteFile(String sessionId, String spaceName, String filePath)
             throws IOException, NotConnectedRestException, PermissionRestException {
         checkAccess(sessionId, "deleteFile");
 
@@ -2225,19 +1825,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return true;
     }
 
-    /**
-     * terminates the session id <code>sessionId</code>
-     *
-     * @param sessionId a valid session id
-     * @throws NotConnectedRestException if the scheduler cannot be contacted
-     * @throws PermissionRestException   if you are not authorized to perform the action
-     */
     @Override
-    @PUT
-    @Path("disconnect")
-    @Produces("application/json")
-    public void disconnect(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public void disconnect(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             final Scheduler s = checkAccess(sessionId, "disconnect");
             logger.info("disconnection user " + sessionStore.get(sessionId) + " to session " + sessionId);
@@ -2252,20 +1841,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * pauses the scheduler
-     *
-     * @param sessionId a valid session id
-     * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("pause")
-    @Produces("application/json")
-    public boolean pauseScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public boolean pauseScheduler(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "pause");
             return s.pause();
@@ -2276,20 +1853,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * stops the scheduler
-     *
-     * @param sessionId a valid session id
-     * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("stop")
-    @Produces("application/json")
-    public boolean stopScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public boolean stopScheduler(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "stop");
             return s.stop();
@@ -2300,20 +1865,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * resumes the scheduler
-     *
-     * @param sessionId a valid session id
-     * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("resume")
-    @Produces("application/json")
-    public boolean resumeScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public boolean resumeScheduler(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "resume");
             return s.resume();
@@ -2324,24 +1877,10 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * changes the priority of a job
-     *
-     * @param sessionId    a valid session id
-     * @param jobId        the job id
-     * @param priorityName a string representing the name of the priority
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     * @throws PermissionRestException
-     * @throws JobAlreadyFinishedRestException
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/priority/byname/{name}")
-    public void schedulerChangeJobPriorityByName(@HeaderParam("sessionid")
-    final String sessionId, @PathParam("jobid")
-    final String jobId, @PathParam("name") String priorityName) throws NotConnectedRestException,
-            UnknownJobRestException, PermissionRestException, JobAlreadyFinishedRestException {
+    public void schedulerChangeJobPriorityByName(String sessionId, String jobId, String priorityName)
+            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException,
+            JobAlreadyFinishedRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/priority/byname/" + priorityName);
             s.changeJobPriority(jobId, JobPriority.findPriority(priorityName));
@@ -2356,24 +1895,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * changes the priority of a job
-     *
-     * @param sessionId     a valid session id
-     * @param jobId         the job id
-     * @param priorityValue a string representing the value of the priority
-     * @throws NumberFormatException
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     * @throws PermissionRestException
-     * @throws JobAlreadyFinishedRestException
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/priority/byvalue/{value}")
-    public void schedulerChangeJobPriorityByValue(@HeaderParam("sessionid")
-    final String sessionId, @PathParam("jobid")
-    final String jobId, @PathParam("value") String priorityValue)
+    public void schedulerChangeJobPriorityByValue(String sessionId, String jobId, String priorityValue)
             throws NumberFormatException, NotConnectedRestException, UnknownJobRestException, PermissionRestException,
             JobAlreadyFinishedRestException {
         try {
@@ -2390,20 +1913,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * freezes the scheduler
-     *
-     * @param sessionId a valid session id
-     * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("freeze")
-    @Produces("application/json")
-    public boolean freezeScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public boolean freezeScheduler(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "freeze");
             return s.freeze();
@@ -2414,20 +1925,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * returns the status of the scheduler
-     *
-     * @param sessionId a valid session id
-     * @return the scheduler status
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @GET
-    @Path("status")
-    @Produces("application/json")
-    public SchedulerStatusData getSchedulerStatus(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public SchedulerStatusData getSchedulerStatus(String sessionId)
+            throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "status");
             return SchedulerStatusData.valueOf(SchedulerStateListener.getInstance().getSchedulerStatus(s).name());
@@ -2438,20 +1938,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * starts the scheduler
-     *
-     * @param sessionId a valid session id
-     * @return true if success, false otherwise
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("start")
-    @Produces("application/json")
-    public boolean startScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public boolean startScheduler(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "start");
             return s.start();
@@ -2462,20 +1950,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * kills and shutdowns the scheduler
-     *
-     * @param sessionId a valid session id
-     * @return true if success, false if not
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("kill")
-    @Produces("application/json")
-    public boolean killScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public boolean killScheduler(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "kill");
             return s.kill();
@@ -2486,21 +1962,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * shutdown the scheduler
-     *
-     * @param sessionId
-     *            a valid session id
-     * @return true if success, false if not
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("shutdown")
-    @Produces("application/json")
-    public boolean shutdownScheduler(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public boolean shutdownScheduler(String sessionId) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "shutdown");
             return s.shutdown();
@@ -2511,23 +1974,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Reconnect a new Resource Manager to the scheduler. Can be used if the
-     * resource manager has crashed.
-     *
-     * @param sessionId a valid session id
-     * @param rmURL     the url of the resource manager
-     * @return true if success, false otherwise.
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @POST
-    @Path("linkrm")
-    @Produces("application/json")
-    public boolean linkRm(@HeaderParam("sessionid")
-    final String sessionId, @FormParam("rmurl") String rmURL)
-            throws NotConnectedRestException, PermissionRestException {
+    public boolean linkRm(String sessionId, String rmURL) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "linkrm");
             return s.linkResourceManager(rmURL);
@@ -2538,39 +1986,14 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Tests whether or not the user is connected to the ProActive Scheduler
-     *
-     * @param sessionId the session to test
-     * @return true if the user connected to a Scheduler, false otherwise.
-     * @throws NotConnectedRestException
-     */
     @Override
-    @GET
-    @Path("isconnected")
-    @Produces("application/json")
-    public boolean isConnected(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException {
+    public boolean isConnected(String sessionId) throws NotConnectedRestException {
         Scheduler s = checkAccess(sessionId, "isconnected");
         return s.isConnected();
     }
 
-    /**
-     * Login to the scheduler using a form containing 2 fields (username and
-     * password).
-     *
-     * @param username username
-     * @param password password
-     * @return the session id associated to the login.
-     * @throws LoginException
-     */
     @Override
-    @POST
-    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @Path("login")
-    @Produces("application/json")
-    public String login(@FormParam("username") String username, @FormParam("password") String password)
-            throws LoginException, SchedulerRestException {
+    public String login(String username, String password) throws LoginException, SchedulerRestException {
         try {
             if ((username == null) || (password == null)) {
                 throw new LoginException("Empty login/password");
@@ -2589,12 +2012,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @PUT
-    @Path("session")
-    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @Produces("application/json")
-    public String loginOrRenewSession(@HeaderParam("sessionid") String sessionId,
-            @FormParam("username") String username, @FormParam("password") String password)
+    public String loginOrRenewSession(String sessionId, String username, String password)
             throws SchedulerRestException, LoginException, NotConnectedRestException {
         if (sessionId == null || !sessionStore.exists(sessionId)) {
             return login(username, password);
@@ -2608,11 +2026,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @PUT
-    @Path("session")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @Produces("application/json")
-    public String loginOrRenewSession(@HeaderParam("sessionid") String sessionId, @MultipartForm LoginForm multipart)
+    public String loginOrRenewSession(String sessionId, LoginForm multipart)
             throws KeyException, SchedulerRestException, LoginException, NotConnectedRestException {
         if (sessionId == null || !sessionStore.exists(sessionId)) {
             return loginWithCredential(multipart);
@@ -2626,10 +2040,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @GET
-    @Path("logins/sessionid/{sessionId}")
-    @Produces("application/json")
-    public String getLoginFromSessionId(@PathParam("sessionId") String sessionId) {
+    public String getLoginFromSessionId(String sessionId) {
         if (sessionId != null && sessionStore.exists(sessionId)) {
             try {
                 renewSession(sessionId);
@@ -2647,9 +2058,6 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @GET
-    @Path("logins/sessionid/{sessionId}/userdata")
-    @Produces("application/json")
     public UserData getUserDataFromSessionId(@PathParam("sessionId") String sessionId) {
         if (sessionId != null && sessionStore.exists(sessionId)) {
             try {
@@ -2665,23 +2073,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return null;
     }
 
-    /**
-     * Login to the scheduler using a multipart form can be used either by
-     * submitting 2 fields ({@code username} and {@code password}) or by sending
-     * a credential file with field name {@code credential}.
-     *
-     * @return the session id associated to this new connection.
-     * @throws KeyException
-     * @throws LoginException
-     * @throws SchedulerRestException
-     */
     @Override
-    @POST
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @Path("login")
-    @Produces("application/json")
-    public String loginWithCredential(@MultipartForm LoginForm multipart)
-            throws LoginException, KeyException, SchedulerRestException {
+    public String loginWithCredential(LoginForm multipart) throws LoginException, KeyException, SchedulerRestException {
         try {
             Session session;
             if (multipart.getCredential() != null) {
@@ -2713,29 +2106,15 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * returns statistics about the scheduler
-     *
-     * @param sessionId the session id associated to this new connection
-     * @return a string containing the statistics
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @GET
-    @Path("stats")
-    @Produces("application/json")
-    public Map<String, String> getStatistics(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public Map<String, String> getStatistics(String sessionId)
+            throws NotConnectedRestException, PermissionRestException {
         SchedulerProxyUserInterface s = checkAccess(sessionId, "stats");
         return s.getMappedInfo("ProActiveScheduler:name=RuntimeData");
     }
 
     @Override
-    @GET
-    @Path("stathistory")
-    @Produces("application/json")
-    public String getStatHistory(@HeaderParam("sessionid") String sessionId) throws NotConnectedRestException {
+    public String getStatHistory(String sessionId) throws NotConnectedRestException {
         SchedulerProxyUserInterface s = checkAccess(sessionId, "stats");
         return s.getStatHistory("ProActiveScheduler:name=RuntimeData",
                                 "dddd", // all for ranges for the days
@@ -2743,39 +2122,16 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                                                "StalledJobsCount", "InErrorJobsCount" });
     }
 
-    /**
-     * returns a string containing some data regarding the user's account
-     *
-     * @param sessionId the session id associated to this new connection
-     * @return a string containing some data regarding the user's account
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @GET
-    @Path("stats/myaccount")
-    @Produces("application/json")
-    public Map<String, String> getStatisticsOnMyAccount(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public Map<String, String> getStatisticsOnMyAccount(String sessionId)
+            throws NotConnectedRestException, PermissionRestException {
         SchedulerProxyUserInterface s = checkAccess(sessionId, "stats/myaccount");
         return s.getMappedInfo("ProActiveScheduler:name=MyAccount");
     }
 
-    /**
-     * Users currently connected to the scheduler
-     *
-     * @param sessionId the session id associated to this new connection\
-     * @return list of users
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("users")
-    @Produces("application/json")
-    public List<SchedulerUserData> getUsers(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public List<SchedulerUserData> getUsers(String sessionId)
+            throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "users");
             return map(s.getUsers(), SchedulerUserData.class);
@@ -2786,21 +2142,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Users having jobs in the scheduler
-     *
-     * @param sessionId the session id associated to this new connection\
-     * @return list of users
-     * @throws NotConnectedRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("userswithjobs")
-    @Produces("application/json")
-    public List<SchedulerUserData> getUsersWithJobs(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public List<SchedulerUserData> getUsersWithJobs(String sessionId)
+            throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "userswithjobs");
             return map(s.getUsersWithJobs(), SchedulerUserData.class);
@@ -2823,24 +2167,13 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     @GET
     @Path("version")
     public String getVersion() {
-        return "{ " + "\"scheduler\" : \"" + SchedulerStateRest.class.getPackage().getSpecificationVersion() + "\", " +
-               "\"rest\" : \"" + SchedulerStateRest.class.getPackage().getImplementationVersion() + "\"" + "}";
+        return String.format("{ \"scheduler\" : \"%s\", \"rest\" : \"%s\"}",
+                             SchedulerStateRest.class.getPackage().getSpecificationVersion(),
+                             SchedulerStateRest.class.getPackage().getImplementationVersion());
     }
 
-    /**
-     * generates a credential file from user provided credentials
-     *
-     * @return the credential file generated by the scheduler
-     * @throws LoginException
-     * @throws SchedulerRestException
-     */
     @Override
-    @POST
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @Path("createcredential")
-    @Produces("*/*")
-    public byte[] getCreateCredential(@MultipartForm LoginForm multipart)
-            throws LoginException, SchedulerRestException {
+    public byte[] getCreateCredential(LoginForm multipart) throws LoginException, SchedulerRestException {
 
         String username = multipart.getUsername();
         String password = multipart.getPassword();
@@ -2862,14 +2195,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    @GET
-    @Path("usage/myaccount")
-    @Produces("application/json")
     @Override
-    public List<JobUsageData> getUsageOnMyAccount(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("startdate") @DateFormatter.DateFormat() Date startDate,
-            @QueryParam("enddate") @DateFormatter.DateFormat() Date endDate)
-            throws NotConnectedRestException, PermissionRestException {
+    public List<JobUsageData> getUsageOnMyAccount(String sessionId, @DateFormatter.DateFormat() Date startDate,
+            @DateFormatter.DateFormat() Date endDate) throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler scheduler = checkAccess(sessionId);
             return map(scheduler.getMyAccountUsage(startDate, endDate), JobUsageData.class);
@@ -2880,13 +2208,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    @GET
-    @Path("usage/account")
-    @Produces("application/json")
     @Override
-    public List<JobUsageData> getUsageOnAccount(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("user") String user, @QueryParam("startdate") @DateFormatter.DateFormat() Date startDate,
-            @QueryParam("enddate") @DateFormatter.DateFormat() Date endDate)
+    public List<JobUsageData> getUsageOnAccount(String sessionId, String user,
+            @DateFormatter.DateFormat() Date startDate, @DateFormatter.DateFormat() Date endDate)
             throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler scheduler = checkAccess(sessionId);
@@ -2898,12 +2222,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    @GET
-    @Path("/userspace")
-    @Produces("application/json")
     @Override
-    public List<String> userspaceURIs(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, PermissionRestException {
+    public List<String> userspaceURIs(String sessionId) throws NotConnectedRestException, PermissionRestException {
         SchedulerProxyUserInterface proxy = checkAccess(sessionId);
         try {
             return proxy.getUserSpaceURIs();
@@ -2914,12 +2234,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    @GET
-    @Path("/globalspace")
-    @Produces("application/json")
     @Override
-    public List<String> globalspaceURIs(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, PermissionRestException {
+    public List<String> globalspaceURIs(String sessionId) throws NotConnectedRestException, PermissionRestException {
         SchedulerProxyUserInterface proxy = checkAccess(sessionId);
         try {
             return proxy.getGlobalSpaceURIs();
@@ -3282,25 +2598,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return filteredSorts;
     }
 
-    /**
-     * Change the START_AT generic information at job level and reset the
-     * scheduledAt at task level
-     *
-     * @param sessionId current session
-     * @param jobId     id of the job that needs to be updated
-     * @param startAt   its value should be ISO 8601 compliant
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/startat/{startAt}")
-    @Produces("application/json")
-    public boolean changeStartAt(@HeaderParam("sessionid")
-    final String sessionId, @PathParam("jobid")
-    final String jobId, @PathParam("startAt")
-    final String startAt) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
+    public boolean changeStartAt(String sessionId, String jobId, String startAt)
+            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             final Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/startat/" + startAt);
             return s.changeStartAt(JobIdImpl.makeJobId(jobId), startAt);
@@ -3313,11 +2613,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    @GET
     @Override
-    @Path("configuration/portal")
-    @Produces("application/json")
-    public Map<Object, Object> getPortalConfiguration(@HeaderParam("sessionid") String sessionId)
+    public Map<Object, Object> getPortalConfiguration(String sessionId)
             throws NotConnectedRestException, PermissionRestException {
         try {
             final Scheduler s = checkAccess(sessionId, "GET configuration/portal");
@@ -3329,12 +2626,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    @GET
     @Override
-    @Path("properties")
-    @Produces("application/json")
-    public Map<String, Object> getSchedulerPropertiesFromSessionId(@HeaderParam("sessionid")
-    final String sessionId) throws NotConnectedRestException, PermissionRestException {
+    public Map<String, Object> getSchedulerPropertiesFromSessionId(String sessionId)
+            throws NotConnectedRestException, PermissionRestException {
         SchedulerProxyUserInterface scheduler = checkAccess(sessionId, "properties");
         Map<String, Object> schedulerProperties;
         try {

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -177,7 +177,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return new RestPage<>(ids, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -188,7 +188,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "/scheduler/jobs/" + jobId);
             userHasPermission = s.checkJobPermissionMethod(sessionId, jobId, method);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
         return userHasPermission;
     }
@@ -209,7 +209,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             return new RestPage<>(userJobInfoList, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -222,7 +222,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                               .map(jobInfo -> new UserJobData(mapper.map(jobInfo, JobInfoData.class)))
                               .collect(Collectors.toList());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -252,7 +252,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             restMapPage.setSize(page.getSize());
             return restMapPage;
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -272,7 +272,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             return mapper.map(js, JobStateData.class);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -327,7 +327,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/result");
             return mapper.map(PAFuture.getFutureValue(s.getJobResult(jobId)), JobResultData.class);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -342,7 +342,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                 return getJobResultMapAsString(jobResult.getResultMap());
             }
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -358,7 +358,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                                                      entry -> getJobResultMapAsString(entry.getValue())));
             }
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
         return new HashMap<>();
     }
@@ -383,7 +383,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         try {
             return mapper.map(s.getJobInfo(jobId), JobInfoData.class);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -404,7 +404,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return res;
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -414,7 +414,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "DELETE jobs/" + jobId);
             return s.removeJob(jobId);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -424,7 +424,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/log/server");
             return s.getJobServerLogs(jobId);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -434,7 +434,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobId + "/kill");
             return s.killJob(jobId);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -444,7 +444,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/kill");
             return s.killTask(jobid, taskname);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -454,7 +454,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/preempt");
             return s.preemptTask(jobid, taskname, 5);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -464,7 +464,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/restart");
             return s.restartTask(jobid, taskname, 5);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -474,7 +474,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/finishInErrorTask");
             return s.finishInErrorTask(jobid, taskname);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -484,7 +484,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/restartInErrorTask");
             return s.restartInErrorTask(jobid, taskname);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -509,7 +509,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return new RestPage<>(tasksNames, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -528,7 +528,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             return new RestPage<>(tasksName, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -551,7 +551,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             return new RestPage<>(tasksName, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -562,7 +562,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             JobState jobState = s.getJobState(jobId);
             return jobState.getTags();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -573,7 +573,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             JobState jobState = s.getJobState(jobId);
             return jobState.getTags(prefix);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -603,7 +603,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler scheduler = checkAccess(sessionId, "/scheduler/jobs/" + jobId + "/xml");
             return scheduler.getJobContent(JobIdImpl.makeJobId(jobId));
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -623,7 +623,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskStateData> tasks = map(page.getTaskStates(), TaskStateData.class);
             return new RestPage<>(tasks, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -638,7 +638,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskStateData> tasks = map(page.getTaskStates(), TaskStateData.class);
             return new RestPage<>(tasks, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -652,7 +652,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskStateData> tasks = map(page.getTaskStates(), TaskStateData.class);
             return new RestPage<>(tasks, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -671,7 +671,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskStateData> tasks = map(page.getTaskStates(), TaskStateData.class);
             return new RestPage<>(tasks, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -687,7 +687,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskStateData> tasks = map(page.getTaskStates(), TaskStateData.class);
             return new RestPage<>(tasks, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -720,7 +720,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             // will produce HTTP 204 code if null
             return streams.isEmpty() ? null : new SequenceInputStream(Collections.enumeration(streams));
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -767,7 +767,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             throw new UnknownTaskRestException("task " + taskname + "not found");
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -845,7 +845,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                             .map(TaskId::getReadableName)
                             .collect(Collectors.toList());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -856,7 +856,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler scheduler = checkAccess(sessionId, "metadataOfPreciousResults");
             return scheduler.getPreciousTaskNames(jobsId);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -895,7 +895,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return buildTaskResultData(taskResult);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -916,7 +916,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             return results;
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -925,7 +925,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         try {
             return retrieveTaskLogsUsingDatabase(sessionId, jobId, taskname);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -957,7 +957,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return buf.toString();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -978,7 +978,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return jobOutput.toString();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -996,7 +996,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return errLogs.toString();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1013,7 +1013,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return buf.toString();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1031,7 +1031,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return outLogs.toString();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1048,7 +1048,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return result.toString();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1086,7 +1086,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                 return null;
             }
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1096,7 +1096,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + PATH_TASKS + taskname + "/log/server");
             return s.getTaskServerLogs(jobId, taskname);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1106,7 +1106,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tag/" + taskTag + "/log/server");
             return s.getTaskServerLogsByTag(jobId, taskTag);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1161,7 +1161,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             final Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/pause");
             return s.pauseJob(jobId);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1171,7 +1171,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/restartAllInErrorTasks");
             return s.restartAllInErrorTasks(jobId);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1181,7 +1181,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/resume");
             return s.resumeJob(jobId);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1225,7 +1225,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         } catch (IOException e) {
             throw new IOException("I/O Error: " + e.getMessage(), e);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1403,7 +1403,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             String jobContent = scheduler.getJobContent(JobIdImpl.makeJobId(jobId));
             FileUtils.write(tmpJobFile, jobContent, Charset.forName("UTF-8"));
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
         // Get the job submission variables
         Map<String, String> jobVariables = workflowVariablesTransformer.getWorkflowVariablesFromPathSegment(pathSegment);
@@ -1557,7 +1557,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             logger.info("disconnection user " + sessionStore.get(sessionId) + " to session " + sessionId);
             s.disconnect();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         } finally {
             sessionStore.terminate(sessionId);
             logger.debug("sessionid " + sessionId + " terminated");
@@ -1570,7 +1570,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "pause");
             return s.pause();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1580,7 +1580,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "stop");
             return s.stop();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1590,7 +1590,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "resume");
             return s.resume();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1601,7 +1601,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/priority/byname/" + priorityName);
             s.changeJobPriority(jobId, JobPriority.findPriority(priorityName));
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1612,7 +1612,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/priority/byvalue" + priorityValue);
             s.changeJobPriority(jobId, JobPriority.findPriority(Integer.parseInt(priorityValue)));
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
 
     }
@@ -1623,7 +1623,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "freeze");
             return s.freeze();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1633,7 +1633,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "status");
             return SchedulerStatusData.valueOf(SchedulerStateListener.getInstance().getSchedulerStatus(s).name());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1643,7 +1643,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "start");
             return s.start();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1653,7 +1653,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "kill");
             return s.kill();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1663,7 +1663,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "shutdown");
             return s.shutdown();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1673,7 +1673,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "linkrm");
             return s.linkResourceManager(rmURL);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1825,7 +1825,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "users");
             return map(s.getUsers(), SchedulerUserData.class);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1835,7 +1835,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId, "userswithjobs");
             return map(s.getUsersWithJobs(), SchedulerUserData.class);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1886,7 +1886,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler scheduler = checkAccess(sessionId);
             return map(scheduler.getMyAccountUsage(startDate, endDate), JobUsageData.class);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1897,7 +1897,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler scheduler = checkAccess(sessionId);
             return map(scheduler.getAccountUsage(user, startDate, endDate), JobUsageData.class);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1907,7 +1907,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         try {
             return proxy.getUserSpaceURIs();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1917,7 +1917,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         try {
             return proxy.getGlobalSpaceURIs();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -1998,7 +1998,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId);
             s.putThirdPartyCredential(key, value);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         } catch (Exception e) {
             throw new SchedulerRestException(e);
         }
@@ -2011,7 +2011,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId);
             s.removeThirdPartyCredential(key);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         } catch (Exception e) {
             throw new SchedulerRestException(e);
         }
@@ -2023,7 +2023,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             Scheduler s = checkAccess(sessionId);
             return s.thirdPartyCredentialsKeySet();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -2093,7 +2093,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                 }
             });
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         } catch (ActiveObjectCreationException | NodeException e) {
             throw new RuntimeException(e);
         }
@@ -2180,7 +2180,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             }
             return new RestPage<>(taskNames, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -2231,7 +2231,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskStateData> tasks = map(page.getList(), TaskStateData.class);
             return new RestPage<>(tasks, page.getSize());
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -2261,7 +2261,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             final Scheduler s = checkAccess(sessionId, "POST jobs/" + jobId + "/startat/" + startAt);
             return s.changeStartAt(JobIdImpl.makeJobId(jobId), startAt);
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -2271,7 +2271,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             final Scheduler s = checkAccess(sessionId, "GET configuration/portal");
             return s.getPortalConfiguration();
         } catch (SchedulerException e) {
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
     }
 
@@ -2284,28 +2284,10 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
         } catch (SchedulerException e) {
             logger.warn("Attempt to retrieve scheduler properties but failed because connection exception", e);
-            throw wrapExceptionToRest(e);
+            throw RestException.wrapExceptionToRest(e);
         }
         return schedulerProperties;
 
     }
 
-    private RestException wrapExceptionToRest(SchedulerException schedulerException) {
-        if (schedulerException instanceof NotConnectedException) {
-            return new NotConnectedRestException(schedulerException);
-        } else if (schedulerException instanceof PermissionException) {
-            return new PermissionRestException(schedulerException);
-        } else if (schedulerException instanceof UnknownJobException) {
-            return new UnknownJobRestException(schedulerException);
-        } else if (schedulerException instanceof JobAlreadyFinishedException) {
-            return new JobAlreadyFinishedRestException(schedulerException);
-        } else if (schedulerException instanceof SubmissionClosedException) {
-            return new SubmissionClosedRestException(schedulerException);
-        } else if (schedulerException instanceof JobCreationException) {
-            return new JobCreationRestException(schedulerException);
-        } else if (schedulerException instanceof UnknownTaskException) {
-            return new UnknownTaskRestException(schedulerException);
-        }
-        return new UnknownJobRestException(schedulerException);
-    }
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -163,22 +163,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
     private final WorkflowVariablesTransformer workflowVariablesTransformer = new WorkflowVariablesTransformer();
 
-    /**
-     * Returns the ids of the current jobs under a list of string.
-     *
-     * @param sessionId a valid session id
-     * @param index     optional, if a sublist has to be returned the index of the
-     *                  sublist
-     * @param limit     optional, if a sublist has to be returned, the limit of the
-     *                  sublist
-     * @return a list of jobs' ids under the form of a list of string
-     */
     @Override
-    @GET
-    @Path("jobs")
-    @Produces("application/json")
-    public RestPage<String> jobs(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("index") @DefaultValue("-1") int index, @QueryParam("limit") @DefaultValue("-1") int limit)
+    public RestPage<String> jobs(String sessionId, int index, int limit)
             throws NotConnectedRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "/scheduler/jobs");
@@ -200,23 +186,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Check if the user has the permission to execute the method passed as argument
-     *
-     * @param sessionId
-     * @param jobId
-     * @param method
-     * @return true if the user has the permission to execute the java method
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     */
     @Override
-    @GET
-    @Path("job/{jobid}/permission/{method}")
-    @Consumes(value = MediaType.APPLICATION_JSON)
-    @Produces("application/json")
-    public boolean checkJobPermissionMethod(@HeaderParam("sessionid") String sessionId,
-            @PathParam("method") String method, @PathParam("jobid") String jobId)
+    public boolean checkJobPermissionMethod(String sessionId, String method, String jobId)
             throws NotConnectedRestException, UnknownJobRestException {
         boolean userHasPermission = false;
         try {
@@ -230,24 +201,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return userHasPermission;
     }
 
-    /**
-     * Returns a subset of the scheduler state, including pending, running,
-     * finished jobs (in this particular order). each jobs is described using -
-     * its id - its owner - the JobInfo class
-     *
-     * @param index     optional, if a sublist has to be returned the index of the
-     *                  sublist
-     * @param limit     optional, if a sublist has to be returned, the limit of the
-     *                  sublist
-     * @param sessionId a valid session id
-     * @return a list of UserJobData
-     */
     @Override
-    @GET
-    @Path("jobsinfo")
-    @Produces({ "application/json", "application/xml" })
-    public RestPage<UserJobData> jobsInfo(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("index") @DefaultValue("-1") int index, @QueryParam("limit") @DefaultValue("-1") int limit)
+    public RestPage<UserJobData> jobsInfo(String sessionId, int index, int limit)
             throws PermissionRestException, NotConnectedRestException {
         try {
             Scheduler s = checkAccess(sessionId, "/scheduler/jobsinfo");
@@ -269,20 +224,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of jobs info corresponding to the given job IDs (in the same order)
-     *
-     * @param jobsId    the list of id of the jobs to return, in the same order
-     * @param sessionId a valid session id
-     * @return a list of UserJobData
-     */
     @Override
-    @GET
-    @Path("jobsinfolist")
-    @Produces({ "application/json", "application/xml" })
-    public List<UserJobData> jobsInfoList(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("jobsid") List<String> jobsId)
-            throws PermissionRestException, NotConnectedRestException, UnknownJobRestException {
+    public List<UserJobData> jobsInfoList(String sessionId, List<String> jobsId)
+            throws PermissionRestException, NotConnectedRestException {
         try {
             Scheduler s = checkAccess(sessionId, "/scheduler/jobsinfolist");
             List<JobInfo> jobInfoList = s.getJobsInfoList(jobsId);
@@ -296,34 +240,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a map containing one entry with the revision id as key and the
-     * list of UserJobData as value. each jobs is described using - its id - its
-     * owner - the JobInfo class
-     *
-     * @param sessionId a valid session id
-     * @param index     optional, if a sublist has to be returned the index of the
-     *                  sublist
-     * @param limit     optional, if a sublist has to be returned, the limit of the
-     *                  sublist
-     * @param myJobs    fetch only the jobs for the user making the request
-     * @param pending   fetch pending jobs
-     * @param running   fetch running jobs
-     * @param finished  fetch finished jobs
-     * @return a map containing one entry with the revision id as key and the
-     * list of UserJobData as value.
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("revisionjobsinfo")
-    @Produces({ "application/json", "application/xml" })
-    public RestMapPage<Long, ArrayList<UserJobData>> revisionAndJobsInfo(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("index") @DefaultValue("-1") int index, @QueryParam("limit") @DefaultValue("-1") int limit,
-            @QueryParam("myjobs") @DefaultValue("false") boolean myJobs,
-            @QueryParam("pending") @DefaultValue("true") boolean pending,
-            @QueryParam("running") @DefaultValue("true") boolean running,
-            @QueryParam("finished") @DefaultValue("true") boolean finished)
+    public RestMapPage<Long, ArrayList<UserJobData>> revisionAndJobsInfo(String sessionId, int index, int limit,
+            boolean myJobs, boolean pending, boolean running, boolean finished)
             throws PermissionRestException, NotConnectedRestException {
         try {
             Scheduler s = checkAccess(sessionId, "revisionjobsinfo?index=" + index + "&limit=" + limit);
@@ -354,32 +273,14 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns the revision number of the scheduler state
-     *
-     * @param sessionId a valid session id.
-     * @return the revision of the scheduler state
-     */
     @Override
-    @GET
-    @Path("state/revision")
-    @Produces({ "application/json", "application/xml" })
-    public long schedulerStateRevision(@HeaderParam("sessionid") String sessionId) throws NotConnectedRestException {
+    public long schedulerStateRevision(String sessionId) throws NotConnectedRestException {
         checkAccess(sessionId, "/scheduler/revision");
         return SchedulerStateListener.getInstance().getSchedulerStateRevision();
     }
 
-    /**
-     * Returns a JobState of the job identified by the id <code>jobid</code>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job to retrieve
-     */
     @Override
-    @GET
-    @Path("jobs/{jobid}")
-    @Produces({ "application/json", "application/xml" })
-    public JobStateData listJobs(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    public JobStateData listJobs(String sessionId, String jobId)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "/scheduler/jobs/" + jobId);
@@ -397,24 +298,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Stream the output of job identified by the id <code>jobid</code> only
-     * stream currently available logs, call this method several times to get
-     * the complete output.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job to retrieve
-     * @throws IOException
-     * @throws LogForwardingRestException
-     */
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/livelog")
-    @Produces("application/json")
     @Override
-    public String getLiveLogJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException,
-            LogForwardingRestException, IOException {
+    public String getLiveLogJob(String sessionId, String jobId) throws NotConnectedRestException,
+            UnknownJobRestException, PermissionRestException, LogForwardingRestException, IOException {
         try {
             Scheduler scheduler = checkAccess(sessionId, "/scheduler/jobs/" + jobId + "/livelog");
             Session session = sessionStore.get(sessionId);
@@ -441,38 +327,15 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * number of available bytes in the stream or -1 if the stream does not
-     * exist.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job to retrieve
-     */
     @Override
-    @GET
-    @Path("jobs/{jobid}/livelog/available")
-    @Produces("application/json")
-    public int getLiveLogJobAvailable(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException {
+    public int getLiveLogJobAvailable(String sessionId, String jobId) throws NotConnectedRestException {
         checkAccess(sessionId, "/scheduler/jobs/" + jobId + "/livelog/available");
         Session ss = sessionStore.get(sessionId);
-
         return ss.getJobsOutputController().availableLinesCount(jobId);
     }
 
-    /**
-     * remove the live log object.
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job to retrieve
-     * @throws NotConnectedRestException
-     */
     @Override
-    @DELETE
-    @Path("jobs/{jobid}/livelog")
-    @Produces("application/json")
-    public boolean deleteLiveLogJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
-            throws NotConnectedRestException {
+    public boolean deleteLiveLogJob(String sessionId, String jobId) throws NotConnectedRestException {
         checkAccess(sessionId, "delete /scheduler/jobs/livelog" + jobId);
         Session ss = sessionStore.get(sessionId);
         ss.getJobsOutputController().removeAppender(jobId);
@@ -480,19 +343,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
     }
 
-    /**
-     * Returns the job result associated to the job referenced by the id
-     * <code>jobid</code>
-     *
-     * @param sessionId a valid session id
-     * @return the job result of the corresponding job
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/result")
-    @Produces("application/json")
-    public JobResultData jobResult(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    public JobResultData jobResult(String sessionId, String jobId)
             throws NotConnectedRestException, PermissionRestException, UnknownJobRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/result");
@@ -506,21 +358,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns the job results map associated to the job referenced by the id
-     * <code>jobid</code>
-     *
-     * @param sessionId
-     *            a valid session id
-     * @return the job results map of the corresponding job
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/resultmap")
-    @Produces("application/json")
-    public Map<String, String> jobResultMap(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId)
+    public Map<String, String> jobResultMap(String sessionId, String jobId)
             throws NotConnectedRestException, PermissionRestException, UnknownJobRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/resultmap");
@@ -539,8 +378,6 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    // request:  http://localhost:8080/rest/scheduler/jobs/resultmap?jobsid=102&jobsid=152
-    // response: {"102": {"var1" : "val1", "var2" : "val2"}}
     @Override
     public Map<Long, Map<String, String>> jobResultMaps(String sessionId, List<String> jobsId)
             throws NotConnectedRestException, PermissionRestException {
@@ -592,24 +429,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         return job;
     }
 
-    /**
-     * Returns all the task results of this job as a map whose the key is the
-     * name of the task and its task result.<br>
-     * If the result cannot be instantiated, the content is replaced by the
-     * string 'Unknown value type'. To get the serialized form of a given
-     * result, one has to call the following restful service
-     * jobs/{jobid}/tasks/{taskname}/result/serializedvalue
-     *
-     * @param sessionId a valid session id
-     * @param jobId     a job id
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/result/value")
-    @Produces("application/json")
-    public Map<String, String> jobResultValue(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId)
+    public Map<String, String> jobResultValue(String sessionId, String jobId)
             throws NotConnectedRestException, PermissionRestException, UnknownJobRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/result/value");
@@ -634,19 +455,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Delete a job
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job to delete
-     * @return true if success, false if the job not yet finished (not removed,
-     * kill the job then remove it)
-     */
     @Override
-    @DELETE
-    @Path("jobs/{jobid}")
-    @Produces("application/json")
-    public boolean removeJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    public boolean removeJob(String sessionId, String jobId)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "DELETE jobs/" + jobId);
@@ -660,19 +470,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns job server logs
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the id of the job
-     * @return job traces from the scheduler and resource manager
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/log/server")
-    @Produces("application/json")
-    public String jobServerLog(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    public String jobServerLog(String sessionId, String jobId)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/log/server");
@@ -686,18 +485,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Kill the job represented by jobId.<br>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     the job to kill.
-     * @return true if success, false if not.
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/kill")
-    @Produces("application/json")
-    public boolean killJob(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    public boolean killJob(String sessionId, String jobId)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobId + "/kill");
@@ -711,23 +500,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Kill a task within a job
-     *
-     * @param sessionId current session
-     * @param jobid     id of the job containing the task to kill
-     * @param taskname  name of the task to kill
-     * @throws UnknownJobRestException
-     * @throws UnknownTaskRestException
-     * @throws PermissionRestException
-     * @throws NotConnectedRestException
-     */
-    @PUT
-    @Path("jobs/{jobid}/tasks/{taskname}/kill")
-    @Produces("application/json")
-    public boolean killTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    @Override
+    public boolean killTask(String sessionId, String jobid, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/kill");
             return s.killTask(jobid, taskname);
@@ -742,26 +517,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Preempt a task within a job
-     * <p>
-     * The task will be stopped and restarted later
-     *
-     * @param sessionId current session
-     * @param jobid     id of the job containing the task to preempt
-     * @param taskname  name of the task to preempt
-     * @throws NotConnectedRestException
-     * @throws org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownJobRestException
-     * @throws org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownTaskRestException
-     * @throws org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/tasks/{taskname}/preempt")
-    @Produces("application/json")
-    public boolean preemptTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public boolean preemptTask(String sessionId, String jobid, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/preempt");
             return s.preemptTask(jobid, taskname, 5);
@@ -776,24 +534,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Restart a task within a job
-     *
-     * @param sessionId current session
-     * @param jobid     id of the job containing the task to kill
-     * @param taskname  name of the task to kill
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     * @throws UnknownTaskRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/tasks/{taskname}/restart")
-    @Produces("application/json")
-    public boolean restartTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public boolean restartTask(String sessionId, String jobid, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/restart");
             return s.restartTask(jobid, taskname, 5);
@@ -808,24 +551,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Finish a task, which is in InError state inside a job.
-     *
-     * @param sessionId current session
-     * @param jobid     id of the job containing the task to finish (only when InError state)
-     * @param taskname  name of the task to finish (only when InError state)
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     * @throws UnknownTaskRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/tasks/{taskname}/finishInErrorTask")
-    @Produces("application/json")
-    public boolean finishInErrorTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public boolean finishInErrorTask(String sessionId, String jobid, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/finishInErrorTask");
             return s.finishInErrorTask(jobid, taskname);
@@ -840,24 +568,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Restart a pause on error task within a job
-     *
-     * @param sessionId current session
-     * @param jobid     id of the job containing the task to kill
-     * @param taskname  name of the task to kill
-     * @throws NotConnectedRestException
-     * @throws UnknownJobRestException
-     * @throws UnknownTaskRestException
-     * @throws PermissionRestException
-     */
     @Override
-    @PUT
-    @Path("jobs/{jobid}/tasks/{taskname}/restartInErrorTask")
-    @Produces("application/json")
-    public boolean restartInErrorTask(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobid,
-            @PathParam("taskname") String taskname) throws NotConnectedRestException, UnknownJobRestException,
-            UnknownTaskRestException, PermissionRestException {
+    public boolean restartInErrorTask(String sessionId, String jobid, String taskname) throws NotConnectedRestException,
+            UnknownJobRestException, UnknownTaskRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, "PUT jobs/" + jobid + PATH_TASKS + taskname + "/restartInErrorTask");
             return s.restartInErrorTask(jobid, taskname);
@@ -872,40 +585,14 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of the name of the tasks belonging to job
-     * <code>jobId</code>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     jobid one wants to list the tasks' name
-     * @return a list of tasks' name
-     */
     @Override
-    @GET
-    @Path("jobs/{jobid}/tasks")
-    @Produces("application/json")
-    public RestPage<String> getTasksNames(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    public RestPage<String> getTasksNames(String sessionId, String jobId)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         return getTasksNamesPaginated(sessionId, jobId, 0, TASKS_PAGE_SIZE);
     }
 
-    /**
-     * Returns a list of the name of the tasks belonging to job
-     * <code>jobId</code> with pagination
-     *
-     * @param sessionId a valid session id
-     * @param jobId     jobid one wants to list the tasks' name
-     * @param offset    the number of the first task to fetch
-     * @param limit     the number of the last task to fetch (non inclusive)
-     * @return the list of task ids with the total number of them
-     */
     @Override
-    @GET
-    @Path("jobs/{jobid}/tasks/paginated")
-    @Produces("application/json")
-    public RestPage<String> getTasksNamesPaginated(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("-1") int limit)
+    public RestPage<String> getTasksNamesPaginated(String sessionId, String jobId, int offset, int limit)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         if (limit == -1)
             limit = TASKS_PAGE_SIZE;
@@ -928,21 +615,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of the name of the tasks belonging to job and filtered by
-     * a given tag. <code>jobId</code>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     jobid one wants to list the tasks' name
-     * @param taskTag   the tag used to filter the tasks.
-     * @return the list of task ids with the total number of them
-     */
     @Override
-    @GET
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}")
-    @Produces("application/json")
-    public RestPage<String> getJobTasksIdsByTag(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag)
+    public RestPage<String> getJobTasksIdsByTag(String sessionId, String jobId, String taskTag)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks");
@@ -965,27 +639,9 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of the name of the tasks belonging to job
-     * <code>jobId</code> (with pagination)
-     *
-     * @param sessionId a valid session id.
-     * @param jobId     the job id.
-     * @param taskTag   the tag used to filter the tasks.
-     * @param offset    the number of the first task to fetch
-     * @param limit     the number of the last task to fetch (non inclusive)
-     * @return a list of task' states of the job <code>jobId</code> filtered by
-     * a given tag, for a given pagination.
-     */
     @Override
-    @GET
-    @GZIP
-    @Path("jobs/{jobid}/tasks/tag/{tasktag}/paginated")
-    @Produces("application/json")
-    public RestPage<String> getJobTasksIdsByTagPaginated(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("tasktag") String taskTag,
-            @QueryParam("offset") @DefaultValue("0") int offset, @QueryParam("limit") @DefaultValue("-1") int limit)
-            throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
+    public RestPage<String> getJobTasksIdsByTagPaginated(String sessionId, String jobId, String taskTag, int offset,
+            int limit) throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         if (limit == -1)
             limit = TASKS_PAGE_SIZE;
         try {
@@ -1010,18 +666,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of the tags of the tasks belonging to job
-     * <code>jobId</code>
-     *
-     * @param sessionId a valid session id
-     * @param jobId     jobid one wants to list the tasks' tags
-     * @return a list of tasks' name
-     */
-    @GET
-    @Path("jobs/{jobid}/tasks/tags")
-    @Produces("application/json")
-    public List<String> getJobTaskTags(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    @Override
+    public List<String> getJobTaskTags(String sessionId, String jobId)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tags");
@@ -1036,20 +682,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         }
     }
 
-    /**
-     * Returns a list of the tags of the tasks belonging to job
-     * <code>jobId</code> and filtered by a prefix pattern
-     *
-     * @param sessionId a valid session id
-     * @param jobId     jobid one wants to list the tasks' tags
-     * @param prefix    the prefix used to filter tags
-     * @return a list of tasks' name
-     */
-    @GET
-    @Path("jobs/{jobid}/tasks/tags/startsWith/{prefix}")
-    @Produces("application/json")
-    public List<String> getJobTaskTagsPrefix(@HeaderParam("sessionid") String sessionId,
-            @PathParam("jobid") String jobId, @PathParam("prefix") String prefix)
+    @Override
+    public List<String> getJobTaskTagsPrefix(String sessionId, String jobId, String prefix)
             throws NotConnectedRestException, UnknownJobRestException, PermissionRestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/tasks/tags/startswith/" + prefix);
@@ -1068,10 +702,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
      * {@inheritDoc}
      */
     @Override
-    @GET
-    @Path("jobs/{jobid}/html")
-    @Produces("text/html")
-    public String getJobHtml(@HeaderParam("sessionid") String sessionId, @PathParam("jobid") String jobId)
+    public String getJobHtml(String sessionId, @PathParam("jobid") String jobId)
             throws NotConnectedRestException, IOException {
         checkAccess(sessionId);
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -39,15 +39,11 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import javax.security.auth.login.LoginException;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.core.PathSegment;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
-import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.ow2.proactive.authentication.UserData;
@@ -99,28 +95,25 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public String login(@FormParam("username") String username, @FormParam("password") String password)
-            throws KeyException, LoginException, SchedulerRestException {
+    public String login(String username, String password) throws LoginException, SchedulerRestException {
         logger.info("Logging as " + username);
         return scheduler().login(username, password);
     }
 
     @Override
-    public String loginWithCredential(@MultipartForm LoginForm multipart)
-            throws IOException, KeyException, LoginException, SchedulerRestException {
+    public String loginWithCredential(LoginForm multipart) throws KeyException, LoginException, SchedulerRestException {
         logger.info("Logging using credential file");
         return scheduler().loginWithCredential(multipart);
     }
 
     @Override
-    public void logout(@HeaderParam("sessionid")
-    final String sessionId) throws RestException {
+    public void logout(String sessionId) throws RestException {
         logger.info("logout");
         scheduler().disconnect(sessionId);
     }
 
     @Override
-    public boolean isConnected(@HeaderParam("sessionid") String sessionId) {
+    public boolean isConnected(String sessionId) {
         try {
             getUserName(sessionId);
             return true;
@@ -130,7 +123,7 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public String currentUser(@HeaderParam("sessionid") String sessionId) {
+    public String currentUser(String sessionId) {
         try {
             return getUserName(sessionId);
         } catch (NotConnectedRestException e) {
@@ -139,102 +132,91 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public UserData currentUserData(@HeaderParam("sessionid") String sessionId) {
+    public UserData currentUserData(String sessionId) {
         return scheduler().getUserDataFromSessionId(sessionId);
     }
 
     @Override
-    public List<Workflow> getWorkflows(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, IOException {
+    public List<Workflow> getWorkflows(String sessionId) throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         logger.info("Reading workflows as " + userName);
         return getFileStorageSupport().getWorkflowStorage(userName).readAll();
     }
 
     @Override
-    public Workflow createWorkflow(@HeaderParam("sessionid") String sessionId, Workflow workflow)
-            throws NotConnectedRestException, IOException {
+    public Workflow createWorkflow(String sessionId, Workflow workflow) throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         logger.info("Creating workflow as " + userName);
         return getFileStorageSupport().getWorkflowStorage(userName).store(workflow);
     }
 
     @Override
-    public Workflow getWorkflow(@HeaderParam("sessionid") String sessionId, @PathParam("id") String workflowId)
-            throws NotConnectedRestException, IOException {
+    public Workflow getWorkflow(String sessionId, String workflowId) throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         return getFileStorageSupport().getWorkflowStorage(userName).read(workflowId);
     }
 
     @Override
-    public String getWorkflowXmlContent(@HeaderParam("sessionid") String sessionId, @PathParam("id") String workflowId)
+    public String getWorkflowXmlContent(String sessionId, String workflowId)
             throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         return getFileStorageSupport().getWorkflowStorage(userName).read(workflowId).getXml();
     }
 
     @Override
-    public Workflow updateWorkflow(@HeaderParam("sessionid") String sessionId, @PathParam("id") String workflowId,
-            Workflow workflow) throws NotConnectedRestException, IOException {
+    public Workflow updateWorkflow(String sessionId, String workflowId, Workflow workflow)
+            throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         logger.info("Updating workflow " + workflowId + " as " + userName);
         return getFileStorageSupport().getWorkflowStorage(userName).update(workflowId, workflow);
     }
 
     @Override
-    public void deleteWorkflow(@HeaderParam("sessionid") String sessionId, @PathParam("id") String workflowId)
-            throws NotConnectedRestException, IOException {
+    public void deleteWorkflow(String sessionId, String workflowId) throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         logger.info("Deleting workflow " + workflowId + " as " + userName);
         getFileStorageSupport().getWorkflowStorage(userName).delete(workflowId);
     }
 
     @Override
-    public List<Workflow> getTemplates(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, IOException {
+    public List<Workflow> getTemplates(String sessionId) throws IOException {
         return getFileStorageSupport().getTemplateStorage().readAll();
     }
 
     @Override
-    public Workflow createTemplate(@HeaderParam("sessionid") String sessionId, Workflow template)
-            throws NotConnectedRestException, IOException {
+    public Workflow createTemplate(String sessionId, Workflow template) throws IOException {
         return getFileStorageSupport().getTemplateStorage().store(template);
     }
 
     @Override
-    public Workflow getTemplate(@HeaderParam("sessionid") String sessionId, @PathParam("id") String templateId)
-            throws NotConnectedRestException, IOException {
+    public Workflow getTemplate(String sessionId, String templateId) throws IOException {
         return getFileStorageSupport().getTemplateStorage().read(templateId);
     }
 
     @Override
-    public String getTemplateXmlContent(@HeaderParam("sessionid") String sessionId, @PathParam("id") String templateId)
-            throws NotConnectedRestException, IOException {
+    public String getTemplateXmlContent(String sessionId, String templateId) throws IOException {
         return getFileStorageSupport().getTemplateStorage().read(templateId).getXml();
     }
 
     @Override
-    public Workflow updateTemplate(@HeaderParam("sessionid") String sessionId, @PathParam("id") String templateId,
-            Workflow template) throws NotConnectedRestException, IOException {
+    public Workflow updateTemplate(String sessionId, String templateId, Workflow template) throws IOException {
         return getFileStorageSupport().getTemplateStorage().update(templateId, template);
     }
 
     @Override
-    public void deleteTemplate(@HeaderParam("sessionid") String sessionId, @PathParam("id") String templateId)
-            throws NotConnectedRestException, IOException {
+    public void deleteTemplate(String sessionId, String templateId) throws IOException {
         getFileStorageSupport().getTemplateStorage().delete(templateId);
     }
 
     @Override
-    public List<Script> getScripts(@HeaderParam("sessionid") String sessionId)
-            throws NotConnectedRestException, IOException {
+    public List<Script> getScripts(String sessionId) throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         return getFileStorageSupport().getScriptStorage(userName).readAll();
     }
 
     @Override
-    public String createScript(@HeaderParam("sessionid") String sessionId, @FormParam("name") String name,
-            @FormParam("content") String content) throws NotConnectedRestException, IOException {
+    public String createScript(String sessionId, String name, String content)
+            throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         FileStorage<Script> scriptStorage = getFileStorageSupport().getScriptStorage(userName);
         Script storedScript = scriptStorage.store(new Script(name, content));
@@ -242,14 +224,14 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public String updateScript(@HeaderParam("sessionid") String sessionId, @PathParam("name") String name,
-            @FormParam("content") String content) throws NotConnectedRestException, IOException {
+    public String updateScript(String sessionId, String name, String content)
+            throws NotConnectedRestException, IOException {
 
         return createScript(sessionId, name, content);
     }
 
     @Override
-    public ArrayList<String> getClasses(@HeaderParam("sessionid") String sessionId) throws NotConnectedRestException {
+    public ArrayList<String> getClasses(String sessionId) throws NotConnectedRestException {
         String userName = getUserName(sessionId);
         File classesDir = new File(getFileStorageSupport().getWorkflowsDir(userName), "classes");
 
@@ -280,7 +262,7 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public String createClass(@HeaderParam("sessionid") String sessionId, MultipartFormDataInput input)
+    public String createClass(String sessionId, MultipartFormDataInput input)
             throws NotConnectedRestException, IOException {
         try {
             String userName = getUserName(sessionId);
@@ -324,16 +306,15 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public JobValidationData validate(@HeaderParam("sessionid") String sessionId,
-            @PathParam("path") PathSegment pathSegment, MultipartFormDataInput multipart)
+    public JobValidationData validate(String sessionId, PathSegment pathSegment, MultipartFormDataInput multipart)
             throws NotConnectedRestException {
         return scheduler().validate(sessionId, pathSegment, multipart);
     }
 
     @Override
-    public JobIdData submit(@HeaderParam("sessionid") String sessionId, @PathParam("path") PathSegment pathSegment,
-            MultipartFormDataInput multipart) throws JobCreationRestException, NotConnectedRestException,
-            PermissionRestException, SubmissionClosedRestException, IOException {
+    public JobIdData submit(String sessionId, PathSegment pathSegment, MultipartFormDataInput multipart)
+            throws JobCreationRestException, NotConnectedRestException, PermissionRestException,
+            SubmissionClosedRestException, IOException {
         return scheduler().submit(sessionId, pathSegment, multipart, null);
     }
 
@@ -345,8 +326,7 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public String getVisualization(@HeaderParam("sessionid") String sessionId, @PathParam("id") String jobId)
-            throws NotConnectedRestException, IOException {
+    public String getVisualization(String sessionId, String jobId) throws IOException {
         File visualizationFile = new File(PortalConfiguration.jobIdToPath(jobId) + ".html");
         if (visualizationFile.exists()) {
             return FileUtils.readFileToString(new File(visualizationFile.getAbsolutePath()),
@@ -356,8 +336,7 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
-    public boolean updateVisualization(@HeaderParam("sessionid") String sessionId, @PathParam("id") String jobId,
-            @FormParam("visualization") String visualization) throws NotConnectedRestException, IOException {
+    public boolean updateVisualization(String sessionId, String jobId, String visualization) throws IOException {
         File visualizationFile = new File(PortalConfiguration.jobIdToPath(jobId) + ".html");
         Files.deleteIfExists(visualizationFile.toPath());
         FileUtils.write(new File(visualizationFile.getAbsolutePath()), visualization, Charset.forName(FILE_ENCODING));

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -62,6 +62,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobValidationData;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SchedulerRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SubmissionClosedRestException;
 import org.ow2.proactive_grid_cloud_portal.studio.storage.FileStorage;
@@ -113,7 +114,7 @@ public class StudioRest implements StudioInterface {
 
     @Override
     public void logout(@HeaderParam("sessionid")
-    final String sessionId) throws PermissionRestException, NotConnectedRestException {
+    final String sessionId) throws RestException {
         logger.info("logout");
         scheduler().disconnect(sessionId);
     }

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -49,6 +49,7 @@ import org.ow2.proactive.scheduler.common.TaskDescriptor;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
@@ -677,15 +678,14 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
 
     @Override
     public Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, boolean running,
-            boolean pending, boolean finished, int offset, int limit)
-            throws NotConnectedException, PermissionException {
+            boolean pending, boolean finished, int offset, int limit) throws SchedulerException {
         return _getScheduler().getTaskIds(taskTag, from, to, mytasks, running, pending, finished, offset, limit);
     }
 
     @Override
     public Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
-            throws NotConnectedException, PermissionException {
+            throws SchedulerException {
         return _getScheduler().getTaskStates(taskTag,
                                              from,
                                              to,
@@ -699,7 +699,7 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public JobInfo getJobInfo(String jobId) throws UnknownJobException, NotConnectedException, PermissionException {
+    public JobInfo getJobInfo(String jobId) throws SchedulerException {
         return _getScheduler().getJobInfo(jobId);
     }
 
@@ -710,13 +710,12 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public String getJobContent(JobId jobId) throws UnknownJobException, SubmissionClosedException,
-            JobCreationException, NotConnectedException, PermissionException {
+    public String getJobContent(JobId jobId) throws SchedulerException {
         return _getScheduler().getJobContent(jobId);
     }
 
     @Override
-    public Map<Object, Object> getPortalConfiguration() throws NotConnectedException, PermissionException {
+    public Map<Object, Object> getPortalConfiguration() throws SchedulerException {
         return _getScheduler().getPortalConfiguration();
     }
 
@@ -731,7 +730,7 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException {
+    public Map<String, Object> getSchedulerProperties() throws SchedulerException {
         return _getScheduler().getSchedulerProperties();
     }
 
@@ -754,14 +753,12 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
         return _getScheduler().getJobResultMaps(jobsId);
     }
 
     @Override
-    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException {
         return _getScheduler().getPreciousTaskNames(jobsId);
     }
 
@@ -787,9 +784,8 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method)
-            throws NotConnectedException, UnknownJobException {
-        return ((ISchedulerClient) _getScheduler()).checkJobPermissionMethod(sessionId, jobId, method);
+    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
+        return (_getScheduler()).checkJobPermissionMethod(sessionId, jobId, method);
     }
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -84,8 +84,7 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @throws NotConnectedException
      * @throws UnknownJobException
      */
-    boolean checkJobPermissionMethod(String sessionId, String jobId, String method)
-            throws NotConnectedException, UnknownJobException;
+    boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException;
 
     /**
      * Returns the USER DataSpace URIs associated with the current user
@@ -1428,7 +1427,7 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @throws PermissionException
      */
     Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, boolean running, boolean pending,
-            boolean finished, int offset, int limit) throws NotConnectedException, PermissionException;
+            boolean finished, int offset, int limit) throws SchedulerException;
 
     /**
      * Retrieve a taskstates list from the scheduler.
@@ -1461,8 +1460,7 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @throws PermissionException
      */
     Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running, boolean pending,
-            boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
-            throws NotConnectedException, PermissionException;
+            boolean finished, int offset, int limit, SortSpecifierContainer sortParams) throws SchedulerException;
 
     /**
      * Retrieve a job info by it id.
@@ -1474,7 +1472,7 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @throws NotConnectedException
      * @throws PermissionException
      */
-    JobInfo getJobInfo(String jobId) throws UnknownJobException, NotConnectedException, PermissionException;
+    JobInfo getJobInfo(String jobId) throws SchedulerException;
 
     /**
      * Change the START_AT generic information at job level and reset the
@@ -1495,15 +1493,14 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @param jobId job id of existing job
      * @return copy of the xml which was submitted to the scheduler
      */
-    String getJobContent(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException,
-            SubmissionClosedException, JobCreationException;
+    String getJobContent(JobId jobId) throws SchedulerException;
 
     /**
      * @return
      * @throws PermissionException 
      * @throws NotConnectedException 
      */
-    Map<Object, Object> getPortalConfiguration() throws NotConnectedException, PermissionException;
+    Map<Object, Object> getPortalConfiguration() throws SchedulerException;
 
     /**
      * Returns the user currently connected
@@ -1521,7 +1518,7 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * Returns the scheduler properties associated with the user currently connected
      * @return scheduler properties
      */
-    Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException;
+    Map<String, Object> getSchedulerProperties() throws SchedulerException;
 
     /**
      * Return the page of tasks of the given job.<br>
@@ -1546,8 +1543,7 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
     List<TaskResult> getPreciousTaskResults(String jobId)
             throws NotConnectedException, PermissionException, UnknownJobException;
 
-    Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
-            throws NotConnectedException, PermissionException;
+    Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException;
 
-    Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws NotConnectedException, PermissionException;
+    Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException;
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/ThirdPartyCredentials.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/ThirdPartyCredentials.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 
 
 /**
@@ -45,14 +46,14 @@ public interface ThirdPartyCredentials {
      * @throws NotConnectedException if you are not authenticated.
      * @throws PermissionException if you can't access this particular method.
      */
-    void putThirdPartyCredential(String key, String value) throws NotConnectedException, PermissionException;
+    void putThirdPartyCredential(String key, String value) throws SchedulerException;
 
     /**
      * @return all third-party credential keys stored for the current user
      * @throws NotConnectedException if you are not authenticated.
      * @throws PermissionException if you can't access this particular method.
      */
-    Set<String> thirdPartyCredentialsKeySet() throws NotConnectedException, PermissionException;
+    Set<String> thirdPartyCredentialsKeySet() throws SchedulerException;
 
     /**
      *
@@ -60,5 +61,5 @@ public interface ThirdPartyCredentials {
      * @throws NotConnectedException if you are not authenticated.
      * @throws PermissionException if you can't access this particular method.
      */
-    void removeThirdPartyCredential(String key) throws NotConnectedException, PermissionException;
+    void removeThirdPartyCredential(String key) throws SchedulerException;
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.ModelValidatorContext;
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.ValidationException;
 
@@ -61,6 +62,8 @@ public class CredentialValidator implements Validator<String> {
         } catch (NotConnectedException | PermissionException e) {
             throw new ValidationException("Could not read third party-credentials from the scheduler, make sure you are connected and you have permission rights to read third-party credentials.",
                                           e);
+        } catch (SchedulerException e) {
+            logger.error(e);
         }
         return parameterValue;
     }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -629,31 +629,30 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
-    public void putThirdPartyCredential(String key, String value) throws NotConnectedException, PermissionException {
+    public void putThirdPartyCredential(String key, String value) throws SchedulerException {
         uischeduler.putThirdPartyCredential(key, value);
     }
 
     @Override
-    public Set<String> thirdPartyCredentialsKeySet() throws NotConnectedException, PermissionException {
+    public Set<String> thirdPartyCredentialsKeySet() throws SchedulerException {
         return uischeduler.thirdPartyCredentialsKeySet();
     }
 
     @Override
-    public void removeThirdPartyCredential(String key) throws NotConnectedException, PermissionException {
+    public void removeThirdPartyCredential(String key) throws SchedulerException {
         uischeduler.removeThirdPartyCredential(key);
     }
 
     @Override
     public Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, boolean running,
-            boolean pending, boolean finished, int offset, int limit)
-            throws NotConnectedException, PermissionException {
+            boolean pending, boolean finished, int offset, int limit) throws SchedulerException {
         return uischeduler.getTaskIds(taskTag, from, to, mytasks, running, pending, finished, offset, limit);
     }
 
     @Override
     public Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
-            throws NotConnectedException, PermissionException {
+            throws SchedulerException {
         return uischeduler.getTaskStates(taskTag,
                                          from,
                                          to,
@@ -667,7 +666,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
-    public JobInfo getJobInfo(String jobId) throws UnknownJobException, NotConnectedException, PermissionException {
+    public JobInfo getJobInfo(String jobId) throws SchedulerException {
         return uischeduler.getJobInfo(jobId);
     }
 
@@ -678,13 +677,12 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
-    public String getJobContent(JobId jobId) throws UnknownJobException, SubmissionClosedException,
-            JobCreationException, NotConnectedException, PermissionException {
+    public String getJobContent(JobId jobId) throws SchedulerException {
         return uischeduler.getJobContent(jobId);
     }
 
     @Override
-    public Map<Object, Object> getPortalConfiguration() throws NotConnectedException, PermissionException {
+    public Map<Object, Object> getPortalConfiguration() throws SchedulerException {
         return uischeduler.getPortalConfiguration();
     }
 
@@ -699,7 +697,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
-    public Map getSchedulerProperties() throws NotConnectedException, PermissionException {
+    public Map getSchedulerProperties() throws SchedulerException {
         return uischeduler.getSchedulerProperties();
     }
 
@@ -722,20 +720,17 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
         return uischeduler.getJobResultMaps(jobsId);
     }
 
     @Override
-    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException {
         return uischeduler.getPreciousTaskNames(jobsId);
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method)
-            throws NotConnectedException, UnknownJobException {
+    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
         return uischeduler.checkJobPermissionMethod(sessionId, jobId, method);
     }
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -52,6 +52,7 @@ import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
@@ -658,8 +659,7 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
 
     @Override
     public Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, boolean running,
-            boolean pending, boolean finished, int offset, int limit)
-            throws NotConnectedException, PermissionException {
+            boolean pending, boolean finished, int offset, int limit) throws SchedulerException {
         renewSession();
         return client.getTaskIds(taskTag, from, to, mytasks, running, pending, finished, offset, limit);
     }
@@ -667,13 +667,13 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     @Override
     public Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
-            throws NotConnectedException, PermissionException {
+            throws SchedulerException {
         renewSession();
         return client.getTaskStates(taskTag, from, to, mytasks, running, pending, finished, offset, limit, sortParams);
     }
 
     @Override
-    public JobInfo getJobInfo(String jobId) throws UnknownJobException, NotConnectedException, PermissionException {
+    public JobInfo getJobInfo(String jobId) throws SchedulerException {
         renewSession();
         return client.getJobInfo(jobId);
     }
@@ -686,8 +686,7 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
-    public String getJobContent(JobId jobId) throws UnknownJobException, SubmissionClosedException,
-            JobCreationException, NotConnectedException, PermissionException {
+    public String getJobContent(JobId jobId) throws SchedulerException {
         renewSession();
         return client.getJobContent(jobId);
     }
@@ -810,25 +809,25 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
-    public void putThirdPartyCredential(String key, String value) throws NotConnectedException, PermissionException {
+    public void putThirdPartyCredential(String key, String value) throws SchedulerException {
         renewSession();
         client.putThirdPartyCredential(key, value);
     }
 
     @Override
-    public Set<String> thirdPartyCredentialsKeySet() throws NotConnectedException, PermissionException {
+    public Set<String> thirdPartyCredentialsKeySet() throws SchedulerException {
         renewSession();
         return client.thirdPartyCredentialsKeySet();
     }
 
     @Override
-    public void removeThirdPartyCredential(String key) throws NotConnectedException, PermissionException {
+    public void removeThirdPartyCredential(String key) throws SchedulerException {
         renewSession();
         client.removeThirdPartyCredential(key);
     }
 
     @Override
-    public Map<Object, Object> getPortalConfiguration() throws NotConnectedException, PermissionException {
+    public Map<Object, Object> getPortalConfiguration() throws SchedulerException {
         renewSession();
         return client.getPortalConfiguration();
     }
@@ -846,7 +845,7 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
-    public Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException {
+    public Map<String, Object> getSchedulerProperties() throws SchedulerException {
         renewSession();
         return client.getSchedulerProperties();
     }
@@ -873,21 +872,18 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
         renewSession();
         return client.getJobResultMaps(jobsId);
     }
 
     @Override
-    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException {
         return client.getPreciousTaskNames(jobsId);
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method)
-            throws NotConnectedException, UnknownJobException {
+    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
         renewSession();
         return client.checkJobPermissionMethod(sessionId, jobId, method);
     }

--- a/scheduler/scheduler-smartproxy-common/src/main/java/org/ow2/proactive/scheduler/smartproxy/common/AbstractSmartProxy.java
+++ b/scheduler/scheduler-smartproxy-common/src/main/java/org/ow2/proactive/scheduler/smartproxy/common/AbstractSmartProxy.java
@@ -1237,17 +1237,17 @@ public abstract class AbstractSmartProxy<T extends JobTracker> implements Schedu
     }
 
     @Override
-    public void putThirdPartyCredential(String key, String value) throws NotConnectedException, PermissionException {
+    public void putThirdPartyCredential(String key, String value) throws SchedulerException {
         getScheduler().putThirdPartyCredential(key, value);
     }
 
     @Override
-    public Set<String> thirdPartyCredentialsKeySet() throws NotConnectedException, PermissionException {
+    public Set<String> thirdPartyCredentialsKeySet() throws SchedulerException {
         return getScheduler().thirdPartyCredentialsKeySet();
     }
 
     @Override
-    public void removeThirdPartyCredential(String key) throws NotConnectedException, PermissionException {
+    public void removeThirdPartyCredential(String key) throws SchedulerException {
         getScheduler().removeThirdPartyCredential(key);
     }
 

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -812,15 +812,14 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
 
     @Override
     public Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, boolean running,
-            boolean pending, boolean finished, int offset, int limit)
-            throws NotConnectedException, PermissionException {
+            boolean pending, boolean finished, int offset, int limit) throws SchedulerException {
         return schedulerProxy.getTaskIds(taskTag, from, to, mytasks, running, pending, finished, offset, limit);
     }
 
     @Override
     public Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
-            throws NotConnectedException, PermissionException {
+            throws SchedulerException {
         return schedulerProxy.getTaskStates(taskTag,
                                             from,
                                             to,
@@ -834,7 +833,7 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
-    public JobInfo getJobInfo(String jobId) throws UnknownJobException, NotConnectedException, PermissionException {
+    public JobInfo getJobInfo(String jobId) throws SchedulerException {
         return schedulerProxy.getJobInfo(jobId);
     }
 
@@ -845,13 +844,12 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
-    public String getJobContent(JobId jobId) throws UnknownJobException, SubmissionClosedException,
-            JobCreationException, NotConnectedException, PermissionException {
+    public String getJobContent(JobId jobId) throws SchedulerException {
         return schedulerProxy.getJobContent(jobId);
     }
 
     @Override
-    public Map<Object, Object> getPortalConfiguration() throws NotConnectedException, PermissionException {
+    public Map<Object, Object> getPortalConfiguration() throws SchedulerException {
         return schedulerProxy.getPortalConfiguration();
     }
 
@@ -866,7 +864,7 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
-    public Map<String, Object> getSchedulerProperties() throws NotConnectedException, PermissionException {
+    public Map<String, Object> getSchedulerProperties() throws SchedulerException {
         return schedulerProxy.getSchedulerProperties();
     }
 
@@ -889,20 +887,17 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
         return schedulerProxy.getJobResultMaps(jobsId);
     }
 
     @Override
-    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId)
-            throws NotConnectedException, PermissionException {
+    public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException {
         return schedulerProxy.getPreciousTaskNames(jobsId);
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method)
-            throws NotConnectedException, UnknownJobException {
+    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
         return schedulerProxy.checkJobPermissionMethod(sessionId, jobId, method);
     }
 


### PR DESCRIPTION
We have RMRestInterface interface and RMRest implementation. 
All javadocs and REST annotations ARE taken from the interface. Annotation inside Implementation are useless. 
The same idea will be applied to the Studio and the Scheduler REST implementations.