### PR TITLE
Improve resultMap and preciousResult frontend

### DIFF
--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -1451,9 +1451,10 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        Map<Long, Map<String, Serializable>> result = new HashMap<>();
         try {
-            Map<Long, Map<String, Serializable>> result = new HashMap<>();
             Map<Long, Map<String, String>> map = restApi().jobResultMaps(sid, jobsId);
             for (Entry<Long, Map<String, String>> entry : map.entrySet()) {
                 Map<String, Serializable> resultMap = new HashMap<>();
@@ -1463,11 +1464,10 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
 
                 result.put(entry.getKey(), resultMap);
             }
-
-            return result;
-        } catch (RestException e) {
-            throw RestException.unwrapRestException(e);
+        } catch (Exception e) {
+            throwUJEOrNCEOrPE(e);
         }
+        return result;
     }
 
     @Override

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -463,11 +463,12 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     public Map<String, String> jobResultMap(String sessionId, String jobId) throws RestException {
         try {
             Scheduler s = checkAccess(sessionId, PATH_JOBS + jobId + "/resultmap");
-            JobResult jobResult = PAFuture.getFutureValue(s.getJobResult(jobId));
-            if (jobResult == null) {
+            Map<Long, Map<String, Serializable>> maps = PAFuture.getFutureValue(s.getJobResultMaps(Collections.singletonList(jobId)));
+            Map<String, Serializable> resultMap = maps.get(Long.valueOf(jobId));
+            if (resultMap == null) {
                 return null;
             } else {
-                return getJobResultMapAsString(jobResult.getResultMap());
+                return getJobResultMapAsString(resultMap);
             }
         } catch (SchedulerException e) {
             throw RestException.wrapExceptionToRest(e);

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -756,7 +756,8 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
+            throws UnknownJobException, NotConnectedException, PermissionException {
         return _getScheduler().getJobResultMaps(jobsId);
     }
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -1637,10 +1637,39 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
     TaskStatesPage getTaskPaginated(String jobId, String statusFilter, int offset, int limit)
             throws NotConnectedException, UnknownJobException, PermissionException;
 
+    /**
+     * Return a list of task results which where declared as "preciousResult" for the given job
+     * @param jobId id of the job
+     * @return a list of precious tasks' results
+     * @throws NotConnectedException
+     *             if you are not authenticated.
+     * @throws UnknownJobException
+     *             if the job does not exist.
+     * @throws PermissionException
+     *             if you can't access to this particular job.
+     */
     List<TaskResult> getPreciousTaskResults(String jobId)
             throws NotConnectedException, PermissionException, UnknownJobException;
 
-    Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException;
+    /**
+     * Return result maps associated with multiple jobs
+     * @param jobsId list of jobs ids
+     * @return a map containing, for each job, the resultMap associated with that job
+     * @throws NotConnectedException
+     *             if you are not authenticated.
+     * @throws UnknownJobException
+     *             if one of the jobs in the list does not exist.
+     * @throws PermissionException
+     *             if you can't access one job in the list.
+     */
+    Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
+            throws NotConnectedException, UnknownJobException, PermissionException;
 
+    /**
+     * Return the list of task names declared as precious results
+     * @param jobsId id of the job
+     * @return a list of task names declared as "preciousResult" for the given job
+     * @throws SchedulerException
+     */
     Map<Long, List<String>> getPreciousTaskNames(List<String> jobsId) throws SchedulerException;
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -869,7 +869,8 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
 
     @Override
     @ImmediateService
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
+            throws UnknownJobException, NotConnectedException, PermissionException {
         return uischeduler.getJobResultMaps(jobsId);
     }
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -963,7 +963,8 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
+            throws UnknownJobException, NotConnectedException, PermissionException {
         renewSession();
         return client.getJobResultMaps(jobsId);
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -512,7 +512,7 @@ class LiveJobs {
         }
         task.setStatus(status);
         job.newWaitingTask();
-        ((JobInfoImpl) job.getJobInfo()).setPreciousTasks(job.getPreciousTasks());
+        ((JobInfoImpl) job.getJobInfo()).setPreciousTasks(job.getPreciousTasksFinished());
         dbManager.updateAfterTaskFinished(job, task, result);
         listener.taskStateUpdated(job.getOwner(),
                                   new NotificationData<TaskInfo>(SchedulerEvent.TASK_WAITING_FOR_RESTART,
@@ -799,7 +799,7 @@ class LiveJobs {
             // to be done before terminating the task, once terminated it is not
             // running anymore..
             ChangedTasksInfo changesInfo = job.finishInErrorTask(taskId, taskResult, listener);
-            ((JobInfoImpl) job.getJobInfo()).setPreciousTasks(job.getPreciousTasks());
+            ((JobInfoImpl) job.getJobInfo()).setPreciousTasks(job.getPreciousTasksFinished());
 
             boolean jobFinished = job.isFinished();
 
@@ -1090,7 +1090,7 @@ class LiveJobs {
         //merge task map result to job map result
         job.getResultMap().putAll(result.getResultMap());
         ChangedTasksInfo changesInfo = job.terminateTask(errorOccurred, taskId, listener, result.getAction(), result);
-        ((JobInfoImpl) job.getJobInfo()).setPreciousTasks(job.getPreciousTasks());
+        ((JobInfoImpl) job.getJobInfo()).setPreciousTasks(job.getPreciousTasksFinished());
 
         boolean jobFinished = job.isFinished();
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -1316,7 +1316,9 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
     @ImmediateService
     public List<TaskResult> getPreciousTaskResults(String jobId)
             throws NotConnectedException, PermissionException, UnknownJobException {
-        frontendState.checkPermission("getJobResult", YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THE_TASK_RESULT_OF_THIS_JOB);
+        frontendState.checkPermissions("getJobResult",
+                                       frontendState.getIdentifiedJob(JobIdImpl.makeJobId(jobId)),
+                                       YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THE_TASK_RESULT_OF_THIS_JOB);
         List<TaskState> taskStates = getJobState(jobId).getTasks()
                                                        .stream()
                                                        .filter(Task::isPreciousResult)
@@ -1341,7 +1343,13 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
 
     @Override
     @ImmediateService
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
+            throws UnknownJobException, NotConnectedException, PermissionException {
+        for (String jobId : jobsId) {
+            frontendState.checkPermissions("getJobResult",
+                                           frontendState.getIdentifiedJob(JobIdImpl.makeJobId(jobId)),
+                                           YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THE_TASK_RESULT_OF_THIS_JOB);
+        }
         return dbManager.getJobResultMaps(jobsId);
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -27,9 +27,7 @@ package org.ow2.proactive.scheduler.core.db;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -340,7 +338,7 @@ public class JobData implements Serializable {
         jobRuntimeData.addJobContent(job.getTaskFlowJob());
         jobRuntimeData.setLastUpdatedTime(job.getSubmittedTime());
         jobRuntimeData.setResultMap(SerializationUtil.serializeVariableMap(job.getResultMap()));
-        jobRuntimeData.setPreciousTasks(job.getPreciousTasks());
+        jobRuntimeData.setPreciousTasks(job.getPreciousTasksFinished());
         jobRuntimeData.setParentId(job.getParentId());
         jobRuntimeData.setAttachedServices(job.getAttachedServices());
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -41,13 +41,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
@@ -1005,7 +1003,7 @@ public class SchedulerDBManager {
         for (JobData jobData : jobsList) {
             InternalJob internalJob = jobData.toInternalJob();
             internalJob.setTasks(toInternalTasks(fullState, internalJob, tasksMap.get(jobData.getId())));
-            ((JobInfoImpl) internalJob.getJobInfo()).setPreciousTasks(internalJob.getPreciousTasks());
+            ((JobInfoImpl) internalJob.getJobInfo()).setPreciousTasks(internalJob.getPreciousTasksFinished());
 
             jobs.add(internalJob);
         }
@@ -1265,7 +1263,7 @@ public class SchedulerDBManager {
                                .setParameter("lastUpdatedTime", new Date().getTime())
                                .setParameter("resultMap",
                                              ObjectByteConverter.mapOfSerializableToByteArray(job.getResultMap()))
-                               .setParameter("preciousTasks", job.getPreciousTasks())
+                               .setParameter("preciousTasks", job.getPreciousTasksFinished())
                                .setParameter("jobId", jobId)
                                .executeUpdate();
 
@@ -1351,7 +1349,7 @@ public class SchedulerDBManager {
                                         .setParameter("lastUpdatedTime", new Date().getTime())
                                         .setParameter("resultMap",
                                                       ObjectByteConverter.mapOfSerializableToByteArray(job.getResultMap()))
-                                        .setParameter("preciousTasks", job.getPreciousTasks())
+                                        .setParameter("preciousTasks", job.getPreciousTasksFinished())
                                         .setParameter("jobId", jobId)
                                         .executeUpdate();
                     if (result != 0) {
@@ -1628,7 +1626,7 @@ public class SchedulerDBManager {
                    .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
                    .setParameter("lastUpdatedTime", new Date().getTime())
                    .setParameter("resultMap", ObjectByteConverter.mapOfSerializableToByteArray(job.getResultMap()))
-                   .setParameter("preciousTasks", job.getPreciousTasks())
+                   .setParameter("preciousTasks", job.getPreciousTasksFinished())
                    .setParameter("jobId", jobId)
                    .executeUpdate();
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -1362,10 +1362,12 @@ public abstract class InternalJob extends JobState {
         this.resultMap = resultMap;
     }
 
-    public List<String> getPreciousTasks() {
+    public List<String> getPreciousTasksFinished() {
         List<String> preciousTasks = new ArrayList<>();
         for (InternalTask task : tasks.values()) {
-            if (task.isPreciousResult()) {
+            if (task.isPreciousResult() && (!task.getStatus().isTaskAlive() && task.getStatus() != TaskStatus.SKIPPED ||
+                                            task.getStatus() == TaskStatus.IN_ERROR)) {
+                // Include only precious tasks which can contain a result or an error
                 preciousTasks.add(task.getName());
             }
         }

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -907,7 +907,8 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
-    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId) throws SchedulerException {
+    public Map<Long, Map<String, Serializable>> getJobResultMaps(List<String> jobsId)
+            throws UnknownJobException, NotConnectedException, PermissionException {
         return schedulerProxy.getJobResultMaps(jobsId);
     }
 


### PR DESCRIPTION
 - check permissions for preciousResults and resultMap endpoints
 - resultMap no longer return empty results if the job is not finished
 - preciousTaskNames contains only tasks which have results available
 - minor javadoc additions