### PR TITLE
Improve RM proxy sessions handling

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -77,6 +77,7 @@ import org.ow2.proactive.resourcemanager.common.event.RMNodeHistory;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeSourceEvent;
 import org.ow2.proactive.resourcemanager.common.event.dto.RMStateDelta;
 import org.ow2.proactive.resourcemanager.common.event.dto.RMStateFull;
+import org.ow2.proactive.resourcemanager.common.util.RMListenerProxy;
 import org.ow2.proactive.resourcemanager.common.util.RMProxyUserInterface;
 import org.ow2.proactive.resourcemanager.core.jmx.RMJMXBeans;
 import org.ow2.proactive.resourcemanager.exception.RMActiveObjectCreationException;
@@ -156,7 +157,7 @@ public class RMRest implements RMRestInterface {
     @Override
     public void rmDisconnect(String sessionId) throws NotConnectedException {
         RMProxyUserInterface rm = checkAccess(sessionId);
-        rm.disconnect();
+        PAFuture.getFutureValue(rm.disconnect(), RMListenerProxy.MONITORING_INTERFACE_TIMEOUT);
         sessionStore.terminate(sessionId);
     }
 

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/frontend/RMMonitoring.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/frontend/RMMonitoring.java
@@ -28,7 +28,6 @@ package org.ow2.proactive.resourcemanager.frontend;
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.resourcemanager.common.event.RMEventType;
 import org.ow2.proactive.resourcemanager.common.event.RMInitialState;
-import org.ow2.proactive.resourcemanager.exception.RMException;
 
 
 /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -2008,6 +2008,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     /**
      * Gets RM monitoring stub
      */
+    @ImmediateService
     public RMMonitoring getMonitoring() {
         try {
             // return the stub on RMMonitoring interface to keep avoid using server class on client side

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -156,6 +156,13 @@ public class SchedulerStarter {
         configureLogging();
         configureDerby();
 
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                LOGGER.warn("Exception in thread \"" + t.getName() + "\" " + e.getMessage(), e);
+            }
+        });
+
         args = JVMPropertiesPreloader.overrideJVMProperties(args);
 
         Options options = getOptions();


### PR DESCRIPTION
To fix an observed thread leak due to RMListenerProxy hanging on getMonitoring().removeRMEventListener() this change aims at rationalizing and adding timeouts to the linked requests.

Additionally, add a Thread.setDefaultUncaughtExceptionHandler to properly log uncaught exceptions in Scheduler.log