### PR TITLE
LDAP : allow using user id instead of distinguished name in group filter

### DIFF
--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPLoginModule.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPLoginModule.java
@@ -128,6 +128,9 @@ public abstract class LDAPLoginModule extends FileLoginModule implements Loggabl
     private final boolean ANY_HOSTNAME = Boolean.parseBoolean(ldapProperties.getProperty(LDAPProperties.LDAP_START_TLS_ANY_HOSTNAME,
                                                                                          "false"));
 
+    private final boolean USE_UID_IN_GROUP_SEARCH = Boolean.parseBoolean(ldapProperties.getProperty(LDAPProperties.LDAP_GROUPSEARCH_USE_UID,
+                                                                                                    "false"));
+
     /** user name used to bind to LDAP (if authentication method is different from none) */
     private final String BIND_LOGIN = ldapProperties.getProperty(LDAPProperties.LDAP_BIND_LOGIN);
 
@@ -551,7 +554,7 @@ public abstract class LDAPLoginModule extends FileLoginModule implements Loggabl
 
                     // looking for the user groups
                     String groupFilter = String.format(ldapProperties.getProperty(LDAPProperties.LDAP_GROUP_FILTER),
-                                                       userDN);
+                                                       USE_UID_IN_GROUP_SEARCH ? username : userDN);
 
                     NamingEnumeration<SearchResult> groupResults = ctx.getDirContext().search(new LdapName(GROUPS_DN),
                                                                                               groupFilter,

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPProperties.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPProperties.java
@@ -73,6 +73,9 @@ public class LDAPProperties {
      **/
     public static final String LDAP_GROUP_FILTER = "pa.ldap.group.filter";
 
+    /** use member uid in group search */
+    public static final String LDAP_GROUPSEARCH_USE_UID = "pa.ldap.group.search.use.uid";
+
     /** the attribute in the group entry that matches the jaas' group name */
     public static final String LDAP_GROUPNAME_ATTR = "pa.ldap.group.name.attr";
 

--- a/config/authentication/ldap.cfg
+++ b/config/authentication/ldap.cfg
@@ -39,14 +39,20 @@ pa.ldap.userssubtree=dc=activeeon,dc=com
 # %s is replaced by the user-submitted login
 pa.ldap.user.filter=(&(objectclass=inetOrgPerson)(uid=%s))
 
-# on windows active directory, use the following filter instead
+# on windows active directory, use the following user filter
 # pa.ldap.user.filter=(&(objectclass=user)(sAMAccountName=%s))
+
+# if set to true, the username instead of distinguished name will be used in group search
+pa.ldap.group.search.use.uid=false
 
 # retrieves the groups the user dn belongs to
 # the '%s' parameter is the user dn previously retrieved
 pa.ldap.group.filter=(&(objectclass=groupOfUniqueNames)(uniqueMember=%s))
 
-# on windows active directory, use the following filter
+# example group filter on OpenLDAP using uid instead of dn
+# pa.ldap.group.filter=(&(objectclass=posixGroup)(memberUID=%s))
+
+# on windows active directory, use the following group filter
 # pa.ldap.group.filter=(&(objectclass=group)(member:1.2.840.113556.1.4.1941:=%s))
 
 # the attribute in the group entry that matches the jaas' group name


### PR DESCRIPTION
This change allows finding groups for recent OpenLDAP configurations