### PR TITLE
Add sessionid to scripts

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/Script.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/Script.java
@@ -103,6 +103,8 @@ public abstract class Script<E> implements Serializable {
 
     private static Boolean lazyFetch = null;
 
+    private String sessionid = null;
+
     /** ProActive needed constructor */
     public Script() {
     }
@@ -111,9 +113,8 @@ public abstract class Script<E> implements Serializable {
      * @param script String representing the script's source code
      * @param engineName String representing the execution engine
      * @param parameters script's execution arguments.
-     * @throws InvalidScriptException if the creation fails.
      */
-    public Script(String script, String engineName, Serializable[] parameters) throws InvalidScriptException {
+    public Script(String script, String engineName, Serializable[] parameters) {
         this.scriptEngineLookupName = engineName;
         this.script = script;
         this.id = script;
@@ -128,10 +129,8 @@ public abstract class Script<E> implements Serializable {
      * @param engineName String representing the execution engine
      * @param parameters script's execution arguments.
      * @param scriptName name of the script
-     * @throws InvalidScriptException if the creation fails.
      */
-    public Script(String script, String engineName, Serializable[] parameters, String scriptName)
-            throws InvalidScriptException {
+    public Script(String script, String engineName, Serializable[] parameters, String scriptName) {
         this.scriptEngineLookupName = engineName;
         this.script = script;
         this.id = script;
@@ -142,9 +141,8 @@ public abstract class Script<E> implements Serializable {
     /** Directly create a script with a string.
      * @param script String representing the script's source code
      * @param engineName String representing the execution engine
-     * @throws InvalidScriptException if the creation fails.
      */
-    public Script(String script, String engineName) throws InvalidScriptException {
+    public Script(String script, String engineName) {
         this(script, engineName, (Serializable[]) null);
     }
 
@@ -152,9 +150,8 @@ public abstract class Script<E> implements Serializable {
      * @param script String representing the script's source code
      * @param engineName String representing the execution engine
      * @param scriptName name of the script
-     * @throws InvalidScriptException if the creation fails.
      */
-    public Script(String script, String engineName, String scriptName) throws InvalidScriptException {
+    public Script(String script, String engineName, String scriptName) {
         this(script, engineName, null, scriptName);
     }
 
@@ -240,9 +237,8 @@ public abstract class Script<E> implements Serializable {
 
     /** Create a script from another script object
      * @param script2 script object source
-     * @throws InvalidScriptException if the creation fails.
      */
-    public Script(Script<?> script2) throws InvalidScriptException {
+    public Script(Script<?> script2) {
         this(script2.getScript(), script2.scriptEngineLookupName, script2.getParameters(), script2.getScriptName());
         this.url = script2.url;
         this.id = script2.id;
@@ -250,12 +246,19 @@ public abstract class Script<E> implements Serializable {
 
     /** Create a script from another script object
      * @param script2 script object source
-     * @throws InvalidScriptException if the creation fails.
      */
-    public Script(Script<?> script2, String scriptName) throws InvalidScriptException {
+    public Script(Script<?> script2, String scriptName) {
         this(script2.script, script2.scriptEngineLookupName, script2.parameters, scriptName);
         this.url = script2.url;
         this.id = script2.id;
+    }
+
+    public String getSessionid() {
+        return sessionid;
+    }
+
+    public void setSessionid(String sessionid) {
+        this.sessionid = sessionid;
     }
 
     protected static boolean isLazyFetch() {
@@ -462,7 +465,7 @@ public abstract class Script<E> implements Serializable {
         result.setOutput(outputBuffer.toString());
     }
 
-    protected void fetchUrlIfNeeded() throws IOException {
+    public void fetchUrlIfNeeded() throws IOException {
         if (script == null && url != null) {
             ScriptContentAndEngineName fetchedInformation = getScriptContentAndEngineName();
             script = fetchedInformation.getScriptContent();
@@ -485,7 +488,7 @@ public abstract class Script<E> implements Serializable {
 
     private ScriptContentAndEngineName fetchScriptUsingHttpDownloader(URL url) throws IOException {
         CommonHttpResourceDownloader.UrlContent content = CommonHttpResourceDownloader.getInstance()
-                                                                                      .getResourceContent(null,
+                                                                                      .getResourceContent(sessionid,
                                                                                                           url.toExternalForm(),
                                                                                                           true);
         String scriptContent = content.getContent();

--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/SimpleScript.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/SimpleScript.java
@@ -52,9 +52,8 @@ public class SimpleScript extends Script<Object> {
     /** Directly create a script with a string.
      * @param script a String containing script code
      * @param engineName script's engine execution name.
-     * @throws InvalidScriptException if the creation fails.
      */
-    public SimpleScript(String script, String engineName) throws InvalidScriptException {
+    public SimpleScript(String script, String engineName) {
         super(script, engineName);
     }
 
@@ -100,9 +99,8 @@ public class SimpleScript extends Script<Object> {
      * @param script a String containing script code
      * @param engineName script's engine execution name.
      * @param parameters execution parameters
-     * @throws InvalidScriptException if the creation fails.
      */
-    public SimpleScript(String script, String engineName, Serializable[] parameters) throws InvalidScriptException {
+    public SimpleScript(String script, String engineName, Serializable[] parameters) {
         super(script, engineName, parameters);
     }
 
@@ -115,9 +113,8 @@ public class SimpleScript extends Script<Object> {
      * Copy constructor
      * 
      * @param original script to copy
-     * @throws InvalidScriptException 
      */
-    public SimpleScript(Script<?> original) throws InvalidScriptException {
+    public SimpleScript(Script<?> original) {
         super(original);
     }
 

--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/TaskScript.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/TaskScript.java
@@ -48,7 +48,7 @@ public class TaskScript extends Script<Serializable> {
      */
     public static final String RESULT_VARIABLE = "result";
 
-    public TaskScript(Script script) throws InvalidScriptException {
+    public TaskScript(Script script) {
         super(script);
     }
 

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/rm/CreateNodeSourceCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/rm/CreateNodeSourceCommand.java
@@ -44,7 +44,7 @@ import org.ow2.proactive_grid_cloud_portal.cli.utils.QueryStringBuilder;
 
 /**
  * @deprecated  As of version 8.1, replaced by
- * {@link DefineNodeSourceCommand)} and {@link DeployNodeSourceCommand}
+ * {@link DefineNodeSourceCommand} and {@link DeployNodeSourceCommand}
  */
 @Deprecated
 public class CreateNodeSourceCommand extends AbstractCommand implements Command {

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/PackageDownloader.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/PackageDownloader.java
@@ -84,10 +84,9 @@ public class PackageDownloader {
      *         <li>Sub-directories within a github repository</li>
      *         <li>Supports forwarded URLS as in shortened bitly urls, etc </li>
      *     </ul>
-     * @param packageUrl
-     * @return
-     * @throws IOException
-     * @throws URISyntaxException
+     * @param packageUrl url of the package to download
+     * @return path of the temporary folder where the package has been downloaded
+     * @throws CLIException
      */
     public String downloadPackage(String packageUrl) {
         // Get the real URL in case it is a shortened one (via bit.ly, etc)

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/frontend/RMMonitoring.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/frontend/RMMonitoring.java
@@ -70,8 +70,6 @@ public interface RMMonitoring {
      * Gets the current snapshot of the resource manager state providing
      * detailed nodes and node source information.
      *
-     * To obtain summary of the resource manager state use {@link ResourceManager}.getState()
-     *
      * @return the current state of the resource manager
      */
     RMInitialState getState();

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/nodesource/dataspace/DataSpaceNodeConfigurationAgent.java
@@ -250,8 +250,6 @@ public class DataSpaceNodeConfigurationAgent implements Serializable {
      * This method must be used by the TaskLauncher at the end of a Task execution, allowing the cleaning timer to run
      * <p>
      * The cleaning timer will be released only when all read locks have been released.
-     *
-     * @throws InterruptedException
      */
     public static void unlockCacheSpaceCleaning() {
         try {

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
@@ -190,7 +190,7 @@ public class RMNodeStarter {
     /** to inform that the user supplied a value from the command line for the ping */
     private static boolean PING_DELAY_IN_MS_USER_SUPPLIED = false;
 
-    /** Name of the java property to set the node -> rm ping frequency value */
+    /** Name of the java property to set the node rm ping frequency value */
     public final static String PING_DELAY_PROP_NAME = "proactive.node.ping.delay";
 
     /** The number of attempts to add the local node to the RM before quitting */

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/ForkEnvironment.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/ForkEnvironment.java
@@ -110,9 +110,8 @@ public class ForkEnvironment implements Serializable {
      * Copy constructor.
      * 
      * @param forkEnvironment the object to copy
-     * @throws ExecutableCreationException script copy failed
      */
-    public ForkEnvironment(ForkEnvironment forkEnvironment) throws ExecutableCreationException {
+    public ForkEnvironment(ForkEnvironment forkEnvironment) {
         this();
 
         if (forkEnvironment.javaHome != null) {
@@ -144,11 +143,7 @@ public class ForkEnvironment implements Serializable {
         }
 
         if (forkEnvironment.script != null) {
-            try {
-                this.script = new SimpleScript(forkEnvironment.script);
-            } catch (InvalidScriptException e) {
-                throw new ExecutableCreationException("Failed to copy ForkEnvironment script", e);
-            }
+            this.script = new SimpleScript(forkEnvironment.script);
         }
     }
 
@@ -398,4 +393,44 @@ public class ForkEnvironment implements Serializable {
                (script != null ? script.display() : null) + nl + '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ForkEnvironment that = (ForkEnvironment) o;
+
+        if (isDockerWindowsToLinux != that.isDockerWindowsToLinux)
+            return false;
+        if (javaHome != null ? !javaHome.equals(that.javaHome) : that.javaHome != null)
+            return false;
+        if (workingDir != null ? !workingDir.equals(that.workingDir) : that.workingDir != null)
+            return false;
+        if (systemEnvironment != null ? !systemEnvironment.equals(that.systemEnvironment)
+                                      : that.systemEnvironment != null)
+            return false;
+        if (jvmArguments != null ? !jvmArguments.equals(that.jvmArguments) : that.jvmArguments != null)
+            return false;
+        if (additionalClasspath != null ? !additionalClasspath.equals(that.additionalClasspath)
+                                        : that.additionalClasspath != null)
+            return false;
+        if (script != null ? !script.equals(that.script) : that.script != null)
+            return false;
+        return preJavaCommand != null ? preJavaCommand.equals(that.preJavaCommand) : that.preJavaCommand == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = javaHome != null ? javaHome.hashCode() : 0;
+        result = 31 * result + (workingDir != null ? workingDir.hashCode() : 0);
+        result = 31 * result + (systemEnvironment != null ? systemEnvironment.hashCode() : 0);
+        result = 31 * result + (jvmArguments != null ? jvmArguments.hashCode() : 0);
+        result = 31 * result + (additionalClasspath != null ? additionalClasspath.hashCode() : 0);
+        result = 31 * result + (script != null ? script.hashCode() : 0);
+        result = 31 * result + (preJavaCommand != null ? preJavaCommand.hashCode() : 0);
+        result = 31 * result + (isDockerWindowsToLinux ? 1 : 0);
+        return result;
+    }
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/flow/FlowScript.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/flow/FlowScript.java
@@ -131,9 +131,8 @@ public class FlowScript extends Script<FlowAction> {
      * Copy constructor 
      * 
      * @param fl Source script
-     * @throws InvalidScriptException
      */
-    public FlowScript(FlowScript fl) throws InvalidScriptException {
+    public FlowScript(FlowScript fl) {
         super(fl);
         if (fl.getActionType() != null) {
             this.actionType = new String(fl.getActionType());
@@ -149,11 +148,11 @@ public class FlowScript extends Script<FlowAction> {
         }
     }
 
-    private FlowScript(Script<?> scr) throws InvalidScriptException {
+    private FlowScript(Script<?> scr) {
         super(scr);
     }
 
-    public static FlowScript createContinueFlowScript() throws InvalidScriptException {
+    public static FlowScript createContinueFlowScript() {
         FlowScript fs = new FlowScript(new SimpleScript("", "javascript"));
         fs.setActionType(FlowActionType.CONTINUE);
         return fs;

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherInitializer.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLauncherInitializer.java
@@ -44,6 +44,7 @@ import org.ow2.proactive.scheduler.common.util.VariableSubstitutor;
 import org.ow2.proactive.scheduler.signal.SignalApi;
 import org.ow2.proactive.scheduler.synchronization.Synchronization;
 import org.ow2.proactive.scripting.Script;
+import org.ow2.proactive.scripting.SimpleScript;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -165,7 +166,7 @@ public class TaskLauncherInitializer implements Serializable {
      * @param pre the pre-script to set
      */
     public void setPreScript(Script<?> pre) {
-        this.pre = pre;
+        this.pre = new SimpleScript(pre);
     }
 
     /**
@@ -183,7 +184,7 @@ public class TaskLauncherInitializer implements Serializable {
      * @param flow the control flow script to set
      */
     public void setControlFlowScript(FlowScript flow) {
-        flowScript = flow;
+        flowScript = new FlowScript(flow);
     }
 
     /**
@@ -201,7 +202,7 @@ public class TaskLauncherInitializer implements Serializable {
      * @param post the post-script to set
      */
     public void setPostScript(Script<?> post) {
-        this.post = post;
+        this.post = new SimpleScript(post);
     }
 
     /**
@@ -526,7 +527,11 @@ public class TaskLauncherInitializer implements Serializable {
     }
 
     public void setForkEnvironment(ForkEnvironment forkEnvironment) {
-        this.forkEnvironment = forkEnvironment;
+        if (forkEnvironment == null) {
+            this.forkEnvironment = null;
+        } else {
+            this.forkEnvironment = new ForkEnvironment(forkEnvironment);
+        }
     }
 
     public boolean isAuthorizedForkEnvironmentScript() {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/containers/ExecutableContainer.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/containers/ExecutableContainer.java
@@ -46,6 +46,16 @@ public abstract class ExecutableContainer implements Serializable {
 
     private boolean runAsUser;
 
+    protected ExecutableContainer() {
+
+    }
+
+    protected ExecutableContainer(ExecutableContainer container) {
+        this.nodes = container.nodes;
+        this.credentials = container.credentials;
+        this.runAsUser = container.runAsUser;
+    }
+
     /**
      * Set the nodes value to the given nodes value
      *

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/containers/ScriptExecutableContainer.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/containers/ScriptExecutableContainer.java
@@ -42,12 +42,18 @@ import org.ow2.proactive.scripting.TaskScript;
 public class ScriptExecutableContainer extends ExecutableContainer {
 
     /** Arguments of the task as a map */
-    protected final Map<String, ByteArrayWrapper> serializedArguments = new HashMap<>();
+    protected Map<String, ByteArrayWrapper> serializedArguments = new HashMap<>();
 
     private final TaskScript script;
 
     public ScriptExecutableContainer(TaskScript script) {
         this.script = script;
+    }
+
+    public ScriptExecutableContainer(ScriptExecutableContainer container) {
+        super(container);
+        this.script = new TaskScript(container.script);
+        this.serializedArguments = container.serializedArguments;
     }
 
     public Script<Serializable> getScript() {

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManagerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManagerTest.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.scheduler.task.executors.forked.env;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.isA;
@@ -551,7 +552,7 @@ public class ForkedTaskVariablesManagerTest extends ProActiveTestClean {
                                                                                         resultMetadata);
 
         // Check if element exists
-        assertThat((T) scriptHandlerBindings.get(key), is(entry));
+        assertThat((T) scriptHandlerBindings.get(key), equalTo(entry));
     }
 
     private <T> void validateThatScriptHandlerBindingsInstanceOf(ScriptHandler scriptHandler, TaskContext taskContext,

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/ManageUsers.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/ManageUsers.java
@@ -123,8 +123,6 @@ public class ManageUsers {
      * Entry point
      *
      * @param args arguments, try '-h' for help
-     * @throws IOException
-     * @throws ParseException
      * @see org.ow2.proactive.authentication.crypto.Credentials
      */
     public static void main(String[] args) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -791,12 +791,14 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                 job.setSynchronizationAPI(schedulingService.getSynchronizationAPI());
                 schedulingMainLoopTimingLogger.end("startDataspaceApp");
                 NodeSet nodes = new NodeSet();
+                String sessionid = getRMProxiesManager().getUserRMProxy(job.getOwner(), job.getCredentials())
+                                                        .getSessionid();
                 try {
 
                     // create launcher
                     schedulingMainLoopTimingLogger.start("createLauncher");
 
-                    launcher = task.createLauncher(node);
+                    launcher = task.createLauncher(node, sessionid);
 
                     schedulingMainLoopTimingLogger.end("createLauncher");
 
@@ -847,7 +849,8 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
                                                                        schedulingService,
                                                                        terminateNotification,
                                                                        corePrivateKey,
-                                                                       taskRecoveryData),
+                                                                       taskRecoveryData,
+                                                                       sessionid),
 
                                                  dotaskActionTimeout,
                                                  TimeUnit.MILLISECONDS);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
@@ -315,7 +315,7 @@ public class RMProxyActiveObject {
      * <p>
      * Check the nodes to release and release the one that have to (clean script has returned)
      * Take care when renaming this method, method name is linked to
-     * {@link #handleCleaningScript(NodeSet, Script, VariablesMap, Map, TaskId, Credentials, Synchronization)}
+     * {@link #handleCleaningScript(NodeSet, Script, VariablesMap, Map, TaskId, Credentials, Synchronization, SignalApi)}
      */
     @ImmediateService
     public synchronized void cleanCallBack(Future<ScriptResult<?>> future, NodeSet nodes) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
@@ -270,21 +270,17 @@ public class InternalJobFactory {
         if (task.getExecutableClassName() != null) {
             HashMap<String, byte[]> args = task.getSerializedArguments();
 
-            try {
-                if (TaskConfiguration.isForkingTask(task)) {
-                    javaTask = new InternalForkedScriptTask(new ScriptExecutableContainer(new TaskScript(new SimpleScript(task.getExecutableClassName(),
-                                                                                                                          JavaClassScriptEngineFactory.JAVA_CLASS_SCRIPT_ENGINE_NAME,
-                                                                                                                          new Serializable[] { args }))),
-                                                            internalJob);
-                    javaTask.setForkEnvironment(task.getForkEnvironment());
-                } else {
-                    javaTask = new InternalScriptTask(new ScriptExecutableContainer(new TaskScript(new SimpleScript(task.getExecutableClassName(),
-                                                                                                                    JavaClassScriptEngineFactory.JAVA_CLASS_SCRIPT_ENGINE_NAME,
-                                                                                                                    new Serializable[] { args }))),
-                                                      internalJob);
-                }
-            } catch (InvalidScriptException e) {
-                throw new JobCreationException(e);
+            if (TaskConfiguration.isForkingTask(task)) {
+                javaTask = new InternalForkedScriptTask(new ScriptExecutableContainer(new TaskScript(new SimpleScript(task.getExecutableClassName(),
+                                                                                                                      JavaClassScriptEngineFactory.JAVA_CLASS_SCRIPT_ENGINE_NAME,
+                                                                                                                      new Serializable[] { args }))),
+                                                        internalJob);
+                javaTask.setForkEnvironment(task.getForkEnvironment());
+            } else {
+                javaTask = new InternalScriptTask(new ScriptExecutableContainer(new TaskScript(new SimpleScript(task.getExecutableClassName(),
+                                                                                                                JavaClassScriptEngineFactory.JAVA_CLASS_SCRIPT_ENGINE_NAME,
+                                                                                                                new Serializable[] { args }))),
+                                                  internalJob);
             }
         } else {
             String msg = "You must specify your own executable task class to be launched (in every task)!";

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/permissions/HandleJobsWithGenericInformationPermission.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/permissions/HandleJobsWithGenericInformationPermission.java
@@ -49,7 +49,7 @@ public class HandleJobsWithGenericInformationPermission extends ClientPermission
     /**
      * Construct the permission with specified authorization string.
      *
-     * @param keyValue
+     * @param keysValuesCommaSeparated
      *            string that represents a key value comma separated String. Ex
      *            : "KEY1=VALUE1,KEY2=VALUE2"
      */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalForkedScriptTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalForkedScriptTask.java
@@ -25,6 +25,8 @@
  */
 package org.ow2.proactive.scheduler.task.internal;
 
+import java.io.IOException;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
@@ -62,10 +64,11 @@ public class InternalForkedScriptTask extends InternalScriptTask {
      * {@inheritDoc}
      */
     @Override
-    public TaskLauncher createLauncher(Node node) throws ActiveObjectCreationException, NodeException {
+    public TaskLauncher createLauncher(Node node, String sessionid)
+            throws ActiveObjectCreationException, NodeException, IOException {
         logger.info(getTaskInfo().getTaskId(), "creating forked task launcher");
         TaskLauncher launcher = (TaskLauncher) PAActiveObject.newActive(TaskLauncher.class.getName(),
-                                                                        new Object[] { getDefaultTaskLauncherInitializer(),
+                                                                        new Object[] { getDefaultTaskLauncherInitializer(sessionid),
                                                                                        new ProActiveForkedTaskLauncherFactory() },
                                                                         node);
         // wait until the task launcher is active

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalScriptTask.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/task/internal/InternalScriptTask.java
@@ -25,6 +25,8 @@
  */
 package org.ow2.proactive.scheduler.task.internal;
 
+import java.io.IOException;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
@@ -65,10 +67,11 @@ public class InternalScriptTask extends InternalTask {
      * {@inheritDoc}
      */
     @Override
-    public TaskLauncher createLauncher(Node node) throws ActiveObjectCreationException, NodeException {
+    public TaskLauncher createLauncher(Node node, String sessionid)
+            throws ActiveObjectCreationException, NodeException, IOException {
         logger.info(getTaskInfo().getTaskId(), "creating non forked task launcher");
         TaskLauncher launcher = (TaskLauncher) PAActiveObject.newActive(TaskLauncher.class.getName(),
-                                                                        new Object[] { getDefaultTaskLauncherInitializer(),
+                                                                        new Object[] { getDefaultTaskLauncherInitializer(sessionid),
                                                                                        new ProActiveNonForkedTaskLauncherFactory() },
                                                                         node);
         // wait until the task launcher is active

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/EncryptCommand.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/EncryptCommand.java
@@ -53,8 +53,6 @@ public class EncryptCommand {
      * Entry point
      *
      * @param args arguments, try '-h' for help
-     * @throws IOException
-     * @throws ParseException
      * @see org.ow2.proactive.authentication.crypto.Credentials
      */
     public static void main(String[] args) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -139,6 +139,8 @@ public class SchedulerStarter {
 
     private static final String OPTION_STOPPED = "stopped";
 
+    public static final String REST_DISABLED_PROPERTY = "pa.scheduler.rest.disabled";
+
     private static final int DEFAULT_NODES_TIMEOUT = 120 * 1000;
 
     private static final int DISCOVERY_DEFAULT_PORT = 64739;
@@ -234,6 +236,10 @@ public class SchedulerStarter {
         }
 
         schedulerURL = getSchedulerUrl(commandLine);
+        if (commandLine.hasOption(OPTION_NO_REST)) {
+            System.setProperty(REST_DISABLED_PROPERTY, "true");
+        }
+
         if (!commandLine.hasOption(OPTION_SCHEDULER_URL)) {
             SchedulerAuthenticationInterface schedulerAuthenticationInterface = startScheduler(commandLine, rmURL);
             schedulerURL = schedulerAuthenticationInterface.getHostURL();

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/OnErrorPolicyInterpreterTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/OnErrorPolicyInterpreterTest.java
@@ -265,7 +265,8 @@ public class OnErrorPolicyInterpreterTest extends ProActiveTestClean {
             }
 
             @Override
-            public TaskLauncher createLauncher(Node node) throws ActiveObjectCreationException, NodeException {
+            public TaskLauncher createLauncher(Node node, String sessionid)
+                    throws ActiveObjectCreationException, NodeException {
                 // TODO Auto-generated method stub
                 return null;
             }


### PR DESCRIPTION
 - PerUserConnectionRMProxiesManager creates a rest session for each user
 - This works only if the rest server is launched in the same JVM as the scheduler server
 - sessionids are propagated to selection (via RMProxy and Criteria), task (TimedDoAction), pre, post, forkenv, flow (TaskLaunchedInitializer) and clean scripts (RMProxy)
 - The script must be "cloned" before execution, the original Script object, reference by InternalTask must not be modified. Otherwise, it would break the late binding reference mechanism, allowing to edit the script definition on task restarts.