### PR TITLE
Remove credentials generating in rm-node

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -478,7 +478,7 @@ createGenerateCredentialTask('Admin', ['-F', 'config/authentication/keys/pub.key
                                        '-l', 'admin', '-p', 'admin', '-o', 'config/authentication/admin_user.cred'])
 
 task generateCredentials
-generateCredentials.dependsOn generateCredentialsAdmin, generateCredentialsScheduler, generateCredentialsRm, generateCredentialsNode
+generateCredentials.dependsOn generateCredentialsAdmin, generateCredentialsScheduler, generateCredentialsRm
 
 def exportedProjects= [
         ":common:common-api",

--- a/build.gradle
+++ b/build.gradle
@@ -476,8 +476,6 @@ createGenerateCredentialTask('Scheduler', ['-F', 'config/authentication/keys/pub
                                            '-l', 'scheduler', '-p', 'scheduler_pwd', '-o', 'config/authentication/scheduler.cred'])
 createGenerateCredentialTask('Admin', ['-F', 'config/authentication/keys/pub.key',
                                        '-l', 'admin', '-p', 'admin', '-o', 'config/authentication/admin_user.cred'])
-createGenerateCredentialTask('Node', ['-F', 'config/authentication/keys/pub.key',
-                                      '-l', 'rm', '-p', 'rm_pwd', '-o', 'rm/rm-node/src/main/resources/config/authentication/rm.cred'])
 
 task generateCredentials
 generateCredentials.dependsOn generateCredentialsAdmin, generateCredentialsScheduler, generateCredentialsRm, generateCredentialsNode


### PR DESCRIPTION
It might brake agents. But we need to remove this horrible credentials. 