### PR TITLE
Add new Global variables mechanism

### DIFF
--- a/config/scheduler/global_generic_info.properties
+++ b/config/scheduler/global_generic_info.properties
@@ -1,4 +1,0 @@
-# GLOBAL GENERIC INFORMATION
-# This file can be used to define generic information which will be affected to all workflows
-# e.g.
-# MY_GLOBAL_INFO=some_value

--- a/config/scheduler/global_variables.properties
+++ b/config/scheduler/global_variables.properties
@@ -1,4 +1,0 @@
-# GLOBAL VARIABLES
-# This file can be used to define variables which will be affected to all workflows
-# e.g.
-# MY_GLOBAL_VAR=some_value

--- a/config/scheduler/global_variables.xml
+++ b/config/scheduler/global_variables.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<globalvariables
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:globalvariables:3.12" xsi:schemaLocation="urn:proactive:globalvariables:3.12 http://www.activeeon.com/public_content/schemas/proactive/globalvariables/3.12/globalvariables.xsd">
+        <filter>
+            <select>
+                <!-- Xpath expressions are used to filter workflows affected by global variables.
+                Example: to select workflows belonging to the basic-examples bucket
+                <xpath><![CDATA[/job/genericInformation/info[@name='bucketName' and @value='basic-examples']]]></xpath>
+                -->
+                <xpath><![CDATA[.]]></xpath>
+                <!-- more than one xpath expression can be added. In that case, global variables are applied when all xpath expressions match -->
+            </select>
+            <!-- add global variables or generic information below -->
+            <variables>
+            </variables>
+            <genericInformation>
+            </genericInformation>
+        </filter>
+        <!-- Multiple filters can be added, to apply different set of global variables to different workflows -->
+</globalvariables>

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -457,10 +457,10 @@ pa.scheduler.db.fetch.batch_size=50
 #-------------------------------------------------------
 
 # file containing variables which can be used in all workflows
-pa.scheduler.global.variables.configuration=config/scheduler/global_variables.properties
+pa.scheduler.global.variables.configuration=config/scheduler/global_variables.xml
 
-# file containing generic information which can be used in all workflows
-pa.scheduler.global.generic.info.configuration=config/scheduler/global_generic_info.properties
+# refresh period, in minutes, for the global variables configuration
+pa.scheduler.global.variables.refresh=10
 
 #-------------------------------------------------------
 #----------  EMAIL NOTIFICATION PROPERTIES  ------------

--- a/scheduler/scheduler-api/build.gradle
+++ b/scheduler/scheduler-api/build.gradle
@@ -48,6 +48,28 @@ task convertSchemas
     convertSchemas.dependsOn << "convertSchemasRng-$schemaVersion"
 }
 
+task convertSchemasGV
+['3.12', 'dev'].each { schemaVersion ->
+    task("convertSchemasGVXsd-$schemaVersion", type: org.hsudbrock.tranggradleplugin.TrangTask) {
+        sourceDirectory = project.file("src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/${schemaVersion}")
+        targetDirectory = sourceDirectory
+        doLast {
+            project.delete project.file("src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/${schemaVersion}/xsi.xsd")
+        }
+    }
+    task("convertSchemasGVRng-$schemaVersion", type: org.hsudbrock.tranggradleplugin.TrangTask) {
+        sourceDirectory = project.file("src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/${schemaVersion}")
+        targetDirectory = sourceDirectory
+        targetExtension = 'rng'
+        doLast {
+            project.delete project.file("src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/${schemaVersion}/xsi.xsd")
+        }
+    }
+    task("convertSchemasGV-$schemaVersion").dependsOn << ["convertSchemasGVXsd-$schemaVersion", "convertSchemasGVRng-$schemaVersion"]
+    convertSchemasGV.dependsOn << "convertSchemasGVXsd-$schemaVersion"
+    convertSchemasGV.dependsOn << "convertSchemasGVRng-$schemaVersion"
+}
+
 task stub(type: StubTask) {
     classes = ['org.ow2.proactive.scheduler.common.Scheduler', 'org.ow2.proactive.scheduler.synchronization.SynchronizationInternal']
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
@@ -115,6 +115,16 @@ public abstract class Job extends CommonAttribute {
     protected Map<String, JobVariable> unresolvedVariables = Collections.synchronizedMap(new LinkedHashMap());
 
     /**
+     * Configured global variables for this job
+     */
+    protected Map<String, JobVariable> globalVariables = Collections.synchronizedMap(new LinkedHashMap());
+
+    /**
+     * Configured global generic information for this job
+     */
+    protected Map<String, String> globalGenericInformation = new LinkedHashMap<>();
+
+    /**
      * represent xml submitted, where variables and genetic info were updated according provided maps
      */
     private String jobContent = null;
@@ -337,6 +347,32 @@ public abstract class Job extends CommonAttribute {
      */
     public Map<String, JobVariable> getUnresolvedVariables() {
         return this.unresolvedVariables;
+    }
+
+    /**
+     * Returns the global variables of this job
+     *
+     * @return global variables map
+     */
+    public Map<String, JobVariable> getGlobalVariables() {
+        return globalVariables;
+    }
+
+    public void setGlobalVariables(Map<String, JobVariable> globalVariables) {
+        this.globalVariables = Collections.synchronizedMap(globalVariables);
+    }
+
+    /**
+     * Returns the global generic information of this job
+     *
+     * @return global generic information map
+     */
+    public Map<String, String> getGlobalGenericInformation() {
+        return globalGenericInformation;
+    }
+
+    public void setGlobalGenericInformation(Map<String, String> globalGenericInformation) {
+        this.globalGenericInformation = globalGenericInformation;
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobVariable.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobVariable.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 
 import org.objectweb.proactive.annotation.PublicAPI;
 
@@ -43,10 +44,13 @@ import org.objectweb.proactive.annotation.PublicAPI;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class JobVariable implements Serializable {
 
+    @XmlAttribute
     private String name;
 
+    @XmlAttribute
     private String value;
 
+    @XmlAttribute
     private String model;
 
     public JobVariable() {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/Filter.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/Filter.java
@@ -1,0 +1,72 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.globalvariables;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.ow2.proactive.scheduler.common.job.JobVariable;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 13/07/2021
+ */
+@XmlRootElement(name = "filter")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Filter implements Serializable {
+
+    @XmlElementWrapper(name = "select")
+    @XmlElement(name = "xpath")
+    private List<String> xpath;
+
+    @XmlElementWrapper(name = "variables")
+    @XmlElement(name = "variable")
+    private List<JobVariable> variables;
+
+    @XmlElementWrapper(name = "genericInformation")
+    @XmlElement(name = "info")
+    private List<GenericInformation> genericInformation;
+
+    public List<String> getXpath() {
+        return xpath.stream().map(xp -> xp.trim()).collect(Collectors.toList());
+    }
+
+    public List<JobVariable> getVariables() {
+        return variables;
+    }
+
+    public List<GenericInformation> getGenericInformation() {
+        return genericInformation;
+    }
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GenericInformation.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GenericInformation.java
@@ -1,0 +1,64 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.globalvariables;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 15/07/2021
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class GenericInformation implements Serializable {
+
+    public GenericInformation() {
+
+    }
+
+    public GenericInformation(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @XmlAttribute
+    private String name;
+
+    @XmlAttribute
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariables.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariables.java
@@ -1,0 +1,50 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.globalvariables;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 13/07/2021
+ */
+@XmlRootElement(name = "globalvariables")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class GlobalVariables {
+
+    @XmlElement(name = "filter")
+    private List<Filter> filters;
+
+    public List<Filter> getFilters() {
+        return filters;
+    }
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesData.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesData.java
@@ -1,0 +1,67 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.globalvariables;
+
+import java.util.Map;
+
+import org.ow2.proactive.scheduler.common.job.JobVariable;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 15/07/2021
+ */
+public class GlobalVariablesData {
+
+    Map<String, JobVariable> variables;
+
+    Map<String, String> genericInformation;
+
+    public GlobalVariablesData() {
+
+    }
+
+    public GlobalVariablesData(Map<String, JobVariable> variables, Map<String, String> genericInformation) {
+        this.variables = variables;
+        this.genericInformation = genericInformation;
+    }
+
+    public Map<String, JobVariable> getVariables() {
+        return variables;
+    }
+
+    public Map<String, String> getGenericInformation() {
+        return genericInformation;
+    }
+
+    public void setVariables(Map<String, JobVariable> variables) {
+        this.variables = variables;
+    }
+
+    public void setGenericInformation(Map<String, String> genericInformation) {
+        this.genericInformation = genericInformation;
+    }
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesParser.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesParser.java
@@ -1,0 +1,191 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.globalvariables;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.log4j.Logger;
+import org.objectweb.proactive.utils.NamedThreadFactory;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
+import org.ow2.proactive.scheduler.common.util.Object2ByteConverter;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 13/07/2021
+ */
+public class GlobalVariablesParser {
+
+    public static final Logger logger = Logger.getLogger(GlobalVariablesParser.class);
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
+                                                                                        new NamedThreadFactory("GlobalVariablesParser",
+                                                                                                               true));
+
+    private static GlobalVariablesParser instance = null;
+
+    private static String configurationPath = null;
+
+    private List<Filter> loadedFilters = null;
+
+    private String md5 = null;
+
+    private GlobalVariablesParser() {
+        if (configurationPath == null) {
+            configurationPath = PASchedulerProperties.getAbsolutePath(PASchedulerProperties.GLOBAL_VARIABLES_CONFIGURATION.getValueAsString());
+        }
+    }
+
+    public static synchronized void setConfigurationPath(String path) {
+        configurationPath = path;
+    }
+
+    public static synchronized GlobalVariablesParser getInstance() {
+        if (instance == null) {
+            instance = new GlobalVariablesParser();
+            instance.loadFilters();
+            int refreshPeriod = PASchedulerProperties.GLOBAL_VARIABLES_REFRESH.getValueAsInt();
+            instance.scheduler.scheduleWithFixedDelay(() -> instance.loadFilters(),
+                                                      refreshPeriod,
+                                                      refreshPeriod,
+                                                      TimeUnit.MINUTES);
+        }
+        return instance;
+    }
+
+    public void reloadFilters() {
+        instance.loadFilters();
+    }
+
+    public synchronized List<Filter> getLoadedFilters() {
+        return loadedFilters;
+    }
+
+    /**
+     * Return the global variables and generic information configured for the given workflow
+     * @param jobContent xml workflow as string
+     * @return global data containing variables and generic information
+     */
+    public synchronized GlobalVariablesData getVariablesFor(String jobContent) {
+
+        GlobalVariablesData answer = new GlobalVariablesData();
+        Map<String, JobVariable> configuredVariables = new LinkedHashMap<>();
+        Map<String, String> configuredGenericInfo = new LinkedHashMap<>();
+        answer.setVariables(configuredVariables);
+        answer.setGenericInformation(configuredGenericInfo);
+
+        DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = null;
+        try {
+            builder = builderFactory.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            logger.error("Error when configuring DocumentBuilder", e);
+            return answer;
+        }
+
+        try (StringReader reader = new StringReader(jobContent)) {
+            InputSource inputSource = new InputSource(reader);
+            Document xmlDocument = builder.parse(inputSource);
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            for (Filter filter : loadedFilters) {
+                boolean allMatch = true;
+                for (String xpathExpression : filter.getXpath()) {
+                    NodeList nodeList = (NodeList) xPath.compile(xpathExpression).evaluate(xmlDocument,
+                                                                                           XPathConstants.NODESET);
+                    allMatch = allMatch && (nodeList.getLength() > 0);
+                }
+                if (allMatch) {
+                    for (JobVariable variable : filter.getVariables()) {
+                        configuredVariables.put(variable.getName(), variable);
+                    }
+
+                    for (GenericInformation info : filter.getGenericInformation()) {
+                        configuredGenericInfo.put(info.getName(), info.getValue());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error analysing workflow global variables", e);
+        }
+        return answer;
+    }
+
+    private synchronized void loadFilters() {
+        loadedFilters = loadFilters(configurationPath);
+        try {
+            md5 = DigestUtils.md5Hex(Object2ByteConverter.convertObject2Byte(loadedFilters));
+        } catch (Exception e) {
+            logger.error("Could not compute MD5 of loaded filter", e);
+            md5 = "INVALID";
+        }
+    }
+
+    private List<Filter> loadFilters(String filePath) {
+
+        try {
+            DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            Document document = docBuilder.parse(filePath);
+
+            org.w3c.dom.Element varElement = document.getDocumentElement();
+            JAXBContext context = JAXBContext.newInstance(GlobalVariables.class);
+            Unmarshaller unmarshaller = context.createUnmarshaller();
+            JAXBElement<GlobalVariables> loader = unmarshaller.unmarshal(varElement, GlobalVariables.class);
+            GlobalVariables inputFromXml = loader.getValue();
+            return inputFromXml.getFilters();
+        } catch (Exception e) {
+            logger.error("Error when parsing global variables configuration", e);
+            return Collections.emptyList();
+        }
+    }
+
+    public synchronized String getMD5() {
+        return md5;
+    }
+
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/CommonAttribute.java
@@ -77,7 +77,7 @@ public abstract class CommonAttribute implements Serializable {
     protected UpdatableProperties<IntegerWrapper> maxNumberOfExecution = new UpdatableProperties<IntegerWrapper>(new IntegerWrapper(1));
 
     /** Common user informations */
-    protected Map<String, String> genericInformation = new HashMap<String, String>();
+    protected Map<String, String> genericInformation = new LinkedHashMap<>();
 
     protected Map<String, String> unresolvedGenericInformation = new LinkedHashMap<>();
 
@@ -198,7 +198,7 @@ public abstract class CommonAttribute implements Serializable {
      */
     public Map<String, String> getGenericInformation() {
         Set<Entry<String, String>> entries = this.genericInformation.entrySet();
-        Map<String, String> result = new HashMap<>(entries.size());
+        Map<String, String> result = new LinkedHashMap<>(entries.size());
         for (Entry<String, String> entry : entries) {
             result.put(entry.getKey(), entry.getValue());
         }
@@ -256,7 +256,7 @@ public abstract class CommonAttribute implements Serializable {
         if (genericInformation != null) {
             this.genericInformation = genericInformation;
         } else {
-            this.genericInformation = new HashMap<>();
+            this.genericInformation = new LinkedHashMap<>();
         }
 
     }
@@ -270,7 +270,7 @@ public abstract class CommonAttribute implements Serializable {
         if (unresolvedGenericInformation != null) {
             this.unresolvedGenericInformation = unresolvedGenericInformation;
         } else {
-            this.unresolvedGenericInformation = new HashMap<>();
+            this.unresolvedGenericInformation = new LinkedHashMap<>();
         }
 
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -471,12 +471,9 @@ public enum PASchedulerProperties implements PACommonProperties {
     GLOBAL_VARIABLES_CONFIGURATION(
             "pa.scheduler.global.variables.configuration",
             PropertyType.STRING,
-            "config/scheduler/global_variables.properties"),
+            "config/scheduler/global_variables.xml"),
 
-    GLOBAL_GENERIC_INFO_CONFIGURATION(
-            "pa.scheduler.global.generic.info.configuration",
-            PropertyType.STRING,
-            "config/scheduler/global_generic_info.properties"),
+    GLOBAL_VARIABLES_REFRESH("pa.scheduler.global.variables.refresh", PropertyType.INTEGER, "10"),
 
     /* ***************************************************************** */
     /* ***************** EMAIL NOTIFICATION PROPERTIES ***************** */

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/3.12/globalvariables.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/3.12/globalvariables.rnc
@@ -1,0 +1,48 @@
+default namespace = "urn:proactive:globalvariables:3.12"
+namespace jd = "urn:proactive:globalvariables:3.12"
+namespace xsi = "http://www.w3.org/2001/XMLSchema-instance"
+namespace doc = "http://relaxng.org/ns/compatibility/annotations/1.0"
+start = globalvariables
+
+globalvariables = ## a set of global variables, applying to workflows according to filters
+    element globalvariables {
+        filter+
+    }
+
+filter = ## Definition of a filter for global variables
+    element filter {
+        select,
+        variables,
+        genericInformation
+    }
+
+select = ## select workflows according to criterias
+    element select {
+        xpath+
+    }
+
+
+xpath = ## filter workflows based on a xpath expression
+    element xpath { text }
+
+variables = ## Definition of global variables which will be applied to workflows matching the given xpath expression
+    element variables { variable* }
+
+variable = ## Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}
+    element variable { variableName, variableValue, variableModel?}
+
+variableName = ## Name of a variable
+    attribute name  { xsd:NCName }
+variableValue = ## The patterns ${variable_name} will be replaced by this value
+    attribute value { xsd:string }
+variableModel = ## Model definition of the variable
+    attribute model { xsd:string }
+
+genericInformation = ## Definition of any extra information assigned to the workflow
+	element genericInformation {info*}
+info = ## Extra Information assigned to the workflow
+	element info {infoName, infoValue}
+infoName = ## Name of the information variable
+	attribute name { xsd:NCName }
+infoValue = ## Value of the information variable
+	attribute value {xsd:string}

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/3.12/globalvariables.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/3.12/globalvariables.rng
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="urn:proactive:globalvariables:3.12" xmlns:doc="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:jd="urn:proactive:globalvariables:3.12" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="globalvariables"/>
+  </start>
+  <define name="globalvariables">
+    <element name="globalvariables">
+      <doc:documentation>a set of global variables, applying to workflows according to filters</doc:documentation>
+      <oneOrMore>
+        <ref name="filter"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="filter">
+    <element name="filter">
+      <doc:documentation>Definition of a filter for global variables</doc:documentation>
+      <ref name="select"/>
+      <ref name="variables"/>
+      <ref name="genericInformation"/>
+    </element>
+  </define>
+  <define name="select">
+    <element name="select">
+      <doc:documentation>select workflows according to criterias</doc:documentation>
+      <oneOrMore>
+        <ref name="xpath"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="xpath">
+    <element name="xpath">
+      <doc:documentation>filter workflows based on a xpath expression</doc:documentation>
+      <text/>
+    </element>
+  </define>
+  <define name="variables">
+    <element name="variables">
+      <doc:documentation>Definition of global variables which will be applied to workflows matching the given xpath expression</doc:documentation>
+      <zeroOrMore>
+        <ref name="variable"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="variable">
+    <element name="variable">
+      <doc:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</doc:documentation>
+      <ref name="variableName"/>
+      <ref name="variableValue"/>
+      <optional>
+        <ref name="variableModel"/>
+      </optional>
+    </element>
+  </define>
+  <define name="variableName">
+    <attribute name="name">
+      <doc:documentation>Name of a variable</doc:documentation>
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="variableValue">
+    <attribute name="value">
+      <doc:documentation>The patterns ${variable_name} will be replaced by this value</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="variableModel">
+    <attribute name="model">
+      <doc:documentation>Model definition of the variable</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="genericInformation">
+    <element name="genericInformation">
+      <doc:documentation>Definition of any extra information assigned to the workflow</doc:documentation>
+      <zeroOrMore>
+        <ref name="info"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="info">
+    <element name="info">
+      <doc:documentation>Extra Information assigned to the workflow</doc:documentation>
+      <ref name="infoName"/>
+      <ref name="infoValue"/>
+    </element>
+  </define>
+  <define name="infoName">
+    <attribute name="name">
+      <doc:documentation>Name of the information variable</doc:documentation>
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="infoValue">
+    <attribute name="value">
+      <doc:documentation>Value of the information variable</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+</grammar>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/3.12/globalvariables.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/3.12/globalvariables.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:proactive:globalvariables:3.12" xmlns:jd="urn:proactive:globalvariables:3.12">
+  <xs:element name="globalvariables">
+    <xs:annotation>
+      <xs:documentation>a set of global variables, applying to workflows according to filters</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:filter"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="filter">
+    <xs:annotation>
+      <xs:documentation>Definition of a filter for global variables</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="jd:select"/>
+        <xs:element ref="jd:variables"/>
+        <xs:element ref="jd:genericInformation"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="select">
+    <xs:annotation>
+      <xs:documentation>select workflows according to criterias</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:xpath"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="xpath" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>filter workflows based on a xpath expression</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="variables">
+    <xs:annotation>
+      <xs:documentation>Definition of global variables which will be applied to workflows matching the given xpath expression</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="jd:variable"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="variable">
+    <xs:annotation>
+      <xs:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:variableName"/>
+      <xs:attributeGroup ref="jd:variableValue"/>
+      <xs:attribute name="model" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Model definition of the variable</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="variableName">
+    <xs:attribute name="name" use="required" type="xs:NCName">
+      <xs:annotation>
+        <xs:documentation>Name of a variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="variableValue">
+    <xs:attribute name="value" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The patterns ${variable_name} will be replaced by this value</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="variableModel">
+    <xs:attribute name="model" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Model definition of the variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="genericInformation">
+    <xs:annotation>
+      <xs:documentation>Definition of any extra information assigned to the workflow</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="jd:info"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="info">
+    <xs:annotation>
+      <xs:documentation>Extra Information assigned to the workflow</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:infoName"/>
+      <xs:attributeGroup ref="jd:infoValue"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="infoName">
+    <xs:attribute name="name" use="required" type="xs:NCName">
+      <xs:annotation>
+        <xs:documentation>Name of the information variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="infoValue">
+    <xs:attribute name="value" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Value of the information variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+</xs:schema>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/dev/globalvariables.rnc
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/dev/globalvariables.rnc
@@ -1,0 +1,48 @@
+default namespace = "urn:proactive:globalvariables:dev"
+namespace jd = "urn:proactive:globalvariables:dev"
+namespace xsi = "http://www.w3.org/2001/XMLSchema-instance"
+namespace doc = "http://relaxng.org/ns/compatibility/annotations/1.0"
+start = globalvariables
+
+globalvariables = ## a set of global variables, applying to workflows according to filters
+    element globalvariables {
+        filter+
+    }
+
+filter = ## Definition of a filter for global variables
+    element filter {
+        select,
+        variables,
+        genericInformation
+    }
+
+select = ## select workflows according to criterias
+    element select {
+        xpath+
+    }
+
+
+xpath = ## filter workflows based on a xpath expression
+    element xpath { text }
+
+variables = ## Definition of global variables which will be applied to workflows matching the given xpath expression
+    element variables { variable* }
+
+variable = ## Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}
+    element variable { variableName, variableValue, variableModel?}
+
+variableName = ## Name of a variable
+    attribute name  { xsd:NCName }
+variableValue = ## The patterns ${variable_name} will be replaced by this value
+    attribute value { xsd:string }
+variableModel = ## Model definition of the variable
+    attribute model { xsd:string }
+
+genericInformation = ## Definition of any extra information assigned to the workflow
+	element genericInformation {info*}
+info = ## Extra Information assigned to the workflow
+	element info {infoName, infoValue}
+infoName = ## Name of the information variable
+	attribute name { xsd:NCName }
+infoValue = ## Value of the information variable
+	attribute value {xsd:string}

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/dev/globalvariables.rng
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/dev/globalvariables.rng
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="urn:proactive:globalvariables:dev" xmlns:doc="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:jd="urn:proactive:globalvariables:dev" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="globalvariables"/>
+  </start>
+  <define name="globalvariables">
+    <element name="globalvariables">
+      <doc:documentation>a set of global variables, applying to workflows according to filters</doc:documentation>
+      <oneOrMore>
+        <ref name="filter"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="filter">
+    <element name="filter">
+      <doc:documentation>Definition of a filter for global variables</doc:documentation>
+      <ref name="select"/>
+      <ref name="variables"/>
+      <ref name="genericInformation"/>
+    </element>
+  </define>
+  <define name="select">
+    <element name="select">
+      <doc:documentation>select workflows according to criterias</doc:documentation>
+      <oneOrMore>
+        <ref name="xpath"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="xpath">
+    <element name="xpath">
+      <doc:documentation>filter workflows based on a xpath expression</doc:documentation>
+      <text/>
+    </element>
+  </define>
+  <define name="variables">
+    <element name="variables">
+      <doc:documentation>Definition of global variables which will be applied to workflows matching the given xpath expression</doc:documentation>
+      <zeroOrMore>
+        <ref name="variable"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="variable">
+    <element name="variable">
+      <doc:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</doc:documentation>
+      <ref name="variableName"/>
+      <ref name="variableValue"/>
+      <optional>
+        <ref name="variableModel"/>
+      </optional>
+    </element>
+  </define>
+  <define name="variableName">
+    <attribute name="name">
+      <doc:documentation>Name of a variable</doc:documentation>
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="variableValue">
+    <attribute name="value">
+      <doc:documentation>The patterns ${variable_name} will be replaced by this value</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="variableModel">
+    <attribute name="model">
+      <doc:documentation>Model definition of the variable</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+  <define name="genericInformation">
+    <element name="genericInformation">
+      <doc:documentation>Definition of any extra information assigned to the workflow</doc:documentation>
+      <zeroOrMore>
+        <ref name="info"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="info">
+    <element name="info">
+      <doc:documentation>Extra Information assigned to the workflow</doc:documentation>
+      <ref name="infoName"/>
+      <ref name="infoValue"/>
+    </element>
+  </define>
+  <define name="infoName">
+    <attribute name="name">
+      <doc:documentation>Name of the information variable</doc:documentation>
+      <data type="NCName"/>
+    </attribute>
+  </define>
+  <define name="infoValue">
+    <attribute name="value">
+      <doc:documentation>Value of the information variable</doc:documentation>
+      <data type="string"/>
+    </attribute>
+  </define>
+</grammar>

--- a/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/dev/globalvariables.xsd
+++ b/scheduler/scheduler-api/src/main/resources/org/ow2/proactive/scheduler/common/xml/schemas/globalvariables/dev/globalvariables.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:proactive:globalvariables:dev" xmlns:jd="urn:proactive:globalvariables:dev">
+  <xs:element name="globalvariables">
+    <xs:annotation>
+      <xs:documentation>a set of global variables, applying to workflows according to filters</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:filter"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="filter">
+    <xs:annotation>
+      <xs:documentation>Definition of a filter for global variables</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="jd:select"/>
+        <xs:element ref="jd:variables"/>
+        <xs:element ref="jd:genericInformation"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="select">
+    <xs:annotation>
+      <xs:documentation>select workflows according to criterias</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="jd:xpath"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="xpath" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>filter workflows based on a xpath expression</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="variables">
+    <xs:annotation>
+      <xs:documentation>Definition of global variables which will be applied to workflows matching the given xpath expression</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="jd:variable"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="variable">
+    <xs:annotation>
+      <xs:documentation>Definition of one variable, the variable can be reused (even in another following variable definition) by using the syntax ${name_of_variable}</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:variableName"/>
+      <xs:attributeGroup ref="jd:variableValue"/>
+      <xs:attribute name="model" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Model definition of the variable</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="variableName">
+    <xs:attribute name="name" use="required" type="xs:NCName">
+      <xs:annotation>
+        <xs:documentation>Name of a variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="variableValue">
+    <xs:attribute name="value" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The patterns ${variable_name} will be replaced by this value</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="variableModel">
+    <xs:attribute name="model" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Model definition of the variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="genericInformation">
+    <xs:annotation>
+      <xs:documentation>Definition of any extra information assigned to the workflow</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="jd:info"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="info">
+    <xs:annotation>
+      <xs:documentation>Extra Information assigned to the workflow</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="jd:infoName"/>
+      <xs:attributeGroup ref="jd:infoValue"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="infoName">
+    <xs:attribute name="name" use="required" type="xs:NCName">
+      <xs:annotation>
+        <xs:documentation>Name of the information variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="infoValue">
+    <xs:attribute name="value" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Value of the information variable</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+</xs:schema>

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
@@ -46,6 +46,8 @@ import org.ow2.proactive.scheduler.common.exception.JobCreationException;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobVariable;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
+import org.ow2.proactive.scheduler.common.job.factories.globalvariables.GlobalVariablesParser;
+import org.ow2.proactive.scheduler.common.job.factories.globalvariables.GlobalVariablesParserTest;
 import org.ow2.proactive.scheduler.common.task.JavaTask;
 import org.ow2.proactive.scheduler.common.task.TaskVariable;
 
@@ -135,14 +137,16 @@ public class TestStaxJobFactory {
     @Before
     public void setJobFactory() {
         factory = (StaxJobFactory) JobFactory.getFactory(JOB_FACTORY_IMPL);
-        factory.globalVariables = new LinkedHashMap<>();
-        factory.globalGenericInformation = new LinkedHashMap<>();
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_stax_factory.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
     }
 
     @After
     public void cleanGlobals() {
-        factory.globalVariables = new LinkedHashMap<>();
-        factory.globalGenericInformation = new LinkedHashMap<>();
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_default.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
     }
 
     @Test
@@ -174,6 +178,9 @@ public class TestStaxJobFactory {
 
     @Test
     public void testCreateJobShouldPreserveVariablesOrder() throws Exception {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_default.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
         Job job = factory.createJob(jobDescriptorVariableOrder);
         int index = 1;
         for (String variable : job.getVariables().keySet()) {
@@ -184,8 +191,6 @@ public class TestStaxJobFactory {
 
     @Test
     public void testCreateJobWithNoVariablesShouldReferenceGlobalVariablesAndGenericInfo() throws Exception {
-        factory.globalVariables.put("globalVar", new JobVariable("globalVar", "globalValue"));
-        factory.globalGenericInformation.put("globalGI", "globalGIValue");
         Job testScriptJob = factory.createJob(jobDescriptorNoVariablesUri);
         assertNotNull(testScriptJob.getVariables().get("globalVar"));
         assertEquals("globalValue", testScriptJob.getVariables().get("globalVar").getValue());
@@ -194,8 +199,6 @@ public class TestStaxJobFactory {
 
     @Test
     public void testCreateJobWithVariablesAndGenericInfoShouldReferenceGlobalVariables() throws Exception {
-        factory.globalVariables.put("referenced_global_var",
-                                    new JobVariable("referenced_global_var", "global_var_value"));
         Job testScriptJob = factory.createJob(jobDescriptorWithGlobalVariablesAndGenericInfo);
         assertNotNull(testScriptJob.getVariables().get("job_var_referencing_global_var"));
         assertEquals("global_var_value", testScriptJob.getVariables().get("job_var_referencing_global_var").getValue());
@@ -207,8 +210,6 @@ public class TestStaxJobFactory {
 
     @Test
     public void testCreateJobWithVariablesAndGenericInfoShouldOverrideGlobalVariablesAndGenericInfo() throws Exception {
-        factory.globalVariables.put("global_var", new JobVariable("global_var", "global_var_value"));
-        factory.globalGenericInformation.put("global_gi", "global_gi_value");
         Job testScriptJob = factory.createJob(jobDescriptorWithGlobalVariablesAndGenericInfo);
         assertNotNull(testScriptJob.getVariables().get("global_var"));
         assertEquals("global_var_overridden_by_xml", testScriptJob.getVariables().get("global_var").getValue());
@@ -222,8 +223,6 @@ public class TestStaxJobFactory {
     public void
             testCreateJobWithVariablesAndGenericInfoAndGlobalOnesShouldBeOverriddenBySubmittedVariablesAndGenericInfo()
                     throws Exception {
-        factory.globalVariables.put("global_var", new JobVariable("global_var", "global_var_value"));
-        factory.globalGenericInformation.put("global_gi", "global_gi_value");
         Job testScriptJob = factory.createJob(jobDescriptorWithGlobalVariablesAndGenericInfo,
                                               ImmutableMap.of("global_var", "submitted_var_value"),
                                               ImmutableMap.of("global_gi", "submitted_gi_value"));
@@ -237,8 +236,6 @@ public class TestStaxJobFactory {
 
     @Test
     public void testCreateJobWithSubmittedVariablesAndGenericInfoShouldReferenceGlobalVariables() throws Exception {
-        factory.globalVariables.put("global_var", new JobVariable("global_var", "global_var_value"));
-        factory.globalGenericInformation.put("global_gi", "global_gi_value");
         Job testScriptJob = factory.createJob(jobDescriptorNoVariablesUri,
                                               ImmutableMap.of("submitted_var", "${global_var}"),
                                               ImmutableMap.of("submitted_gi", "${global_var}"));
@@ -253,8 +250,6 @@ public class TestStaxJobFactory {
     @Test
     public void testCreateJobWithSubmittedVariablesAndGenericInfoShouldOverrideGlobalVariablesAndGenericInfo()
             throws Exception {
-        factory.globalVariables.put("global_var", new JobVariable("global_var", "global_var_value"));
-        factory.globalGenericInformation.put("global_gi", "global_gi_value");
         Job testScriptJob = factory.createJob(jobDescriptorNoVariablesUri,
                                               ImmutableMap.of("global_var", "submitted_var_value"),
                                               ImmutableMap.of("global_gi", "submitted_gi_value"));
@@ -469,6 +464,9 @@ public class TestStaxJobFactory {
     @Test
     public void testJobCreationAttributeOrderDefinitionVariableXmlElement()
             throws URISyntaxException, JobCreationException {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_default.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
         Job job = factory.createJob(jobDescriptorAttrDefVariableXmlElement);
         Map<String, JobVariable> jobVariables = job.getVariables();
         assertEquals(2, jobVariables.size());

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesParserTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesParserTest.java
@@ -1,0 +1,146 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job.factories.globalvariables;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.ow2.proactive.scheduler.common.job.JobVariable;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 13/07/2021
+ */
+public class GlobalVariablesParserTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        BasicConfigurator.configure();
+        Logger.getRootLogger().setLevel(Level.INFO);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("global_variables_default.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
+    }
+
+    @Test
+    public void testParseDefaultConfig() throws IOException {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("global_variables_default.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
+        List<Filter> filters = GlobalVariablesParser.getInstance().getLoadedFilters();
+        Assert.assertEquals(1, filters.size());
+        Assert.assertEquals(1, filters.get(0).getXpath().size());
+        Assert.assertEquals(".", filters.get(0).getXpath().get(0));
+        Assert.assertEquals(0, filters.get(0).getVariables().size());
+        String md5First = GlobalVariablesParser.getInstance().getMD5();
+        GlobalVariablesParser.getInstance().reloadFilters();
+        String md5Second = GlobalVariablesParser.getInstance().getMD5();
+        Assert.assertEquals("MD5 should be equals after reload", md5First, md5Second);
+    }
+
+    @Test
+    public void testParseConfigTwoVars() throws IOException {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("global_variables_two_vars.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
+        List<Filter> filters = GlobalVariablesParser.getInstance().getLoadedFilters();
+        Assert.assertEquals(1, filters.size());
+        Assert.assertEquals(1, filters.get(0).getXpath().size());
+        Assert.assertEquals(".", filters.get(0).getXpath().get(0));
+        Assert.assertEquals(2, filters.get(0).getVariables().size());
+        Assert.assertEquals(new JobVariable("var1", "value1", "model1"), filters.get(0).getVariables().get(0));
+        Assert.assertEquals(new JobVariable("var2", "value2", "model2"), filters.get(0).getVariables().get(1));
+        GlobalVariablesData globalData = GlobalVariablesParser.getInstance()
+                                                              .getVariablesFor(IOUtils.toString(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/job_no_variables.xml"),
+                                                                                                PASchedulerProperties.FILE_ENCODING.getValueAsString()));
+        ;
+        Map<String, JobVariable> globalVariables = globalData.getVariables();
+        Assert.assertEquals(2, globalVariables.size());
+        Assert.assertEquals(new JobVariable("var1", "value1", "model1"), globalVariables.get("var1"));
+        Assert.assertEquals(new JobVariable("var2", "value2", "model2"), globalVariables.get("var2"));
+        Map<String, String> globalGI = globalData.getGenericInformation();
+        Assert.assertEquals(2, globalGI.size());
+        Assert.assertEquals("gi_value1", globalGI.get("gi1"));
+        Assert.assertEquals("gi_value2", globalGI.get("gi2"));
+    }
+
+    @Test
+    public void testParseConfigOneFilterOK() throws IOException {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("global_variables_one_filter.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
+        List<Filter> filters = GlobalVariablesParser.getInstance().getLoadedFilters();
+        Assert.assertEquals(1, filters.size());
+        Assert.assertEquals(2, filters.get(0).getXpath().size());
+        Assert.assertEquals(2, filters.get(0).getVariables().size());
+
+        GlobalVariablesData globalData = GlobalVariablesParser.getInstance()
+                                                              .getVariablesFor(IOUtils.toString(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/job_with_global_variables_and_gi.xml"),
+                                                                                                PASchedulerProperties.FILE_ENCODING.getValueAsString()));
+        Map<String, JobVariable> globalVariables = globalData.getVariables();
+        // As this job matches the xpath filters, it will return the configured variables
+        Assert.assertEquals(2, globalVariables.size());
+        Assert.assertEquals(new JobVariable("var1", "value1", "model1"), globalVariables.get("var1"));
+        Assert.assertEquals(new JobVariable("var2", "value2", "model2"), globalVariables.get("var2"));
+        Map<String, String> globalGI = globalData.getGenericInformation();
+        Assert.assertEquals(2, globalGI.size());
+        Assert.assertEquals("gi_value1", globalGI.get("gi1"));
+        Assert.assertEquals("gi_value2", globalGI.get("gi2"));
+    }
+
+    @Test
+    public void testParseConfigOneFilterKO() throws IOException {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("global_variables_one_filter.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
+        List<Filter> filters = GlobalVariablesParser.getInstance().getLoadedFilters();
+        Assert.assertEquals(1, filters.size());
+        Assert.assertEquals(2, filters.get(0).getXpath().size());
+        Assert.assertEquals(2, filters.get(0).getVariables().size());
+
+        GlobalVariablesData globalData = GlobalVariablesParser.getInstance()
+                                                              .getVariablesFor(IOUtils.toString(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/job_variables_order.xml"),
+                                                                                                PASchedulerProperties.FILE_ENCODING.getValueAsString()));
+        Map<String, JobVariable> globalVariables = globalData.getVariables();
+        // As this job does not match the xpath filters, it will return no variables
+        Assert.assertEquals(0, globalVariables.size());
+    }
+}

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_default.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_default.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<globalvariables
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:globalvariables:dev" xsi:schemaLocation="urn:proactive:globalvariables:dev http://www.activeeon.com/public_content/schemas/proactive/globalvariables/dev/globalvariables.xsd">
+        <filter>
+            <select>
+                <xpath><![CDATA[.]]></xpath>
+            </select>
+            <variables>
+            </variables>
+            <genericInformation>
+            </genericInformation>
+        </filter>
+</globalvariables>

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_one_filter.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_one_filter.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<globalvariables
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:globalvariables:dev" xsi:schemaLocation="urn:proactive:globalvariables:dev http://www.activeeon.com/public_content/schemas/proactive/globalvariables/dev/globalvariables.xsd">
+        <filter>
+            <select>
+                <xpath><![CDATA[/job[@name='NoJobVariables']]]></xpath>
+                <xpath><![CDATA[/job/variables/variable[@name='job_var']]]></xpath>
+            </select>
+            <variables>
+                <variable name="var1" value="value1" model="model1"/>
+                <variable name="var2" value="value2" model="model2"/>
+            </variables>
+            <genericInformation>
+                <info name="gi1" value="gi_value1" />
+                <info name="gi2" value="gi_value2" />
+            </genericInformation>
+        </filter>
+</globalvariables>

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_stax_factory.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_stax_factory.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<globalvariables
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:globalvariables:dev" xsi:schemaLocation="urn:proactive:globalvariables:dev http://www.activeeon.com/public_content/schemas/proactive/globalvariables/dev/globalvariables.xsd">
+        <filter>
+            <select>
+                <xpath><![CDATA[.]]></xpath>
+            </select>
+            <variables>
+                <variable name="globalVar" value="globalValue"/>
+                <variable name="referenced_global_var" value="global_var_value"/>
+                <variable name="global_var" value="global_var_value"/>
+            </variables>
+            <genericInformation>
+                <info name="globalGI" value="globalGIValue"/>
+                <info name="global_gi" value="global_gi_value"/>
+            </genericInformation>
+        </filter>
+</globalvariables>

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_two_filters.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_two_filters.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<globalvariables
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:globalvariables:dev" xsi:schemaLocation="urn:proactive:globalvariables:dev http://www.activeeon.com/public_content/schemas/proactive/globalvariables/dev/globalvariables.xsd">
+        <filter>
+            <select>
+                <xpath><![CDATA[/job[@name='NoJobVariables']]]></xpath>
+                <xpath><![CDATA[/job/variables/variable[@name='job_var']]]></xpath>
+            </select>
+            <variables>
+                <variable name="var1" value="value1" model="model1"/>
+                <variable name="var2" value="value2" model="model2"/>
+            </variables>
+            <genericInformation>
+                <info name="gi1" value="gi_value1" />
+                <info name="gi2" value="gi_value2" />
+            </genericInformation>
+        </filter>
+</globalvariables>

--- a/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_two_vars.xml
+++ b/scheduler/scheduler-api/src/test/resources/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_two_vars.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<globalvariables
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:proactive:globalvariables:dev" xsi:schemaLocation="urn:proactive:globalvariables:dev http://www.activeeon.com/public_content/schemas/proactive/globalvariables/dev/globalvariables.xsd">
+        <filter>
+            <select>
+                <xpath><![CDATA[.]]></xpath>
+            </select>
+            <variables>
+                <variable name="var1" value="value1" model="model1"/>
+                <variable name="var2" value="value2" model="model2"/>
+            </variables>
+            <genericInformation>
+                <info name="gi1" value="gi_value1" />
+                <info name="gi2" value="gi_value2" />
+            </genericInformation>
+        </filter>
+</globalvariables>

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -101,7 +102,7 @@ public class ClientJobState extends JobState {
 
         this.setOnTaskError(jobState.getOnTaskErrorProperty().getValue());
 
-        this.genericInformation = new HashMap<>(jobState.getGenericInformation());
+        this.genericInformation = new LinkedHashMap<>(jobState.getGenericInformation());
 
         List<ClientTaskState> clientTaskStates = new ArrayList<>(taskStates.size());
         for (TaskState ts : taskStates) {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherInitializer.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherInitializer.java
@@ -103,6 +103,8 @@ public class TaskLauncherInitializer implements Serializable {
 
     private ImmutableMap<String, String> genericInformation;
 
+    private ImmutableMap<String, String> globalGenericInformation;
+
     private boolean authorizedForkEnvironmentScript = true;
 
     /** DataSpaces needed parameter */
@@ -117,6 +119,8 @@ public class TaskLauncherInitializer implements Serializable {
     private ImmutableMap<String, JobVariable> variables;
 
     private ImmutableMap<String, TaskVariable> taskVariables = ImmutableMap.of();
+
+    private ImmutableMap<String, JobVariable> globalVariables;
 
     private int pingPeriod;
 
@@ -321,6 +325,14 @@ public class TaskLauncherInitializer implements Serializable {
         return genericInformation;
     }
 
+    public ImmutableMap<String, String> getGlobalGenericInformation() {
+        return globalGenericInformation;
+    }
+
+    public void setGlobalGenericInformation(Map<String, String> globalGenericInformation) {
+        this.globalGenericInformation = ImmutableMap.copyOf(globalGenericInformation);
+    }
+
     /**
      * @return the preciousLogs
      */
@@ -425,6 +437,14 @@ public class TaskLauncherInitializer implements Serializable {
 
     public ImmutableMap<String, JobVariable> getJobVariables() {
         return this.variables;
+    }
+
+    public ImmutableMap<String, JobVariable> getGlobalVariables() {
+        return globalVariables;
+    }
+
+    public void setGlobalVariables(Map<String, JobVariable> globalVariables) {
+        this.globalVariables = ImmutableMap.copyOf(globalVariables);
     }
 
     public void setTaskVariables(Map<String, TaskVariable> taskVariables) {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
@@ -180,7 +180,9 @@ public class ForkedTaskVariablesManager implements Serializable {
         if (container.getDecrypter() != null && !Strings.isNullOrEmpty(container.getSchedulerRestUrl())) {
             return new SchedulerNodeClient(container.getDecrypter(),
                                            container.getSchedulerRestUrl(),
-                                           container.getTaskId().getJobId());
+                                           container.getTaskId().getJobId(),
+                                           container.getInitializer().getGlobalVariables(),
+                                           container.getInitializer().getGlobalGenericInformation());
         }
         return null;
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
@@ -27,6 +27,7 @@ package org.ow2.proactive.scheduler.core.rmproxies;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -257,7 +258,11 @@ public class RMProxyActiveObject {
             String schedulerUrl = PASchedulerProperties.SCHEDULER_REST_URL.getValueAsString();
 
             logger.debug("Binding schedulerapi...");
-            SchedulerNodeClient client = new SchedulerNodeClient(decrypter, schedulerUrl, taskId.getJobId());
+            SchedulerNodeClient client = new SchedulerNodeClient(decrypter,
+                                                                 schedulerUrl,
+                                                                 taskId.getJobId(),
+                                                                 Collections.emptyMap(),
+                                                                 Collections.emptyMap());
             handler.addBinding(SchedulerConstants.SCHEDULER_CLIENT_BINDING_NAME, client);
 
             logger.debug("Binging rmapi...");

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalTask.java
@@ -1175,6 +1175,7 @@ public abstract class InternalTask extends TaskState {
 
         Map<String, String> gInfo = getRuntimeGenericInformation();
         tli.setGenericInformation(gInfo);
+        tli.setGlobalGenericInformation(internalJob.getGlobalGenericInformation());
 
         ForkEnvironment environment = getForkEnvironment();
         if (environment != null) {
@@ -1189,6 +1190,7 @@ public abstract class InternalTask extends TaskState {
         }
         tli.setPreciousLogs(isPreciousLogs());
         tli.setJobVariables(internalJob.getVariables());
+        tli.setGlobalVariables(internalJob.getGlobalVariables());
         tli.setTaskVariables(getVariables());
 
         tli.setPingPeriod(PASchedulerProperties.SCHEDULER_NODE_PING_FREQUENCY.getValueAsInt());


### PR DESCRIPTION
 - relax-ng schema for global variables configuration
 - configuration parser (refreshed periodically)
 - global variables and/or generic info can be applied to submitted workflows according to xpath filters
 - added unit tests
 - Handled the special case of schedulerapi (SchedulerNodeClient). When a task submits a new workflow, we expect this new workflow to preserve by default the global variables values (if overridden).