### PR TITLE
Fix result propagation for replicate skipped block

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/termination/handlers/TerminateReplicateTaskHandler.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/termination/handlers/TerminateReplicateTaskHandler.java
@@ -217,7 +217,7 @@ public class TerminateReplicateTaskHandler {
     private void skipReplication(InternalTask initiator, ChangedTasksInfo changesInfo, InternalTask internalTask) {
         long finishedTime = initiator.getFinishedTime() + 1;
         if (internalTask.getFlowBlock().equals(FlowBlock.START)) {
-            skipTasksUntilEndBlock(changesInfo, internalTask, finishedTime);
+            skipTasksUntilEndBlock(changesInfo, internalTask, finishedTime, internalTask.getMatchingBlock());
         } else {
             skipTask(changesInfo, internalTask, finishedTime);
         }
@@ -228,11 +228,12 @@ public class TerminateReplicateTaskHandler {
         return internalTaskDependency.getId().equals(initiator.getId()) && !toReplicate.contains(internalTask);
     }
 
-    private void skipTasksUntilEndBlock(ChangedTasksInfo changesInfo, InternalTask blockTaskToSkip, long finishedTime) {
+    private void skipTasksUntilEndBlock(ChangedTasksInfo changesInfo, InternalTask blockTaskToSkip, long finishedTime,
+            String matchingBlock) {
         skipTask(changesInfo, blockTaskToSkip, finishedTime);
-        if (!blockTaskToSkip.getFlowBlock().equals(FlowBlock.END)) {
+        if (!blockTaskToSkip.getFlowBlock().equals(FlowBlock.END) || !matchingBlock.equals(blockTaskToSkip.getName())) {
             for (InternalTask nextBlockTask : getTaskChildren(blockTaskToSkip)) {
-                skipTasksUntilEndBlock(changesInfo, nextBlockTask, finishedTime);
+                skipTasksUntilEndBlock(changesInfo, nextBlockTask, finishedTime, matchingBlock);
             }
         }
     }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/job/termination/handlers/TerminateReplicateTaskHandlerTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/job/termination/handlers/TerminateReplicateTaskHandlerTest.java
@@ -160,7 +160,9 @@ public class TerminateReplicateTaskHandlerTest extends ProActiveTestClean {
     private Map<TaskId, InternalTask> generateTasksWithBlock() {
         Map<TaskId, InternalTask> tempTasks = Maps.newHashMap();
         InternalTask startTask = generateInternalTask(555L);
+        InternalTask endTask = generateInternalTask(999L);
         startTask.setFlowBlock(FlowBlock.START);
+        startTask.setMatchingBlock(endTask.getName());
         tempTasks.put(startTask.getId(), startTask);
 
         InternalTask internalTask2 = generateInternalTask(666L);
@@ -173,7 +175,6 @@ public class TerminateReplicateTaskHandlerTest extends ProActiveTestClean {
         when(jobDescriptorImpl.getTaskChildrenWithIfBranches(startTask)).thenReturn(Lists.newArrayList(internalTask2,
                                                                                                        internalTask3));
 
-        InternalTask endTask = generateInternalTask(999L);
         tempTasks.put(endTask.getId(), endTask);
         endTask.setFlowBlock(FlowBlock.END);
         when(jobDescriptorImpl.getTaskChildrenWithIfBranches(internalTask2)).thenReturn(Lists.newArrayList(endTask));
@@ -200,7 +201,8 @@ public class TerminateReplicateTaskHandlerTest extends ProActiveTestClean {
                                                   OnTaskError.CANCEL_JOB,
                                                   "description");
         InternalTask internalTask = new InternalScriptTask(job);
-        internalTask.setId(TaskIdImpl.createTaskId(new JobIdImpl(666L, "JobName"), "readableName", id));
+        internalTask.setId(TaskIdImpl.createTaskId(new JobIdImpl(666L, "JobName"), "test-name-" + id, id));
+        internalTask.setName("test-name-" + id);
         internalTask.setStatus(TaskStatus.PENDING);
         return internalTask;
 


### PR DESCRIPTION
 - consider if/else/continuation dependency when searching for non-skipped parent tasks
 - use LinkedHashSet/Map to ensure parent task ordering
 - additionally, fix matching block search when skipping blocks