### PR TITLE
API for remote visualization, necessary additions

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -599,7 +599,7 @@ public interface SchedulerRestInterface {
 
     /**
      * Returns a list of taskState
-     * 
+     *
      * @param sessionId
      *            a valid session id
      * @param jobId
@@ -612,6 +612,21 @@ public interface SchedulerRestInterface {
     @Path("jobs/{jobid}/taskstates")
     @Produces("application/json")
     RestPage<TaskStateData> getJobTaskStates(@HeaderParam("sessionid") String sessionId,
+            @PathParam("jobid") String jobId) throws RestException;
+
+    /**
+     * Returns a list of taskStates, only tasks with visualization activated
+     *
+     * @param sessionId
+     *            a valid session id
+     * @param jobId
+     *            the job id
+     * @return a list of task' states with visualization activated
+     */
+    @GET
+    @Path("jobs/{jobid}/taskstates/visualization")
+    @Produces("application/json")
+    List<TaskStateData> getJobTaskStatesWithVisualization(@HeaderParam("sessionid") String sessionId,
             @PathParam("jobid") String jobId) throws RestException;
 
     /**

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -307,6 +307,19 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
+    public TaskState getTaskState(JobId jobId, String taskName)
+            throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
+        TaskState taskState = null;
+        try {
+            TaskStateData taskStateData = restApi().jobTask(sid, jobId.toString(), taskName);
+            taskState = new TaskStateImpl(taskStateData);
+        } catch (Exception e) {
+            throwUJEOrNCEOrPEOrUTE(e);
+        }
+        return taskState;
+    }
+
+    @Override
     public Page<JobInfo> getJobs(int index, int range, JobFilterCriteria criteria,
             List<SortParameter<JobSortParameter>> arg3) throws NotConnectedException, PermissionException {
         Page<JobInfo> jobInfos = null;

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -660,6 +660,23 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
+    public List<TaskStateData> getJobTaskStatesWithVisualization(String sessionId, String jobId) throws RestException {
+        List<TaskStateData> answer = new ArrayList<>();
+        try {
+            Scheduler scheduler = checkAccess(sessionId, PATH_JOBS + jobId + "/taskstates/visualization");
+            JobState jobState = scheduler.getJobState(jobId);
+            for (TaskState task : jobState.getTasks()) {
+                if (task.getTaskInfo().isVisualizationActivated()) {
+                    answer.add(mapper.map(task, TaskStateData.class));
+                }
+            }
+            return answer;
+        } catch (SchedulerException e) {
+            throw RestException.wrapExceptionToRest(e);
+        }
+    }
+
+    @Override
     public RestPage<TaskStateData> getJobTaskStatesPaginated(String sessionId, String jobId, int offset, int limit)
             throws RestException {
         if (limit == -1)

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -1123,7 +1123,7 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
 
     /**
      * Return the state of the given job.<br>
-     * The state contains informations about the job, every tasks and
+     * The state contains information about the job, every tasks and
      * informations about the tasks.<br>
      * <br>
      * A user can only get the state of HIS job.<br>
@@ -1141,6 +1141,29 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      *             if you can't access to this particular job.
      */
     JobState getJobState(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException;
+
+    /**
+     * Return the state of the given task.<br>
+     * The state contains information about a single task.<br>
+     * <br>
+     * A standard user can only get the state of HIS jobs.<br>
+     * If the job or the task does not exist, a schedulerException is sent with the proper
+     * message.
+     *
+     * @param jobId
+     *            the job on which to get the state.
+     * @param taskName
+     *            the name of the task.
+     * @return the current state of the given task
+     * @throws NotConnectedException
+     *             if you are not authenticated.
+     * @throws UnknownJobException
+     *             if the job does not exist.
+     * @throws PermissionException
+     *             if you can't access to this particular job.
+     */
+    TaskState getTaskState(JobId jobId, String taskName)
+            throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException;
 
     /**
      * Get the list of job states that describe every jobs in the Scheduler. The

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -592,6 +592,13 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
 
     @Override
     @ImmediateService
+    public TaskState getTaskState(JobId jobId, String taskName)
+            throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
+        return uischeduler.getTaskState(jobId, taskName);
+    }
+
+    @Override
+    @ImmediateService
     public SchedulerState getState() throws NotConnectedException, PermissionException {
         return uischeduler.getState();
     }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -560,6 +560,13 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
+    public TaskState getTaskState(JobId jobId, String taskName)
+            throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
+        renewSession();
+        return client.getTaskState(jobId, taskName);
+    }
+
+    @Override
     public SchedulerState getState() throws NotConnectedException, PermissionException {
         renewSession();
         return client.getState();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -1241,6 +1241,12 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
         return frontendState.getJobState(jobId);
     }
 
+    @Override
+    public TaskState getTaskState(JobId jobId, String taskName)
+            throws NotConnectedException, UnknownJobException, PermissionException, UnknownTaskException {
+        return frontendState.getTaskState(jobId, taskName);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/scheduler/scheduler-smartproxy-common/src/main/java/org/ow2/proactive/scheduler/smartproxy/common/AbstractSmartProxy.java
+++ b/scheduler/scheduler-smartproxy-common/src/main/java/org/ow2/proactive/scheduler/smartproxy/common/AbstractSmartProxy.java
@@ -52,6 +52,7 @@ import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.SchedulerEventListener;
 import org.ow2.proactive.scheduler.common.SchedulerState;
 import org.ow2.proactive.scheduler.common.SchedulerStatus;
+import org.ow2.proactive.scheduler.common.SortSpecifierContainer;
 import org.ow2.proactive.scheduler.common.TaskDescriptor;
 import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
@@ -981,6 +982,12 @@ public abstract class AbstractSmartProxy<T extends JobTracker> implements Schedu
     @Override
     public JobState getJobState(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return getScheduler().getJobState(jobId);
+    }
+
+    @Override
+    public TaskState getTaskState(JobId jobId, String taskName)
+            throws NotConnectedException, UnknownJobException, UnknownTaskException, PermissionException {
+        return getScheduler().getTaskState(jobId, taskName);
     }
 
     @Override


### PR DESCRIPTION
 - NoVncSecuredTargetResolver was using streaming logs to retrieve the connection info => now make also use of TaskState
 - add utility method getTaskState for a single task in Scheduler api
 - in the target of integrating remote visualization inside other portals, add a new rest endpoint which returns a list of tasks with remote visualization activated