### PR TITLE
Fix selection log max size

### DIFF
--- a/config/rm/settings.ini
+++ b/config/rm/settings.ini
@@ -252,5 +252,5 @@ pa.rm.topology.pinger.class=org.ow2.proactive.resourcemanager.frontend.topology.
 pa.rm.logs.selection.location=logs/jobs/
 
 # Size limit for selection scripts' logs in bytes
-pa.rm.logs.selection.max.size=10000
+pa.rm.logs.selection.max.size=10MB
 


### PR DESCRIPTION
This setting can overwrite pa.scheduler.job.logs.max.size=10MB from config/scheduler/settings.ini
Accordingly, they must be both equal