### PR TITLE
Disable scheduling loop node partitioning

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -108,6 +108,10 @@ pa.scheduler.policy=org.ow2.proactive.scheduler.policy.ExtendedSchedulerPolicy
 # Defines the maximum number of tasks to be scheduled in each scheduling loop.
 pa.scheduler.policy.nbtaskperloop=10
 
+# if set to true, the scheduling loop will partition the task list according to the amount of free nodes.
+# Enabling it can cause performance issues
+pa.scheduler.policy.use.free.nodes=false
+
 # Path of the license properties file
 pa.scheduler.license.policy.configuration=config/scheduler/license.properties
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -58,8 +58,11 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Scheduler default policy full name. */
     SCHEDULER_DEFAULT_POLICY("pa.scheduler.policy", PropertyType.STRING, "org.ow2.proactive.scheduler.policy.ExtendedSchedulerPolicy"),
 
-    /** Defines the maximum number of tasks to be scheduled in each scheduling loop. */
+    /** Defines the maximum number of tasks to be scheduled in each scheduling loop (not used any more). */
     SCHEDULER_POLICY_NBTASKPERLOOP("pa.scheduler.policy.nbtaskperloop", PropertyType.INTEGER, "10"),
+
+    /** If set to true, the scheduling loop will partition the task list according to the amount of free nodes. Enabling it can cause performance issues */
+    SCHEDULER_POLICY_USE_FREE_NODES("pa.scheduler.policy.use.free.nodes", PropertyType.BOOLEAN, "false"),
 
     /** Path of the license properties file. */
     SCHEDULER_LICENSE_POLICY_CONFIGURATION("pa.scheduler.license.policy.configuration", PropertyType.STRING),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/VariableBatchSizeIterator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/VariableBatchSizeIterator.java
@@ -51,7 +51,12 @@ public class VariableBatchSizeIterator<T> {
         if (limit < 0) {
             throw new IllegalArgumentException("limit cannot be negative. Given: " + limit);
         }
-        int upperIndexExclusive = Math.min(rawList.size(), offset + limit);
+        int upperIndexExclusive;
+        if (limit == Integer.MAX_VALUE) {
+            upperIndexExclusive = rawList.size();
+        } else {
+            upperIndexExclusive = Math.min(rawList.size(), offset + limit);
+        }
         List<T> subList = rawList.subList(offset, upperIndexExclusive);
         offset = upperIndexExclusive;
         return subList;


### PR DESCRIPTION
Even though in general usage the current implementation works, it became very inefficient when there are nodes protected by tokens. In that case, if many tasks (10K more) needs to be scheduled, the scheduling loop is querying the rm several thousand times for a small number of nodes.

This change disable the node partitioning. When there are 10K tasks to be scheduled and all are "compatible", the scheduling loop send a single request to the RM, which returns in a single call the available nodes.