### PR TITLE
Improve SchedulerFrontend concurrency

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/utils/Lambda.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/utils/Lambda.java
@@ -44,6 +44,11 @@ public class Lambda {
     private Lambda() {
     }
 
+    /**
+     * Execute a runnable with lock acquire/release
+     * @param lock the lock to acquire
+     * @param runnable code to execute
+     */
     public static void withLock(Lock lock, Runnable runnable) {
         lock.lock();
         try {
@@ -53,11 +58,104 @@ public class Lambda {
         }
     }
 
+    /**
+     * Execute a callable with lock acquire/release
+     * @param lock the lock to acquire
+     * @param callable code to execute
+     * @param <T> return type
+     * @return the callable result
+     */
     public static <T> T withLock(Lock lock, Callable<T> callable) {
         lock.lock();
         try {
             return callable.call();
         } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Execute a callable with lock acquire/release, handling InterruptedException
+     * @param lock the lock to acquire interruptibly
+     * @param callable code to execute
+     * @param interruptedException exception which will be used to wrap the InterruptedException (null to use a RuntimeException)
+     * @param <T> return type
+     * @param <E> wrapper exception type
+     * @return the callable result
+     * @throws E when the lock is interrupted
+     */
+    public static <T, E extends Exception> T withLockInterruptible(Lock lock, Callable<T> callable,
+            E interruptedException) throws E {
+
+        try {
+            lock.lockInterruptibly();
+            return callable.call();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (interruptedException != null) {
+                interruptedException.initCause(e);
+                throw interruptedException;
+            }
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Execute a callable with lock acquire/release, handling one checked exception
+     * @param lock the lock to acquire
+     * @param callable code to execute
+     * @param exception1Class the class of the checked exception which will be handled
+     * @param <T> return type
+     * @param <E1> type of checked exception
+     * @return the callable result
+     * @throws E1 when this exception occurs in the callable
+     */
+    public static <T, E1 extends Exception> T withLockException1(Lock lock, Callable<T> callable,
+            Class<E1> exception1Class) throws E1 {
+        lock.lock();
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            if (exception1Class.isInstance(e)) {
+                throw (E1) e;
+            }
+            throw new RuntimeException(e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Execute a callable with lock acquire/release, handling two checked exceptions
+     * @param lock the lock to acquire
+     * @param callable code to execute
+     * @param exception1Class the class of the first checked exception which will be handled
+     * @param exception2Class the class of the second checked exception which will be handled
+     * @param <T> return type
+     * @param <E1> type of the first checked exception
+     * @param <E2> type of the second checked exception
+     * @return the callable result
+     * @throws E1 when the first exception type occurs in the callable
+     * @throws E2 when the second exception type occurs in the callable
+     */
+    public static <T, E1 extends Exception, E2 extends Exception> T withLockException2(Lock lock, Callable<T> callable,
+            Class<E1> exception1Class, Class<E2> exception2Class) throws E1, E2 {
+        lock.lock();
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            if (exception1Class.isInstance(e)) {
+                throw (E1) e;
+            }
+            if (exception2Class.isInstance(e)) {
+                throw (E2) e;
+            }
             throw new RuntimeException(e);
         } finally {
             lock.unlock();

--- a/common/common-api/src/main/java/org/ow2/proactive/utils/PAExecutors.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/utils/PAExecutors.java
@@ -1,0 +1,83 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.utils;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Helper class to create executors (not provided by java standard api)
+ * @author ActiveEon Team
+ * @since 17/10/2019
+ */
+public class PAExecutors {
+
+    /**
+     * Similar to Executors.newCachedThreadPool but allows a maximum pool size.
+     * Cached thread pool are interesting in the sense that they can grow and shrink at will.
+     * Default cachedThreadPool implementation does not allow to have a maximum capacity
+     * @param corePoolSize the number of threads to keep in the pool, even if they are idle
+     * @param maximumPoolSize the maximum number of threads to allow in the pool
+     * @param keepAliveTime when the number of threads is greater than the core, this is the maximum time that excess idle threads
+     *        will wait for new tasks before terminating.
+     * @param timeUnit the time unit for the {@code keepAliveTime} argument
+     * @param threadFactory the factory to use when the executor
+     *        creates a new thread
+     * @return the newly created thread pool
+     */
+    public static ExecutorService newCachedBoundedThreadPool(int corePoolSize, int maximumPoolSize, long keepAliveTime,
+            TimeUnit timeUnit, ThreadFactory threadFactory) {
+        BlockingQueue<Runnable> queue = new LinkedTransferQueue<Runnable>() {
+            @Override
+            public boolean offer(Runnable e) {
+                return tryTransfer(e);
+            }
+        };
+        ThreadPoolExecutor threadPool = new ThreadPoolExecutor(corePoolSize,
+                                                               maximumPoolSize,
+                                                               keepAliveTime,
+                                                               timeUnit,
+                                                               queue,
+                                                               threadFactory);
+        threadPool.setRejectedExecutionHandler(new RejectedExecutionHandler() {
+            @Override
+            public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+                try {
+                    executor.getQueue().put(r);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+        return threadPool;
+    }
+}

--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -66,7 +66,7 @@ public enum WebProperties implements PACommonProperties {
 
     WEB_HTTPS_PORT("web.https.port", PropertyType.INTEGER, "8443"),
 
-    WEB_MAX_THREADS("web.max_threads", PropertyType.INTEGER, "100"),
+    WEB_MAX_THREADS("web.max_threads", PropertyType.INTEGER, "300"),
 
     WEB_IDLE_TIMEOUT("web.idle_timeout", PropertyType.INTEGER, "60000"),
 

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -25,23 +25,26 @@ pa.scheduler.core.rmconnection.autoconnect = true
 pa.scheduler.core.rmconnection.timespan = 10000
 pa.scheduler.core.rmconnection.attempts = 360
 
-# Number of threads used to execute client requests
+# Maximum number of threads used to execute client requests
 # (e.g. change Job priority, kill Job, etc.)
-pa.scheduler.core.clientpoolnbthreads=5
+pa.scheduler.core.clientpoolnbthreads=100
 
-# Number of threads used to execute internal scheduling operations
+# Maximum number of threads used to execute internal scheduling operations
 # (handle task termination, restart task, etc.)
-pa.scheduler.core.internalpoolnbthreads=5
+pa.scheduler.core.internalpoolnbthreads=100
 
-# Number of threads used to ping tasks regularly to get its progress and detect node failures
-pa.scheduler.core.taskpingerpoolnbthreads=10
+# Maximum number of threads used to ping tasks regularly to get its progress and detect node failures
+pa.scheduler.core.taskpingerpoolnbthreads=100
 
 # Number of threads used to delay operations which are NOT related to housekeeping
 # (e.g. scheduler shutdown, handle task restart on error, etc.)
-pa.scheduler.core.scheduledpoolnbthreads=2
+pa.scheduler.core.scheduledpoolnbthreads=20
 
 # Number of threads used to handle scheduled operations with the housekeeping feature
 pa.scheduler.core.housekeeping.scheduledpoolnbthreads=5
+
+# Maximum number of threads in the thread pool that serves to recover running tasks in parallel at scheduler start up
+pa.scheduler.core.parallel.scheduler.state.recover.nbthreads=100
 
 # Check for failed node frequency in second
 # Also used by the node to ping the scheduler after finishing a task

--- a/config/web/settings.ini
+++ b/config/web/settings.ini
@@ -4,7 +4,7 @@
 web.deploy=true
 
 # the maximum number of threads in Jetty for parallel request processing
-web.max_threads=100
+web.max_threads=300
 
 # timeout on http requests, default to 1 minute, can be increased to handle long requests
 web.idle_timeout=60000

--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     runtime 'org.jruby:jruby-complete:9.0.5.0'
     runtime 'org.python:jython-standalone:2.7.0'
 
+    runtime 'org.apache.ivy:ivy:2.1.0'
     runtime 'org.codehaus.groovy:groovy-all:2.4.12'
     runtime 'jsr223:jsr223-nativeshell:0.4.9'
     runtime 'jsr223:jsr223-docker-compose:0.3.2'

--- a/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
+++ b/rm/rm-server/src/test/java/functionaltests/utils/RMTHelper.java
@@ -106,7 +106,8 @@ public class RMTHelper {
     private String currentTestConfiguration;
 
     public static void log(String s) {
-        System.out.println("------------------------------ " + s);
+        System.out.println("------------------------------" +
+                           String.format("[%1$tH:%1$tM:%1$tS,%1$tL] ", Calendar.getInstance().getTime()) + s);
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -85,23 +85,23 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Time in milliseconds before sending a kill request to the scheduler. */
     SCHEDULER_KILL_DELAY("pa.scheduler.core.killdelay", PropertyType.INTEGER, "2000"),
 
-    /** Number of threads used to execute client requests  */
-    SCHEDULER_CLIENT_POOL_NBTHREAD("pa.scheduler.core.clientpoolnbthreads", PropertyType.INTEGER, "5"),
+    /** Maximum number of threads used to execute client requests  */
+    SCHEDULER_CLIENT_POOL_NBTHREAD("pa.scheduler.core.clientpoolnbthreads", PropertyType.INTEGER, "100"),
 
-    /** Number of threads used to execute internal scheduling operations */
-    SCHEDULER_INTERNAL_POOL_NBTHREAD("pa.scheduler.core.internalpoolnbthreads", PropertyType.INTEGER, "5"),
+    /** Maximum number of threads used to execute internal scheduling operations */
+    SCHEDULER_INTERNAL_POOL_NBTHREAD("pa.scheduler.core.internalpoolnbthreads", PropertyType.INTEGER, "100"),
 
-    /** Number of threads used to ping tasks */
-    SCHEDULER_TASK_PINGER_POOL_NBTHREAD("pa.scheduler.core.taskpingerpoolnbthreads", PropertyType.INTEGER, "10"),
+    /** Maximum number of threads used to ping tasks */
+    SCHEDULER_TASK_PINGER_POOL_NBTHREAD("pa.scheduler.core.taskpingerpoolnbthreads", PropertyType.INTEGER, "50"),
 
     /** Number of threads used to handle scheduled operations other than housekeeping operations */
-    SCHEDULER_SCHEDULED_POOL_NBTHREAD("pa.scheduler.core.scheduledpoolnbthreads", PropertyType.INTEGER, "2"),
+    SCHEDULER_SCHEDULED_POOL_NBTHREAD("pa.scheduler.core.scheduledpoolnbthreads", PropertyType.INTEGER, "20"),
 
     /** Number of threads used to handle scheduled operations related to housekeeping */
     SCHEDULER_HOUSEKEEPING_SCHEDULED_POOL_NBTHREAD("pa.scheduler.core.housekeeping.scheduledpoolnbthreads", PropertyType.INTEGER, "5"),
 
-    /** The number of threads in the thread pool that serves to recover running tasks in parallel at scheduler start up */
-    SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_NBTHREAD("pa.scheduler.core.parallel.scheduler.state.recover.nbthreads", PropertyType.INTEGER, "16"),
+    /** Maximum number of threads in the thread pool that serves to recover running tasks in parallel at scheduler start up */
+    SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_NBTHREAD("pa.scheduler.core.parallel.scheduler.state.recover.nbthreads", PropertyType.INTEGER, "100"),
 
     /** The timeout - to be used in minutes - for the scheduler state to be fully recovered */
     SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_TIMEOUT("pa.scheduler.core.parallel.scheduler.state.recover.timeout", PropertyType.INTEGER, "60"),

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -187,6 +187,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
      * Subscribes a listener to the Scheduler
      */
     @Override
+    @ImmediateService
     public SchedulerState addEventListener(SchedulerEventListener sel, boolean myEventsOnly, boolean getCurrentState,
             SchedulerEvent... events) throws NotConnectedException, PermissionException {
         checkSchedulerConnection();
@@ -196,6 +197,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public void disconnect() throws NotConnectedException, PermissionException {
         if (uischeduler == null)
             throw new NotConnectedException("Not connected to the scheduler.");
@@ -205,6 +207,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public boolean isConnected() {
         if (uischeduler == null) {
             return false;
@@ -220,30 +223,35 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public String getCurrentPolicy() throws NotConnectedException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.getCurrentPolicy();
     }
 
     @Override
+    @ImmediateService
     public Map getJobsToSchedule() throws NotConnectedException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.getJobsToSchedule();
     }
 
     @Override
+    @ImmediateService
     public List<TaskDescriptor> getTasksToSchedule() throws NotConnectedException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.getTasksToSchedule();
     }
 
     @Override
+    @ImmediateService
     public void renewSession() throws NotConnectedException {
         checkSchedulerConnection();
         uischeduler.renewSession();
     }
 
     @Override
+    @ImmediateService
     public void removeEventListener() throws NotConnectedException, PermissionException {
         checkSchedulerConnection();
         uischeduler.removeEventListener();
@@ -251,6 +259,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public JobId submit(Job job)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
         checkSchedulerConnection();
@@ -258,6 +267,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
             throws NotConnectedException, UnknownJobException, PermissionException, JobCreationException,
             SubmissionClosedException {
@@ -266,6 +276,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public void changeJobPriority(JobId jobId, JobPriority priority)
             throws NotConnectedException, UnknownJobException, PermissionException, JobAlreadyFinishedException {
         checkSchedulerConnection();
@@ -274,28 +285,33 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public JobResult getJobResult(String jobId) throws NotConnectedException, PermissionException, UnknownJobException {
         checkSchedulerConnection();
         return uischeduler.getJobResult(jobId);
     }
 
     @Override
+    @ImmediateService
     public List<String> getUserSpaceURIs() throws NotConnectedException, PermissionException {
         return uischeduler.getUserSpaceURIs();
     }
 
     @Override
+    @ImmediateService
     public List<String> getGlobalSpaceURIs() throws NotConnectedException, PermissionException {
         return uischeduler.getGlobalSpaceURIs();
     }
 
     @Override
+    @ImmediateService
     public JobResult getJobResult(JobId jobId) throws NotConnectedException, PermissionException, UnknownJobException {
         checkSchedulerConnection();
         return uischeduler.getJobResult(jobId);
     }
 
     @Override
+    @ImmediateService
     public TaskResult getTaskResult(String jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
@@ -303,6 +319,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public TaskResult getTaskResult(JobId jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
@@ -310,6 +327,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public List<TaskResult> getTaskResultsByTag(JobId jobId, String taskTag)
             throws NotConnectedException, UnknownJobException, PermissionException {
         checkSchedulerConnection();
@@ -317,6 +335,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public List<TaskResult> getTaskResultsByTag(String jobId, String taskTag)
             throws NotConnectedException, UnknownJobException, PermissionException {
         checkSchedulerConnection();
@@ -324,53 +343,67 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public TaskResult getTaskResultFromIncarnation(JobId jobId, String taskName, int inc)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         return uischeduler.getTaskResultFromIncarnation(jobId, taskName, inc);
     }
 
     @Override
+    @ImmediateService
     public List<TaskResult> getTaskResultAllIncarnations(JobId jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         return uischeduler.getTaskResultAllIncarnations(jobId, taskName);
     }
 
     @Override
+    @ImmediateService
     public List<TaskResult> getTaskResultAllIncarnations(String jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         return uischeduler.getTaskResultAllIncarnations(jobId, taskName);
     }
 
     @Override
+    @ImmediateService
     public TaskResult getTaskResultFromIncarnation(String jobId, String taskName, int inc)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         return uischeduler.getTaskResultFromIncarnation(jobId, taskName, inc);
     }
 
+    @Override
+    @ImmediateService
     public boolean killTask(JobId jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.killTask(jobId, taskName);
     }
 
+    @Override
+    @ImmediateService
     public boolean restartTask(JobId jobId, String taskName, int restartDelay)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.restartTask(jobId, taskName, restartDelay);
     }
 
+    @Override
+    @ImmediateService
     public boolean preemptTask(JobId jobId, String taskName, int restartDelay)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.preemptTask(jobId, taskName, restartDelay);
     }
 
+    @Override
+    @ImmediateService
     public boolean killTask(String jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.killTask(jobId, taskName);
     }
 
+    @Override
+    @ImmediateService
     public boolean restartTask(String jobId, String taskName, int restartDelay)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
@@ -378,6 +411,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public boolean finishInErrorTask(String jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
@@ -385,12 +419,15 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public boolean restartInErrorTask(String jobId, String taskName)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.restartInErrorTask(jobId, taskName);
     }
 
+    @Override
+    @ImmediateService
     public boolean preemptTask(String jobId, String taskName, int restartDelay)
             throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
         checkSchedulerConnection();
@@ -398,12 +435,14 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public boolean killJob(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.killJob(jobId);
     }
 
     @Override
+    @ImmediateService
     public void listenJobLogs(JobId jobId, AppenderProvider appenderProvider)
             throws NotConnectedException, UnknownJobException, PermissionException {
         checkSchedulerConnection();
@@ -412,6 +451,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public boolean pauseJob(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.pauseJob(jobId);
@@ -419,18 +459,21 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public boolean removeJob(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.removeJob(jobId);
     }
 
     @Override
+    @ImmediateService
     public boolean removeJobs(List<JobId> jobIds) throws NotConnectedException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.removeJobs(jobIds);
     }
 
     @Override
+    @ImmediateService
     public boolean resumeJob(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         checkSchedulerConnection();
         return uischeduler.resumeJob(jobId);
@@ -443,6 +486,7 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public void changeJobPriority(String jobId, JobPriority priority)
             throws NotConnectedException, UnknownJobException, PermissionException, JobAlreadyFinishedException {
         uischeduler.changeJobPriority(jobId, priority);
@@ -450,103 +494,142 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public SchedulerStatus getStatus() throws NotConnectedException, PermissionException {
         return uischeduler.getStatus();
     }
 
     @Override
+    @ImmediateService
     public boolean killJob(String jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.killJob(jobId);
     }
 
     @Override
+    @ImmediateService
     public boolean killJobs(List<String> jobsId) throws NotConnectedException, PermissionException {
         return uischeduler.killJobs(jobsId);
     }
 
     @Override
+    @ImmediateService
     public boolean pauseJob(String jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.pauseJob(jobId);
     }
 
     @Override
+    @ImmediateService
     public boolean restartAllInErrorTasks(String jobId)
             throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.restartAllInErrorTasks(jobId);
     }
 
     @Override
+    @ImmediateService
     public boolean removeJob(String jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.removeJob(jobId);
     }
 
     @Override
+    @ImmediateService
     public boolean resumeJob(String jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.resumeJob(jobId);
     }
 
+    @Override
+    @ImmediateService
     public void addEventListener(SchedulerEventListener sel, boolean myEventsOnly, SchedulerEvent... events)
             throws NotConnectedException, PermissionException {
         uischeduler.addEventListener(sel, myEventsOnly, events);
     }
 
+    @Override
+    @ImmediateService
     public JobState getJobState(String jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.getJobState(jobId);
     }
 
+    @Override
+    @ImmediateService
     public void listenJobLogs(String jobId, AppenderProvider appenderProvider)
             throws NotConnectedException, UnknownJobException, PermissionException {
         uischeduler.listenJobLogs(jobId, appenderProvider);
     }
 
+    @Override
+    @ImmediateService
     public boolean changePolicy(String newPolicyClassName) throws NotConnectedException, PermissionException {
         return uischeduler.changePolicy(newPolicyClassName);
     }
 
+    @Override
+    @ImmediateService
     public boolean reloadPolicyConfiguration() throws NotConnectedException, PermissionException {
         return uischeduler.reloadPolicyConfiguration();
     }
 
+    @Override
+    @ImmediateService
     public boolean freeze() throws NotConnectedException, PermissionException {
         return uischeduler.freeze();
     }
 
+    @Override
+    @ImmediateService
     public JobState getJobState(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.getJobState(jobId);
     }
 
+    @Override
+    @ImmediateService
     public SchedulerState getState() throws NotConnectedException, PermissionException {
         return uischeduler.getState();
     }
 
+    @Override
+    @ImmediateService
     public boolean kill() throws NotConnectedException, PermissionException {
         return uischeduler.kill();
     }
 
+    @Override
+    @ImmediateService
     public boolean linkResourceManager(String rmURL) throws NotConnectedException, PermissionException {
         return uischeduler.linkResourceManager(rmURL);
     }
 
+    @Override
+    @ImmediateService
     public boolean pause() throws NotConnectedException, PermissionException {
         return uischeduler.pause();
     }
 
+    @Override
+    @ImmediateService
     public boolean resume() throws NotConnectedException, PermissionException {
         return uischeduler.resume();
     }
 
+    @Override
+    @ImmediateService
     public boolean shutdown() throws NotConnectedException, PermissionException {
         return uischeduler.shutdown();
     }
 
+    @Override
+    @ImmediateService
     public boolean start() throws NotConnectedException, PermissionException {
         return uischeduler.start();
     }
 
+    @Override
+    @ImmediateService
     public boolean stop() throws NotConnectedException, PermissionException {
         return uischeduler.stop();
     }
 
+    @Override
+    @ImmediateService
     public SchedulerState getState(boolean myJobsOnly) throws NotConnectedException, PermissionException {
         return uischeduler.getState(myJobsOnly);
     }
@@ -589,77 +672,91 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public String getJobServerLogs(String id) throws UnknownJobException, NotConnectedException, PermissionException {
         return uischeduler.getJobServerLogs(id);
     }
 
     @Override
+    @ImmediateService
     public String getTaskServerLogs(String id, String taskName)
             throws UnknownJobException, UnknownTaskException, NotConnectedException, PermissionException {
         return uischeduler.getTaskServerLogs(id, taskName);
     }
 
     @Override
+    @ImmediateService
     public String getTaskServerLogsByTag(String id, String taskTag)
             throws UnknownJobException, NotConnectedException, PermissionException {
         return uischeduler.getTaskServerLogsByTag(id, taskTag);
     }
 
     @Override
+    @ImmediateService
     public Page<JobInfo> getJobs(int index, int range, JobFilterCriteria filterCriteria,
             List<SortParameter<JobSortParameter>> sortParameters) throws NotConnectedException, PermissionException {
         return uischeduler.getJobs(index, range, filterCriteria, sortParameters);
     }
 
     @Override
+    @ImmediateService
     public List<JobInfo> getJobsInfoList(List<String> jobsId) throws PermissionException, NotConnectedException {
         return uischeduler.getJobsInfoList(jobsId);
     }
 
     @Override
+    @ImmediateService
     public List<SchedulerUserInfo> getUsers() throws NotConnectedException, PermissionException {
         return uischeduler.getUsers();
     }
 
     @Override
+    @ImmediateService
     public List<SchedulerUserInfo> getUsersWithJobs() throws NotConnectedException, PermissionException {
         return uischeduler.getUsersWithJobs();
     }
 
     @Override
+    @ImmediateService
     public List<JobUsage> getMyAccountUsage(Date startDate, Date endDate)
             throws NotConnectedException, PermissionException {
         return uischeduler.getMyAccountUsage(startDate, endDate);
     }
 
     @Override
+    @ImmediateService
     public List<JobUsage> getAccountUsage(String user, Date startDate, Date endDate)
             throws NotConnectedException, PermissionException {
         return uischeduler.getAccountUsage(user, startDate, endDate);
     }
 
     @Override
+    @ImmediateService
     public void putThirdPartyCredential(String key, String value) throws SchedulerException {
         uischeduler.putThirdPartyCredential(key, value);
     }
 
     @Override
+    @ImmediateService
     public Set<String> thirdPartyCredentialsKeySet() throws SchedulerException {
         return uischeduler.thirdPartyCredentialsKeySet();
     }
 
     @Override
+    @ImmediateService
     public void removeThirdPartyCredential(String key) throws SchedulerException {
         uischeduler.removeThirdPartyCredential(key);
     }
 
     @Override
+    @ImmediateService
     public Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit) throws SchedulerException {
         return uischeduler.getTaskIds(taskTag, from, to, mytasks, running, pending, finished, offset, limit);
     }
 
     @Override
+    @ImmediateService
     public Page<TaskState> getTaskStates(String taskTag, long from, long to, boolean mytasks, boolean running,
             boolean pending, boolean finished, int offset, int limit, SortSpecifierContainer sortParams)
             throws SchedulerException {
@@ -676,70 +773,83 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     }
 
     @Override
+    @ImmediateService
     public JobInfo getJobInfo(String jobId) throws SchedulerException {
         return uischeduler.getJobInfo(jobId);
     }
 
     @Override
+    @ImmediateService
     public boolean changeStartAt(JobId jobId, String startAt)
             throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.changeStartAt(jobId, startAt);
     }
 
     @Override
+    @ImmediateService
     public String getJobContent(JobId jobId) throws SchedulerException {
         return uischeduler.getJobContent(jobId);
     }
 
     @Override
+    @ImmediateService
     public Map<Object, Object> getPortalConfiguration() throws SchedulerException {
         return uischeduler.getPortalConfiguration();
     }
 
     @Override
+    @ImmediateService
     public String getCurrentUser() throws NotConnectedException {
         return uischeduler.getCurrentUser();
     }
 
     @Override
+    @ImmediateService
     public UserData getCurrentUserData() throws NotConnectedException {
         return uischeduler.getCurrentUserData();
     }
 
     @Override
+    @ImmediateService
     public Map getSchedulerProperties() throws SchedulerException {
         return uischeduler.getSchedulerProperties();
     }
 
     @Override
+    @ImmediateService
     public TaskStatesPage getTaskPaginated(String jobId, int offset, int limit)
             throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.getTaskPaginated(jobId, offset, limit);
     }
 
     @Override
+    @ImmediateService
     public TaskStatesPage getTaskPaginated(String jobId, String statusFilter, int offset, int limit)
             throws NotConnectedException, UnknownJobException, PermissionException {
         return uischeduler.getTaskPaginated(jobId, statusFilter, offset, limit);
     }
 
     @Override
+    @ImmediateService
     public List<TaskResult> getPreciousTaskResults(String jobId)
             throws NotConnectedException, PermissionException, UnknownJobException {
         return uischeduler.getPreciousTaskResults(jobId);
     }
 
     @Override
+    @ImmediateService
     public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
         return uischeduler.getJobResultMaps(jobsId);
     }
 
     @Override
+    @ImmediateService
     public Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException {
         return uischeduler.getPreciousTaskNames(jobsId);
     }
 
     @Override
+    @ImmediateService
     public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
         return uischeduler.checkJobPermissionMethod(sessionId, jobId, method);
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -100,7 +100,7 @@ import com.google.common.collect.Lists;
                                                                      "numberOfFailedTasks = :numberOfFailedTasks, numberOfFaultyTasks = :numberOfFaultyTasks, " +
                                                                      "numberOfInErrorTasks = :numberOfInErrorTasks, inErrorTime = :inErrorTime, lastUpdatedTime = :lastUpdatedTime " +
                                                                      "where id = :jobId"),
-                @NamedQuery(name = "updateJobDataRemovedTime", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where ids in :ids"),
+                @NamedQuery(name = "updateJobDataRemovedTime", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in :ids"),
                 @NamedQuery(name = "updateJobDataRemovedTimeInBulk", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in :jobIdList"),
                 @NamedQuery(name = "updateJobDataSetJobToBeRemoved", query = "update JobData set toBeRemoved = :toBeRemoved, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "updateJobDataPriority", query = "update JobData set priority = :priority, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -32,11 +32,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.log4j.Logger;
+import org.objectweb.proactive.utils.NamedThreadFactory;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
@@ -47,6 +47,7 @@ import org.ow2.proactive.scheduler.task.TaskLauncher;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 import org.ow2.proactive.scheduler.util.JobLogger;
 import org.ow2.proactive.utils.NodeSet;
+import org.ow2.proactive.utils.PAExecutors;
 
 
 public class SchedulerStateRecoverHelper {
@@ -75,7 +76,11 @@ public class SchedulerStateRecoverHelper {
         Vector<InternalJob> pendingJobs = new Vector<>();
         Vector<InternalJob> runningJobs = new Vector<>();
 
-        ExecutorService recoverRunningTasksThreadPool = Executors.newFixedThreadPool(PASchedulerProperties.SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_NBTHREAD.getValueAsInt());
+        ExecutorService recoverRunningTasksThreadPool = PAExecutors.newCachedBoundedThreadPool(1,
+                                                                                               PASchedulerProperties.SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_NBTHREAD.getValueAsInt(),
+                                                                                               60L,
+                                                                                               TimeUnit.SECONDS,
+                                                                                               new NamedThreadFactory("TaskRecoverThreadPool"));
 
         for (InternalJob job : notFinishedJobs) {
             recoverJob(rmProxy, pendingJobs, runningJobs, job, recoverRunningTasksThreadPool);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxy.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
+import org.objectweb.proactive.api.PAFuture;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.resourcemanager.authentication.RMAuthentication;
@@ -90,14 +91,14 @@ public class RMProxy {
         if (proxyActiveObject == null) {
             return new BooleanWrapper(false);
         }
-        return proxyActiveObject.isActive();
+        return PAFuture.getFutureValue(proxyActiveObject.isActive());
     }
 
     public RMState getState() {
         if (proxyActiveObject == null) {
             throw new RuntimeException("Proxy is not initialized");
         }
-        return proxyActiveObject.getState();
+        return PAFuture.getFutureValue(proxyActiveObject.getState());
     }
 
     public void rebind(URI rmURI) throws RMException, RMProxyCreationException {
@@ -118,7 +119,7 @@ public class RMProxy {
     }
 
     public NodeSet getNodes(Criteria criteria) {
-        return proxyActiveObject.getNodes(criteria);
+        return PAFuture.getFutureValue(proxyActiveObject.getNodes(criteria));
     }
 
     public void releaseNodes(NodeSet nodeSet) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -282,7 +283,8 @@ public class SchedulerTHelper {
      * Log a String on console.
      */
     public static void log(String s) {
-        System.out.println("------------------------------ " + s);
+        System.out.println("------------------------------" +
+                           String.format("[%1$tH:%1$tM:%1$tS,%1$tL] ", Calendar.getInstance().getTime()) + s);
     }
 
     public static void log(Exception e) {

--- a/scheduler/scheduler-server/src/test/java/performancetests/PerformanceTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/performancetests/PerformanceTestSuite.java
@@ -28,11 +28,7 @@ package performancetests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import performancetests.metrics.GetResultMetricTest;
-import performancetests.metrics.ParallelTaskSchedulingTest;
-import performancetests.metrics.SchedulerEfficiencyMetricsTest;
-import performancetests.metrics.TaskCreationTimeTest;
-import performancetests.metrics.TaskSchedulingTimeTest;
+import performancetests.metrics.*;
 import performancetests.recovery.JobRecoveryTest;
 import performancetests.recovery.NodeRecoveryTest;
 
@@ -44,7 +40,7 @@ import performancetests.recovery.NodeRecoveryTest;
 
                       // Metrics
                       TaskCreationTimeTest.class, GetResultMetricTest.class, SchedulerEfficiencyMetricsTest.class,
-                      ParallelTaskSchedulingTest.class,
+                      ParallelTaskSchedulingTest.class, JobSubmissionTest.class,
 
                       // Test which computes average metrics
                       TaskSchedulingTimeTest.class

--- a/scheduler/scheduler-server/src/test/java/performancetests/recovery/NodeRecoveryTest.java
+++ b/scheduler/scheduler-server/src/test/java/performancetests/recovery/NodeRecoveryTest.java
@@ -68,7 +68,7 @@ public class NodeRecoveryTest extends PerformanceTestBase {
      */
     @Parameters
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { { 10, 2000 }, { 100, 5000 }, { 500, 30000 } });
+        return Arrays.asList(new Object[][] { { 10, 5000 }, { 100, 10000 }, { 500, 30000 } });
     }
 
     // number of nodes
@@ -158,7 +158,8 @@ public class NodeRecoveryTest extends PerformanceTestBase {
         final List<Integer> numbersFromLine = LogProcessor.getNumbersFromLine(line);
 
         if (!numbersFromLine.isEmpty()) {
-            return numbersFromLine.get(0);
+            // depends on the logger format, and name of the hosts, the idea is to retrive number of nodes
+            return numbersFromLine.get(1);
         } else {
             throw new RuntimeException("Cannot retrieve number of nodes recovered from this line: " + line);
         }


### PR DESCRIPTION
 - SchedulerFrontendState: use read/write locks instead of synchronized on all methods
 - SchedulerFrontend: use dynamic instead of fixed thread pools. Use ImmediateService whenever possible
 - settings : increase maximum number of thread parameters (dynamicity allows to increase these values)
 - make SchedulerProxyUserInterface use also @ImmediateService to allow concurrent operations in the same user session.
 - test helpers: add current time in log output