### PR TITLE
Add configurable fetch mode for scripts

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/core/properties/PASharedProperties.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/core/properties/PASharedProperties.java
@@ -79,9 +79,14 @@ public enum PASharedProperties implements PACommonProperties {
     /** comma-separated list of folder and/or files which need to be backup */
     SERVER_BACKUP_TARGETS("pa.server.backup.targets", PropertyType.STRING, "data,logs"),
 
-    /** backup mechanism may wait possible.delay (in seconds) untill all tasks are finished,
-     * if some task will still run then backup will not be performed */
-    SERVER_BACKUP_POSSIBLE_DELAY("pa.server.backup.possile.delay", PropertyType.INTEGER, "600");
+    /** backup mechanism may wait possible.delay (in seconds) until all currently running tasks are finished.
+     * if some tasks are still running after this delay, the backup will not be performed */
+    SERVER_BACKUP_POSSIBLE_DELAY("pa.server.backup.possible.delay", PropertyType.INTEGER, "600"),
+
+    /** Controls the fetch mode of scripts defined by URL.
+    If true (default), it means that the script is fetched at task execution time
+    If false, it means that the script is fetch when the job is submitted to the scheduler */
+    LAZY_FETCH_SCRIPT("pa.lazy.fetch.script", PropertyType.BOOLEAN, "true");
 
     /* ***************************************************************************** */
     /* ***************************************************************************** */

--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/Script.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/Script.java
@@ -52,6 +52,7 @@ import javax.script.ScriptEngineManager;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.core.properties.PASharedProperties;
 import org.ow2.proactive.http.CommonHttpResourceDownloader;
 import org.ow2.proactive.utils.BoundedStringWriter;
 import org.ow2.proactive.utils.FileUtils;
@@ -99,6 +100,8 @@ public abstract class Script<E> implements Serializable {
 
     /** Name of the script **/
     private String scriptName;
+
+    private static Boolean lazyFetch = null;
 
     /** ProActive needed constructor */
     public Script() {
@@ -253,6 +256,19 @@ public abstract class Script<E> implements Serializable {
         this(script2.script, script2.scriptEngineLookupName, script2.parameters, scriptName);
         this.url = script2.url;
         this.id = script2.id;
+    }
+
+    protected static boolean isLazyFetch() {
+        if (lazyFetch == null) {
+            try {
+                lazyFetch = PASharedProperties.LAZY_FETCH_SCRIPT.getValueAsBoolean();
+            } catch (Exception e) {
+                logger.warn("Incorrect value of " + PASharedProperties.LAZY_FETCH_SCRIPT.getKey() +
+                            ", default value will be used.", e);
+                lazyFetch = true;
+            }
+        }
+        return lazyFetch;
     }
 
     /**

--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/SelectionScript.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/SelectionScript.java
@@ -38,6 +38,7 @@ import javax.script.Bindings;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.core.properties.PASharedProperties;
 
 
 /**
@@ -211,8 +212,7 @@ public class SelectionScript extends Script<Boolean> {
      */
     public SelectionScript(URL url, String engineName, Serializable[] parameters, boolean dynamic)
             throws InvalidScriptException {
-        // Selection scripts cannot use url late binding, i.e. fetchImmediately must be false.
-        super(url, engineName, parameters, false);
+        super(url, engineName, parameters, !isLazyFetch());
         this.dynamic = dynamic;
     }
 

--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/SimpleScript.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/SimpleScript.java
@@ -36,6 +36,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
 import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.core.properties.PASharedProperties;
 
 
 /**
@@ -82,7 +83,7 @@ public class SimpleScript extends Script<Object> {
      */
     public SimpleScript(URL url, Serializable[] parameters) throws InvalidScriptException {
         // standard scripts (i.e. other than Selection scripts) use url late binding by default
-        super(url, parameters, false);
+        super(url, parameters, !isLazyFetch());
     }
 
     /** Create a script from an URL.
@@ -92,7 +93,7 @@ public class SimpleScript extends Script<Object> {
      * @throws InvalidScriptException if the creation fails.
      */
     public SimpleScript(URL url, String engineName, Serializable[] parameters) throws InvalidScriptException {
-        super(url, engineName, parameters, false);
+        super(url, engineName, parameters, !isLazyFetch());
     }
 
     /** Directly create a script with a string.

--- a/config/shared/settings.ini
+++ b/config/shared/settings.ini
@@ -12,6 +12,11 @@
 pa.shared.failed.max.attempts=3
 pa.shared.failed.renew.minutes=10
 
+# Controls the fetch mode of scripts defined by URL.
+# If true (default), it means that the script is fetched at task execution time
+# If false, it means that the script is fetch when the job is submitted to the scheduler
+pa.lazy.fetch.script=true
+
 
 # *****************************************************************
 # ******************* SCHEDULER BACKUP PROPERTIES *****************
@@ -34,6 +39,6 @@ pa.server.backup.destination=backup
 # comma-separated list of folder and/or files which need to be backup
 pa.server.backup.targets=data,logs
 
-# backup mechanism may wait possible.delay (in seconds) until all tasks are finished,
-# if some task will still run then backup will not be performed */
-pa.server.backup.possile.delay=600
+# backup mechanism may wait possible.delay (in seconds) until all currently running tasks are finished.
+# if some tasks are still running after this delay, the backup will not be performed.
+pa.server.backup.possible.delay=600


### PR DESCRIPTION
Make fetch mode (lazy, eager) configurable. This allows, for example, script by reference in environments where http connection to the server is not guaranteed on the node side.