### PR TITLE
MemoryLeak: do not keep finished jobs state in memory

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -1147,6 +1147,9 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * If a PermissionException is thrown, try using {@link #getState(boolean)}
      * method with argument {@code true}.
      *
+     * NOTE: the total list of finished jobs is limited by the Java property 'scheduler.state.max.finished.jobs'
+     * configured on the server. Default is 1000 finished jobs.
+     *
      * @return the list of every jobs in the Scheduler
      * @throws NotConnectedException
      *             if you are not authenticated.
@@ -1160,6 +1163,10 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * SchedulerState contains 3 list of jobs, pending, running, and finished If
      * the given argument is true, only job that you own will be returned,
      * otherwise every jobs will be returned depending on your right.
+     *
+     * NOTE: the total list of finished jobs is limited by the Java property 'scheduler.state.max.finished.jobs'
+     * configured on the server. Default is 1000 finished jobs.
+     * From this list, only jobs belonging to the current user will be returned.
      *
      * @param myJobsOnly
      *            true to get only my jobs, false to get any.

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -1299,12 +1299,14 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
                             schedulerState.pendingToFinished(js);
                             // set this job finished, user can get its result
                             jobs.remove(notification.getData().getJobId()).setFinished(true);
+                            jobsMap.remove(notification.getData().getJobId());
                             withAttachment = true;
                             break;
                         case JOB_RUNNING_TO_FINISHED:
                             schedulerState.runningToFinished(js);
                             // set this job finished, user can get its result
                             jobs.remove(notification.getData().getJobId()).setFinished(true);
+                            jobsMap.remove(notification.getData().getJobId());
                             withAttachment = true;
                             break;
                         default:


### PR DESCRIPTION
 - SchedulerStateImpl : use a maximum size for finished jobs. As test is using the getState method a lot, it is necessary to keep some retro-compatibility. The default number of jobs kept in SchedulerStateImpl is 1000, but can be configured through a JVM property.
 - SchedulerFrontendState : delete job from jobsMap when the job is finished.