### PR TITLE
Remove usage of ProActiveCounter in ssh infrastructures

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostsFileBasedInfrastructureManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/HostsFileBasedInfrastructureManager.java
@@ -558,7 +558,7 @@ public abstract class HostsFileBasedInfrastructureManager extends Infrastructure
             String configuredAddress = hostTracker.getConfiguredAddress();
             String compliantAddress = convertToCompliantAddress(configuredAddress);
             return nodeSource.getName() + COMPLIANT_ADDRESS_DELIMITER + compliantAddress + COMPLIANT_ADDRESS_DELIMITER +
-                   ProActiveCounter.getUniqID();
+                   0;
         }
 
         protected String extractHostFromNode(String nodeNameOrUrl) {


### PR DESCRIPTION
ProActiveCounter creates different node names on successive deployments.
This generates multiple log and rrd files which can be very big, progressively eating all disk space.

Unicity of the node name is already guaranteed by node source, host name and worker node index, so the proactive counter does not bring much added value.