### PR TITLE
Improve SchedulerFrontendState concurrency

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
@@ -509,6 +509,17 @@ public abstract class SelectionManager {
         return matched;
     }
 
+    private boolean isClientNodeUserAllPermission(Client client) {
+        try {
+            client.checkPermission(new NodeUserAllPermission(), client.getName() + " is not super-admin");
+            return true;
+        } catch (SecurityException e) {
+            // NO
+            logger.trace(e.getMessage());
+            return false;
+        }
+    }
+
     /**
      * Removes exclusion nodes and nodes not accessible for the client
      */
@@ -536,6 +547,10 @@ public abstract class SelectionManager {
         HashSet<Permission> clientPermissions = new HashSet<>();
         for (RMNode node : freeNodes) {
             try {
+                if (node.isProtectedByToken() && !nodeWithTokenRequested && !isClientNodeUserAllPermission(client)) {
+                    logger.debug("Node " + node.getNodeURL() + " is protected by token");
+                    continue;
+                }
                 if (!clientPermissions.contains(node.getUserPermission())) {
                     client.checkPermission(node.getUserPermission(),
                                            client + " is not authorized to get the node " + node.getNodeURL() +

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
@@ -69,7 +69,7 @@ public abstract class UserIdentification implements Serializable, Comparable<Use
 
     private static int currentOrder = ASC_ORDER;
 
-    protected boolean toRemove = false;
+    protected volatile boolean toRemove = false;
 
     /**
      * To get the user name

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.ow2.proactive.scheduler.common.Scheduler;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
@@ -70,6 +71,13 @@ public class ClientJobState extends JobState {
 
     private int maxNumberOfExecution;
 
+    /** lock protecting client job state changes */
+    private transient ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private transient ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+
+    private transient ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+
     public ClientJobState(JobState jobState) {
         List<TaskState> taskStates = jobState.getTasks();
         this.tasks = new HashMap<>(taskStates.size());
@@ -100,6 +108,22 @@ public class ClientJobState extends JobState {
             clientTaskStates.add(new ClientTaskState(ts));
         }
         addTasks(clientTaskStates);
+    }
+
+    public void readLock() {
+        readLock.lock();
+    }
+
+    public void readUnlock() {
+        readLock.unlock();
+    }
+
+    public void writeLock() {
+        writeLock.lock();
+    }
+
+    public void writeUnlock() {
+        writeLock.unlock();
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/ListeningUser.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/ListeningUser.java
@@ -31,7 +31,7 @@ import org.ow2.proactive.scheduler.job.UserIdentificationImpl;
 public class ListeningUser {
 
     /** Associated listener to client */
-    private ClientRequestHandler listener;
+    private volatile ClientRequestHandler listener;
 
     private UserIdentificationImpl user;
 


### PR DESCRIPTION
This improvement follows a dead lock observed in SchedulerFrontendState
 - use ConcurrentHashMap instead of global locks for user sessions. This reduces the lock complexity by having only a global schedulerStateLock
 - Additinnally, improve token checks in SelectionManager (due to a bug observed at Creos)
 - Add missing null checks on jobState
 - Use ReentrantReadWriteLock instead of synchronized for ClientJobState