### PR TITLE
Apply JaCoCo configuration as defined in jacoco-scheduling.gradle to subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,8 @@ configure(javaSubprojects) {
     apply plugin: 'jacoco'
     apply plugin: 'net.ossindex.audit'
 
+    apply from: custom("jacoco-scheduling")
+
 
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Configuration of the `jacocoTestReport` task need to be done for each individual subprojects in order to get XML report format required by SonarQube to generate test coverage report (see results at https://sonarqube.ow2.org/dashboard?id=org.ow2.proactive%3AScheduling)