### PR TITLE
Fix global variables and generic info issue

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesData.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesData.java
@@ -51,11 +51,11 @@ public class GlobalVariablesData {
     }
 
     public Map<String, JobVariable> getVariables() {
-        return variables;
+        return new LinkedHashMap<>(variables);
     }
 
     public Map<String, String> getGenericInformation() {
-        return genericInformation;
+        return new LinkedHashMap<>(genericInformation);
     }
 
     public void setVariables(Map<String, JobVariable> variables) {
@@ -64,5 +64,10 @@ public class GlobalVariablesData {
 
     public void setGenericInformation(Map<String, String> genericInformation) {
         this.genericInformation = genericInformation;
+    }
+
+    @Override
+    public String toString() {
+        return "GlobalVariablesData{" + "variables=" + variables + ", genericInformation=" + genericInformation + '}';
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
@@ -209,6 +209,13 @@ public class TestStaxJobFactory {
     }
 
     @Test
+    public void testCreateJobWithVariablesAndGenericInfoShouldNotModifyGlobalVariables() throws Exception {
+        Job testScriptJob = factory.createJob(jobDescriptorWithGlobalVariablesAndGenericInfo);
+        Assert.assertFalse(testScriptJob.getGlobalVariables().containsKey("job_var"));
+        Assert.assertFalse(testScriptJob.getGlobalGenericInformation().containsKey("gen_info"));
+    }
+
+    @Test
     public void testCreateJobWithVariablesAndGenericInfoShouldOverrideGlobalVariablesAndGenericInfo() throws Exception {
         Job testScriptJob = factory.createJob(jobDescriptorWithGlobalVariablesAndGenericInfo);
         assertNotNull(testScriptJob.getVariables().get("global_var"));

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesParserTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/globalvariables/GlobalVariablesParserTest.java
@@ -74,6 +74,12 @@ public class GlobalVariablesParserTest {
         GlobalVariablesParser.getInstance().reloadFilters();
         String md5Second = GlobalVariablesParser.getInstance().getMD5();
         Assert.assertEquals("MD5 should be equals after reload", md5First, md5Second);
+
+        GlobalVariablesData globalData = GlobalVariablesParser.getInstance()
+                                                              .getVariablesFor(IOUtils.toString(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/job_no_variables.xml"),
+                                                                                                PASchedulerProperties.FILE_ENCODING.getValueAsString()));
+        Assert.assertEquals(0, globalData.getVariables().size());
+        Assert.assertEquals(0, globalData.getGenericInformation().size());
     }
 
     @Test

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -101,7 +101,7 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
 
     private JobId parentJobId;
 
-    private Map<String, String> globalGenericInformation;
+    private Map<String, String> globalGenericInformation = new LinkedHashMap<>();
 
     private Map<String, String> globalVariables = new LinkedHashMap<>();
 


### PR DESCRIPTION
variables or generic info present in the workflow was added to global variables. The parser was manipulating the global maps during workflow parsing
 - fixed by returning global data by copy instead of reference
 - added unit tests