### PR TITLE
Add maximum login attempts mechanism

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/core/properties/PASharedProperties.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/core/properties/PASharedProperties.java
@@ -46,6 +46,13 @@ public enum PASharedProperties implements PACommonProperties {
     /** reusing existing rm home property **/
     SHARED_HOME("pa.rm.home", PropertyType.STRING),
 
+    /** maximum number of failed attempts accepted in the given time window (to prevent brute force attacks). The mechanism can be disabled
+     * by using a zero or negative value **/
+    FAILED_LOGIN_MAX_ATTEMPTS("pa.shared.failed.max.attempts", PropertyType.INTEGER, "3"),
+
+    /** time window in minutes after which a failed login attempt is forgotten **/
+    FAILED_LOGIN_RENEW_MINUTES("pa.shared.failed.renew.minutes", PropertyType.INTEGER, "10"),
+
     /** Key used when decrypting properties */
     PROPERTIES_CRYPT_KEY("pa.shared.properties.crypt.key", PropertyType.STRING, "activeeon");
 

--- a/config/shared/settings.ini
+++ b/config/shared/settings.ini
@@ -5,3 +5,9 @@
 
 # Uncomment the following property to define the password used for configuration files encryption
 #pa.shared.properties.crypt.key=
+
+# The following properties define how successive login failed attempts are handled
+# In the default setting, 3 successive failed attempts for a user in a time window of 10 minutes will disable further.
+# tentatives until the time window is expired. The mechanism can be disabled by using max.attempts <= 0
+pa.shared.failed.max.attempts=3
+pa.shared.failed.renew.minutes=10


### PR DESCRIPTION
Configurable mechanism with shared properties. By default 3 unsuccesful attempts on a 10 minutes window disables
further authentication attempts until the window is expired.