### PR TITLE
Fix variables propagation issue

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -867,7 +867,7 @@ public class StaxJobFactory extends JobFactory {
         LinkedHashMap<String, TaskVariable> updatedVariablesMap = new LinkedHashMap<>(variablesMap);
 
         // replacements will include at first variables defined in the job
-        for (TaskVariable variable : updatedVariablesMap.values()) {
+        for (TaskVariable variable : variablesMap.values()) {
             updatedReplacementVariables.put(variable.getName(), variable.getValue());
         }
         if (replacementVariables != null) {
@@ -892,16 +892,9 @@ public class StaxJobFactory extends JobFactory {
                                                           updatedReplacementVariables));
                 }
                 updatedVariablesMap.put(replacementVariableKey, replacedTaskVariable);
-            } else {
-                // if the variable is not defined in the task, create a new non-inherited task variable with an empty model
-                updatedVariablesMap.put(replacementVariableKey,
-                                        new TaskVariable(replacementVariableKey,
-                                                         replace(replacementVariable.getValue(),
-                                                                 updatedReplacementVariables),
-                                                         null,
-                                                         false));
             }
         }
+        // when the replacement variable is not defined as task variable the workflow, we do not add it
         return updatedVariablesMap;
     }
 

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
@@ -644,6 +644,8 @@ public class TestStaxJobFactory {
         // task variable is not inherited, has the same name as a job variable, and uses another task variable as default value
         assertEquals("${task_variable2}", unresolvedVariables.get("variable2").getValue());
         assertEquals("task_value1", variables.get("variable2").getValue());
+        // job variable should not appear as task variable
+        assertFalse(variables.containsKey("variable3"));
     }
 
     @Test

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_with_unresolved_generic_info_and_variables.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/job_with_unresolved_generic_info_and_variables.xml
@@ -5,6 +5,7 @@
     <variables>
         <variable name="variable1" value="value1" />
         <variable name="variable2" value="${variable1}" />
+        <variable name="variable3" value="value3" />
     </variables>
     <description>UpdateVariablesTestJob</description>
     <genericInformation>

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/VariablesMap.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/utils/VariablesMap.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.log4j.Logger;
 import org.ow2.proactive.core.properties.PropertyDecrypter;
 
 
@@ -56,6 +57,8 @@ public class VariablesMap implements Map<String, Serializable>, Serializable {
      * Map containing variables overriden into scripts
      */
     private Map<String, Serializable> scriptMap;
+
+    private static final Logger logger = Logger.getLogger(VariablesMap.class);
 
     /**
      * Constructor

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestModifyPropagatedVariables.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/variables/TestModifyPropagatedVariables.java
@@ -31,8 +31,11 @@ import static org.objectweb.proactive.utils.OperatingSystem.unix;
 import java.io.File;
 import java.net.URL;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobResult;
 
 import functionaltests.utils.SchedulerFunctionalTestNoRestart;
 
@@ -40,6 +43,8 @@ import functionaltests.utils.SchedulerFunctionalTestNoRestart;
 public class TestModifyPropagatedVariables extends SchedulerFunctionalTestNoRestart {
 
     private static URL job_desc = TestModifyPropagatedVariables.class.getResource("/functionaltests/descriptors/Job_modify_propagated_vars.xml");
+
+    private static URL job_desc2 = TestModifyPropagatedVariables.class.getResource("/functionaltests/descriptors/Job_modify_propagated_vars_2.xml");
 
     private static URL job_desc_unix = TestModifyPropagatedVariables.class.getResource("/functionaltests/descriptors/Job_modify_propagated_vars_on_unix.xml");
 
@@ -53,6 +58,15 @@ public class TestModifyPropagatedVariables extends SchedulerFunctionalTestNoRest
             setExecutable(absolutePath(unix_sh));
             schedulerHelper.testJobSubmission(absolutePath(job_desc_unix));
         }
+    }
+
+    @Test
+    public void testModifyPropagatedVariables2() throws Throwable {
+        JobId jobid = schedulerHelper.testJobSubmission(absolutePath(job_desc2));
+        JobResult result = schedulerHelper.getJobResult(jobid);
+        System.out.println(result.getPreciousResults().get("task2").getOutput().getAllLogs());
+        Assert.assertEquals("propagated-value", result.getPreciousResults().get("task2").getValue());
+
     }
 
     private String absolutePath(URL file) throws Exception {

--- a/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_modify_propagated_vars_2.xml
+++ b/scheduler/scheduler-server/src/test/resources/functionaltests/descriptors/Job_modify_propagated_vars_2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<job xmlns="urn:proactive:jobdescriptor:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:proactive:jobdescriptor:dev ../../../src/org/ow2/proactive/scheduler/common/xml/schemas/jobdescriptor/dev/schedulerjob.xsd"
+    name="job_propagate_vars" onTaskError="continueJobExecution" priority="normal">
+    <variables>
+        <variable name="var" value="job-var-value" />
+    </variables>
+    <description>PropagateVariables</description>
+    <taskFlow>
+        <task name="task1" preciousResult="true">
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+variables.put("var","propagated-value")
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+        <task name="task2" preciousResult="true">
+            <variables>
+                <variable name="task_var" value="task-var-value"/>
+            </variables>
+            <depends>
+                <task ref="task1" />
+            </depends>
+            <scriptExecutable>
+                <script>
+                    <code language="groovy">
+                        <![CDATA[
+result = variables.get("var")
+]]>
+                    </code>
+                </script>
+            </scriptExecutable>
+        </task>
+    </taskFlow>
+</job>


### PR DESCRIPTION
During the workflow parsing, a job variable became converted to a task variable

Added unit and functional tests