### PR TITLE
Improve status of rest server start

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -345,6 +345,11 @@ public enum PASchedulerProperties implements PACommonProperties {
     HSQLDB_LOCATION("pa.hsqldb.location", PropertyType.STRING),
 
     /**
+     * An internal property which is set to true automatically after the rest server is started
+     */
+    JETTY_STARTED("pa.scheduler.rest.started", PropertyType.BOOLEAN),
+
+    /**
      * Scheduler rest url
      * Accessed inside workflows and tasks with the PA_SCHEDULER_REST_URL variable
      */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -491,7 +491,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
             throw new IllegalArgumentException("The two given lists must not be null !");
         }
         int totalNeededNodes = 0;
-        if (!PASchedulerProperties.SCHEDULER_REST_URL.isSet()) {
+        if (PASchedulerProperties.JETTY_STARTED.isSet() && !PASchedulerProperties.JETTY_STARTED.getValueAsBoolean()) {
             Iterator<EligibleTaskDescriptor> it = bagOfTasks.iterator();
             EligibleTaskDescriptor etd;
             while (it.hasNext()) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -238,6 +238,9 @@ public class SchedulerStarter {
         schedulerURL = getSchedulerUrl(commandLine);
         if (commandLine.hasOption(OPTION_NO_REST)) {
             System.setProperty(REST_DISABLED_PROPERTY, "true");
+            PASchedulerProperties.JETTY_STARTED.updateProperty("true");
+        } else if (PASchedulerProperties.SCHEDULER_REST_URL.isSet()) {
+            PASchedulerProperties.JETTY_STARTED.updateProperty("false");
         }
 
         if (!commandLine.hasOption(OPTION_SCHEDULER_URL)) {
@@ -252,6 +255,7 @@ public class SchedulerStarter {
             long jettyEndTime = System.nanoTime();
             LOGGER.debug("Jetty started in " +
                          String.valueOf(((double) jettyEndTime - jettyStartTime) / 1_000_000_000) + " seconds");
+            PASchedulerProperties.JETTY_STARTED.updateProperty("true");
         }
 
         addShutdownMessageHook();


### PR DESCRIPTION
The scheduling loop task filter was previously delaying relevant tasks at scheduler start until the property pa.scheduler.rest.url was set automatically by the SchedulerStarter class (rest server is started). Now, it is possible to configure pa.scheduler.rest.url to a custom value without breaking the filter mechanism.