### PR TITLE
Fix NodeRecovery eligible status

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1047,8 +1047,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         }, preemptive, isTriggeredFromShutdownHook));
     }
 
-    public void setEligibleNodesToRecover(List<RMNode> eligibleNodes) {
-        this.eligibleNodes = eligibleNodes;
+    public void addEligibleNodesToRecover(List<RMNode> eligibleNodes) {
+        this.eligibleNodes.addAll(eligibleNodes);
     }
 
     private final class RemoveAllNodes implements Function<NodeSource, Void> {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/NodesRecoveryManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/NodesRecoveryManager.java
@@ -181,7 +181,7 @@ public class NodesRecoveryManager {
             }
         }
         nodeRecoveryThreadPool.shutdownNow();
-        this.rmCore.setEligibleNodesToRecover(recoveredEligibleNodes);
+        this.rmCore.addEligibleNodesToRecover(recoveredEligibleNodes);
         this.logNodeRecoverySummary(nodeSourceName, recoveredNodeStatesCounter, recoveredEligibleNodes.size());
     }
 

--- a/tools/proactive-scheduler
+++ b/tools/proactive-scheduler
@@ -89,7 +89,7 @@ createnodes() {
     	PA_URL=pnp://${ALIAS}:64738
     fi
 
-	CMD="nohup $PROACTIVE_HOME/bin/proactive-node -w $NB_NODES -f $PROACTIVE_HOME/config/authentication/rm.cred -s Default -r $PA_URL &> /dev/null & "
+	CMD="nohup $PROACTIVE_HOME/bin/proactive-node -w $NB_NODES -f $PROACTIVE_HOME/config/authentication/rm.cred -s Default -n $HOSTNAME -r $PA_URL &> /dev/null & "
 	if [ "$USER" != "" ]
         then
         	$(su $USER -c "$CMD")


### PR DESCRIPTION
 - use of setEligibleNodesToRecover in NodesRecoveryManager means that if several node sources are present, the set of eligible nodes is overwritten.
 - replaced by a list add method
 - additionnally, in proactive-scheduler service definition fix the node name parameter.