### PR TITLE
Allow docker fork environment on windows

### DIFF
--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/TestForkEnvironment.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/TestForkEnvironment.java
@@ -93,6 +93,21 @@ public class TestForkEnvironment {
         Assert.assertFalse(forkEnvironment.getAdditionalClasspath() == forkEnvironment.getAdditionalClasspath());
     }
 
+    @Test
+    public void testPreJavaCommand() {
+        forkEnvironment.addPreJavaCommand("a");
+        Assert.assertEquals(1, forkEnvironment.getPreJavaCommand().size());
+
+        forkEnvironment.addPreJavaCommand("b");
+        Assert.assertEquals(2, forkEnvironment.getPreJavaCommand().size());
+
+        forkEnvironment.addPreJavaCommand("c");
+        Assert.assertEquals(3, forkEnvironment.getPreJavaCommand().size());
+        Assert.assertEquals("a", forkEnvironment.getPreJavaCommand().get(0));
+        Assert.assertEquals("b", forkEnvironment.getPreJavaCommand().get(1));
+        Assert.assertEquals("c", forkEnvironment.getPreJavaCommand().get(2));
+    }
+
     @Test(expected = NullPointerException.class)
     public void testAddNullAdditionalClasspath() {
         forkEnvironment.addJVMArgument(null);

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
@@ -25,6 +25,8 @@
  */
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
+import static org.ow2.proactive.scheduler.common.task.ForkEnvironment.DOCKER_FORK_WINDOWS2LINUX;
+
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.security.KeyException;
@@ -34,6 +36,7 @@ import java.util.Map;
 import org.ow2.proactive.resourcemanager.common.RMConstants;
 import org.ow2.proactive.resourcemanager.task.client.RMNodeClient;
 import org.ow2.proactive.scheduler.common.SchedulerConstants;
+import org.ow2.proactive.scheduler.common.task.ForkEnvironment;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive.scheduler.common.task.util.SerializationUtil;
@@ -93,24 +96,36 @@ public class ForkedTaskVariablesManager implements Serializable {
         scriptHandler.addBinding(SchedulerConstants.SYNCHRONIZATION_API_BINDING_NAME,
                                  taskContext.getSynchronizationAPI());
 
+        boolean isDockerWindows2Linux = "true".equals(System.getProperty(DOCKER_FORK_WINDOWS2LINUX));
+
         scriptHandler.addBinding(SchedulerConstants.DS_SCRATCH_BINDING_NAME,
-                                 taskContext.getNodeDataSpaceURIs().getScratchURI());
+                                 convertToLinuxIfNeeded(isDockerWindows2Linux,
+                                                        taskContext.getNodeDataSpaceURIs().getScratchURI()));
         scriptHandler.addBinding(SchedulerConstants.DS_CACHE_BINDING_NAME,
-                                 taskContext.getNodeDataSpaceURIs().getCacheURI());
+                                 convertToLinuxIfNeeded(isDockerWindows2Linux,
+                                                        taskContext.getNodeDataSpaceURIs().getCacheURI()));
         scriptHandler.addBinding(SchedulerConstants.DS_INPUT_BINDING_NAME,
-                                 taskContext.getNodeDataSpaceURIs().getInputURI());
+                                 convertToLinuxIfNeeded(isDockerWindows2Linux,
+                                                        taskContext.getNodeDataSpaceURIs().getInputURI()));
         scriptHandler.addBinding(SchedulerConstants.DS_OUTPUT_BINDING_NAME,
-                                 taskContext.getNodeDataSpaceURIs().getOutputURI());
+                                 convertToLinuxIfNeeded(isDockerWindows2Linux,
+                                                        taskContext.getNodeDataSpaceURIs().getOutputURI()));
         scriptHandler.addBinding(SchedulerConstants.DS_GLOBAL_BINDING_NAME,
-                                 taskContext.getNodeDataSpaceURIs().getGlobalURI());
+                                 convertToLinuxIfNeeded(isDockerWindows2Linux,
+                                                        taskContext.getNodeDataSpaceURIs().getGlobalURI()));
         scriptHandler.addBinding(SchedulerConstants.DS_USER_BINDING_NAME,
-                                 taskContext.getNodeDataSpaceURIs().getUserURI());
+                                 convertToLinuxIfNeeded(isDockerWindows2Linux,
+                                                        taskContext.getNodeDataSpaceURIs().getUserURI()));
 
         scriptHandler.addBinding(SchedulerConstants.MULTI_NODE_TASK_NODESURL_BINDING_NAME,
                                  taskContext.getOtherNodesURLs());
 
         scriptHandler.addBinding(SchedulerConstants.FORK_ENVIRONMENT_BINDING_NAME,
                                  taskContext.getInitializer().getForkEnvironment());
+    }
+
+    private String convertToLinuxIfNeeded(boolean isDockerWindows2Linux, String uri) {
+        return isDockerWindows2Linux ? ForkEnvironment.convertToLinuxPath(uri) : uri;
     }
 
     public Map<String, String> extractThirdPartyCredentials(TaskContext container) throws Exception {


### PR DESCRIPTION
 - add new fork environment property "isDockerWindowsToLinux" to control path transformations
 - transform paths if needed in ForkedJvmTaskExecutionCommandCreator
 - also add the possibility to define the preJavaCommand as list (more robust)
 - added some unit tests