### PR TITLE
Fix bad mistake in housekeeping

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -185,7 +185,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
      * Delay to wait for between getting a job result and removing the job
      * concerned
      */
-    private static final long SCHEDULER_REMOVED_JOB_DELAY = PASchedulerProperties.SCHEDULER_REMOVED_JOB_DELAY.getValueAsInt() *
+    private static final long SCHEDULER_REMOVED_JOB_DELAY = PASchedulerProperties.SCHEDULER_REMOVED_JOB_DELAY.getValueAsLong() *
                                                             1000;
 
     private static final Logger logger = Logger.getLogger(SchedulerFrontend.class);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -86,10 +86,10 @@ public class SchedulingService {
 
     static final JobLogger jlogger = JobLogger.getInstance();
 
-    static final long SCHEDULER_AUTO_REMOVED_JOB_DELAY = PASchedulerProperties.SCHEDULER_AUTOMATIC_REMOVED_JOB_DELAY.getValueAsInt() *
+    static final long SCHEDULER_AUTO_REMOVED_JOB_DELAY = PASchedulerProperties.SCHEDULER_AUTOMATIC_REMOVED_JOB_DELAY.getValueAsLong() *
                                                          1000;
 
-    static final long SCHEDULER_REMOVED_JOB_DELAY = PASchedulerProperties.SCHEDULER_REMOVED_JOB_DELAY.getValueAsInt() *
+    static final long SCHEDULER_REMOVED_JOB_DELAY = PASchedulerProperties.SCHEDULER_REMOVED_JOB_DELAY.getValueAsLong() *
                                                     1000;
 
     static final String GENERIC_INFO_REMOVE_DELAY = "REMOVE_DELAY";
@@ -158,7 +158,7 @@ public class SchedulingService {
         pinger = new NodePingThread(this);
         pinger.start();
 
-        if (PASchedulerProperties.SCHEDULER_AUTOMATIC_REMOVED_JOB_DELAY.getValueAsInt() > 0) {
+        if (PASchedulerProperties.SCHEDULER_AUTOMATIC_REMOVED_JOB_DELAY.getValueAsLong() > 0) {
             startHouseKeeping();
         }
 


### PR DESCRIPTION
Conversion from long to integer implied to set SCHEDULER_REMOVED_JOB_DELAY = 0 when the configured value is bigger than 24 days (due to MAX_INTEGER reached).

Use now the appropriate getValueAsLong() method.