### PR TITLE
Fix exporting job of old schemas, only export advanced when it's true.

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/GetJobContentGenerator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/GetJobContentGenerator.java
@@ -262,7 +262,9 @@ public class GetJobContentGenerator {
         if (jobVariable.getGroup() != null && !jobVariable.getGroup().trim().isEmpty()) {
             content.append(String.format(ATTRIBUTE_FORMAT, XMLAttributes.VARIABLE_GROUP, jobVariable.getGroup()));
         }
-        content.append(String.format(ATTRIBUTE_FORMAT, XMLAttributes.VARIABLE_ADVANCED, jobVariable.getAdvanced()));
+        if (jobVariable.getAdvanced()) {
+            content.append(String.format(ATTRIBUTE_FORMAT, XMLAttributes.VARIABLE_ADVANCED, jobVariable.getAdvanced()));
+        }
 
         content.append(" />");
         return content.toString();

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/Job2XMLTransformer.java
@@ -322,8 +322,10 @@ public class Job2XMLTransformer {
             if (variable.getGroup() != null) {
                 varAttributes.add(new Attribute(XMLAttributes.VARIABLE_GROUP.getXMLName(), variable.getGroup()));
             }
-            varAttributes.add(new Attribute(XMLAttributes.VARIABLE_ADVANCED.getXMLName(),
-                                            String.valueOf(variable.getAdvanced())));
+            if (variable.getAdvanced()) {
+                varAttributes.add(new Attribute(XMLAttributes.VARIABLE_ADVANCED.getXMLName(),
+                                                String.valueOf(variable.getAdvanced())));
+            }
             Element variableE = createElement(doc,
                                               XMLTags.VARIABLE.getXMLName(),
                                               null,
@@ -353,8 +355,10 @@ public class Job2XMLTransformer {
             if (variable.getGroup() != null) {
                 varAttributes.add(new Attribute(XMLAttributes.VARIABLE_GROUP.getXMLName(), variable.getGroup()));
             }
-            varAttributes.add(new Attribute(XMLAttributes.VARIABLE_ADVANCED.getXMLName(),
-                                            String.valueOf(variable.getAdvanced())));
+            if (variable.getAdvanced()) {
+                varAttributes.add(new Attribute(XMLAttributes.VARIABLE_ADVANCED.getXMLName(),
+                                                String.valueOf(variable.getAdvanced())));
+            }
             varAttributes.add(new Attribute(XMLAttributes.VARIABLE_JOB_INHERITED.getXMLName(),
                                             String.valueOf(variable.isJobInherited())));
             Element variableE = createElement(doc,


### PR DESCRIPTION
Fix the bug when exporting a job which is using old schemas, it should not contain the new variable parameter "advanced". 
Now we only export the advanced parameter when it's set to true, which is the case needed to be handled.