### PR TITLE
NodesRecoveryManager: fix down nodes after restart

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/FakeDownNodeForRecovery.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/recovery/FakeDownNodeForRecovery.java
@@ -27,6 +27,8 @@ package org.ow2.proactive.resourcemanager.core.recovery;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.InetAddress;
+import java.rmi.dgc.VMID;
 import java.util.Objects;
 
 import org.objectweb.proactive.ActiveObjectCreationException;
@@ -55,9 +57,55 @@ public class FakeDownNodeForRecovery implements Node, Serializable {
 
     private String url;
 
-    public FakeDownNodeForRecovery(String name, String url) {
+    private String hostname;
+
+    private VMInformation vmInformation;
+
+    public FakeDownNodeForRecovery(String name, String url, String hostname) {
         this.name = name;
         this.url = url;
+        this.hostname = hostname;
+        this.vmInformation = new VMInformation() {
+            @Override
+            public VMID getVMID() {
+                return null;
+            }
+
+            @Override
+            public InetAddress getInetAddress() {
+                return null;
+            }
+
+            @Override
+            public String getName() {
+                return null;
+            }
+
+            @Override
+            public String getHostName() {
+                return FakeDownNodeForRecovery.this.hostname;
+            }
+
+            @Override
+            public String getDescriptorVMName() {
+                return null;
+            }
+
+            @Override
+            public long getCapacity() {
+                return 0;
+            }
+
+            @Override
+            public long getDeploymentId() {
+                return 0;
+            }
+
+            @Override
+            public long getTopologyId() {
+                return 0;
+            }
+        };
     }
 
     @Override
@@ -75,14 +123,14 @@ public class FakeDownNodeForRecovery implements Node, Serializable {
 
             @Override
             public VMInformation getVMInformation() {
-                return null;
+                return vmInformation;
             }
         };
     }
 
     @Override
     public VMInformation getVMInformation() {
-        return null;
+        return vmInformation;
     }
 
     @Override

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/topology/TopologyManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/topology/TopologyManager.java
@@ -149,8 +149,6 @@ public class TopologyManager {
                 logger.debug("Adding Node " + node.getNodeInformation().getURL() + " to topology");
             }
 
-            InetAddress inetAddress = node.getVMInformation().getInetAddress();
-
             String hostName = node.getVMInformation().getHostName();
 
             if (topology.knownHost(hostName)) {
@@ -162,6 +160,8 @@ public class TopologyManager {
                 nodesOnHost.get(hostName).add(node);
                 return;
             }
+
+            InetAddress inetAddress = node.getVMInformation().getInetAddress();
 
             // unknown host => start pinging process
             NodeSet toPing = new NodeSet();


### PR DESCRIPTION
 - a wrong if test was preventing down nodes from being aknownledged by the corresponding node source. This prevented the RestartDownNodes policy to redeploy the down nodes
 - added a test scenario which tests the RestartDownNodes policy on a recover.