### PR TITLE
improve load finished jobs

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/flow/FlowScript.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/flow/FlowScript.java
@@ -696,6 +696,13 @@ public class FlowScript extends Script<FlowAction> {
     }
 
     @Override
+    public String display() {
+        String nl = System.lineSeparator();
+        return "actionType = " + actionType + " target = " + target + " targetElse = " + targetElse +
+               " targetContinuation = " + targetContinuation + nl + super.display();
+    }
+
+    @Override
     protected void prepareSpecialBindings(Bindings bindings) {
     }
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobResultImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobResultImpl.java
@@ -115,7 +115,9 @@ public class JobResultImpl implements JobResult {
     public void addTaskResult(String taskName, TaskResult taskResult, boolean isPrecious) {
         //add to all Results
         allResults.put(taskName, taskResult);
-        resultMap.putAll(taskResult.getResultMap());
+        if (taskResult.getResultMap() != null) {
+            resultMap.putAll(taskResult.getResultMap());
+        }
         //add to precious results if needed
         if (isPrecious) {
             preciousResults.put(taskName, taskResult);

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/TaskResultImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/task/TaskResultImpl.java
@@ -119,6 +119,10 @@ public class TaskResultImpl implements TaskResult {
         this.isRaw = isRaw;
     }
 
+    public TaskResultImpl(TaskId id) {
+        this.id = id;
+    }
+
     private TaskResultImpl(TaskId id, TaskLogs output) {
         this.id = id;
         this.output = output;
@@ -269,6 +273,9 @@ public class TaskResultImpl implements TaskResult {
                                                      " : " + e.getMessage(), e);
             }
             throw thrown;
+        } else if (serializedValue == null) {
+            // empty result (for example a skipped task)
+            return null;
         } else {
             try {
                 return this.instanciateValue(this.getTaskClassLoader());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -691,7 +691,13 @@ public class SchedulingService {
 
     void submitTerminationDataHandler(TerminationData terminationData) {
         if (!terminationData.isEmpty()) {
-            getInfrastructure().getInternalOperationsThreadPool().submit(new TerminationDataHandler(terminationData));
+            try {
+                getInfrastructure().getInternalOperationsThreadPool()
+                                   .submit(new TerminationDataHandler(terminationData))
+                                   .get();
+            } catch (Exception e) {
+                logger.warn("Error when executing job or task termination", e);
+            }
         }
     }
 
@@ -1256,7 +1262,7 @@ public class SchedulingService {
                 Credentials credentials = null;
 
                 if (jobs.isJobAlive(jobId)) {
-                    TerminationData terminationData = jobs.removeJob(jobId);
+                    TerminationData terminationData = jobs.killJob(jobId);
                     credentials = terminationData.getCredentials(jobId);
                     submitTerminationDataHandler(terminationData);
                 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -958,8 +958,8 @@ public class SchedulerDBManager {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<Long, List<TaskData>> loadJobsTasks(Session session, List<Long> jobIds) {
-        Query tasksQuery = session.getNamedQuery("loadJobsTasks")
+    private Map<Long, List<TaskData>> loadJobsTasks(Session session, List<Long> jobIds, boolean fullState) {
+        Query tasksQuery = session.getNamedQuery(fullState ? "loadJobsTasksFull" : "loadJobsTasks")
                                   .setParameterList("ids", jobIds)
                                   .setReadOnly(true)
                                   .setResultTransformer(DistinctRootEntityResultTransformer.INSTANCE);
@@ -1004,7 +1004,7 @@ public class SchedulerDBManager {
     // Executed in a transaction from the caller
     private void batchLoadJobs(Session session, boolean fullState, Query jobQuery, List<Long> ids,
             Collection<InternalJob> jobs) {
-        Map<Long, List<TaskData>> tasksMap = loadJobsTasks(session, ids);
+        Map<Long, List<TaskData>> tasksMap = loadJobsTasks(session, ids, fullState);
 
         jobQuery.setParameterList("ids", ids);
         List<JobData> jobsList = (List<JobData>) jobQuery.list();
@@ -1018,55 +1018,61 @@ public class SchedulerDBManager {
         }
     }
 
+    private InternalTask toInternalTask(boolean loadFullState, InternalJob internalJob, TaskData taskData)
+            throws InvalidScriptException {
+        InternalTask internalTask = taskData.toInternalTask(internalJob, loadFullState);
+        if (loadFullState) {
+            internalTask.setParallelEnvironment(taskData.getParallelEnvironment());
+            internalTask.setGenericInformation(taskData.getGenericInformation());
+            for (SelectionScriptData scriptData : taskData.getSelectionScripts()) {
+                internalTask.addSelectionScript(scriptData.createSelectionScript());
+            }
+            if (taskData.getCleanScript() != null) {
+                internalTask.setCleaningScript(taskData.getCleanScript().createSimpleScript());
+            }
+            if (taskData.getPreScript() != null) {
+                internalTask.setPreScript(taskData.getPreScript().createSimpleScript());
+            }
+            if (taskData.getPostScript() != null) {
+                internalTask.setPostScript(taskData.getPostScript().createSimpleScript());
+            }
+            if (taskData.getFlowScript() != null) {
+                internalTask.setFlowScript(taskData.getFlowScript().createFlowScript());
+            }
+            for (SelectorData selectorData : taskData.getDataspaceSelectors()) {
+                if (selectorData.isInput()) {
+                    InputSelector selector = selectorData.createInputSelector();
+                    internalTask.addInputFiles(selector.getInputFiles(), selector.getMode());
+                } else {
+                    OutputSelector selector = selectorData.createOutputSelector();
+                    internalTask.addOutputFiles(selector.getOutputFiles(), selector.getMode());
+                }
+            }
+        }
+        return internalTask;
+    }
+
     private Collection<InternalTask> toInternalTasks(boolean loadFullState, InternalJob internalJob,
             List<TaskData> taskRuntimeDataList) {
         Map<DBTaskId, InternalTask> tasks = new HashMap<>(taskRuntimeDataList.size());
 
         try {
             for (TaskData taskData : taskRuntimeDataList) {
-                InternalTask internalTask = taskData.toInternalTask(internalJob, loadFullState);
-                if (loadFullState) {
-                    internalTask.setParallelEnvironment(taskData.getParallelEnvironment());
-                    internalTask.setGenericInformation(taskData.getGenericInformation());
-                    for (SelectionScriptData scriptData : taskData.getSelectionScripts()) {
-                        internalTask.addSelectionScript(scriptData.createSelectionScript());
-                    }
-                    if (taskData.getCleanScript() != null) {
-                        internalTask.setCleaningScript(taskData.getCleanScript().createSimpleScript());
-                    }
-                    if (taskData.getPreScript() != null) {
-                        internalTask.setPreScript(taskData.getPreScript().createSimpleScript());
-                    }
-                    if (taskData.getPostScript() != null) {
-                        internalTask.setPostScript(taskData.getPostScript().createSimpleScript());
-                    }
-                    if (taskData.getFlowScript() != null) {
-                        internalTask.setFlowScript(taskData.getFlowScript().createFlowScript());
-                    }
-                    for (SelectorData selectorData : taskData.getDataspaceSelectors()) {
-                        if (selectorData.isInput()) {
-                            InputSelector selector = selectorData.createInputSelector();
-                            internalTask.addInputFiles(selector.getInputFiles(), selector.getMode());
-                        } else {
-                            OutputSelector selector = selectorData.createOutputSelector();
-                            internalTask.addOutputFiles(selector.getOutputFiles(), selector.getMode());
-                        }
-                    }
-                }
+                InternalTask internalTask = toInternalTask(loadFullState, internalJob, taskData);
                 tasks.put(taskData.getId(), internalTask);
             }
         } catch (InvalidScriptException e) {
             throw new DatabaseManagerException("Failed to initialize loaded script", e);
         }
 
-        for (TaskData taskData : taskRuntimeDataList) {
-            InternalTask internalTask = tasks.get(taskData.getId());
-            if (!taskData.getDependentTasks().isEmpty()) {
-                for (DBTaskId dependent : taskData.getDependentTasks()) {
-                    internalTask.addDependence(tasks.get(dependent));
+        if (loadFullState) {
+            for (TaskData taskData : taskRuntimeDataList) {
+                InternalTask internalTask = tasks.get(taskData.getId());
+                if (!taskData.getDependentTasks().isEmpty()) {
+                    for (DBTaskId dependent : taskData.getDependentTasks()) {
+                        internalTask.addDependence(tasks.get(dependent));
+                    }
                 }
-            }
-            if (loadFullState) {
                 if (taskData.getIfBranch() != null) {
                     internalTask.setIfBranch(tasks.get(taskData.getIfBranch().getId()));
                 }
@@ -1751,8 +1757,10 @@ public class SchedulerDBManager {
                     }
                 }
                 if (taskResult == null) {
-                    throw new DatabaseManagerException("Failed to load result for task " + taskId + " (job: " + jobId +
-                                                       ")");
+                    // a null result indicates a skipped task
+                    TaskResult emptyResult = new TaskResultImpl(taskId);
+                    resultsMap.put(taskId, emptyResult);
+                    jobResult.addTaskResult(taskId.getReadableName(), emptyResult, false);
                 } else {
                     resultsMap.put(taskId, taskResult);
                 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestWorkflowDataspace.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/dataspaces/TestWorkflowDataspace.java
@@ -115,6 +115,7 @@ public class TestWorkflowDataspace extends SchedulerFunctionalTestNoRestart {
         job.addTask(t2);
 
         JobId id = TWorkflowJobs.testJobSubmission(schedulerHelper, job, null);
+        TWorkflowJobs.waitForJobFinished(id, schedulerHelper, job, null);
         Assert.assertFalse(schedulerHelper.getJobResult(id).hadException());
 
         for (int it = 0; it < 3; it++) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerTasksStateRecoverIntegrationTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerTasksStateRecoverIntegrationTest.java
@@ -126,8 +126,10 @@ public class SchedulerTasksStateRecoverIntegrationTest extends BaseSchedulerDBTe
         state = checkRecoveredState(recoverHelper.recover(-1), state().withFinished(expectedJob));
 
         job = state.getFinishedJobs().get(0);
+        Assert.assertEquals(3, job.getJobDescriptor().getEligibleTasks().size());
         task = job.getJobDescriptor().getEligibleTasks().iterator().next();
-        Assert.assertEquals(2, task.getChildren().size());
+        // finished jobs tasks have no dependency information
+        Assert.assertEquals(0, task.getChildren().size());
         Assert.assertEquals(0, task.getParents().size());
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowIterationAwareness.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowIterationAwareness.java
@@ -115,6 +115,7 @@ public class TestWorkflowIterationAwareness extends SchedulerFunctionalTestNoRes
         ((JavaTask) job.getTask("T1")).setPostScript(new SimpleScript(postScript, "groovy"));
 
         JobId id = TWorkflowJobs.testJobSubmission(schedulerHelper, job, null);
+        TWorkflowJobs.waitForJobFinished(id, schedulerHelper, job, null);
         JobResult res = schedulerHelper.getJobResult(id);
         Assert.assertFalse(schedulerHelper.getJobResult(id).hadException());
 
@@ -162,6 +163,7 @@ public class TestWorkflowIterationAwareness extends SchedulerFunctionalTestNoRes
         }
 
         JobId id = TWorkflowJobs.testJobSubmission(schedulerHelper, job, null);
+        TWorkflowJobs.waitForJobFinished(id, schedulerHelper, job, null);
         JobResult res = schedulerHelper.getJobResult(id);
         Assert.assertFalse(schedulerHelper.getJobResult(id).hadException());
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/synchronization/AOSynchronizationTestLeak.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/synchronization/AOSynchronizationTestLeak.java
@@ -61,7 +61,7 @@ public class AOSynchronizationTestLeak extends ProActiveTestClean {
     }
 
     /**
-     * Run a groovy closure many time and check that there is no leak in org.codehaus.groovy.reflection.ClassInfo
+     * Run a groovy closure many times and check that there is no leak in org.codehaus.groovy.reflection.ClassInfo
      * @throws CompilationException
      */
     @Test


### PR DESCRIPTION
 - do not load unnecessary info (task dependencies, task variables, etc)
 - fix workflows tests which were relying on analysing dependencies after the job is finished

Additionally:

 - fix database error when loading results of skipped task
 - improve JobRemoveHandler