### PR TITLE
Add email notification for JOB_RUNNING_TO_FINISHED_WITH_ERRORS

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerEvent.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerEvent.java
@@ -109,10 +109,13 @@ public enum SchedulerEvent {
     /** A job has just been restarted from error. */
     JOB_RESTARTED_FROM_ERROR("Job restarted from error"),
     /** A job has just been updated.*/
-    JOB_UPDATED("job updated"),
+    JOB_UPDATED("Job updated"),
     /** A task has just had an error, was marked as finished. */
-    TASK_IN_ERROR_TO_FINISHED("Task In-Error to finished");
-
+    TASK_IN_ERROR_TO_FINISHED("Task In-Error to finished"),
+    /** A job has been terminated with at least one faulty task
+     * This event is only used in the JobEmailNotification to filter finishied jobs with errors from all finished jobs
+     * */
+    JOB_RUNNING_TO_FINISHED_WITH_ERRORS("Job running to finished with errors");
     /** Name of the method */
     private String methodName;
 

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/TestSchedulerEvent.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/TestSchedulerEvent.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 /**
  * TestSchedulerEvent tests that the scheduler event ordinal have not been changed.<br>
  * The ordinal of the SchedulerEvent class must not changed as it is used by user.
- * Changing this ordinal may imply many bugs in client implementation that already use the API. 
+ * Changing this ordinal may imply many bugs in client implementation that already use the API.
  *
  * @author The ProActive Team
  * @since ProActive Scheduling 1.0
@@ -73,8 +73,9 @@ public class TestSchedulerEvent {
         Assert.assertEquals(SchedulerEvent.JOB_RESTARTED_FROM_ERROR.ordinal(), 29);
         Assert.assertEquals(SchedulerEvent.JOB_UPDATED.ordinal(), 30);
         Assert.assertEquals(SchedulerEvent.TASK_IN_ERROR_TO_FINISHED.ordinal(), 31);
+        Assert.assertEquals(SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.ordinal(), 32);
 
-        Assert.assertEquals(32, SchedulerEvent.values().length);
+        Assert.assertEquals(33, SchedulerEvent.values().length);
     }
 
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
@@ -237,7 +237,7 @@ public class JobEmailNotification {
     }
 
     private String getSubject(boolean withErrors) {
-        String event = withErrors ? SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.toString().toLowerCase()
+        String event = withErrors ? SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.toString()
                                   : eventType.toString();
         String jobID = jobState.getId().value();
         return String.format(SUBJECT_TEMPLATE, jobID, event);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
@@ -155,6 +155,7 @@ public class JobEmailNotification {
                 } else {
                     sendEmail(withAttachment, false);
                 }
+                break;
             case JOB_CHANGE_PRIORITY:
             case JOB_IN_ERROR:
             case JOB_PAUSED:

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
@@ -147,8 +147,11 @@ public class JobEmailNotification {
                 if ((jobStatusList.contains(SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.toString()
                                                                                               .toLowerCase()) ||
                      jobStatusList.contains(SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.name().toLowerCase()))) {
-                    if (hasTasksWithIssues())
+                    if (hasTasksWithIssues()) {
                         sendEmail(withAttachment, true);
+                    } else {
+                        return false;
+                    }
                 } else {
                     sendEmail(withAttachment, false);
                 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
@@ -152,7 +152,6 @@ public class JobEmailNotification {
                 } else {
                     sendEmail(withAttachment, false);
                 }
-                break;
             case JOB_CHANGE_PRIORITY:
             case JOB_IN_ERROR:
             case JOB_PAUSED:
@@ -164,11 +163,11 @@ public class JobEmailNotification {
                     jobStatusList.contains(eventType.toString().toLowerCase())) {
                     sendEmail(withAttachment, false);
                 }
+                break;
             default:
                 logger.trace("Event not in the list of email notification, doing nothing");
                 return false;
         }
-
         return true;
 
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/JobEmailNotification.java
@@ -116,7 +116,8 @@ public class JobEmailNotification {
                                           "JOB_RESTARTED_FROM_ERROR",
                                           "JOB_RESUMED",
                                           "JOB_RUNNING_TO_FINISHED",
-                                          "JOB_SUBMITTED")
+                                          "JOB_SUBMITTED",
+                                          "JOB_RUNNING_TO_FINISHED_WITH_ERRORS")
                                       .map(status -> status.toLowerCase())
                                       .collect(Collectors.toList());
             } else {
@@ -125,48 +126,81 @@ public class JobEmailNotification {
             }
         }
 
-        switch (eventType) {
-            case JOB_CHANGE_PRIORITY:
-            case JOB_IN_ERROR:
-            case JOB_PAUSED:
-            case JOB_PENDING_TO_FINISHED:
-            case JOB_PENDING_TO_RUNNING:
-            case JOB_RESTARTED_FROM_ERROR:
-            case JOB_RESUMED:
-            case JOB_RUNNING_TO_FINISHED:
-            case JOB_SUBMITTED:
-                break;
-            default:
-                logger.trace("Event not in the list of email notification, doing nothing");
-                return false;
-        }
         if (!PASchedulerProperties.EMAIL_NOTIFICATIONS_ENABLED.getValueAsBoolean()) {
             logger.debug("Notification emails disabled, doing nothing");
             return false;
         }
-        if (!jobStatusList.contains(eventType.toString().toLowerCase()) &&
-            !jobStatusList.contains(eventType.name().toLowerCase())) {
+
+        if ((!jobStatusList.contains(eventType.toString().toLowerCase()) &&
+             !jobStatusList.contains(eventType.name().toLowerCase())) &&
+            (!jobStatusList.contains(SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.name().toLowerCase())) &&
+            (!jobStatusList.contains(SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.toString().toLowerCase()))) {
             return false;
         }
 
+        switch (eventType) {
+            case JOB_PENDING_TO_FINISHED:
+            case JOB_RUNNING_TO_FINISHED:
+                if ((jobStatusList.contains(SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.toString()
+                                                                                              .toLowerCase()) ||
+                     jobStatusList.contains(SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.name().toLowerCase()))) {
+                    if (hasFaultyTasks())
+                        sendEmail(withAttachment, true);
+                } else {
+                    sendEmail(withAttachment, false);
+                }
+                break;
+            case JOB_CHANGE_PRIORITY:
+            case JOB_IN_ERROR:
+            case JOB_PAUSED:
+            case JOB_RESTARTED_FROM_ERROR:
+            case JOB_PENDING_TO_RUNNING:
+            case JOB_RESUMED:
+            case JOB_SUBMITTED:
+                if (jobStatusList.contains(eventType.name().toLowerCase()) ||
+                    jobStatusList.contains(eventType.toString().toLowerCase())) {
+                    sendEmail(withAttachment, false);
+                }
+            default:
+                logger.trace("Event not in the list of email notification, doing nothing");
+                return false;
+        }
+
+        return true;
+
+    }
+
+    private void sendEmail(boolean withAttachment, boolean withErrors)
+            throws JobEmailNotificationException, IOException, UnknownJobException, PermissionException {
         try {
             if (withAttachment) {
                 String attachment = getAttachment();
                 if (attachment != null) {
-                    sender.sender(getTo(), getSubject(), getBody(), attachment, getAttachmentName());
+                    sender.sender(getTo(), getSubject(withErrors), getBody(), attachment, getAttachmentName());
                     FileUtils.deleteQuietly(new File(attachment));
                 } else {
-                    sender.sender(getTo(), getSubject(), getBody());
+                    sender.sender(getTo(), getSubject(withErrors), getBody());
                 }
             } else {
-                sender.sender(getTo(), getSubject(), getBody());
+                sender.sender(getTo(), getSubject(withErrors), getBody());
             }
-            return true;
-        } catch (EmailException e) {
+
+        } catch (EmailException e)
+
+        {
             throw new JobEmailNotificationException(String.join(",", getTo()),
                                                     "Error sending email: " + e.getMessage(),
                                                     e);
         }
+    }
+
+    private boolean hasFaultyTasks() {
+        List<TaskState> tasks = jobState.getTasks();
+        boolean withErrors = tasks.stream()
+                                  .map(task -> task.getStatus().name().toLowerCase())
+                                  .anyMatch(t -> t.equals("Faulty".toLowerCase()));
+
+        return withErrors;
     }
 
     public void checkAndSendAsync(boolean withAttachment) {
@@ -204,9 +238,10 @@ public class JobEmailNotification {
         return Arrays.asList(toList);
     }
 
-    private String getSubject() {
+    private String getSubject(boolean withErrors) {
+        String event = withErrors ? SchedulerEvent.JOB_RUNNING_TO_FINISHED_WITH_ERRORS.toString().toLowerCase()
+                                  : eventType.toString();
         String jobID = jobState.getId().value();
-        String event = eventType.toString();
         return String.format(SUBJECT_TEMPLATE, jobID, event);
     }
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobEmailNotificationTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobEmailNotificationTest.java
@@ -123,21 +123,6 @@ public class JobEmailNotificationTest extends ProActiveTestClean {
         return internalJob;
     }
 
-    private InternalJob createJobWithFailedTask(String userEmail) throws Exception {
-        TaskFlowJob job = new TaskFlowJob();
-        job.setName(JOB_NAME);
-        if (userEmail != null) {
-            job.addGenericInformation(JobEmailNotification.GENERIC_INFORMATION_KEY_EMAIL, userEmail);
-        }
-        JavaTask javaTask = new JavaTask();
-        javaTask.setExecutableClassName(null);
-        javaTask.setName(TASK_NAME);
-        job.addTask(javaTask);
-        InternalJob internalJob = InternalJobFactory.createJob(job, null);
-        internalJob.setOwner(DEFAULT_USER_NAME);
-        return internalJob;
-    }
-
     private static boolean sendNotification(JobState jobState, SchedulerEvent event, SendMail sender)
             throws JobEmailNotificationException, UnknownJobException, IOException, PermissionException {
         NotificationData<JobInfo> notification = getNotification(jobState, event);
@@ -319,12 +304,13 @@ public class JobEmailNotificationTest extends ProActiveTestClean {
 
     @Test
     public void testFinishedWithErrors() throws Exception {
-        InternalJob job = createJobWithFailedTask(USER_EMAIL);
+        InternalJob job = createJob(USER_EMAIL);
         job.setId(new JobIdImpl(123890, job.getName()));
         job.setStatus(JobStatus.FINISHED);
         Map<String, String> genericInfo = job.getGenericInformation();
         genericInfo.put("NOTIFICATION_EVENTS", "Job running to finished with errors");
         job.setGenericInformation(genericInfo);
+        job.setNumberOfFaultyTasks(1);
 
         boolean sent = sendNotification(job, SchedulerEvent.JOB_RUNNING_TO_FINISHED, stubbedSender);
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobEmailNotificationTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobEmailNotificationTest.java
@@ -303,6 +303,26 @@ public class JobEmailNotificationTest extends ProActiveTestClean {
     }
 
     @Test
+    public void testFinishedWithErrors() throws Exception {
+        InternalJob job = createJob(USER_EMAIL);
+        job.setId(new JobIdImpl(123890, job.getName()));
+        job.setStatus(JobStatus.FINISHED);
+        Map<String, String> genericInfo = job.getGenericInformation();
+        genericInfo.put("NOTIFICATION_EVENTS", "Job running to finished with errors");
+        job.setGenericInformation(genericInfo);
+
+        boolean sent = sendNotification(job, SchedulerEvent.JOB_RUNNING_TO_FINISHED, stubbedSender);
+
+        assertTrue(sent);
+        ArgumentCaptor<List> varArgs = ArgumentCaptor.forClass(List.class);
+        verify(stubbedSender).sender(varArgs.capture(),
+                                     contains("ProActive Job 123890 : Job running to finished with errors"),
+                                     contains("Status: Finished"));
+        assertTrue(varArgs.getValue().contains(USER_EMAIL));
+        verifyNoMoreInteractions(stubbedSender);
+    }
+
+    @Test
     public void testKilled() throws Exception {
         InternalJob job = createJob(USER_EMAIL);
         job.setId(new JobIdImpl(123890, job.getName()));

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobEmailNotificationTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/JobEmailNotificationTest.java
@@ -123,6 +123,21 @@ public class JobEmailNotificationTest extends ProActiveTestClean {
         return internalJob;
     }
 
+    private InternalJob createJobWithFailedTask(String userEmail) throws Exception {
+        TaskFlowJob job = new TaskFlowJob();
+        job.setName(JOB_NAME);
+        if (userEmail != null) {
+            job.addGenericInformation(JobEmailNotification.GENERIC_INFORMATION_KEY_EMAIL, userEmail);
+        }
+        JavaTask javaTask = new JavaTask();
+        javaTask.setExecutableClassName(null);
+        javaTask.setName(TASK_NAME);
+        job.addTask(javaTask);
+        InternalJob internalJob = InternalJobFactory.createJob(job, null);
+        internalJob.setOwner(DEFAULT_USER_NAME);
+        return internalJob;
+    }
+
     private static boolean sendNotification(JobState jobState, SchedulerEvent event, SendMail sender)
             throws JobEmailNotificationException, UnknownJobException, IOException, PermissionException {
         NotificationData<JobInfo> notification = getNotification(jobState, event);
@@ -304,7 +319,7 @@ public class JobEmailNotificationTest extends ProActiveTestClean {
 
     @Test
     public void testFinishedWithErrors() throws Exception {
-        InternalJob job = createJob(USER_EMAIL);
+        InternalJob job = createJobWithFailedTask(USER_EMAIL);
         job.setId(new JobIdImpl(123890, job.getName()));
         job.setStatus(JobStatus.FINISHED);
         Map<String, String> genericInfo = job.getGenericInformation();
@@ -320,6 +335,19 @@ public class JobEmailNotificationTest extends ProActiveTestClean {
                                      contains("Status: Finished"));
         assertTrue(varArgs.getValue().contains(USER_EMAIL));
         verifyNoMoreInteractions(stubbedSender);
+    }
+
+    @Test
+    public void testFinishedWithoutErrors() throws Exception {
+        InternalJob job = createJob(USER_EMAIL);
+        job.setId(new JobIdImpl(123890, job.getName()));
+        job.setStatus(JobStatus.FINISHED);
+        Map<String, String> genericInfo = job.getGenericInformation();
+        genericInfo.put("NOTIFICATION_EVENTS", "Job running to finished with errors");
+        job.setGenericInformation(genericInfo);
+
+        assertFalse(sendNotification(job, SchedulerEvent.JOB_RUNNING_TO_FINISHED, stubbedSender));
+
     }
 
     @Test


### PR DESCRIPTION
Add email notification for jobs having the notification event `JOB RUNNING TO FINISHED WITH ERRORS`:

-Consider a job `running to finished with errors` if it has one or more `faulty` tasks
-Add event to SchedulerEvent (`JOB_RUNNING_TO_FINISHED_WITH_ERRORS` or `Job running to finished with errors` could be introduced as GI)
-For now, the filtering concerns only past finished jobs, which means jobs having finished as status.
