### PR TITLE
Remove empty lines from job logs full

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -966,8 +966,11 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         List<TaskResult> resultList = scheduler.getTaskResultAllIncarnations(jobId, taskName);
         for (TaskResult result : resultList) {
             if (result.getOutput() != null) {
-                allLogs.append(result.getOutput().getAllLogs(true));
-                allLogs.append(NL);
+                String taskAllLogs = result.getOutput().getAllLogs(true);
+                allLogs.append(taskAllLogs);
+                if (!taskAllLogs.endsWith("\n")) {
+                    allLogs.append(NL);
+                }
             }
         }
         return allLogs.toString();
@@ -1019,8 +1022,11 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskResult> resultList = s.getTaskResultAllIncarnations(jobId, taskname);
             for (TaskResult result : resultList) {
                 if (result.getOutput() != null) {
-                    errLogs.append(result.getOutput().getStderrLogs(true));
-                    errLogs.append(NL);
+                    String taskErrLogs = result.getOutput().getStderrLogs(true);
+                    errLogs.append(taskErrLogs);
+                    if (!taskErrLogs.endsWith("\n")) {
+                        errLogs.append(NL);
+                    }
                 }
             }
             return errLogs.toString();
@@ -1054,8 +1060,11 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             List<TaskResult> resultList = s.getTaskResultAllIncarnations(jobId, taskname);
             for (TaskResult result : resultList) {
                 if (result.getOutput() != null) {
-                    outLogs.append(result.getOutput().getStdoutLogs(true));
-                    outLogs.append(NL);
+                    String taskOutLogs = result.getOutput().getStdoutLogs(true);
+                    outLogs.append(taskOutLogs);
+                    if (!taskOutLogs.endsWith("\n")) {
+                        outLogs.append(NL);
+                    }
                 }
             }
             return outLogs.toString();

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogs.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogs.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Layout;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -138,10 +139,10 @@ public class Log4JTaskLogs implements TaskLogs {
 
     private void appendEventToLogs(LoggingEvent logEvent, StringBuffer logs, Layout logFormat, boolean timeStamp) {
         if (timeStamp) {
-            logs.append(logFormat.format(logEvent));
+            logs.append(StringUtils.stripEnd(logFormat.format(logEvent), null) + nl);
         } else {
-            logs.append(logEvent.getMessage());
-            logs.append(nl);
+            Object message = logEvent.getMessage();
+            logs.append(StringUtils.stripEnd(message.toString(), null) + nl);
         }
     }
 

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogsTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogsTest.java
@@ -47,9 +47,14 @@ public class Log4JTaskLogsTest {
         assertEquals(String.format("output%n"), taskLogs.getStdoutLogs(false));
         assertEquals(String.format("error%n"), taskLogs.getStderrLogs(false));
         assertEquals(String.format("error%noutput%n"), taskLogs.getAllLogs(false));
-
-        assertTrue(taskLogs.getStdoutLogs(true).matches(String.format("\\[.*\\] output %n")));
-        assertTrue(taskLogs.getStderrLogs(true).matches(String.format("\\[.*\\] error %n")));
-        assertTrue(taskLogs.getAllLogs(true).matches(String.format("\\[.*\\] error %n\\[.*\\] output %n")));
+        String stdoutLogs = taskLogs.getStdoutLogs(true);
+        System.out.println("STDOUT: " + stdoutLogs);
+        String stderrLogs = taskLogs.getStderrLogs(true);
+        System.out.println("STDERR: " + stderrLogs);
+        String stdallLogs = taskLogs.getAllLogs(true);
+        System.out.println("STDALLL: " + stdallLogs);
+        assertTrue(stdoutLogs.matches("\\A\\[.*\\] output\\r?\\n\\z"));
+        assertTrue(stderrLogs.matches("\\A\\[.*\\] error\\r?\\n\\z"));
+        assertTrue(stdallLogs.matches("\\A\\[.*\\] error\\r?\\n\\[.*\\] output\\r?\\n\\z"));
     }
 }

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
@@ -85,12 +85,12 @@ public class TaskLoggerTest extends ProActiveTestClean {
 
         System.out.println(taskLogger.getLogs().getAllLogs(false));
 
-        assertEquals(String.format("hello%n%n"), taskLogger.getLogs().getAllLogs(false));
-        assertEquals(String.format("hello%n%n"), taskLogger.getLogs().getStdoutLogs(false));
+        assertEquals(String.format("hello%n"), taskLogger.getLogs().getAllLogs(false));
+        assertEquals(String.format("hello%n"), taskLogger.getLogs().getStdoutLogs(false));
 
         taskLogger.getErrorSink().println("error");
-        assertEquals(String.format("hello%n%nerror%n%n"), taskLogger.getLogs().getAllLogs(false));
-        assertEquals(String.format("error%n%n"), taskLogger.getLogs().getStderrLogs(false));
+        assertEquals(String.format("hello%nerror%n"), taskLogger.getLogs().getAllLogs(false));
+        assertEquals(String.format("error%n"), taskLogger.getLogs().getStderrLogs(false));
     }
 
     @Test
@@ -154,13 +154,13 @@ public class TaskLoggerTest extends ProActiveTestClean {
         assertTrue(taskLogger.getLogs()
                              .getAllLogs(true)
                              .matches("\\[" + quotedStringTaskId +
-                                      "@myhost;[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\] hello\r?\n \r?\n"));
+                                      "@myhost;[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\] hello\r?\n"));
 
         taskLogger.getErrorSink().println("error");
         assertTrue(taskLogger.getLogs()
                              .getStderrLogs(true)
                              .matches("\\[" + quotedStringTaskId +
-                                      "@myhost;[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\] error\r?\n \r?\n"));
+                                      "@myhost;[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\\] error\r?\n"));
 
     }
 


### PR DESCRIPTION
Empty lines was created by log4j messages already containing end of lines characters.
This fix makes sure that each log message terminates with a single end-of-line (in Log4JTaskLogs, thanks to StringUtils.stripEnd).
It also makes sure that no blank lines are added between individual task logs (changes in SchedulerStateRest).