### PR TITLE
Add permission to jobSignal

### DIFF
--- a/config/security.java.policy-server
+++ b/config/security.java.policy-server
@@ -169,11 +169,16 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.putThirdPartyCredential";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.thirdPartyCredentialsKeySet";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeThirdPartyCredential";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.enableRemoteVisualization";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.registerService";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.detachService";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addJobSignal";
+
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pushFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pullFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.deleteFile";
 
     // API - access to database
     permission java.sql.SQLPermission "setLog";
@@ -530,6 +535,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobResult";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResult";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultFromIncarnation";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobContent";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobState";
 
@@ -541,6 +547,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.listenJobLogs";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getUsers";
@@ -551,11 +558,16 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.putThirdPartyCredential";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.thirdPartyCredentialsKeySet";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeThirdPartyCredential";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.enableRemoteVisualization";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.registerService";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.detachService";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addJobSignal";
+
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pushFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pullFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.deleteFile";
 
 
     // API - access to database
@@ -657,11 +669,16 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.putThirdPartyCredential";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.thirdPartyCredentialsKeySet";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeThirdPartyCredential";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.enableRemoteVisualization";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.registerService";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.detachService";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addJobSignal";
+
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pushFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pullFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.deleteFile";
 
     // API - access to database
     permission java.sql.SQLPermission "setLog";

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -2280,6 +2280,13 @@ public interface SchedulerRestInterface {
     /**
      * 
      * Check if the user has the permission to execute the method passed as argument
+     *
+     * @param sessionId
+     *            current session
+     * @param jobId
+     *            id of the job
+     * @param method
+     *            method name to check
      * 
      * @return true if the user has the permission to execute the java method
      */
@@ -2294,12 +2301,19 @@ public interface SchedulerRestInterface {
      *
      * Add a signal to the list of signals used by the considered job
      *
-     * @return true if the given signal is added to the list of job signals
+     * @param sessionId
+     *            current session
+     * @param jobId
+     *            id of the job
+     * @param signal
+     *            signal name to add
+     *
+     * @return the set of job signals associated with the given job after the addition
      */
     @POST
     @Path("job/{jobid}/signals")
     @Consumes(value = MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     Set<String> addJobSignal(@HeaderParam("sessionid") String sessionId, @QueryParam("signal") String signal,
-            @PathParam("jobid") String jobId) throws RestException, SignalApiException;
+            @PathParam("jobid") String jobId) throws RestException;
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/exception/RestException.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/exception/RestException.java
@@ -33,6 +33,7 @@ import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
+import org.ow2.proactive.scheduler.signal.SignalApiException;
 
 
 public class RestException extends Exception {
@@ -63,6 +64,8 @@ public class RestException extends Exception {
             return new JobCreationRestException(schedulerException);
         } else if (schedulerException instanceof UnknownTaskException) {
             return new UnknownTaskRestException(schedulerException);
+        } else if (schedulerException instanceof SignalApiException) {
+            return new SignalApiRestException(schedulerException);
         }
         return new UnknownJobRestException(schedulerException);
     }
@@ -82,6 +85,8 @@ public class RestException extends Exception {
             return new JobCreationException(restException);
         } else if (restException instanceof UnknownTaskRestException) {
             return new UnknownTaskException(restException);
+        } else if (restException instanceof SignalApiRestException) {
+            return new SignalApiException(restException);
         }
         return new UnknownJobException(restException);
     }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/exception/SignalApiRestException.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/exception/SignalApiRestException.java
@@ -23,25 +23,19 @@
  * If needed, contact us to obtain a release under GPL Version 2 or 3
  * or a different license than the AGPL.
  */
-package org.ow2.proactive.scheduler.signal;
+package org.ow2.proactive_grid_cloud_portal.scheduler.exception;
 
-import org.ow2.proactive.scheduler.common.exception.SchedulerException;
+/**
+ * @author ActiveEon Team
+ * @since 11/05/2021
+ */
+public class SignalApiRestException extends RestException {
 
-
-public class SignalApiException extends SchedulerException {
-
-    public SignalApiException() {
-    }
-
-    public SignalApiException(String message) {
-        super(message);
-    }
-
-    public SignalApiException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public SignalApiException(Throwable cause) {
+    public SignalApiRestException(Throwable cause) {
         super(cause);
+    }
+
+    public SignalApiRestException(String message) {
+        super(message);
     }
 }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ExceptionUtility.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ExceptionUtility.java
@@ -34,10 +34,12 @@ import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
+import org.ow2.proactive.scheduler.signal.SignalApiException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobAlreadyFinishedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SignalApiRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SubmissionClosedRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownJobRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownTaskRestException;
@@ -74,6 +76,15 @@ public class ExceptionUtility {
             throw reconstructError(e, UnknownJobException.class);
         } else {
             throwNCEOrPE(e);
+        }
+    }
+
+    public static void throwSAEorUJEOrNCEOrPE(Exception e)
+            throws SignalApiException, UnknownJobException, NotConnectedException, PermissionException {
+        if (e instanceof SignalApiRestException) {
+            throw reconstructError(e, SignalApiException.class);
+        } else {
+            throwUJEOrNCEOrPE(e);
         }
     }
 

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -32,6 +32,7 @@ import static org.ow2.proactive.scheduler.rest.ExceptionUtility.exception;
 import static org.ow2.proactive.scheduler.rest.ExceptionUtility.throwJAFEOrUJEOrNCEOrPE;
 import static org.ow2.proactive.scheduler.rest.ExceptionUtility.throwNCEOrPE;
 import static org.ow2.proactive.scheduler.rest.ExceptionUtility.throwNCEOrPEOrSCEOrJCE;
+import static org.ow2.proactive.scheduler.rest.ExceptionUtility.throwSAEorUJEOrNCEOrPE;
 import static org.ow2.proactive.scheduler.rest.ExceptionUtility.throwUJEOrNCEOrPE;
 import static org.ow2.proactive.scheduler.rest.ExceptionUtility.throwUJEOrNCEOrPEOrUTE;
 import static org.ow2.proactive.scheduler.rest.data.DataUtility.jobId;
@@ -58,6 +59,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1480,22 +1482,24 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
+    public boolean checkJobPermissionMethod(String jobId, String method) throws SchedulerException {
         try {
-            return restApi().checkJobPermissionMethod(sessionId, jobId, method);
+            return restApi().checkJobPermissionMethod(sid, jobId, method);
         } catch (RestException e) {
             throw RestException.unwrapRestException(e);
         }
     }
 
     @Override
-    public Set<String> addJobSignal(String sessionId, String jobId, String signal)
-            throws SchedulerException, SignalApiException {
+    public Set<String> addJobSignal(String jobId, String signal)
+            throws NotConnectedException, UnknownJobException, PermissionException, SignalApiException {
+        Set<String> result = new HashSet<>();
         try {
-            return restApi().addJobSignal(sessionId, jobId, signal);
-        } catch (RestException e) {
-            throw RestException.unwrapRestException(e);
+            result = restApi().addJobSignal(sid, jobId, signal);
+        } catch (Exception e) {
+            throwSAEorUJEOrNCEOrPE(e);
         }
+        return result;
     }
 
     private org.apache.http.impl.client.HttpClientBuilder getHttpClientBuilder()

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -237,7 +237,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         boolean userHasPermission = false;
         try {
             Scheduler s = checkAccess(sessionId, "/scheduler/jobs/" + jobId);
-            userHasPermission = s.checkJobPermissionMethod(sessionId, jobId, method);
+            userHasPermission = s.checkJobPermissionMethod(jobId, method);
         } catch (SchedulerException e) {
             throw RestException.wrapExceptionToRest(e);
         }
@@ -245,11 +245,10 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
-    public Set<String> addJobSignal(String sessionId, String signal, String jobId)
-            throws RestException, SignalApiException {
+    public Set<String> addJobSignal(String sessionId, String signal, String jobId) throws RestException {
         try {
             Scheduler s = checkAccess(sessionId, "/scheduler/jobs/" + jobId);
-            return s.addJobSignal(sessionId, jobId, signal);
+            return s.addJobSignal(jobId, signal);
         } catch (SchedulerException e) {
             throw RestException.wrapExceptionToRest(e);
         }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/ExceptionMappers.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/ExceptionMappers.java
@@ -42,6 +42,7 @@ import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
 import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
+import org.ow2.proactive.scheduler.signal.SignalApiException;
 import org.ow2.proactive_grid_cloud_portal.common.exceptionmapper.ExceptionToJson;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
@@ -171,6 +172,13 @@ public class ExceptionMappers {
         @Override
         protected int getErrorCode() {
             return HttpURLConnection.HTTP_FORBIDDEN;
+        }
+    }
+
+    public static class SignalApiExceptionExceptionMapper extends BaseExceptionMapper<SignalApiException> {
+        @Override
+        protected int getErrorCode() {
+            return HttpURLConnection.HTTP_INTERNAL_ERROR;
         }
     }
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/RestRuntime.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/RestRuntime.java
@@ -127,6 +127,7 @@ public class RestRuntime {
         dispatcher.registerProvider(ExceptionMappers.UnknownJobRestExceptionExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.UnknownTaskExceptionExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.PermissionExceptionExceptionMapper.class);
+        dispatcher.registerProvider(ExceptionMappers.SignalApiExceptionExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.ProActiveRuntimeExceptionExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.RuntimeExceptionExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.IllegalArgumentExceptionMapper.class);

--- a/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
+++ b/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
@@ -169,11 +169,16 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.putThirdPartyCredential";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.thirdPartyCredentialsKeySet";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeThirdPartyCredential";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.enableRemoteVisualization";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.registerService";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.detachService";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addJobSignal";
+
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pushFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pullFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.deleteFile";
 
     // API - access to database
     permission java.sql.SQLPermission "setLog";
@@ -522,6 +527,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobResult";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResult";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskResultFromIncarnation";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobContent";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobState";
 
@@ -533,6 +539,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.listenJobLogs";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getUsers";
@@ -543,11 +550,16 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.putThirdPartyCredential";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.thirdPartyCredentialsKeySet";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeThirdPartyCredential";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.enableRemoteVisualization";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.registerService";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.detachService";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addJobSignal";
+
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pushFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pullFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.deleteFile";
 
 
     // API - access to database
@@ -633,11 +645,16 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.putThirdPartyCredential";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.thirdPartyCredentialsKeySet";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.removeThirdPartyCredential";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
-    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.enableRemoteVisualization";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.registerService";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.detachService";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.addJobSignal";
+
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.checkFileExists";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.isFolder";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pushFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.pullFile";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.deleteFile";
 
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -806,14 +806,14 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
-        return (_getScheduler()).checkJobPermissionMethod(sessionId, jobId, method);
+    public boolean checkJobPermissionMethod(String jobId, String method) throws SchedulerException {
+        return (_getScheduler()).checkJobPermissionMethod(jobId, method);
     }
 
     @Override
-    public Set<String> addJobSignal(String sessionId, String jobId, String signal)
-            throws SchedulerException, SignalApiException {
-        return (_getScheduler()).addJobSignal(sessionId, jobId, signal);
+    public Set<String> addJobSignal(String jobId, String signal)
+            throws UnknownJobException, NotConnectedException, PermissionException, SignalApiException {
+        return (_getScheduler()).addJobSignal(jobId, signal);
     }
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -81,26 +81,33 @@ import org.ow2.proactive.scheduler.signal.SignalApiException;
 public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
 
     /**
-     * Check if the user has the permission to execute the method passed as argument
-     * @param sessionId
-     * @param jobId
-     * @param method
+     * Check if the connected user has the permission to execute the method passed as argument
+     *
+     * @param jobId id of the job
+     * @param method operation to test
      * @return true if the user has the permission to execute the java method
      * @throws NotConnectedException
      * @throws UnknownJobException
      */
-    boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException;
+    boolean checkJobPermissionMethod(String jobId, String method) throws SchedulerException;
 
     /**
      * Add the given signal to job signals
-     * @param sessionId
-     * @param jobId
-     * @param signal
+     *
+     * @param jobId id of the job
+     * @param signal signal name
      * @return the set of job signals including the added signal
-     * @throws SchedulerException
+     * @throws NotConnectedException
+     *             if you are not authenticated.
+     * @throws UnknownJobException
+     *             if the job does not exist.
+     * @throws PermissionException
+     *             if you can't access to this particular job.
+     * @throws SignalApiException
+     *             errors related to the signal api
      */
-    Set<String> addJobSignal(String sessionId, String jobId, String signal)
-            throws SchedulerException, SignalApiException;
+    Set<String> addJobSignal(String jobId, String signal)
+            throws NotConnectedException, UnknownJobException, PermissionException, SignalApiException;
 
     /**
      * Returns the USER DataSpace URIs associated with the current user

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -882,15 +882,15 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
 
     @Override
     @ImmediateService
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
-        return uischeduler.checkJobPermissionMethod(sessionId, jobId, method);
+    public boolean checkJobPermissionMethod(String jobId, String method) throws SchedulerException {
+        return uischeduler.checkJobPermissionMethod(jobId, method);
     }
 
     @Override
     @ImmediateService
-    public Set<String> addJobSignal(String sessionId, String jobId, String signal)
-            throws SchedulerException, SignalApiException {
-        return uischeduler.addJobSignal(sessionId, jobId, signal);
+    public Set<String> addJobSignal(String jobId, String signal)
+            throws UnknownJobException, NotConnectedException, PermissionException, SignalApiException {
+        return uischeduler.addJobSignal(jobId, signal);
     }
 
     public String getStatHistory(String mbeanName, String range, String[] dataSources, String function) {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -975,15 +975,15 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
+    public boolean checkJobPermissionMethod(String jobId, String method) throws SchedulerException {
         renewSession();
-        return client.checkJobPermissionMethod(sessionId, jobId, method);
+        return client.checkJobPermissionMethod(jobId, method);
     }
 
     @Override
-    public Set<String> addJobSignal(String sessionId, String jobId, String signal)
-            throws SchedulerException, SignalApiException {
+    public Set<String> addJobSignal(String jobId, String signal)
+            throws NotConnectedException, SignalApiException, UnknownJobException, PermissionException {
         renewSession();
-        return client.addJobSignal(sessionId, jobId, signal);
+        return client.addJobSignal(jobId, signal);
     }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -116,6 +116,8 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
 
     public static final String YOU_DO_NOT_HAVE_PERMISSION_TO_ATTACH_SERVICE_TO_THIS_JOB = "You do not have permission to attach service to this job !";
 
+    public static final String YOU_DO_NOT_HAVE_PERMISSION_TO_SEND_SIGNALS_TO_THIS_JOB = "You do not have permission to send signals to this job !";
+
     public static final String YOU_DO_NOT_HAVE_PERMISSION_TO_KILL_THIS_JOB = "You do not have permission to kill this job !";
 
     public static final String YOU_DO_NOT_HAVE_PERMISSION_TO_REMOVE_THIRD_PARTY_CREDENTIALS_FROM_THE_SCHEDULER = "You do not have permission to remove third-party credentials from the scheduler !";

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -918,13 +918,13 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
-    public boolean checkJobPermissionMethod(String sessionId, String jobId, String method) throws SchedulerException {
-        return schedulerProxy.checkJobPermissionMethod(sessionId, jobId, method);
+    public boolean checkJobPermissionMethod(String jobId, String method) throws SchedulerException {
+        return schedulerProxy.checkJobPermissionMethod(jobId, method);
     }
 
     @Override
-    public Set<String> addJobSignal(String sessionId, String jobId, String signal)
-            throws SchedulerException, SignalApiException {
-        return schedulerProxy.addJobSignal(sessionId, jobId, signal);
+    public Set<String> addJobSignal(String jobId, String signal)
+            throws UnknownJobException, NotConnectedException, PermissionException, SignalApiException {
+        return schedulerProxy.addJobSignal(jobId, signal);
     }
 }


### PR DESCRIPTION
Also:
 - discard signals and remoteVisualization data from jobsInfo on non-authorized jobs.
 - java doc and signal api rest exception improvements
 - fix citizen-ds live jobs permission