### PR TITLE
Add server public url configuration

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -14,8 +14,13 @@ pa.scheduler.home=.
 # When the server has a public endpoint, different from the hostname available on the machine, this property should be used to correctly set the url
 #pa.scheduler.rest.url=
 
-#Catalog rest url. If not defined, it is set automatically when starting the server. Same as scheduler rest url
+# Catalog rest url. If not defined, it is set automatically when starting the server. Same as scheduler rest url
 #pa.catalog.rest.url=
+
+# Set this property to define the public url of the server (e.g. if behind a reverse proxy or accessed through a domain)
+# the pa.scheduler.rest.url and pa.catalog.rest.url properties will be updated accordingly
+# Example https://myserver.mydomain.com
+#pa.server.public.url=
 
 # Timeout for the scheduling loop (in millisecond)
 pa.scheduler.core.timeout=10000

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -328,6 +328,12 @@ public enum PASchedulerProperties implements PACommonProperties {
      */
     CATALOG_REST_URL("pa.catalog.rest.url", PropertyType.STRING),
 
+    /**
+     * Set this property to define the public url of the server (e.g. if behind a reverse proxy or accessed through a domain)
+     * the SCHEDULER_REST_URL and CATALOG_REST_URL properties will be updated accordingly
+     */
+    SERVER_PUBLIC_URL("pa.server.public.url", PropertyType.STRING),
+
     /* ***************************************************************** */
     /* ************************** RM PROPERTIES ************************ */
     /* ***************************************************************** */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -36,6 +36,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.rmi.AlreadyBoundException;
 import java.security.KeyException;
@@ -242,12 +243,29 @@ public class SchedulerStarter {
         if (applicationUrls != null) {
             for (String applicationUrl : applicationUrls) {
                 if (applicationUrl.endsWith("/rest") && !PASchedulerProperties.SCHEDULER_REST_URL.isSet()) {
-                    PASchedulerProperties.SCHEDULER_REST_URL.updateProperty(applicationUrl);
+                    PASchedulerProperties.SCHEDULER_REST_URL.updateProperty(getPublicUrl(applicationUrl));
                 }
                 if (applicationUrl.endsWith("/catalog") && !PASchedulerProperties.CATALOG_REST_URL.isSet()) {
-                    PASchedulerProperties.CATALOG_REST_URL.updateProperty(applicationUrl);
+                    PASchedulerProperties.CATALOG_REST_URL.updateProperty(getPublicUrl(applicationUrl));
                 }
             }
+        }
+    }
+
+    private static String getPublicUrl(String url) {
+        if (PASchedulerProperties.SERVER_PUBLIC_URL.isSet()) {
+            try {
+                URL publicUrl = new URL(PASchedulerProperties.SERVER_PUBLIC_URL.getValueAsString());
+                URL applicationUrl = new URL(url);
+                URL resolvedUrl = new URL(publicUrl, applicationUrl.getPath().substring(1));
+                return resolvedUrl.toExternalForm();
+
+            } catch (Exception e) {
+                LOGGER.warn("Error when resolving public url for " + url, e);
+                return url;
+            }
+        } else {
+            return url;
         }
     }
 


### PR DESCRIPTION
Allows to adapt PASchedulerProperties.SCHEDULER_REST_URL and PASchedulerProperties.CATALOG_REST_URL when the ProActive server has a public url (for example, behind a reverse proxy or resolved with a domain name)