### PR TITLE
Retrieve dataspace file: set encoding with query parameter.

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspace.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspace.java
@@ -106,7 +106,7 @@ public interface RestDataspace {
      * <li>If the pathname represents a file, its contents will be returned as:
      * <ul>
      * <li>an octet stream, if its a compressed file already or if the client doesn't
-     * accept encoded content</li>
+     * accept encoded content (encoding specified as "identity")</li>
      * <li>a 'gzip' encoded stream, if the client accepts 'gzip' encoded content
      * </li>
      * <li>a 'zip' encoded stream, if the client accepts 'zip' encoded contents</li>
@@ -119,21 +119,23 @@ public interface RestDataspace {
      * returned from the specified location.</li>
      * </ul>
      * @param sessionId a valid session id
+     * @param headerAcceptEncoding the accepted encoding supported by the client, can be "*", "gzip", "zip", "identity" or empty. When the query parameter {@code encoding} is specified, it is overridden by {@code encoding}.
      * @param dataspace can have two possible values, 'user' or 'global',
      * depending on the target <i>DATASPACE</i>
      * @param pathname location of the file or folder to retrieve
      * @param component can either be 'list' or empty. If 'list' is used, the response will contain in JSON format the list of files and folder presents at specified location, equivalent to a directory listing.
-     * @param encoding accepted encoding supported by the client, can be "*", "gzip", "zip" or empty.
      * @param includes a list of inclusion directives
      * @param excludes a list of exclusion directives
+     * @param encoding the accepted encoding supported by the client, can be "*", "gzip", "zip", "identity" or empty. It overrides the accepted encoding specified in {@code headerAcceptEncoding}.
      * @return a REST response which can have various content-types
      */
     @GET
     @Path("/{dataspace}/{path-name:.*}")
-    Response retrieve(@HeaderParam("sessionid") String sessionId, @HeaderParam("Accept-Encoding") String encoding,
-            @PathParam("dataspace") String dataspace, @PathParam("path-name") String pathname,
-            @QueryParam("comp") String component, @QueryParam("includes") List<String> includes,
-            @QueryParam("excludes") List<String> excludes) throws NotConnectedRestException, PermissionRestException;
+    Response retrieve(@HeaderParam("sessionid") String sessionId,
+            @HeaderParam("Accept-Encoding") String headerAcceptEncoding, @PathParam("dataspace") String dataspace,
+            @PathParam("path-name") String pathname, @QueryParam("comp") String component,
+            @QueryParam("includes") List<String> includes, @QueryParam("excludes") List<String> excludes,
+            @QueryParam("encoding") String encoding) throws NotConnectedRestException, PermissionRestException;
 
     /**
      * Delete file(s) from the specified location in the <i>dataspace</i>.

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspaceImpl.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspaceImpl.java
@@ -92,10 +92,17 @@ public class RestDataspaceImpl implements RestDataspace {
 
     @Override
     public Response retrieve(@HeaderParam("sessionid") String sessionId,
-            @HeaderParam("Accept-Encoding") String encoding, @PathParam("dataspace") String dataspace,
+            @HeaderParam("Accept-Encoding") String headerAcceptEncoding, @PathParam("dataspace") String dataspace,
             @PathParam("path-name") String pathname, @QueryParam("comp") String component,
-            @QueryParam("includes") List<String> includes, @QueryParam("excludes") List<String> excludes)
-            throws NotConnectedRestException, PermissionRestException {
+            @QueryParam("includes") List<String> includes, @QueryParam("excludes") List<String> excludes,
+            @QueryParam("encoding") String encoding) throws NotConnectedRestException, PermissionRestException {
+        if (encoding == null) {
+            encoding = headerAcceptEncoding;
+        }
+        logger.debug(String.format("Retrieving file %s in %s with encoding %s",
+                                   pathname,
+                                   dataspace.toUpperCase(),
+                                   encoding));
         Session session = checkSessionValidity(sessionId);
         try {
             checkPathParams(dataspace, pathname);


### PR DESCRIPTION
As the http request header "Accept-Encoding" is controlled by the browser, can't be specified programmatically (as explained in [Forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name)), this PR add a query parameter `encoding` to specify accepted encoding in retrieve dataspace files.
The value of `Accept-Encoding` specified in request header will be ignored when the query parameter `encoding` is specified. Otherwise it keeps the previous behavior.