### PR TITLE
Add PendingCurrentPast job and task stats per username in MBeans

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskStatus.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/TaskStatus.java
@@ -132,6 +132,8 @@ public enum TaskStatus implements java.io.Serializable {
                                                                         WAITING_ON_ERROR,
                                                                         WAITING_ON_FAILURE);
 
+    public static final Set<TaskStatus> PAUSED_AND_IN_ERROR_TASKS = ImmutableSet.of(PAUSED, IN_ERROR);
+
     public static final Set<TaskStatus> PENDING_TASKS = ImmutableSet.of(SUBMITTED, PENDING);
 
     /** The name of the current status. */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/account/SchedulerAccount.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/account/SchedulerAccount.java
@@ -47,20 +47,42 @@ public final class SchedulerAccount implements Account {
 
     private long totalJobDuration;
 
+    private int pendingJobsCount;
+
+    private int currentJobsCount;
+
+    private int pastJobsCount;
+
+    private int pendingTasksCount;
+
+    private int currentTasksCount;
+
+    private int pastTasksCount;
+
+    private int pausedInErrorTasksCount;
+
     public SchedulerAccount() {
     }
 
     public SchedulerAccount(String username, int totalTaskCount, long totalTaskDuration, int totalJobCount,
-            long totalJobDuration) {
+            long totalJobDuration, int pendingJobsCount, int currentJobsCount, int pastJobsCount, int pendingTasksCount,
+            int currentTasksCount, int pastTasksCount, int pausedInErrorTasksCount) {
         this.username = username;
         this.totalTaskCount = totalTaskCount;
+        this.pendingTasksCount = pendingTasksCount;
+        this.currentTasksCount = currentTasksCount;
+        this.pastTasksCount = pastTasksCount;
+        this.pausedInErrorTasksCount = pausedInErrorTasksCount;
         this.totalTaskDuration = totalTaskDuration;
         this.totalJobCount = totalJobCount;
         this.totalJobDuration = totalJobDuration;
+        this.pendingJobsCount = pendingJobsCount;
+        this.currentJobsCount = currentJobsCount;
+        this.pastJobsCount = pastJobsCount;
     }
 
     /**
-     * The total count of tasks completed by the current user. 
+     * The total count of tasks completed by the current user.
      * @return the total task count
      */
     public int getTotalTaskCount() {
@@ -68,7 +90,39 @@ public final class SchedulerAccount implements Account {
     }
 
     /**
-     * The total time duration in milliseconds of tasks completed by the current user. 
+     * The total count of pending tasks submitted by the current user.
+     * @return the total task count
+     */
+    public int getPendingTasksCount() {
+        return this.pendingTasksCount;
+    }
+
+    /**
+     * The total count of current tasks submitted by the current user.
+     * @return the total task count
+     */
+    public int getCurrentTasksCount() {
+        return this.currentTasksCount;
+    }
+
+    /**
+     * The total count of past tasks submitted by the current user.
+     * @return the total task count
+     */
+    public int getPastTasksCount() {
+        return this.pastTasksCount;
+    }
+
+    /**
+     * The total count of past tasks submitted by the current user.
+     * @return the total task count
+     */
+    public int getPausedInErrorTasksCount() {
+        return this.pausedInErrorTasksCount;
+    }
+
+    /**
+     * The total time duration in milliseconds of tasks completed by the current user.
      * @return the total task duration in milliseconds
      */
     public long getTotalTaskDuration() {
@@ -76,7 +130,7 @@ public final class SchedulerAccount implements Account {
     }
 
     /**
-     * The total count of jobs completed by the current user. 
+     * The total count of jobs completed by the current user.
      * @return the total jobs count
      */
     public int getTotalJobCount() {
@@ -84,7 +138,31 @@ public final class SchedulerAccount implements Account {
     }
 
     /**
-     * The total time duration in milliseconds of jobs completed by the current user. 
+     * The total count of pending jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getPendingJobsCount() {
+        return pendingJobsCount;
+    }
+
+    /**
+     * The total count of current jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getCurrentJobsCount() {
+        return currentJobsCount;
+    }
+
+    /**
+     * The total count of past jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getPastJobsCount() {
+        return pastJobsCount;
+    }
+
+    /**
+     * The total time duration in milliseconds of jobs completed by the current user.
      * @return the total job duration in milliseconds
      */
     public long getTotalJobDuration() {
@@ -92,7 +170,7 @@ public final class SchedulerAccount implements Account {
     }
 
     /**
-     * Returns the username of this account. 
+     * Returns the username of this account.
      * @return the username of this account
      */
     public String getName() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/account/SchedulerAccount.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/account/SchedulerAccount.java
@@ -27,6 +27,8 @@ package org.ow2.proactive.scheduler.core.account;
 
 import org.ow2.proactive.account.Account;
 
+import lombok.Builder;
+
 
 /**
  * This class represents an account, it contains information about the
@@ -35,6 +37,7 @@ import org.ow2.proactive.account.Account;
  * @author The ProActive Team
  * @since ProActive Scheduling 2.1
  */
+@Builder
 public final class SchedulerAccount implements Account {
 
     private String username;
@@ -47,12 +50,6 @@ public final class SchedulerAccount implements Account {
 
     private long totalJobDuration;
 
-    private int pendingJobsCount;
-
-    private int currentJobsCount;
-
-    private int pastJobsCount;
-
     private int pendingTasksCount;
 
     private int currentTasksCount;
@@ -61,25 +58,23 @@ public final class SchedulerAccount implements Account {
 
     private int pausedInErrorTasksCount;
 
-    public SchedulerAccount() {
-    }
+    private int pendingJobsCount;
 
-    public SchedulerAccount(String username, int totalTaskCount, long totalTaskDuration, int totalJobCount,
-            long totalJobDuration, int pendingJobsCount, int currentJobsCount, int pastJobsCount, int pendingTasksCount,
-            int currentTasksCount, int pastTasksCount, int pausedInErrorTasksCount) {
-        this.username = username;
-        this.totalTaskCount = totalTaskCount;
-        this.pendingTasksCount = pendingTasksCount;
-        this.currentTasksCount = currentTasksCount;
-        this.pastTasksCount = pastTasksCount;
-        this.pausedInErrorTasksCount = pausedInErrorTasksCount;
-        this.totalTaskDuration = totalTaskDuration;
-        this.totalJobCount = totalJobCount;
-        this.totalJobDuration = totalJobDuration;
-        this.pendingJobsCount = pendingJobsCount;
-        this.currentJobsCount = currentJobsCount;
-        this.pastJobsCount = pastJobsCount;
-    }
+    private int stalledJobsCount;
+
+    private int runningJobsCount;
+
+    private int pausedJobsCount;
+
+    private int inErrorJobsCount;
+
+    private int canceledJobsCount;
+
+    private int failedJobsCount;
+
+    private int killedJobsCount;
+
+    private int finishedJobsCount;
 
     /**
      * The total count of tasks completed by the current user.
@@ -138,30 +133,6 @@ public final class SchedulerAccount implements Account {
     }
 
     /**
-     * The total count of pending jobs submitted by the current user.
-     * @return the total jobs count
-     */
-    public int getPendingJobsCount() {
-        return pendingJobsCount;
-    }
-
-    /**
-     * The total count of current jobs submitted by the current user.
-     * @return the total jobs count
-     */
-    public int getCurrentJobsCount() {
-        return currentJobsCount;
-    }
-
-    /**
-     * The total count of past jobs submitted by the current user.
-     * @return the total jobs count
-     */
-    public int getPastJobsCount() {
-        return pastJobsCount;
-    }
-
-    /**
      * The total time duration in milliseconds of jobs completed by the current user.
      * @return the total job duration in milliseconds
      */
@@ -175,5 +146,77 @@ public final class SchedulerAccount implements Account {
      */
     public String getName() {
         return this.username;
+    }
+
+    /**
+     * The total count of pending jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getPendingJobsCount() {
+        return pendingJobsCount;
+    }
+
+    /**
+     * The total count of stalled jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getStalledJobsCount() {
+        return stalledJobsCount;
+    }
+
+    /**
+     * The total count of running jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getRunningJobsCount() {
+        return runningJobsCount;
+    }
+
+    /**
+     * The total count of paused jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getPausedJobsCount() {
+        return pausedJobsCount;
+    }
+
+    /**
+     * The total count of in-error jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getInErrorJobsCount() {
+        return inErrorJobsCount;
+    }
+
+    /**
+     * The total count of canceled jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getCanceledJobsCount() {
+        return canceledJobsCount;
+    }
+
+    /**
+     * The total count of failed jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getFailedJobsCount() {
+        return failedJobsCount;
+    }
+
+    /**
+     * The total count of killed jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getKilledJobsCount() {
+        return killedJobsCount;
+    }
+
+    /**
+     * The total count of finished jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getFinishedJobsCount() {
+        return finishedJobsCount;
     }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -85,7 +85,7 @@ import com.google.common.collect.Lists;
                 @NamedQuery(name = "countJobData", query = "select count (*) from JobData"),
                 @NamedQuery(name = "findUsersWithJobs", query = "select owner, count(owner), max(submittedTime) from JobData group by owner"),
                 @NamedQuery(name = "getJobsNumberWithStatus", query = "select count(*) from JobData where status in (:status) and removedTime = -1"),
-                @NamedQuery(name = "getJobsNumberWithStatusAndUser", query = "select count(*) from JobData where owner = :username and status in (:status) and removedTime = -1"),
+                @NamedQuery(name = "getJobsNumberWithStatusUsername", query = "select count(*) from JobData where owner = :username and status in (:status) and removedTime = -1"),
                 @NamedQuery(name = "getJobSubmittedTime", query = "select submittedTime from JobData where id = :id"),
                 @NamedQuery(name = "getMeanJobExecutionTime", query = "select avg(finishedTime - startTime) from JobData where startTime > 0 and finishedTime > 0"),
                 @NamedQuery(name = "getMeanJobPendingTime", query = "select avg(startTime - submittedTime) from JobData where startTime > 0 and submittedTime > 0"),
@@ -249,8 +249,7 @@ public class JobData implements Serializable {
 
     JobInfo toJobInfo() {
         JobId jobIdInstance = new JobIdImpl(getId(), getJobName());
-        JobInfoImpl jobInfo = createJobInfo(jobIdInstance);
-        return jobInfo;
+        return createJobInfo(jobIdInstance);
     }
 
     InternalJob toInternalJob() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -85,6 +85,7 @@ import com.google.common.collect.Lists;
                 @NamedQuery(name = "countJobData", query = "select count (*) from JobData"),
                 @NamedQuery(name = "findUsersWithJobs", query = "select owner, count(owner), max(submittedTime) from JobData group by owner"),
                 @NamedQuery(name = "getJobsNumberWithStatus", query = "select count(*) from JobData where status in (:status) and removedTime = -1"),
+                @NamedQuery(name = "getJobsNumberWithStatusAndUser", query = "select count(*) from JobData where owner = :username and status in (:status) and removedTime = -1"),
                 @NamedQuery(name = "getJobSubmittedTime", query = "select submittedTime from JobData where id = :id"),
                 @NamedQuery(name = "getMeanJobExecutionTime", query = "select avg(finishedTime - startTime) from JobData where startTime > 0 and finishedTime > 0"),
                 @NamedQuery(name = "getMeanJobPendingTime", query = "select avg(startTime - submittedTime) from JobData where startTime > 0 and submittedTime > 0"),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -108,6 +108,7 @@ import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
                 @NamedQuery(name = "getMeanTaskPendingTime", query = "select avg(startTime - :jobSubmittedTime) from TaskData task where task.jobData.id = :id and task.startTime > 0"),
                 @NamedQuery(name = "getMeanTaskRunningTime", query = "select avg(task.finishedTime - task.startTime) from TaskData task where task.startTime > 0 and task.finishedTime > 0 and task.jobData.id = :id"),
                 @NamedQuery(name = "getTasksCount", query = "select count(*) from TaskData task where taskStatus = :taskStatus and task.jobData.removedTime = -1"),
+                @NamedQuery(name = "getTasksCountForUsername", query = "select count(*) from TaskData task where task.jobData.owner = :username and taskStatus in (:taskStatus) and task.jobData.removedTime = -1"),
                 @NamedQuery(name = "getPendingTasksCount", query = "select count(*) from TaskData task where taskStatus in (:taskStatus) and task.jobData.status in (:jobStatus) and task.jobData.removedTime = -1"),
                 @NamedQuery(name = "getRunningTasksCount", query = "select count(*) from TaskData task where taskStatus in (:taskStatus) " +
                                                                    "and task.jobData.status in (:jobStatus) and task.jobData.removedTime = -1"),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBean.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBean.java
@@ -40,24 +40,6 @@ public interface MyAccountMBean {
     int getTotalJobCount();
 
     /**
-     * The total count of pending jobs submitted by the current user.
-     * @return the total jobs count
-     */
-    int getPendingJobsCount();
-
-    /**
-     * The total count of current jobs submitted by the current user.
-     * @return the total jobs count
-     */
-    int getCurrentJobsCount();
-
-    /**
-     * The total count of finished jobs submitted by the current user.
-     * @return the total jobs count
-     */
-    int getPastJobsCount();
-
-    /**
      * The total time duration in milliseconds of jobs completed by the current user.
      * @return the total job duration in milliseconds
      */
@@ -98,4 +80,58 @@ public interface MyAccountMBean {
      * @return the total task duration in milliseconds
      */
     long getTotalTaskDuration();
+
+    /**
+     * The total count of pending jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    int getPendingJobsCount();
+
+    /**
+     * The total count of stalled jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getStalledJobsCount();
+
+    /**
+     * The total count of running jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getRunningJobsCount();
+
+    /**
+     * The total count of paused jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getPausedJobsCount();
+
+    /**
+     * The total count of in-error jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getInErrorJobsCount();
+
+    /**
+     * The total count of canceled jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getCanceledJobsCount();
+
+    /**
+     * The total count of failed jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getFailedJobsCount();
+
+    /**
+     * The total count of killed jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getKilledJobsCount();
+
+    /**
+     * The total count of finished jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    public int getFinishedJobsCount();
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBean.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBean.java
@@ -34,25 +34,67 @@ package org.ow2.proactive.scheduler.core.jmx.mbean;
 public interface MyAccountMBean {
 
     /**
-     * The total count of jobs completed by the current user. 
+     * The total count of jobs completed by the current user.
      * @return the total job count
      */
     int getTotalJobCount();
 
     /**
-     * The total time duration in milliseconds of jobs completed by the current user. 
+     * The total count of pending jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    int getPendingJobsCount();
+
+    /**
+     * The total count of current jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    int getCurrentJobsCount();
+
+    /**
+     * The total count of finished jobs submitted by the current user.
+     * @return the total jobs count
+     */
+    int getPastJobsCount();
+
+    /**
+     * The total time duration in milliseconds of jobs completed by the current user.
      * @return the total job duration in milliseconds
      */
     long getTotalJobDuration();
 
     /**
-     * The total count of tasks completed by the current user. 
+     * The total count of tasks completed by the current user.
      * @return the total task count
      */
     int getTotalTaskCount();
 
     /**
-     * The total time duration in milliseconds of tasks completed by the current user. 
+     * The total count of pending tasks submitted by the current user.
+     * @return the total task count
+     */
+    int getPendingTasksCount();
+
+    /**
+     * The total count of current tasks submitted by the current user.
+     * @return the total task count
+     */
+    int getCurrentTasksCount();
+
+    /**
+     * The total count of past tasks submitted by the current user.
+     * @return the total task count
+     */
+    int getPastTasksCount();
+
+    /**
+     * The total count of paused and in-error tasks submitted by the current user.
+     * @return the total task count
+     */
+    int getPausedInErrorTasksCount();
+
+    /**
+     * The total time duration in milliseconds of tasks completed by the current user.
      * @return the total task duration in milliseconds
      */
     long getTotalTaskDuration();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBeanImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBeanImpl.java
@@ -77,12 +77,40 @@ public class MyAccountMBeanImpl extends StandardMBean implements MyAccountMBean 
         return this.perThreadAccount.get().getTotalTaskCount();
     }
 
+    public int getPendingTasksCount() {
+        return this.perThreadAccount.get().getPendingTasksCount();
+    }
+
+    public int getCurrentTasksCount() {
+        return this.perThreadAccount.get().getCurrentTasksCount();
+    }
+
+    public int getPastTasksCount() {
+        return this.perThreadAccount.get().getPastTasksCount();
+    }
+
+    public int getPausedInErrorTasksCount() {
+        return this.perThreadAccount.get().getPausedInErrorTasksCount();
+    }
+
     public long getTotalTaskDuration() {
         return this.perThreadAccount.get().getTotalTaskDuration();
     }
 
     public int getTotalJobCount() {
         return this.perThreadAccount.get().getTotalJobCount();
+    }
+
+    public int getPendingJobsCount() {
+        return this.perThreadAccount.get().getPendingJobsCount();
+    }
+
+    public int getCurrentJobsCount() {
+        return this.perThreadAccount.get().getCurrentJobsCount();
+    }
+
+    public int getPastJobsCount() {
+        return this.perThreadAccount.get().getPastJobsCount();
     }
 
     public long getTotalJobDuration() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBeanImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/jmx/mbean/MyAccountMBeanImpl.java
@@ -105,12 +105,36 @@ public class MyAccountMBeanImpl extends StandardMBean implements MyAccountMBean 
         return this.perThreadAccount.get().getPendingJobsCount();
     }
 
-    public int getCurrentJobsCount() {
-        return this.perThreadAccount.get().getCurrentJobsCount();
+    public int getStalledJobsCount() {
+        return this.perThreadAccount.get().getStalledJobsCount();
     }
 
-    public int getPastJobsCount() {
-        return this.perThreadAccount.get().getPastJobsCount();
+    public int getRunningJobsCount() {
+        return this.perThreadAccount.get().getRunningJobsCount();
+    }
+
+    public int getPausedJobsCount() {
+        return this.perThreadAccount.get().getPausedJobsCount();
+    }
+
+    public int getInErrorJobsCount() {
+        return this.perThreadAccount.get().getInErrorJobsCount();
+    }
+
+    public int getCanceledJobsCount() {
+        return this.perThreadAccount.get().getCanceledJobsCount();
+    }
+
+    public int getFailedJobsCount() {
+        return this.perThreadAccount.get().getFailedJobsCount();
+    }
+
+    public int getKilledJobsCount() {
+        return this.perThreadAccount.get().getKilledJobsCount();
+    }
+
+    public int getFinishedJobsCount() {
+        return this.perThreadAccount.get().getFinishedJobsCount();
     }
 
     public long getTotalJobDuration() {
@@ -146,7 +170,7 @@ public class MyAccountMBeanImpl extends StandardMBean implements MyAccountMBean 
         final String username = subject.getPrincipals().iterator().next().getName();
         SchedulerAccount acc = this.accountsManager.getAccount(username);
         if (acc == null) {
-            acc = new SchedulerAccount();
+            acc = SchedulerAccount.builder().build();
         }
         return acc; // never null
     }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
@@ -50,7 +50,6 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
 
         int taskCount;
 
-        // TODO complete the singleJobScenario with task the following statistics
         int pendingTasksCount;
 
         int currentTasksCount;

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
@@ -50,9 +50,20 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
 
         int taskCount;
 
+        // TODO complete the singleJobScenario with task the following statistics
+        int pendingTasksCount;
+        int currentTasksCount;
+        int pastTasksCount;
+
         long jobTime;
 
         int jobCount;
+
+        int pendingJobsCount;
+
+        int currentJobsCount;
+
+        int pastJobsCount;
 
         final String userName;
 
@@ -110,6 +121,7 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         InternalJob job1 = defaultSubmitJobAndLoadInternal(true, jobDef1, accountData.userName);
 
         // job is submitted
+        accountData.pendingJobsCount++;
 
         checkAccount(invalidUser);
         checkAccount(accountData);
@@ -118,6 +130,8 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         job1.start();
         startTask(job1, job1.getTask("task1"));
         dbManager.jobTaskStarted(job1, job1.getTask("task1"), true);
+        accountData.pendingJobsCount--;
+        accountData.currentJobsCount++;
 
         checkAccount(invalidUser);
         checkAccount(accountData);
@@ -149,6 +163,8 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         accountData.taskTime += finishTask(job1, "task3");
         accountData.taskCount++;
         accountData.jobCount++;
+        accountData.pastJobsCount++;
+        accountData.currentJobsCount--;
         accountData.jobTime += job1.getFinishedTime() - job1.getStartTime();
 
         checkAccount(invalidUser);
@@ -177,6 +193,8 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         Assert.assertEquals("Tasks duration", accountData.taskTime, account.getTotalTaskDuration());
         Assert.assertEquals("Jobs count", accountData.jobCount, account.getTotalJobCount());
         Assert.assertEquals("Jobs duration", accountData.jobTime, account.getTotalJobDuration());
-
+        Assert.assertEquals("Pending jobs count", accountData.pendingJobsCount, account.getPendingJobsCount());
+        Assert.assertEquals("Current jobs count", accountData.currentJobsCount, account.getCurrentJobsCount());
+        Assert.assertEquals("Past jobs count", accountData.pastJobsCount, account.getPastJobsCount());
     }
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
@@ -46,25 +46,19 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
     static final String TEST_USER_NAME2 = "TestReadSchedulerAccount2";
 
     static class AccountData {
+
         long taskTime;
-
         int taskCount;
-
         int pendingTasksCount;
-
         int currentTasksCount;
-
         int pastTasksCount;
 
         long jobTime;
-
         int jobCount;
-
         int pendingJobsCount;
-
         int runningJobsCount;
-
         int finishedJobsCount;
+        int stalledJobsCount;
 
         final String userName;
 
@@ -133,9 +127,9 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         startTask(job1, job1.getTask("task1"));
         dbManager.jobTaskStarted(job1, job1.getTask("task1"), true);
         accountData.pendingJobsCount--;
+        accountData.runningJobsCount++;
         accountData.pendingTasksCount--;
         accountData.currentTasksCount++;
-        accountData.runningJobsCount++;
 
         checkAccount(invalidUser);
         checkAccount(accountData);
@@ -145,6 +139,8 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         accountData.currentTasksCount--;
         accountData.pastTasksCount++;
         accountData.taskCount++;
+        accountData.runningJobsCount--;
+        accountData.stalledJobsCount++;
 
         checkAccount(invalidUser);
         checkAccount(accountData);
@@ -158,6 +154,8 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         dbManager.jobTaskStarted(job1, job1.getTask("task3"), true);
         accountData.pendingTasksCount--;
         accountData.currentTasksCount++;
+        accountData.runningJobsCount++;
+        accountData.stalledJobsCount--;
 
         checkAccount(invalidUser);
         checkAccount(accountData);
@@ -213,5 +211,6 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         Assert.assertEquals("Pending jobs count", accountData.pendingJobsCount, account.getPendingJobsCount());
         Assert.assertEquals("Running jobs count", accountData.runningJobsCount, account.getRunningJobsCount());
         Assert.assertEquals("Finished jobs count", accountData.finishedJobsCount, account.getFinishedJobsCount());
+        Assert.assertEquals("Stalled jobs count", accountData.stalledJobsCount, account.getStalledJobsCount());
     }
 }


### PR DESCRIPTION
In this PR I add a few metrics to the MBeans responsible for keeping job and task statistics for the `stats/myaccount` endpoint (stats per user) 