### PR TITLE
Add security headers to jetty responses

### DIFF
--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -109,6 +109,19 @@ public enum WebProperties implements PACommonProperties {
 
     WEB_REDIRECT_HTTP_TO_HTTPS("web.redirect_http_to_https", PropertyType.BOOLEAN, "false"),
 
+    WEB_X_FRAME_OPTIONS("web.x_frame_options", PropertyType.STRING, "SAMEORIGIN"),
+
+    WEB_X_XSS_PROTECTION("web.x_xss_protection", PropertyType.STRING, "1"),
+
+    WEB_X_CONTENT_TYPE_OPTIONS("web.x_content_type_options", PropertyType.STRING, "nosniff"),
+
+    WEB_STRICT_TRANSPORT_SECURITY(
+            "web.strict_transport_security",
+            PropertyType.STRING,
+            "max-age=63072000; includeSubDomains; preload"),
+
+    WEB_EXPECT_CT("web.expect_ct", PropertyType.STRING),
+
     WEB_PCA_PROXY_REWRITE_ENABLED("web.pca.proxy.rewrite.enabled", PropertyType.BOOLEAN, "true"),
 
     WEB_PCA_PROXY_REWRITE_REFERER_CACHE_SIZE("web.pca.proxy.rewrite.referer.cache.size", PropertyType.INTEGER, "10000"),

--- a/config/web/settings.ini
+++ b/config/web/settings.ini
@@ -62,6 +62,13 @@ web.https.cyphers.excluded.add=TLS_DHE.*,TLS_EDH.*
 # web.https.session.cache.size=
 # web.https.session.timeout=
 
+### additional http header-related properties ###
+# web.x_frame_options=SAMEORIGIN
+# web.x_xss_protection=1
+# web.x_content_type_options=nosniff
+# web.strict_transport_security=max-age=63072000; includeSubDomains; preload
+# web.expect_ct=
+
 # Enable PCA Proxy rewriter to route requests coming from proxyfied applications
 web.pca.proxy.rewrite.enabled=true
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JettyStarter.java
@@ -26,18 +26,22 @@
 package org.ow2.proactive.utils;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.DispatcherType;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Logger;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.rewrite.handler.RewriteHandler;
+import org.eclipse.jetty.rewrite.handler.Rule;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -128,6 +132,8 @@ public class JettyStarter {
                 redirectHandler.setVirtualHosts(httpVirtualHost);
                 topLevelHandlerList.addHandler(redirectHandler);
             }
+
+            topLevelHandlerList.addHandler(createSecurityHeadersHandler());
 
             if (WebProperties.JETTY_LOG_FILE.isSet()) {
                 String pathToJettyLogFile = FileStorageSupportFactory.relativeToHomeIfNotAbsolute(WebProperties.JETTY_LOG_FILE.getValueAsString());
@@ -330,6 +336,38 @@ public class JettyStarter {
             connectors = new Connector[] { httpsConnector };
         }
         return connectors;
+    }
+
+    private RewriteHandler createSecurityHeadersHandler() {
+        RewriteHandler rewriteHandlerSecurityHeaders = new RewriteHandler();
+
+        rewriteHandlerSecurityHeaders.addRule(new Rule() {
+            @Override
+            public String matchAndApply(String target, HttpServletRequest request, HttpServletResponse response)
+                    throws IOException {
+                if (!WebProperties.WEB_X_FRAME_OPTIONS.getValueAsString().isEmpty()) {
+                    response.setHeader("X-Frame-Options", WebProperties.WEB_X_FRAME_OPTIONS.getValueAsString());
+                }
+                if (!WebProperties.WEB_X_XSS_PROTECTION.getValueAsString().isEmpty()) {
+                    response.setHeader("X-XSS-Protection", WebProperties.WEB_X_XSS_PROTECTION.getValueAsString());
+                }
+                if (!WebProperties.WEB_X_CONTENT_TYPE_OPTIONS.getValueAsString().isEmpty()) {
+                    response.setHeader("X-Content-Type-Options",
+                                       WebProperties.WEB_X_CONTENT_TYPE_OPTIONS.getValueAsString());
+                }
+                if (WebProperties.WEB_HTTPS.getValueAsBoolean() &&
+                    !WebProperties.WEB_STRICT_TRANSPORT_SECURITY.getValueAsString().isEmpty()) {
+                    response.setHeader("Strict-Transport-Security",
+                                       WebProperties.WEB_STRICT_TRANSPORT_SECURITY.getValueAsString());
+                }
+                if (WebProperties.WEB_HTTPS.getValueAsBoolean() && WebProperties.WEB_EXPECT_CT.isSet() &&
+                    !WebProperties.WEB_EXPECT_CT.getValueAsString().isEmpty()) {
+                    response.setHeader("Expect-CT", WebProperties.WEB_EXPECT_CT.getValueAsString());
+                }
+                return null;
+            }
+        });
+        return rewriteHandlerSecurityHeaders;
     }
 
     private void checkPropertyNotNull(String propertyName, String propertyValue) {


### PR DESCRIPTION
A few recommended security headers are added dynamically by jetty server

Added web properties to allow configuration of these headers