### PR TITLE
Add server-side portal access authorization

### DIFF
--- a/config/security.java.policy-server
+++ b/config/security.java.policy-server
@@ -3,6 +3,7 @@
 // USERS PERMISSIONS (EXAMPLE)
 //
 //grant principal org.ow2.proactive.authentication.principals.UserNamePrincipal "user" {
+//    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "scheduler,rm";
 //    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
 //    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodes";
 //    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
@@ -14,18 +15,9 @@
 //
 // Members of "guest" group can get/free nodes and monitor the state submit jobs
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "guests" {
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNeededNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNode";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "automation_dashboard,workflow_automation";
 
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeSourcesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.listAliveNodeUrls";
@@ -41,10 +33,9 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.disconnect";
-    
+
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getExistingNodeSourcesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUserData";
 
@@ -65,42 +56,19 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 	//"true" means that this user can get only its job in the state and listen for its events
 	//"false" means user can get full state and listen for any events.
     permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
-    permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "1,2,3";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.submit";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobResult";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResult";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultFromIncarnation";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobContent";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.restartTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.restartInErrorTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.finishInErrorTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.preemptTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobState";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.listenJobLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getStatus";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getState";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addEventListener";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pauseJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.restartAllInErrorTasks";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.resumeJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogs";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogsByTag";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultByTag";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobs";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addEventListener";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getUsers";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getMyAccountUsage";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getGlobalSpaceURIs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getUserSpaceURIs";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultFromIncarnation";
 };
 
 // Members of "user" group can get/free nodes and monitor the state, submit jobs and see jobs of other people
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "user" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNeededNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
@@ -128,7 +96,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.disconnect";
     
@@ -193,6 +160,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Resource providers have the same permissions as users + an ability to add remove node
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "providers" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNodeToken";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.removeNodeToken";
@@ -208,6 +176,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNodesAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.removeNode";
@@ -225,7 +194,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeAdmin";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 
@@ -248,6 +216,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Members of "nsadmins" can create/remove node sources (according to their policies)
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "nsadmins" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNodeToken";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.removeNodeToken";
@@ -263,6 +232,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNodesAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.defineNodeSource";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.deployNodeSource";
@@ -312,9 +282,8 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Members of "rmcoreadmins" can call any method of rmcore
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "rmcoreadmins" {
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNodeToken";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.removeNodeToken";
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
+
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.*";
 
     permission org.ow2.proactive.permissions.RMCoreAllPermission;
@@ -338,6 +307,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Members of "scheduleradmins" can call any method of the scheduler
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "scheduleradmins" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
 
     //use the following line to allow a user to download full scheduler state and get events from any user
@@ -375,7 +345,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.disconnect";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getExistingNodeSourcesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUserData";
@@ -412,7 +381,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getStatus";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getTopology";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 };
 //
 // OTHER PERMISSIONS

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRestInterface.java
@@ -1,0 +1,88 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.io.IOException;
+import java.security.KeyException;
+
+import javax.security.auth.login.LoginException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+import org.ow2.proactive.authentication.UserData;
+import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SchedulerRestException;
+
+
+@Path("/common")
+@Produces(APPLICATION_JSON)
+public interface CommonRestInterface {
+    @POST
+    @Path("login")
+    String login(@FormParam("username") String username, @FormParam("password") String password)
+            throws KeyException, LoginException, SchedulerRestException;
+
+    @POST
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Path("login")
+    String loginWithCredential(@MultipartForm LoginForm multipart)
+            throws IOException, KeyException, LoginException, SchedulerRestException;
+
+    @PUT
+    @Path("logout")
+    void logout(@HeaderParam("sessionid")
+    final String sessionId) throws RestException;
+
+    @GET
+    @Path("connected")
+    boolean isConnected(@HeaderParam("sessionid") String sessionId);
+
+    @GET
+    @Path("currentuser")
+    String currentUser(@HeaderParam("sessionid") String sessionId);
+
+    @GET
+    @Path("currentuserdata")
+    UserData currentUserData(@HeaderParam("sessionid") String sessionId);
+
+    @GET
+    @Path("permissions/portals/{portal}")
+    boolean portalAccess(@HeaderParam("sessionid") String sessionId, @PathParam("portal") String portal)
+            throws RestException;
+
+}

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -63,6 +63,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import javax.security.auth.Subject;
+
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -1308,6 +1310,11 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
             throw new NotConnectedException("Session " + sid + " is not connected");
         }
         return connectedUserData;
+    }
+
+    @Override
+    public Subject getSubject() throws NotConnectedException {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRest.java
@@ -1,0 +1,185 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common;
+
+import java.security.KeyException;
+import java.security.Permission;
+import java.security.PrivilegedAction;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginException;
+
+import org.apache.log4j.Logger;
+import org.ow2.proactive.authentication.UserData;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
+import org.ow2.proactive.scheduler.common.exception.PermissionException;
+import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
+import org.ow2.proactive_grid_cloud_portal.scheduler.SchedulerStateRest;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SchedulerRestException;
+
+
+public class CommonRest implements CommonRestInterface {
+
+    private static final Logger logger = Logger.getLogger(CommonRest.class);
+
+    public static final String YOU_ARE_NOT_CONNECTED_TO_THE_SCHEDULER_YOU_SHOULD_LOG_ON_FIRST = "You are not connected to the scheduler, you should log on first";
+
+    private final SessionStore sessionStore = SharedSessionStore.getInstance();
+
+    private SchedulerStateRest schedulerRest = null;
+
+    private SchedulerRestInterface scheduler() {
+        if (schedulerRest == null) {
+            schedulerRest = new SchedulerStateRest();
+        }
+        return schedulerRest;
+    }
+
+    private String getUserName(String sessionId) throws NotConnectedRestException {
+        Session ss = sessionStore.get(sessionId);
+        return ss.getUserName();
+    }
+
+    @Override
+    public String login(String username, String password) throws LoginException, SchedulerRestException {
+        logger.info("Logging as " + username);
+        return scheduler().login(username, password);
+    }
+
+    @Override
+    public String loginWithCredential(LoginForm multipart) throws KeyException, LoginException, SchedulerRestException {
+        logger.info("Logging using credential file");
+        return scheduler().loginWithCredential(multipart);
+    }
+
+    @Override
+    public void logout(String sessionId) throws RestException {
+        logger.info("logout");
+        scheduler().disconnect(sessionId);
+    }
+
+    @Override
+    public boolean isConnected(String sessionId) {
+        try {
+            getUserName(sessionId);
+            return true;
+        } catch (NotConnectedRestException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String currentUser(String sessionId) {
+        try {
+            return getUserName(sessionId);
+        } catch (NotConnectedRestException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public UserData currentUserData(String sessionId) {
+        return scheduler().getUserDataFromSessionId(sessionId);
+    }
+
+    @Override
+    public boolean portalAccess(String sessionId, String portal) throws NotConnectedRestException {
+        Scheduler scheduler = checkAccess(sessionId, "EMPTY");
+
+        try {
+            return checkPermission(scheduler.getSubject(),
+                                   new PortalAccessPermission(portal),
+                                   "Acess to portal " + portal + " is disabled");
+        } catch (PermissionException e) {
+            return false;
+        } catch (NotConnectedException e) {
+            throw new NotConnectedRestException("you are not connected to the scheduler, you should log on first");
+        }
+    }
+
+    /**
+     * the method check if the session id is valid i.e. a scheduler client is
+     * associated to the session id in the session map. If not, a
+     * NotConnectedRestException is thrown specifying the invalid access *
+     *
+     * @return the scheduler linked to the session id, an
+     * NotConnectedRestException, if no such mapping exists.
+     * @throws NotConnectedRestException
+     */
+    private Scheduler checkAccess(String sessionId, String path) throws NotConnectedRestException {
+        Session session = sessionStore.get(sessionId);
+
+        Scheduler schedulerProxy = session.getScheduler();
+
+        if (schedulerProxy == null) {
+            throw new NotConnectedRestException(YOU_ARE_NOT_CONNECTED_TO_THE_SCHEDULER_YOU_SHOULD_LOG_ON_FIRST);
+        }
+
+        renewSession(sessionId);
+
+        return schedulerProxy;
+    }
+
+    /**
+     * Call a method on the scheduler's frontend in order to renew the lease the
+     * user has on this frontend. see PORTAL-70
+     *
+     * @throws NotConnectedRestException
+     */
+    protected void renewSession(String sessionId) throws NotConnectedRestException {
+        try {
+            SharedSessionStore.getInstance().renewSession(sessionId);
+        } catch (NotConnectedException e) {
+            throw new NotConnectedRestException(YOU_ARE_NOT_CONNECTED_TO_THE_SCHEDULER_YOU_SHOULD_LOG_ON_FIRST, e);
+        }
+    }
+
+    /**
+     * Checks if user has the specified permission.
+     *
+     * @return true if it has, throw {@link SecurityException} otherwise with specified error message
+     */
+    private boolean checkPermission(final Subject subject, final Permission permission, String errorMessage)
+            throws PermissionException {
+        try {
+            Subject.doAsPrivileged(subject, (PrivilegedAction<Object>) () -> {
+                SecurityManager sm = System.getSecurityManager();
+                if (sm != null) {
+                    sm.checkPermission(permission);
+                }
+                return null;
+            }, null);
+        } catch (SecurityException ex) {
+            throw new PermissionException(errorMessage);
+        }
+
+        return true;
+    }
+
+}

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/PortalAccessPermission.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/PortalAccessPermission.java
@@ -1,0 +1,81 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common;
+
+import java.security.Permission;
+import java.util.HashSet;
+
+import org.ow2.proactive.permissions.ClientPermission;
+
+import com.google.common.collect.Sets;
+
+
+/**
+ *
+ * This permission allows to set access to portals
+ * Portal naming should be a lowercase string with underscore word separation, e.g
+ * scheduler, job_planner, automation_dashboard
+ *
+ */
+public class PortalAccessPermission extends ClientPermission {
+
+    boolean allPortals = false;
+
+    HashSet<String> portalsAccess = new HashSet<>();
+
+    /**
+     * Construct the permission with portals list.
+     *
+     * @param portals separated by comma, or * for all portals
+     */
+    public PortalAccessPermission(String portals) {
+        super("portal access");
+        portals = portals.trim();
+        if (portals == null || portals.isEmpty()) {
+            portalsAccess = new HashSet<>();
+        } else if (portals.equals("*")) {
+            allPortals = true;
+        } else {
+            portalsAccess = Sets.newHashSet(portals.split("[\\s,]+"));
+        }
+    }
+
+    /**
+     * Checks that all portals of the permission we're checking with
+     * are among allowed portals in "this" permission
+     */
+    @Override
+    public boolean implies(Permission p) {
+        if (!(p instanceof PortalAccessPermission)) {
+            return false;
+        }
+        PortalAccessPermission clientRequest = (PortalAccessPermission) p;
+        if (this.allPortals) {
+            return true;
+        }
+        return portalsAccess.containsAll(clientRequest.portalsAccess);
+    }
+}

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SessionStore.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SessionStore.java
@@ -31,9 +31,12 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.SchedulerStateRest;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 
 
 public class SessionStore {
+
+    public static final String YOU_ARE_NOT_CONNECTED_TO_THE_SERVER_YOU_SHOULD_LOG_ON_FIRST = "You are not connected to the server, you should log on first";
 
     private final Map<String, Session> sessions = new ConcurrentHashMap<>();
 
@@ -58,8 +61,15 @@ public class SessionStore {
         return sessions.containsKey(sessionId);
     }
 
-    public Session get(String sessionId) {
-        return sessions.get(sessionId);
+    public Session get(String sessionId) throws NotConnectedRestException {
+        if (sessionId == null) {
+            throw new NotConnectedRestException(YOU_ARE_NOT_CONNECTED_TO_THE_SERVER_YOU_SHOULD_LOG_ON_FIRST);
+        }
+        Session session = sessions.get(sessionId);
+        if (session == null) {
+            throw new NotConnectedRestException(YOU_ARE_NOT_CONNECTED_TO_THE_SERVER_YOU_SHOULD_LOG_ON_FIRST);
+        }
+        return session;
     }
 
     /** For testing only */

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspaceImpl.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspaceImpl.java
@@ -486,8 +486,8 @@ public class RestDataspaceImpl {
     }
 
     public Session checkSessionValidity(String sessionId) throws NotConnectedRestException {
-        Session session = Strings.isNullOrEmpty(sessionId) ? null : sessions.get(sessionId);
-        if (session == null || session.getScheduler() == null) {
+        Session session = sessions.get(sessionId);
+        if (session.getScheduler() == null) {
             throw new NotConnectedRestException("User not authenticated or session timeout.");
         }
         return session;

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -1144,10 +1144,6 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     private SchedulerProxyUserInterface checkAccess(String sessionId, String path) throws NotConnectedRestException {
         Session session = sessionStore.get(sessionId);
 
-        if (session == null) {
-            throw new NotConnectedRestException(YOU_ARE_NOT_CONNECTED_TO_THE_SCHEDULER_YOU_SHOULD_LOG_ON_FIRST);
-        }
-
         SchedulerProxyUserInterface schedulerProxy = session.getScheduler();
 
         if (schedulerProxy == null) {

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -50,6 +50,7 @@ import org.ow2.proactive.authentication.UserData;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive_grid_cloud_portal.common.SchedulerRestInterface;
 import org.ow2.proactive_grid_cloud_portal.common.Session;
+import org.ow2.proactive_grid_cloud_portal.common.SessionStore;
 import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
 import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
 import org.ow2.proactive_grid_cloud_portal.scheduler.SchedulerStateRest;
@@ -69,11 +70,15 @@ import org.ow2.proactive_grid_cloud_portal.webapp.PortalConfiguration;
 
 public class StudioRest implements StudioInterface {
 
+    public static final String YOU_ARE_NOT_CONNECTED_TO_THE_SCHEDULER_YOU_SHOULD_LOG_ON_FIRST = "You are not connected to the scheduler, you should log on first";
+
     private static final Logger logger = Logger.getLogger(StudioRest.class);
 
     private static final String FILE_ENCODING = PASchedulerProperties.FILE_ENCODING.getValueAsString();
 
     private SchedulerStateRest schedulerRest = null;
+
+    private SessionStore sessions = SharedSessionStore.getInstance();
 
     private SchedulerRestInterface scheduler() {
         if (schedulerRest == null) {
@@ -87,11 +92,8 @@ public class StudioRest implements StudioInterface {
     }
 
     private String getUserName(String sessionId) throws NotConnectedRestException {
-        Session ss = SharedSessionStore.getInstance().get(sessionId);
-        if (ss == null) {
-            throw new NotConnectedRestException("you are not connected to the scheduler, you should log on first");
-        }
-        return ss.getUserName();
+        Session session = sessions.get(sessionId);
+        return session.getUserName();
     }
 
     @Override

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/NoVncSecuredTargetResolver.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/NoVncSecuredTargetResolver.java
@@ -46,6 +46,7 @@ import org.ow2.proactive.scheduler.common.task.TaskState;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
 import org.ow2.proactive_grid_cloud_portal.common.Session;
 import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 
 import com.netiq.websockify.IProxyTargetResolver;
 
@@ -91,9 +92,11 @@ public class NoVncSecuredTargetResolver implements IProxyTargetResolver {
             return null;
         }
 
-        Session session = SharedSessionStore.getInstance().get(sessionId);
-        if (session == null) {
-            LOGGER.warn("Unknown sessionId.");
+        Session session = null;
+        try {
+            session = SharedSessionStore.getInstance().get(sessionId);
+        } catch (NotConnectedRestException e) {
+            LOGGER.warn("Session not valid.");
             return null;
         }
 

--- a/rest/rest-server/src/main/webapp/WEB-INF/web.xml
+++ b/rest/rest-server/src/main/webapp/WEB-INF/web.xml
@@ -29,7 +29,7 @@
     <context-param>
         <param-name>resteasy.resources</param-name>
         <param-value>
-            org.ow2.proactive_grid_cloud_portal.scheduler.SchedulerStateRest,org.ow2.proactive_grid_cloud_portal.studio.StudioRest,org.ow2.proactive_grid_cloud_portal.rm.RMRest,org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl
+            org.ow2.proactive_grid_cloud_portal.scheduler.SchedulerStateRest,org.ow2.proactive_grid_cloud_portal.studio.StudioRest,org.ow2.proactive_grid_cloud_portal.rm.RMRest,org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl,org.ow2.proactive_grid_cloud_portal.common.CommonRest
         </param-value>
     </context-param>
 
@@ -111,6 +111,11 @@
     <servlet-mapping>
         <servlet-name>resteasy-servlet</servlet-name>
         <url-pattern>/studio/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>resteasy-servlet</servlet-name>
+        <url-pattern>/common/*</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/common/SessionStoreTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/common/SessionStoreTest.java
@@ -38,6 +38,7 @@ import org.mockito.Matchers;
 import org.ow2.proactive.authentication.crypto.CredData;
 import org.ow2.proactive.resourcemanager.common.util.RMProxyUserInterface;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 
 
 public class SessionStoreTest {
@@ -57,7 +58,7 @@ public class SessionStoreTest {
         sessionStore.setClock(clock);
     }
 
-    @Test
+    @Test(expected = NotConnectedRestException.class)
     public void testNoSessionWhenNotLoggedIn() throws Exception {
         assertNull(sessionStore.get("unknownSession"));
     }

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/webapp/SessionSharingTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/webapp/SessionSharingTest.java
@@ -46,6 +46,7 @@ import org.ow2.proactive.resourcemanager.common.RMStateNodeUrls;
 import org.ow2.proactive.resourcemanager.common.util.RMProxyUserInterface;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.util.SchedulerProxyUserInterface;
+import org.ow2.proactive_grid_cloud_portal.common.CommonRest;
 import org.ow2.proactive_grid_cloud_portal.common.SchedulerRMProxyFactory;
 import org.ow2.proactive_grid_cloud_portal.common.SharedSessionStore;
 import org.ow2.proactive_grid_cloud_portal.rm.RMRest;
@@ -62,6 +63,8 @@ public class SessionSharingTest {
 
     private StudioRest studioRest;
 
+    private CommonRest commonRest;
+
     private RMProxyUserInterface rmMock;
 
     private SchedulerProxyUserInterface schedulerMock;
@@ -71,6 +74,7 @@ public class SessionSharingTest {
         schedulerRest = new SchedulerStateRest();
         rmRest = new RMRest();
         studioRest = new StudioRest();
+        commonRest = new CommonRest();
 
         SchedulerRMProxyFactory schedulerFactory = mock(SchedulerRMProxyFactory.class);
         rmMock = mock(RMProxyUserInterface.class);

--- a/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
+++ b/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
@@ -14,17 +14,9 @@
 //
 // Members of "guest" group can get/free nodes and monitor the state submit jobs
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "guests" {
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNeededNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNode";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.freeNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseBusyNodesNotInList";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "automation_dashboard,workflow_automation";
 
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeSourcesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.listAliveNodeUrls";
@@ -40,7 +32,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.disconnect";
 
@@ -64,42 +55,19 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 	//"true" means that this user can get only its job in the state and listen for its events
 	//"false" means user can get full state and listen for any events.
     permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
-    permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "1,2,3";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.submit";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobResult";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResult";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultFromIncarnation";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobContent";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.restartTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.restartInErrorTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.finishInErrorTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.preemptTask";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobState";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.listenJobLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getStatus";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getState";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addEventListener";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pauseJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.restartAllInErrorTasks";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.resumeJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogs";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogsByTag";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultByTag";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getUsers";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getMyAccountUsage";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getGlobalSpaceURIs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getUserSpaceURIs";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultFromIncarnation";
 };
 
 // Members of "user" group can get/free nodes and monitor the state, submit jobs and see jobs of other people
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "user" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNeededNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodes";
@@ -126,7 +94,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.disconnect";
 
@@ -191,6 +158,10 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Resource providers have the same permissions as users + an ability to add remove node
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "providers" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNodeToken";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.removeNodeToken";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNeededNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodes";
@@ -203,6 +174,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNodesAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.removeNode";
@@ -220,7 +192,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeAdmin";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 
@@ -243,6 +214,10 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Members of "nsadmins" can create/remove node sources (according to their policies)
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "nsadmins" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.addNodeToken";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.removeNodeToken";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNeededNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodes";
@@ -255,6 +230,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesKnown";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.areNodesRecoverable";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.nodeIsAvailable";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.setNodesAvailable";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.defineNodeSource";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.deployNodeSource";
@@ -304,6 +280,8 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Members of "rmcoreadmins" can call any method of rmcore
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "rmcoreadmins" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
+
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.*";
 
     permission org.ow2.proactive.permissions.RMCoreAllPermission;
@@ -327,6 +305,8 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 
 // Members of "scheduleradmins" can call any method of the scheduler
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "scheduleradmins" {
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
 
     //use the following line to allow a user to download full scheduler state and get events from any user
     //"true" means that this user can get only its job in the state and listen for its events
@@ -363,7 +343,6 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.isNodeUser";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUser";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.disconnect";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getExistingNodeSourcesList";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getCurrentUserData";
@@ -393,13 +372,13 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
 // Members of "watchers" group have only a read access to the scheduler and RM state
 // and the authorization to register a listener in order to receive updates of the scheduler state
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "watchers" {
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getState";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addEventListener";
     permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "false";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getStatus";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getMonitoring";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getTopology";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.registerAvailableNode";
 };
 //
 // OTHER PERMISSIONS

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import javax.security.auth.Subject;
+
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
 import org.ow2.proactive.authentication.ConnectionInfo;
@@ -727,6 +729,11 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     @Override
     public UserData getCurrentUserData() throws NotConnectedException {
         return _getScheduler().getCurrentUserData();
+    }
+
+    @Override
+    public Subject getSubject() throws NotConnectedException {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1140,6 +1140,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     @Override
     public Set<String> setNodesAvailable(Set<String> nodeUrls) {
 
+        checkPermissionAndGetClientIsSuccessful();
         waitForRMCoreToBeInitializedIfNeeded();
 
         if (logger.isTraceEnabled()) {
@@ -2017,6 +2018,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     @Override
     @ImmediateService
     public StringWrapper getRMThreadDump() {
+        checkPermissionAndGetClientIsSuccessful();
         String threadDump;
         try {
             threadDump = this.nodeRM.getThreadDump();
@@ -2032,6 +2034,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     @Override
     @ImmediateService
     public StringWrapper getNodeThreadDump(String nodeUrl) {
+        checkPermissionAndGetClientIsSuccessful();
         RMNode node;
         try {
             node = getAliveNodeOrFail(nodeUrl);
@@ -2445,7 +2448,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         return new BooleanWrapper(!toShutDown && clients.containsKey(sourceBodyCaller.getId()));
     }
 
-    private Client checkPermissionAndGetClientIsSuccessful() {
+    protected Client checkPermissionAndGetClientIsSuccessful() {
         final Request currentRequest = PAActiveObject.getContext().getCurrentRequest();
         String methodName = currentRequest.getMethodName();
         return checkMethodCallPermission(methodName, currentRequest.getSourceBodyID());

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
@@ -57,8 +57,6 @@ import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.core.node.NodeInformation;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
-import org.objectweb.proactive.core.util.wrapper.StringWrapper;
-import org.ow2.proactive.permissions.RMCoreAllPermission;
 import org.ow2.proactive.resourcemanager.authentication.Client;
 import org.ow2.proactive.resourcemanager.common.NodeState;
 import org.ow2.proactive.resourcemanager.common.RMState;
@@ -714,8 +712,9 @@ public class RMCoreTest {
 
         List<RMNode> freeNodes = Collections.emptyList();
 
-        RMCore rmCore = createRmCore(allNodes, freeNodes);
+        RMCore rmCore = spy(createRmCore(allNodes, freeNodes));
 
+        doReturn(mockedCaller).when(rmCore).checkPermissionAndGetClientIsSuccessful();
         assertThat(rmCore.setNodesAvailable(ImmutableSet.of(mockedBusyNode.getNodeURL()))).isEmpty();
     }
 
@@ -725,9 +724,10 @@ public class RMCoreTest {
 
         List<RMNode> freeNodes = Collections.emptyList();
 
-        RMCore rmCore = createRmCore(allNodes, freeNodes);
+        RMCore rmCore = spy(createRmCore(allNodes, freeNodes));
 
         String unknownNodeUrl = mockedRemovableNode.getNodeURL();
+        doReturn(mockedCaller).when(rmCore).checkPermissionAndGetClientIsSuccessful();
         Set<String> unknownNodeUrls = rmCore.setNodesAvailable(ImmutableSet.of(unknownNodeUrl));
         assertThat(unknownNodeUrls).hasSize(1);
         assertThat(unknownNodeUrls).contains(unknownNodeUrl);
@@ -747,6 +747,7 @@ public class RMCoreTest {
 
         verify(rmCore, never()).restoreNodeState(mockedRemovableNode.getNodeURL(), mockedRemovableNode);
 
+        doReturn(mockedCaller).when(rmCore).checkPermissionAndGetClientIsSuccessful();
         Set<String> unknownNodeUrls = rmCore.setNodesAvailable(ImmutableSet.of(unknownNodeUrl));
         assertThat(unknownNodeUrls).isEmpty();
 
@@ -911,6 +912,8 @@ public class RMCoreTest {
                 return nodesRecoveryManager;
             }
         }).when(rmCore).getNodesRecoveryManagerBuilder();
+
+        doReturn(mockedCaller).when(rmCore).checkPermissionAndGetClientIsSuccessful();
 
         rmCore.initiateRecoveryIfRequired();
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+import javax.security.auth.Subject;
+
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.authentication.UserData;
 import org.ow2.proactive.db.SortParameter;
@@ -1528,6 +1530,13 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @return a user data object
      */
     UserData getCurrentUserData() throws NotConnectedException;
+
+    /**
+     * Returns the current user JaaS subject
+     * @return jaas subject
+     * @throws NotConnectedException
+     */
+    Subject getSubject() throws NotConnectedException;
 
     /**
      * Returns the scheduler properties associated with the user currently connected

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
 import org.apache.log4j.Logger;
@@ -807,6 +808,12 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
     @ImmediateService
     public UserData getCurrentUserData() throws NotConnectedException {
         return uischeduler.getCurrentUserData();
+    }
+
+    @Override
+    @ImmediateService
+    public Subject getSubject() throws NotConnectedException {
+        return uischeduler.getSubject();
     }
 
     @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import javax.security.auth.Subject;
+
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.authentication.ConnectionInfo;
 import org.ow2.proactive.authentication.UserData;
@@ -855,6 +857,11 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     public UserData getCurrentUserData() throws NotConnectedException {
         renewSession();
         return client.getCurrentUserData();
+    }
+
+    @Override
+    public Subject getSubject() throws NotConnectedException {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -72,6 +72,8 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import javax.security.auth.Subject;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.Body;
@@ -1673,6 +1675,12 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
     @ImmediateService
     public UserData getCurrentUserData() throws NotConnectedException {
         return frontendState.getCurrentUserData();
+    }
+
+    @Override
+    @ImmediateService
+    public Subject getSubject() throws NotConnectedException {
+        return frontendState.getSubject();
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -32,6 +32,8 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import javax.security.auth.Subject;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.api.PAActiveObject;
@@ -1307,6 +1309,11 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
     public String getCurrentUser() throws NotConnectedException {
         Pair<ListeningUser, UserIdentificationImpl> userSessionInfo = renewSession(false);
         return userSessionInfo.getRight().getUsername();
+    }
+
+    public Subject getSubject() throws NotConnectedException {
+        Pair<ListeningUser, UserIdentificationImpl> userSessionInfo = renewSession(false);
+        return userSessionInfo.getRight().getSubject();
     }
 
     public UserData getCurrentUserData() throws NotConnectedException {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/TestLoadJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/TestLoadJobs.java
@@ -245,7 +245,7 @@ public class TestLoadJobs extends SchedulerFunctionalTestNoRestart {
         PAActiveObject.terminateActiveObject(eventReceiver, true);
 
         // connect as a user who can see only its own jobs
-        cred = Credentials.createCredentials(new CredData("guest", "pwd"), auth.getPublicKey());
+        cred = Credentials.createCredentials(new CredData("user", "pwd"), auth.getPublicKey());
         scheduler = auth.login(cred);
 
         monitorsHandler = new SchedulerMonitorsHandler();

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
 import org.apache.commons.vfs2.FileObject;
@@ -86,6 +87,8 @@ import org.ow2.proactive.scheduler.smartproxy.common.AbstractSmartProxy;
 import org.ow2.proactive.scheduler.smartproxy.common.AwaitedJob;
 import org.ow2.proactive.scheduler.smartproxy.common.AwaitedTask;
 import org.ow2.proactive.scheduler.smartproxy.common.SchedulerEventListenerExtended;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 
 /**
@@ -861,6 +864,11 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     @Override
     public UserData getCurrentUserData() throws NotConnectedException {
         return schedulerProxy.getCurrentUserData();
+    }
+
+    @Override
+    public Subject getSubject() throws NotConnectedException {
+        return schedulerProxy.getSubject();
     }
 
     @Override


### PR DESCRIPTION
 - Create new rest component "common/" with CommonInterface definition and CommonRest implementation
 - CommonInterface defines the method permissions/portals/{portal} to check portal authorization
 - portal authorization is implemented as JaaS PortalAccessPermission
 - cleanup some code related to sessions in rest server
 - RMCore check authorization in ImmediateService requests
 - cleanup authorizations in jaas policy, notably for "guest"