### PR TITLE
Add third party credentials to connection

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -456,7 +456,14 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive {
     @ImmediateService
     public void connect(UniqueID sourceBodyID, UserIdentificationImpl identification, Credentials cred)
             throws AlreadyConnectedException {
-        this.frontendState.connect(sourceBodyID, identification, cred);
+        Credentials enrichedCreds = cred;
+        try {
+            enrichedCreds = schedulingService.addThirdPartyCredentials(cred);
+        } catch (Exception e) {
+            logger.warn("Could not add third party credentials to connection of user " + identification.getUsername() +
+                        " from " + identification.getHostName());
+        }
+        this.frontendState.connect(sourceBodyID, identification, enrichedCreds);
         this.spacesSupport.registerUserSpace(identification.getUsername());
     }
 


### PR DESCRIPTION
 - this is to allow the usage of 3p-credential SSH_PRIVATE_KEY instead of providing a private key file at each connection