### PR TITLE
fix: gson version conflict between 2.8.0 and 2.5.0

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
@@ -372,6 +372,7 @@ public class JettyStarter {
         webApp.setParentLoaderPriority(true);
         // The following setting allows to avoid conflicts between server jackson jars and individual war jackson versions.
         webApp.addServerClass("com.fasterxml.jackson.");
+        webApp.addServerClass("com.google.gson.");
         webApp.setContextPath(contextPath);
         webApp.setVirtualHosts(virtualHost);
         return webApp;


### PR DESCRIPTION
Fix the error: `java.lang.NoSuchMethodError: com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.<init>.`

The error is caused by the gson version conflict between different different infrastructures and connector-iaas. The infrastructure azure scale set is using gson version 2.8.0 which introduce incompatible changes compared to the gson used in other modules: infrastructure-gce (v2.5), infrastructure-kubernetes (v2.6.2), connector-iaas (v2.5)