### PR TITLE
Further improvements in AOSynchronization concurrency

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/signal/SignalApiImpl.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/signal/SignalApiImpl.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.scheduler.signal;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -98,8 +99,7 @@ public class SignalApiImpl implements SignalApi {
 
     @Override
     public boolean isReceived(String signalName) throws SignalApiException {
-        init();
-        HashSet<String> signals = getJobSignals();
+        Set<String> signals = getJobSignals();
         if (!signals.isEmpty()) {
             return signals.contains(signalName);
         } else {
@@ -109,8 +109,7 @@ public class SignalApiImpl implements SignalApi {
 
     @Override
     public String checkForSignals(Set<String> signalsSubSet) throws SignalApiException {
-        init();
-        HashSet<String> signals = getJobSignals();
+        Set<String> signals = getJobSignals();
 
         if (!signals.isEmpty()) {
             return signalsSubSet.stream().filter(signals::contains).findFirst().orElse(null);
@@ -190,11 +189,15 @@ public class SignalApiImpl implements SignalApi {
     }
 
     @Override
-    public HashSet<String> getJobSignals() throws SignalApiException {
+    public Set<String> getJobSignals() throws SignalApiException {
         try {
-            init();
             //noinspection unchecked
-            return (HashSet<String>) synchronization.get(SIGNALS_CHANNEL, jobId);
+            HashSet<String> signals = (HashSet<String>) synchronization.get(SIGNALS_CHANNEL, jobId);
+            if (signals != null) {
+                return signals;
+            }
+            init();
+            return Collections.emptySet();
         } catch (InvalidChannelException e) {
             throw new SignalApiException("Could not read signals channel", e);
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -820,14 +820,15 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
     }
 
     Set<TaskId> getJobTasks(JobId jobId) {
-        return Lambda.withLock(stateReadLock, () -> {
+        return (Set<TaskId>) Lambda.withLock(stateReadLock, () -> {
+            Set<TaskId> tasks;
             ClientJobState jobState = getClientJobState(jobId);
             if (jobState == null) {
                 return new HashSet<>();
             } else {
                 jobState.readLock();
                 try {
-                    Set<TaskId> tasks = new HashSet<>(jobState.getTasks().size());
+                    tasks = new HashSet<>(jobState.getTasks().size());
                     for (TaskState task : jobState.getTasks()) {
                         tasks.add(task.getId());
                     }


### PR DESCRIPTION
Make waitUntil read requests an ImmediateService. waitUntil requests will run in a dedicated thread and execute the predicate periodically. waitUntilThen requests will remain executed by the active object runActivity (as they perform changes on the channel)

Additionally, improve SignalApiImpl initialization behavior to reduce the number of put requests sent to the synchronization api