### PR TITLE
Fix issues with PCA proxy

### DIFF
--- a/rest/rest-server/build.gradle
+++ b/rest/rest-server/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 
     runtime 'org.eclipse.jetty.websocket:websocket-server:9.2.29.v20191105'
     runtime 'org.eclipse.jetty:jetty-webapp:9.2.29.v20191105'
+    runtime 'org.eclipse.jetty:jetty-util:9.2.29.v20191105'
     runtime 'org.eclipse.jetty:jetty-rewrite:9.2.29.v20191105'
 
     runtime "org.objectweb.proactive:programming-extension-pamr:${programmingVersion}"

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     compile 'org.eclipse.jetty:jetty-webapp:9.2.29.v20191105'
     compile 'org.eclipse.jetty:jetty-rewrite:9.2.29.v20191105'
+    compile 'org.eclipse.jetty:jetty-util:9.2.29.v20191105'
     compile "org.objectweb.proactive:programming-core:${programmingVersion}"
 
     compile project(':common:common-api')

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
@@ -409,6 +409,14 @@ public class JettyStarter {
         // The following setting allows to avoid conflicts between server jackson jars and individual war jackson versions.
         webApp.addServerClass("com.fasterxml.jackson.");
         webApp.addServerClass("com.google.gson.");
+        if (contextPath.contains("cloud-automation-service")) {
+            // Make jetty.util not overridable and not hidden for cloud-automation
+            // as jetty websocket is loaded from the system class loader and uses jetty.util
+            // Otherwise, cloud-automation-service will not be able to use SslContextFactory
+            // see https://www.eclipse.org/lists/jetty-dev/msg03096.html for the same issue report
+            webApp.prependServerClass("-org.eclipse.jetty.util.");
+            webApp.prependSystemClass("org.eclipse.jetty.util.");
+        }
         webApp.setContextPath(contextPath);
         webApp.setVirtualHosts(virtualHost);
         return webApp;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/PCAProxyRule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/PCAProxyRule.java
@@ -140,12 +140,22 @@ public class PCAProxyRule extends Rule implements Rule.ApplyURI {
                 logger.debug(String.format("Rewrote %s to %s", target, newTarget));
             }
             referrerCache.put(target, endpointPath);
-            if (request.getMethod().equals(HttpMethod.GET.asString())) {
+            if (HttpMethod.GET.is(request.getMethod())) {
                 redirectGetRequest(target, endpointPath, request, response, newTarget);
             }
             return newTarget;
         } else {
             logger.trace("Target already contains endpoint");
+            if (!target.startsWith(endpointPath)) {
+                // endpoint is in the middle of the path (who did this?), let's bring it on top
+                // NOTE: we don't store this in the referer cache
+                target = target.replace(endpointPath, "");
+                String newTarget = endpointPath.substring(0, endpointPath.length() - 1) + target;
+                if (HttpMethod.GET.is(request.getMethod())) {
+                    redirectGetRequest(target, endpointPath, request, response, newTarget);
+                }
+                return newTarget;
+            }
         }
         return target;
     }


### PR DESCRIPTION
 - add jetty-util to server jars (class loader issue)
 - PCAProxyRule: handle the rare case where the endpoint path appears in the middle (and not the start) of the request uri