### PR TITLE
Fix dataspace warnings in task logs

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProActiveForkedTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProActiveForkedTaskLauncherFactory.java
@@ -38,9 +38,9 @@ import org.ow2.proactive.scheduler.task.executors.TaskExecutor;
 public class ProActiveForkedTaskLauncherFactory implements TaskLauncherFactory {
 
     @Override
-    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser)
-            throws Exception {
-        return new TaskProActiveDataspaces(taskId, namingService, isRunAsUser);
+    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+            TaskLogger taskLogger) throws Exception {
+        return new TaskProActiveDataspaces(taskId, namingService, isRunAsUser, taskLogger);
     }
 
     @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProActiveNonForkedTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProActiveNonForkedTaskLauncherFactory.java
@@ -38,9 +38,9 @@ import org.ow2.proactive.scheduler.task.executors.TaskExecutor;
 public class ProActiveNonForkedTaskLauncherFactory implements TaskLauncherFactory {
 
     @Override
-    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser)
-            throws Exception {
-        return new TaskProActiveDataspaces(taskId, namingService, isRunAsUser);
+    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+            TaskLogger taskLogger) throws Exception {
+        return new TaskProActiveDataspaces(taskId, namingService, isRunAsUser, taskLogger);
     }
 
     @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncher.java
@@ -187,7 +187,8 @@ public class TaskLauncher implements InitActive {
             DataSpaceNodeConfigurationAgent.lockCacheSpaceCleaning();
             dataspaces = factory.createTaskDataspaces(taskId,
                                                       initializer.getNamingService(),
-                                                      executableContainer.isRunAsUser());
+                                                      executableContainer.isRunAsUser(),
+                                                      taskLogger);
 
             copyTaskLogsFromUserSpace(taskLogger.createLogFilePath(dataspaces.getScratchFolder()), dataspaces);
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherFactory.java
@@ -36,8 +36,8 @@ import org.ow2.proactive.scheduler.task.executors.TaskExecutor;
 
 public interface TaskLauncherFactory extends Serializable {
 
-    TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser)
-            throws Exception;
+    TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+            TaskLogger taskLogger) throws Exception;
 
     TaskExecutor createTaskExecutor(File workingDir);
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/SlowDataspacesTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/SlowDataspacesTaskLauncherFactory.java
@@ -51,7 +51,8 @@ public class SlowDataspacesTaskLauncherFactory extends ProActiveForkedTaskLaunch
     }
 
     @Override
-    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser) {
+    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+            TaskLogger taskLogger) {
         return new SlowDataspaces(taskRunning);
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLauncherTest.java
@@ -225,8 +225,8 @@ public class TaskLauncherTest extends TaskLauncherTestAbstract {
         runTaskLauncher(createLauncherWithInjectedMocks(initializer, new TestTaskLauncherFactory() {
 
             @Override
-            public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService,
-                    boolean isRunAsUser) {
+            public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+                    TaskLogger taskLogger) {
                 return dataspacesMock;
             }
         }), executableContainer);
@@ -250,8 +250,8 @@ public class TaskLauncherTest extends TaskLauncherTestAbstract {
         runTaskLauncher(createLauncherWithInjectedMocks(initializer, new TestTaskLauncherFactory() {
 
             @Override
-            public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService,
-                    boolean isRunAsUser) {
+            public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+                    TaskLogger taskLogger) {
                 return dataspacesMock;
             }
         }), executableContainer);
@@ -273,8 +273,8 @@ public class TaskLauncherTest extends TaskLauncherTestAbstract {
         runTaskLauncher(createLauncherWithInjectedMocks(initializer, new TestTaskLauncherFactory() {
 
             @Override
-            public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService,
-                    boolean isRunAsUser) {
+            public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+                    TaskLogger taskLogger) {
                 return dataspacesMock;
             }
         }), executableContainer);

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TestTaskLauncherFactory.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TestTaskLauncherFactory.java
@@ -64,7 +64,8 @@ public class TestTaskLauncherFactory extends ProActiveForkedTaskLauncherFactory 
     }
 
     @Override
-    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser) {
+    public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+            TaskLogger taskLogger) {
         return dataSpaces;
     }
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/WalltimeTaskLauncherTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/WalltimeTaskLauncherTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import org.objectweb.proactive.ActiveObjectCreationException;
 import org.objectweb.proactive.core.node.NodeException;
 import org.objectweb.proactive.extensions.dataspaces.core.naming.NamingService;
-import org.ow2.proactive.scheduler.common.TaskTerminateNotification;
 import org.ow2.proactive.scheduler.common.exception.WalltimeExceededException;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -105,7 +104,8 @@ public class WalltimeTaskLauncherTest extends TaskLauncherTestAbstract {
 
     private class ForkingTaskLauncherFactory extends ProActiveForkedTaskLauncherFactory {
         @Override
-        public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser) {
+        public TaskDataspaces createTaskDataspaces(TaskId taskId, NamingService namingService, boolean isRunAsUser,
+                TaskLogger taskLogger) {
             return new TestTaskLauncherFactory.TaskFileDataspaces();
         }
 


### PR DESCRIPTION
Warnings or errors when transferring files using dataspaces used to appear in task logs but these logs disappeared (regression).
This commit fixes the issue.