### PR TITLE
Use cached bounded thread pool for selection manager and node sources

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -140,12 +140,12 @@ pa.scheduler.core.starttask.timeout=20000
 # Maximum number of threads used for the start task action. This property define the number of blocking resources
 # until the scheduling loop will block as well.
 # As it is related to the number of nodes, this property also define the number of threads used to terminate taskLauncher
-pa.scheduler.core.starttask.threadnumber=5
+pa.scheduler.core.starttask.threadnumber=20
 
 # Maximum number of threads used to send events to clients. This property defines the number of clients
 # than can block at the same time. If this number is reached, every clients won't receive events until
 # a thread unlock.
-pa.scheduler.core.listener.threadnumber=5
+pa.scheduler.core.listener.threadnumber=20
 
 # List of the scripts paths to execute at scheduler start. Paths are separated by a ';'.
 pa.scheduler.startscripts.paths=tools/LoadPackages.groovy

--- a/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestFuncTHelper.java
@@ -106,6 +106,7 @@ public class RestFuncTHelper {
         cmd.add(javaPath);
         cmd.add("-Djava.security.manager");
         cmd.add("-Dresteasy.allowGzip=true");
+        cmd.add("-Dfile.encoding=UTF-8");
         cmd.add(CentralPAPropertyRepository.JAVA_SECURITY_POLICY.getCmdLine() + toPath(serverJavaPolicy));
 
         cmd.add(CentralPAPropertyRepository.PA_HOME.getCmdLine() + getSchedHome());

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
@@ -56,6 +56,7 @@ import org.ow2.proactive.scripting.SelectionScript;
 import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
 import org.ow2.proactive.utils.Criteria;
 import org.ow2.proactive.utils.NodeSet;
+import org.ow2.proactive.utils.PAExecutors;
 import org.ow2.proactive.utils.appenders.MultipleFileAppender;
 
 
@@ -91,8 +92,12 @@ public abstract class SelectionManager {
     public SelectionManager(RMCore rmcore) {
         this.topologyNodesFilter = new TopologyNodesFilter();
         this.rmcore = rmcore;
-        this.scriptExecutorThreadPool = Executors.newFixedThreadPool(PAResourceManagerProperties.RM_SELECTION_MAX_THREAD_NUMBER.getValueAsInt(),
-                                                                     new NamedThreadFactory("Selection manager threadpool"));
+        this.scriptExecutorThreadPool = PAExecutors.newCachedBoundedThreadPool(1,
+                                                                               PAResourceManagerProperties.RM_SELECTION_MAX_THREAD_NUMBER.getValueAsInt(),
+                                                                               120L,
+                                                                               TimeUnit.SECONDS,
+                                                                               new NamedThreadFactory("Selection manager threadpool"));
+
         this.inProgress = Collections.synchronizedSet(new HashSet<String>());
 
         String policyClassName = PAResourceManagerProperties.RM_SELECTION_POLICY.getValueAsString();

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureCronPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureCronPolicy.java
@@ -70,17 +70,17 @@ public class TestLocalInfrastructureCronPolicy extends RMFunctionalTest {
 
         log("Create then remove an empty local node source with cron policy");
         createEmptyNodeSource(EMPTY_NODE_SOURCE_NAME);
-        removeNodeSource(EMPTY_NODE_SOURCE_NAME);
+        removeNodeSource(EMPTY_NODE_SOURCE_NAME, true);
 
         log("Create a local node source with " + NODES_NUMBER + " nodes with cron policy");
         createNodeSource(NODE_SOURCE_NAME);
 
         log("Waiting for the cron policy to remove the nodes");
-        repeater.accept(NODES_NUMBER, () -> this.rmHelper.waitForAnyNodeEvent(RMEventType.NODE_REMOVED));
+        this.rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_REMOVED, NODES_NUMBER);
 
         log("Waiting for the cron policy to add the nodes again");
         RMTHelper.waitForNodesToBeUp(NODES_NUMBER, this.monitorsHandler);
-        removeNodeSource(NODE_SOURCE_NAME);
+        removeNodeSource(NODE_SOURCE_NAME, false);
     }
 
     private void createEmptyNodeSource(String nodeSourceName) throws Exception {
@@ -107,9 +107,13 @@ public class TestLocalInfrastructureCronPolicy extends RMFunctionalTest {
         RMTHelper.waitForNodeSourceCreation(nodeSourceName, NODES_NUMBER, this.monitorsHandler);
     }
 
-    private void removeNodeSource(String sourceName) throws Exception {
+    private void removeNodeSource(String sourceName, boolean empty) throws Exception {
         this.resourceManager.removeNodeSource(sourceName, true);
+        if (!empty) {
+            this.rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_REMOVED, NODES_NUMBER);
+        }
         this.rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_REMOVED, sourceName);
+
     }
 
 }

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureTimeSlotPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestLocalInfrastructureTimeSlotPolicy.java
@@ -69,20 +69,20 @@ public class TestLocalInfrastructureTimeSlotPolicy extends RMFunctionalTest {
 
         log("Create then remove an empty local node source with time slot policy");
         createEmptyNodeSource(EMPTY_NODE_SOURCE_NAME);
-        removeNodeSource(EMPTY_NODE_SOURCE_NAME);
+        removeNodeSource(EMPTY_NODE_SOURCE_NAME, true);
 
         log("Create a local node source with " + NODES_NUMBER + " nodes with time slot policy");
         createDefaultNodeSource(NODE_SOURCE_NAME);
 
         log("Waiting for the time slot policy to remove the nodes");
-        repeater.accept(NODES_NUMBER, () -> this.rmHelper.waitForAnyNodeEvent(RMEventType.NODE_REMOVED));
+        this.rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_REMOVED, NODES_NUMBER);
 
         log("Waiting for the time slot policy to add the nodes again");
         RMTHelper.waitForNodesToBeUp(NODES_NUMBER, this.monitorsHandler);
 
         log("Waiting for the time slot policy to remove the nodes again");
-        repeater.accept(NODES_NUMBER, () -> this.rmHelper.waitForAnyNodeEvent(RMEventType.NODE_REMOVED));
-        removeNodeSource(NODE_SOURCE_NAME);
+        this.rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_REMOVED, NODES_NUMBER);
+        removeNodeSource(NODE_SOURCE_NAME, true);
     }
 
     private void createEmptyNodeSource(String nodeSourceName) throws Exception {
@@ -109,9 +109,13 @@ public class TestLocalInfrastructureTimeSlotPolicy extends RMFunctionalTest {
         RMTHelper.waitForNodeSourceCreation(nodeSourceName, NODES_NUMBER, this.monitorsHandler);
     }
 
-    private void removeNodeSource(String sourceName) throws Exception {
+    private void removeNodeSource(String sourceName, boolean empty) throws Exception {
         this.resourceManager.removeNodeSource(sourceName, true);
+        if (!empty) {
+            this.rmHelper.waitForAnyMultipleNodeEvent(RMEventType.NODE_REMOVED, NODES_NUMBER);
+        }
         this.rmHelper.waitForNodeSourceEvent(RMEventType.NODESOURCE_REMOVED, sourceName);
+
     }
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -131,12 +131,12 @@ public enum PASchedulerProperties implements PACommonProperties {
 
     /** Maximum number of threads used for the start task action. This property defines the number of blocking resources
      * until the scheduling loop will block as well.*/
-    SCHEDULER_STARTTASK_THREADNUMBER("pa.scheduler.core.starttask.threadnumber", PropertyType.INTEGER, "5"),
+    SCHEDULER_STARTTASK_THREADNUMBER("pa.scheduler.core.starttask.threadnumber", PropertyType.INTEGER, "20"),
 
     /** Maximum number of threads used to send events to clients. This property defines the number of clients
      * than can block at the same time. If this number is reached, every clients won't receive events until
      * a thread unlock. */
-    SCHEDULER_LISTENERS_THREADNUMBER("pa.scheduler.core.listener.threadnumber", PropertyType.INTEGER, "5"),
+    SCHEDULER_LISTENERS_THREADNUMBER("pa.scheduler.core.listener.threadnumber", PropertyType.INTEGER, "20"),
 
     /** List of the scripts paths to execute at scheduler start. Paths are separated by a ';'. */
     SCHEDULER_STARTSCRIPTS_PATHS("pa.scheduler.startscripts.paths", PropertyType.LIST),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/ClientRequestHandler.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/ClientRequestHandler.java
@@ -39,6 +39,7 @@ import org.objectweb.proactive.utils.NamedThreadFactory;
 import org.ow2.proactive.scheduler.common.SchedulerEventListener;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.threading.ReifiedMethodCall;
+import org.ow2.proactive.utils.PAExecutors;
 
 
 /**
@@ -56,8 +57,11 @@ public class ClientRequestHandler {
     private static final int THREAD_NUMBER = PASchedulerProperties.SCHEDULER_LISTENERS_THREADNUMBER.getValueAsInt();
 
     /** thread pool */
-    private static final ExecutorService threadPoolForNetworkCalls = Executors.newFixedThreadPool(THREAD_NUMBER,
-                                                                                                  new NamedThreadFactory("ClientEventHandlerPool"));
+    private static final ExecutorService threadPoolForNetworkCalls = PAExecutors.newCachedBoundedThreadPool(1,
+                                                                                                            THREAD_NUMBER,
+                                                                                                            120L,
+                                                                                                            TimeUnit.SECONDS,
+                                                                                                            new NamedThreadFactory("ClientEventHandlerPool"));
 
     private static final AtomicInteger requestLeft = new AtomicInteger();
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -318,22 +318,30 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
                                                                                       PASchedulerProperties.SCHEDULER_CLIENT_POOL_NBTHREAD.getValueAsInt(),
                                                                                       120L,
                                                                                       TimeUnit.SECONDS,
-                                                                                      new NamedThreadFactory("ClientRequestsThreadPool"));
+                                                                                      new NamedThreadFactory("ClientRequestsThreadPool",
+                                                                                                             false,
+                                                                                                             3));
 
             ExecutorService internalThreadPool = PAExecutors.newCachedBoundedThreadPool(1,
                                                                                         PASchedulerProperties.SCHEDULER_INTERNAL_POOL_NBTHREAD.getValueAsInt(),
                                                                                         120L,
                                                                                         TimeUnit.SECONDS,
-                                                                                        new NamedThreadFactory("InternalOperationsThreadPool"));
+                                                                                        new NamedThreadFactory("InternalOperationsThreadPool",
+                                                                                                               false,
+                                                                                                               7));
 
             ExecutorService taskPingerThreadPool = PAExecutors.newCachedBoundedThreadPool(1,
                                                                                           PASchedulerProperties.SCHEDULER_TASK_PINGER_POOL_NBTHREAD.getValueAsInt(),
                                                                                           120L,
                                                                                           TimeUnit.SECONDS,
-                                                                                          new NamedThreadFactory("TaskPingerThreadPool"));
+                                                                                          new NamedThreadFactory("TaskPingerThreadPool",
+                                                                                                                 false,
+                                                                                                                 2));
 
             ScheduledExecutorService scheduledThreadPool = new ScheduledThreadPoolExecutor(PASchedulerProperties.SCHEDULER_SCHEDULED_POOL_NBTHREAD.getValueAsInt(),
-                                                                                           new NamedThreadFactory("SchedulingServiceTimerThread"));
+                                                                                           new NamedThreadFactory("SchedulingServiceTimerThread",
+                                                                                                                  false,
+                                                                                                                  2));
 
             // at this point we must wait the resource manager
             RMConnection.waitAndJoin(rmURL.toString());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingInfrastructureImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingInfrastructureImpl.java
@@ -58,7 +58,9 @@ public class SchedulingInfrastructureImpl implements SchedulingInfrastructure {
     private static class HousekeepingScheduledExecutorLazyHolder {
 
         private static final ScheduledExecutorService INSTANCE = Executors.newScheduledThreadPool(PASchedulerProperties.SCHEDULER_HOUSEKEEPING_SCHEDULED_POOL_NBTHREAD.getValueAsInt(),
-                                                                                                  new NamedThreadFactory("Housekeeping Thread"));
+                                                                                                  new NamedThreadFactory("Housekeeping Thread",
+                                                                                                                         false,
+                                                                                                                         2));
 
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -136,7 +136,9 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                                                           terminateNotificationNode);
 
         this.threadPool = TimeoutThreadPoolExecutor.newFixedThreadPool(PASchedulerProperties.SCHEDULER_STARTTASK_THREADNUMBER.getValueAsInt(),
-                                                                       new NamedThreadFactory("DoTask_Action"));
+                                                                       new NamedThreadFactory("DoTask_Action",
+                                                                                              true,
+                                                                                              7));
         this.corePrivateKey = Credentials.getPrivateKey(PASchedulerProperties.getAbsolutePath(PASchedulerProperties.SCHEDULER_AUTH_PRIVKEY_PATH.getValueAsString()));
     }
 


### PR DESCRIPTION
This reduces the number of threads constantly active