### PR TITLE
Optimize JobData and TaskData queries

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -122,6 +122,7 @@ pa.scheduler.core.automaticremovejobdelay=0
 # This housekeeping feature can be replaced by a stored procedure
 # that runs at the desired period of time (e.g. non-business hours)
 # Such an example is available in samples/scripts/database/postgres/
+# Changing this setting is strongly not recommended as the support for pa.scheduler.job.removeFromDataBase=false has been discontinued
 pa.scheduler.job.removeFromDataBase=true
 
 # This cron expression determines the housekeeping call frequency.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -195,6 +195,7 @@ public enum PASchedulerProperties implements PACommonProperties {
     SCHEDULER_AUTOMATIC_REMOVED_JOB_CRON_EXPR("pa.scheduler.core.automaticremovejobcronexpression", PropertyType.STRING, "*/10 * * * *"),
 
     /** Remove job in dataBase when removing it from scheduler. */
+    /** Changing this setting is strongly not recommended as the support for pa.scheduler.job.removeFromDataBase=false has been discontinued */
     JOB_REMOVE_FROM_DB("pa.scheduler.job.removeFromDataBase", PropertyType.BOOLEAN, "true"),
 
     /** File encoding used by the scheduler */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -84,17 +84,17 @@ import com.google.common.collect.Lists;
                 @NamedQuery(name = "countJobDataFinished", query = "select count (*) from JobData where status = 3"),
                 @NamedQuery(name = "countJobData", query = "select count (*) from JobData"),
                 @NamedQuery(name = "findUsersWithJobs", query = "select owner, count(owner), max(submittedTime) from JobData group by owner"),
-                @NamedQuery(name = "getJobsNumberWithStatus", query = "select count(*) from JobData where status in (:status) and removedTime = -1"),
-                @NamedQuery(name = "getJobsNumberWithStatusUsername", query = "select count(*) from JobData where owner = :username and status in (:status) and removedTime = -1"),
+                @NamedQuery(name = "getJobsNumberWithStatus", query = "select count(*) from JobData where status in (:status)"),
+                @NamedQuery(name = "getJobsNumberWithStatusUsername", query = "select count(*) from JobData where owner = :username and status in (:status)"),
                 @NamedQuery(name = "getJobSubmittedTime", query = "select submittedTime from JobData where id = :id"),
                 @NamedQuery(name = "getMeanJobExecutionTime", query = "select avg(finishedTime - startTime) from JobData where startTime > 0 and finishedTime > 0"),
                 @NamedQuery(name = "getMeanJobPendingTime", query = "select avg(startTime - submittedTime) from JobData where startTime > 0 and submittedTime > 0"),
                 @NamedQuery(name = "getMeanJobSubmittingPeriod", query = "select count(*), min(submittedTime), max(submittedTime) from JobData"),
-                @NamedQuery(name = "getTotalJobsCount", query = "select count(*) from JobData where removedTime = -1"),
+                @NamedQuery(name = "getTotalJobsCount", query = "select count(*) from JobData"),
                 @NamedQuery(name = "loadInternalJobs", query = "from JobData as job where job.id in (:ids)"),
-                @NamedQuery(name = "loadJobs", query = "select id from JobData where status in (:status) and removedTime = -1"),
-                @NamedQuery(name = "loadJobsWithPeriod", query = "select id from JobData where status in (:status) and removedTime = -1 and submittedTime >= :minSubmittedTime"),
-                @NamedQuery(name = "loadJobDataIfNotRemoved", query = "from JobData as job where job.id in (:ids) and job.removedTime = -1"),
+                @NamedQuery(name = "loadJobs", query = "select id from JobData where status in (:status)"),
+                @NamedQuery(name = "loadJobsWithPeriod", query = "select id from JobData where status in (:status) and submittedTime >= :minSubmittedTime"),
+                @NamedQuery(name = "loadJobDataIfNotRemoved", query = "from JobData as job where job.id in (:ids)"),
                 @NamedQuery(name = "readAccountJobs", query = "select count(*), sum(finishedTime) - sum(startTime) from JobData" +
                                                               " where owner = :username and finishedTime > 0"),
                 @NamedQuery(name = "updateJobAndTasksState", query = "update JobData set status = :status, " +
@@ -130,8 +130,11 @@ import com.google.common.collect.Lists;
                                       @Index(name = "JOB_DATA_OWNER", columnList = "OWNER"),
                                       @Index(name = "JOB_DATA_REMOVE_TIME", columnList = "REMOVE_TIME"),
                                       @Index(name = "JOB_DATA_START_TIME", columnList = "START_TIME"),
+                                      @Index(name = "JOB_DATA_SUBMIT_TIME", columnList = "SUBMIT_TIME"),
+                                      @Index(name = "JOB_DATA_REMOVAL_TIME", columnList = "SCHEDULED_TIME_FOR_REMOVAL"),
                                       @Index(name = "JOB_DATA_STATUS", columnList = "STATUS"),
-                                      @Index(name = "JOB_PARENT_JOB_ID", columnList = "PARENT_JOB_ID") })
+                                      @Index(name = "JOB_PARENT_JOB_ID", columnList = "PARENT_JOB_ID"),
+                                      @Index(name = "JOB_ID_STATUS", columnList = "ID,STATUS") })
 public class JobData implements Serializable {
 
     private static final Logger logger = Logger.getLogger(JobData.class);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -71,6 +71,7 @@ public class SchedulerStateRecoverHelper {
     }
 
     public RecoveredSchedulerState recover(long loadJobPeriod, RMProxy rmProxy) {
+        dbManager.setTaskDataOwnerIfNull();
         List<InternalJob> notFinishedJobs = dbManager.loadNotFinishedJobs(true);
 
         Vector<InternalJob> pendingJobs = new Vector<>();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskDBUtils.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskDBUtils.java
@@ -125,31 +125,38 @@ public class TaskDBUtils {
             boolean hasDateTo, SortSpecifierContainer sortParams) {
         StringBuilder result = new StringBuilder();
 
-        result.append("T.jobData.removedTime = -1 ");
+        // Support for removedTime in queries has been discontinued
+        //result.append("T.jobData.removedTime = -1 ");
+        boolean oneClause = false;
 
         // if 'from' and 'to' values are set
         if (hasDateFrom && hasDateTo) {
-            result.append("and ( ( startTime >= :dateFrom and startTime <= :dateTo ) " +
+            result.append("( ( startTime >= :dateFrom and startTime <= :dateTo ) " +
                           "or ( scheduledTime >= :dateFrom and scheduledTime <= :dateTo ) " +
                           "or ( finishedTime >= :dateFrom and finishedTime <= :dateTo ) ) ");
+            oneClause = true;
         } else if (hasDateFrom && !hasDateTo) { // if 'from' only is set
-            result.append("and ( startTime >= :dateFrom or finishedTime >= :dateFrom or scheduledTime >= :dateFrom ) ");
+            result.append("( startTime >= :dateFrom or finishedTime >= :dateFrom or scheduledTime >= :dateFrom ) ");
+            oneClause = true;
         } else if (!hasDateFrom && hasDateTo) { // if 'to' only is set
-            result.append("and ( startTime <= :dateTo or finishedTime <= :dateTo or scheduledTime >= :dateTo ) ");
+            result.append("( startTime <= :dateTo or finishedTime <= :dateTo or scheduledTime >= :dateTo ) ");
+            oneClause = true;
         } else {
             // no datetime filtering required
             // nothing to do
         }
 
         if (hasUser) {
-            result.append("and T.jobData.owner = :user ");
+            result.append((oneClause ? "and " : "") + "owner = :user ");
+            oneClause = true;
         }
 
         if (hasTag) {
-            result.append("and tag = :taskTag ");
+            result.append((oneClause ? "and " : "") + "tag = :taskTag ");
+            oneClause = true;
         }
 
-        result.append("and taskStatus in (:taskStatus) ");
+        result.append((oneClause ? "and " : "") + "taskStatus in (:taskStatus) ");
 
         if (!sortParams.getSortParameters().isEmpty()) {
             result.append("order by ");

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerDbManagerConcurrencyTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerDbManagerConcurrencyTest.java
@@ -56,9 +56,6 @@ public class SchedulerDbManagerConcurrencyTest extends BaseSchedulerDBTest {
                                                 ConcurrentJobInsertionScenario.class.getSimpleName() },
                                               { new ConcurrentJobDeletionScenario(true),
                                                 ConcurrentJobDeletionScenario.class.getSimpleName() + "DeleteData" },
-                                              { new ConcurrentJobDeletionScenario(false),
-                                                ConcurrentJobDeletionScenario.class.getSimpleName() +
-                                                                                          "DoNotDeleteData" },
                                               { new ConcurrentJobInsertionAndDeletionScenario(),
                                                 ConcurrentJobInsertionAndDeletionScenario.class.getSimpleName() } });
     }
@@ -133,7 +130,7 @@ public class SchedulerDbManagerConcurrencyTest extends BaseSchedulerDBTest {
         private AtomicInteger expectedNumberOfJobs;
 
         public ConcurrentJobInsertionAndDeletionScenario() {
-            super(30);
+            super(20);
 
             expectedNumberOfJobs = new AtomicInteger(nbJobs);
         }
@@ -146,7 +143,7 @@ public class SchedulerDbManagerConcurrencyTest extends BaseSchedulerDBTest {
                 threadPool.submit(new Callable<Void>() {
                     @Override
                     public Void call() throws Exception {
-                        int value = iCopy % 3;
+                        int value = iCopy % 2;
 
                         switch (value) {
                             case 0:
@@ -154,10 +151,6 @@ public class SchedulerDbManagerConcurrencyTest extends BaseSchedulerDBTest {
                                 expectedNumberOfJobs.getAndIncrement();
                                 break;
                             case 1:
-                                test.deleteJob(jobIds.get(iCopy), false);
-                                expectedNumberOfJobs.getAndDecrement();
-                                break;
-                            case 2:
                                 test.deleteJob(jobIds.get(iCopy), true);
                                 expectedNumberOfJobs.getAndDecrement();
                                 break;

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestJobOperations.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestJobOperations.java
@@ -63,7 +63,7 @@ public class TestJobOperations extends BaseSchedulerDBTest {
         Assert.assertEquals(JobStatus.PENDING, job.getJobInfo().getStatus());
         Assert.assertEquals(JobPriority.HIGHEST, job.getJobInfo().getPriority());
 
-        dbManager.removeJob(job.getId(), System.currentTimeMillis(), false);
+        dbManager.removeJob(job.getId(), System.currentTimeMillis(), true);
         Assert.assertTrue(dbManager.loadJobWithTasksIfNotRemoved(job.getId()).isEmpty());
 
         Assert.assertTrue(dbManager.loadJobWithTasksIfNotRemoved(JobIdImpl.makeJobId("123456789")).isEmpty());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
@@ -237,7 +237,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
 
         // job marked as removed, method 'getJobs' shouldn't return it
         job = defaultSubmitJob(createJob());
-        dbManager.removeJob(job.getId(), System.currentTimeMillis(), false);
+        dbManager.removeJob(job.getId(), System.currentTimeMillis(), true);
 
         List<JobInfo> jobs;
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
@@ -136,7 +136,7 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
         TaskFlowJob jobDef = new TaskFlowJob();
         jobDef.addTask(createDefaultTask("task1"));
         InternalJob job = defaultSubmitJobAndLoadInternal(false, jobDef);
-        dbManager.removeJob(job.getId(), System.currentTimeMillis(), false);
+        dbManager.removeJob(job.getId(), System.currentTimeMillis(), true);
 
         jobDef = new TaskFlowJob();
         jobDef.addTask(createDefaultTask("task1"));

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReportingQueries.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReportingQueries.java
@@ -145,17 +145,17 @@ public class TestReportingQueries extends BaseSchedulerDBTest {
         checkMeanTaskRunningTime(job2);
         checkJobAndTasksNumbers(0, 0, 2, 2, 0, 0, 6, 6);
 
-        // remove job2
-        dbManager.removeJob(job2.getId(), System.currentTimeMillis(), false);
-
-        checkJobAndTasksNumbers(0, 0, 1, 1, 0, 0, 3, 3);
-
         checkMeanPendingTime(job1, job2);
         checkMeanExecutionTime(job1, job2);
         checkMeanSubmittingPeriod(job1, job2);
 
+        // remove job2
+        dbManager.removeJob(job2.getId(), System.currentTimeMillis(), true);
+
+        checkJobAndTasksNumbers(0, 0, 1, 1, 0, 0, 3, 3);
+
         InternalJob job3 = defaultSubmitJobAndLoadInternal(true, jobDef1);
-        checkMeanSubmittingPeriod(job1, job2, job3);
+        checkMeanSubmittingPeriod(job1, job3);
     }
 
     private void checkNumberOfHosts(InternalJob job, int expected) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/BaseServiceTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/BaseServiceTest.java
@@ -28,6 +28,8 @@ package functionaltests.service;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,7 +45,6 @@ import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptorImpl;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptorImpl;
 import org.ow2.proactive.scheduler.job.InternalJob;
 import org.ow2.proactive.scheduler.policy.DefaultPolicy;
-import org.ow2.proactive.scheduler.synchronization.Synchronization;
 import org.ow2.proactive.scheduler.synchronization.SynchronizationInternal;
 import org.ow2.proactive.scheduler.task.TaskLauncher;
 import org.ow2.proactive.scheduler.task.internal.ExecuterInformation;
@@ -67,6 +68,7 @@ public class BaseServiceTest extends ProActiveTest {
 
     @Before
     public void init() throws Exception {
+        Logger.getLogger("org.hibernate.SQL").setLevel(Level.DEBUG);
         dbManager = SchedulerDBManager.createInMemorySchedulerDBManager();
         infrastructure = new MockSchedulingInfrastructure(dbManager);
         listener = new MockSchedulingListener();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/MockSchedulingInfrastructure.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/MockSchedulingInfrastructure.java
@@ -193,6 +193,7 @@ public class MockSchedulingInfrastructure implements SchedulingInfrastructure {
         try {
             future.get();
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.fail("Unexpected exception");
         }
     }
@@ -204,6 +205,7 @@ public class MockSchedulingInfrastructure implements SchedulingInfrastructure {
         try {
             future.get();
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.fail("Unexpected exception");
         }
     }


### PR DESCRIPTION
 - discontinue support of pa.scheduler.job.removeFromDataBase=false, which implied executing joined tables queries constantly (decreases performance and disallow some indexing)
 - add 3 indexes in JobData (submit_time, scheduled_time_for_removal, and job_id_status : composite index used to optimize scheduler portal default list jobs query)
 - getTaskCounts : avoid joined table query by considering only task statuses.
 - getFinishedTaskCount : fix incomplete list of finished task statuses
 - getPendingTaskCount : add in-error status (similar to pause)
 - adapt db tests