### PR TITLE
Fix In-Error status

### DIFF
--- a/scheduler/scheduler-server/src/test/java/functionaltests/monitor/MonitorEventReceiver.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/monitor/MonitorEventReceiver.java
@@ -103,6 +103,7 @@ public class MonitorEventReceiver implements SchedulerEventListener {
             case JOB_PAUSED:
             case JOB_RESUMED:
             case JOB_RESTARTED_FROM_ERROR:
+            case JOB_IN_ERROR:
             case TASK_REPLICATED:
             case TASK_SKIPPED:
                 monitorsHandler.handleJobEvent(notification.getEventType(), notification.getData());
@@ -120,6 +121,8 @@ public class MonitorEventReceiver implements SchedulerEventListener {
             case TASK_PENDING_TO_RUNNING:
             case TASK_RUNNING_TO_FINISHED:
             case TASK_WAITING_FOR_RESTART:
+            case TASK_IN_ERROR:
+            case TASK_IN_ERROR_TO_FINISHED:
                 monitorsHandler.handleTaskEvent(notification.getEventType(), notification.getData());
                 break;
         }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -451,6 +451,11 @@ public class SchedulerTHelper {
         userInt.removeJob(id);
     }
 
+    public void restartAllInErrorTasks(String jobId) throws Exception {
+        Scheduler userInt = getSchedulerInterface();
+        userInt.restartAllInErrorTasks(jobId);
+    }
+
     /**
      * Creates and submit a job from an XML job descriptor, and check, with assertions,
      * event related to this job submission :
@@ -945,6 +950,42 @@ public class SchedulerTHelper {
                                                               jobId,
                                                               taskName,
                                                               timeout);
+    }
+
+    /**
+     * Wait for a task failed that reaches in-error state.
+     * If corresponding event has been already thrown by scheduler, returns immediately
+     * with TaskInfo object associated to event, otherwise wait for reception
+     * of the corresponding event.
+     *
+     * @param jobId job identifier, for which task belongs.
+     * @param taskName for which event is waited for.
+     * @return TaskInfo event's associated object.
+     */
+    public TaskInfo waitForEventTaskInError(JobId jobId, String taskName) {
+        try {
+            return waitForEventTaskInError(jobId, taskName, 0);
+        } catch (ProActiveTimeoutException e) {
+            //unreachable block, 0 means infinite, no timeout
+            //log sthing ?
+            return null;
+        }
+    }
+
+    /**
+     * Wait for a task failed that reaches in-error state.
+     * If corresponding event has been already thrown by scheduler, returns immediately
+     * with TaskInfo object associated to event, otherwise wait for reception
+     * of the corresponding event.
+     *
+     * @param jobId job identifier, for which task belongs.
+     * @param taskName for which event is waited for.
+     * @param timeout max waiting time in milliseconds.
+     * @return TaskInfo event's associated object.
+     * @throws ProActiveTimeoutException if timeout is reached.
+     */
+    public TaskInfo waitForEventTaskInError(JobId jobId, String taskName, long timeout) {
+        return getSchedulerMonitorsHandler().waitForEventTask(SchedulerEvent.TASK_IN_ERROR, jobId, taskName, timeout);
     }
 
     /**


### PR DESCRIPTION
 - when an In-Error task is restarted, if there is no other task in In-Error state, the job status will be set to Running instead of staying In-Error.