### PR TITLE
Add optimizations to Job submission

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -150,6 +150,9 @@ pa.scheduler.core.listener.threadnumber=5
 # List of the scripts paths to execute at scheduler start. Paths are separated by a ';'.
 pa.scheduler.startscripts.paths=tools/LoadPackages.groovy
 
+# Size of parsed workflow cache, used to optimize workflow submission time
+pa.scheduler.stax.job.cache=10000
+
 #-------------------------------------------------------
 #----------------   JOBS PROPERTIES   ------------------
 #-------------------------------------------------------

--- a/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
@@ -28,6 +28,7 @@ package functionaltests;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -73,7 +74,10 @@ public class AbstractFunctCmdTest extends AbstractRestFuncTestCase {
     protected JobId submitJob(String filename, JobStatus waitForStatus) throws Exception {
         File jobFile = new File(this.getClass().getResource("config/" + filename).toURI());
         WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler, space);
-        JobId id = submitter.submit(jobFile, new HashMap<String, String>(), null);
+        JobId id;
+        try (FileInputStream fileInputStream = new FileInputStream(jobFile)) {
+            id = submitter.submit(fileInputStream, new HashMap<String, String>(), null);
+        }
         waitJobState(id, waitForStatus, 500000);
         return id;
     }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive_grid_cloud_portal.scheduler;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class WorkflowSubmitter {
      * Submits a workflow to the scheduler (XML or archive).
      * It also creates a job visualization HTML file.
      *
-     * @param workflowFile a workflow file (XML or archive)
+     * @param workflowStream a workflow as input stream
      * @param variables variables to be replaced on submission
      * @param genericInfos generic informations to be replaced on submission
      * @return job ID of the job created for the specified workflow and associated variables.
@@ -78,12 +79,12 @@ public class WorkflowSubmitter {
      * @throws PermissionRestException
      * @throws SubmissionClosedRestException
      */
-    public JobId submit(File workflowFile, Map<String, String> variables, Map<String, String> genericInfos)
+    public JobId submit(InputStream workflowStream, Map<String, String> variables, Map<String, String> genericInfos)
             throws NotConnectedRestException, PermissionRestException, SubmissionClosedRestException,
             JobCreationRestException {
         try {
             long t0 = System.currentTimeMillis();
-            Job job = createJobObject(workflowFile, variables, genericInfos);
+            Job job = createJobObject(workflowStream, variables, genericInfos);
             long t1 = System.currentTimeMillis();
             JobId jobId = scheduler.submit(job);
             long t2 = System.currentTimeMillis();
@@ -116,13 +117,9 @@ public class WorkflowSubmitter {
         }
     }
 
-    private Job createJobObject(File jobFile, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws JobCreationException {
-        return JobFactory.getFactory().createJob(jobFile.getAbsolutePath(),
-                                                 jobVariables,
-                                                 jobGenericInfos,
-                                                 scheduler,
-                                                 space);
+    private Job createJobObject(InputStream workflowStream, Map<String, String> jobVariables,
+            Map<String, String> jobGenericInfos) throws JobCreationException {
+        return JobFactory.getFactory().createJob(workflowStream, jobVariables, jobGenericInfos, scheduler, space);
     }
 
 }

--- a/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
@@ -26,6 +26,8 @@
 package functionaltests;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -97,7 +99,10 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
     private JobId submitJob(String filename) throws Exception {
         File jobFile = new File(this.getClass().getResource("config/" + filename).toURI());
         WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler, space);
-        JobId id = submitter.submit(jobFile, new HashMap<String, String>(), null);
+        JobId id;
+        try (InputStream jobStream = new FileInputStream(jobFile)) {
+            id = submitter.submit(jobStream, new HashMap<String, String>(), null);
+        }
         waitJobState(id, JobStatus.FINISHED, 500000);
         return id;
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/Object2ByteConverter.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/util/Object2ByteConverter.java
@@ -33,7 +33,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 
-class Object2ByteConverter {
+public class Object2ByteConverter {
 
     public static byte[] convertObject2Byte(Object o) throws IOException {
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -141,6 +141,9 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** List of the scripts paths to execute at scheduler start. Paths are separated by a ';'. */
     SCHEDULER_STARTSCRIPTS_PATHS("pa.scheduler.startscripts.paths", PropertyType.LIST),
 
+    /** Size of parsed workflow cache, used to optimize workflow submission time */
+    SCHEDULER_STAX_JOB_CACHE("pa.scheduler.stax.job.cache", PropertyType.INTEGER, "10000"),
+
     /* ***************************************************************** */
     /* ********************** AUTHENTICATION PROPERTIES **************** */
     /* ***************************************************************** */

--- a/scheduler/scheduler-server/src/test/java/performancetests/PerformanceTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/performancetests/PerformanceTestSuite.java
@@ -40,7 +40,7 @@ import performancetests.recovery.NodeRecoveryTest;
 
                       // Metrics
                       TaskCreationTimeTest.class, GetResultMetricTest.class, SchedulerEfficiencyMetricsTest.class,
-                      ParallelTaskSchedulingTest.class, JobSubmissionTest.class,
+                      ParallelTaskSchedulingTest.class, JobSubmissionTest.class, JobParsingAndSubmissionTest.class,
 
                       // Test which computes average metrics
                       TaskSchedulingTimeTest.class

--- a/scheduler/scheduler-server/src/test/java/performancetests/metrics/JobParsingAndSubmissionTest.java
+++ b/scheduler/scheduler-server/src/test/java/performancetests/metrics/JobParsingAndSubmissionTest.java
@@ -27,6 +27,8 @@ package performancetests.metrics;
 
 import static org.ow2.proactive.utils.Lambda.repeater;
 
+import java.io.File;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -42,21 +44,23 @@ import performancetests.recovery.PerformanceTestBase;
 
 
 @RunWith(Parameterized.class)
-public class JobSubmissionTest extends PerformanceTestBase {
+public class JobParsingAndSubmissionTest extends PerformanceTestBase {
+
+    private static URL simpleJob = JobParsingAndSubmissionTest.class.getResource("/functionaltests/descriptors/Job_simple.xml");
 
     /**
      * @return number of jobs and limit for average job submission time
      */
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { { 100, 2000 } });
+        return Arrays.asList(new Object[][] { { 100, 200 } });
     }
 
     private final int jobsNumber;
 
     private final long timeLimit;
 
-    public JobSubmissionTest(int jobsNumber, long timeLimit) {
+    public JobParsingAndSubmissionTest(int jobsNumber, long timeLimit) {
         this.jobsNumber = jobsNumber;
         this.timeLimit = timeLimit;
     }
@@ -70,18 +74,16 @@ public class JobSubmissionTest extends PerformanceTestBase {
                                                RM_CONFIGURATION_START.getPath(),
                                                null);
 
-        TaskFlowJob job = SchedulerEfficiencyMetricsTest.createJob(jobsNumber, 1);
-
         // submit a first job to load factories (not counted in the total time)
-        schedulerHelper.submitJob(job);
+        schedulerHelper.submitJob(new File(simpleJob.toURI()).getAbsolutePath());
 
         long start = System.currentTimeMillis();
 
-        repeater.accept(jobsNumber, () -> schedulerHelper.submitJob(job));
+        repeater.accept(jobsNumber, () -> schedulerHelper.submitJob(new File(simpleJob.toURI()).getAbsolutePath()));
 
         long anActualTime = System.currentTimeMillis() - start;
 
-        LOGGER.info(makeCSVString(JobSubmissionTest.class.getSimpleName(),
+        LOGGER.info(makeCSVString(JobParsingAndSubmissionTest.class.getSimpleName(),
                                   jobsNumber,
                                   timeLimit,
                                   anActualTime,


### PR DESCRIPTION
 - SchedulerStateRest : don't use temporary files to store workflows
 - StaxJobFactory : use a LRU cache to store already parsed workflows with the same parameters
 - added a performance test