### PR TITLE
Keep task precious logs in case of kill or walltime

### DIFF
--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     runtime 'org.apache.ivy:ivy:2.1.0'
     runtime 'org.codehaus.groovy:groovy-all:2.4.12'
     runtime 'jsr223:jsr223-nativeshell:0.6.0'
-    runtime 'jsr223:jsr223-docker-compose:0.3.2'
+    runtime 'jsr223:jsr223-docker-compose:0.3.3'
     runtime 'jsr223:jsr223-perl:0.1.1'
     runtime 'jsr223:jsr223-powershell:0.2.1'
     runtime 'jsr223:jsr223-cpython:0.1.7'

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedTaskExecutor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedTaskExecutor.java
@@ -125,10 +125,12 @@ public class ForkedTaskExecutor implements TaskExecutor {
             FileUtils.deleteQuietly(serializedContext);
 
             if (process != null) {
+                logger.info("killing forked JVM process");
                 process.destroy();
                 try {
                     //wait for twice the time of the cleanup process
                     process.waitFor((new CleanupTimeoutGetter()).getCleanupTimeSeconds(), TimeUnit.SECONDS);
+                    logger.info("JVM process killed");
                 } catch (Exception e) {
                     logger.info("Exception while waiting task to finish " + e);
                 }


### PR DESCRIPTION
Additionally:
 - upgrade docker compose engine
 - print log messages when the forked jvm process is being terminated