### PR TITLE
Workflow variable type PA:CATALOG_OBJECT update validation

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/http/CommonHttpResourceDownloader.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/http/CommonHttpResourceDownloader.java
@@ -99,6 +99,21 @@ public class CommonHttpResourceDownloader {
         }
     }
 
+    public int getResponseCode(String sessionId, String url, boolean insecure) throws IOException {
+        CommonHttpClientBuilder builder = new CommonHttpClientBuilder().maxConnections(CONNECTION_POOL_SIZE)
+                                                                       .useSystemProperties()
+                                                                       .insecure(insecure);
+        try (CloseableHttpClient client = builder.build()) {
+            HttpGet request = new HttpGet(url);
+
+            if (sessionId != null) {
+                request.setHeader("sessionid", sessionId);
+            }
+            CloseableHttpResponse response = client.execute(request);
+            return response.getStatusLine().getStatusCode();
+        }
+    }
+
     private CloseableHttpResponse createAndExecuteRequest(String sessionId, String url, CloseableHttpClient client)
             throws IOException {
         HttpGet request = new HttpGet(url);

--- a/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
+++ b/rest/rest-cli/src/test/java/functionaltests/AbstractFunctCmdTest.java
@@ -73,7 +73,7 @@ public class AbstractFunctCmdTest extends AbstractRestFuncTestCase {
 
     protected JobId submitJob(String filename, JobStatus waitForStatus) throws Exception {
         File jobFile = new File(this.getClass().getResource("config/" + filename).toURI());
-        WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler, space);
+        WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler, space, null);
         JobId id;
         try (FileInputStream fileInputStream = new FileInputStream(jobFile)) {
             id = submitter.submit(fileInputStream, new HashMap<String, String>(), null);

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -792,8 +792,8 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
     }
 
     @Override
-    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws NotConnectedException {
+    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
+            String sessionId) throws NotConnectedException {
         final JobIdData jobIdData;
         try {
             jobIdData = restApiClient().reSubmit(sid, currentJobId.value(), jobVariables, jobGenericInfos);

--- a/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
@@ -403,7 +403,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
                                 "/functionaltests/descriptors/dataspace_client_node_fork.groovy",
                                 null);
         JobId jobId = submitJob(job, client);
-        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), Collections.emptyMap());
+        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), Collections.emptyMap(), null);
 
         String jobContent = client.getJobContent(jobId).replaceAll("\\s+", "");
         String jobContent1 = client.getJobContent(jobId1).replaceAll("\\s+", "");
@@ -420,7 +420,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         JobId jobId = submitJob(job, client);
         Map<String, String> vars = new HashMap<>();
         vars.put("myvar", "myvalue");
-        JobId jobId1 = client.reSubmit(jobId, vars, Collections.emptyMap());
+        JobId jobId1 = client.reSubmit(jobId, vars, Collections.emptyMap(), null);
 
         String jobContent1 = client.getJobContent(jobId1);
 
@@ -439,7 +439,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         JobId jobId = submitJob(job, client);
         Map<String, String> infos = new HashMap<>();
         infos.put("myinfo", "myvalue");
-        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), infos);
+        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), infos, null);
 
         String jobContent1 = client.getJobContent(jobId1);
 
@@ -463,7 +463,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         Map<String, String> vars = new HashMap<>();
         vars.put("originalVar", "newValue");
 
-        JobId jobId1 = client.reSubmit(jobId, vars, Collections.emptyMap());
+        JobId jobId1 = client.reSubmit(jobId, vars, Collections.emptyMap(), null);
 
         String jobContent1 = client.getJobContent(jobId1);
 
@@ -490,7 +490,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         Map<String, String> info1 = new HashMap<>();
         info1.put("originalVar", "newValue");
 
-        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), info1);
+        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), info1, null);
 
         String jobContent1 = client.getJobContent(jobId1);
 
@@ -515,7 +515,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         Map<String, String> vars = new HashMap<>();
         vars.put("newVar", "newValue");
 
-        JobId jobId1 = client.reSubmit(jobId, vars, Collections.emptyMap());
+        JobId jobId1 = client.reSubmit(jobId, vars, Collections.emptyMap(), null);
 
         String jobContent1 = client.getJobContent(jobId1);
 
@@ -543,7 +543,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
         Map<String, String> info1 = new HashMap<>();
         info1.put("newVar", "newValue");
 
-        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), info1);
+        JobId jobId1 = client.reSubmit(jobId, Collections.emptyMap(), info1, null);
 
         String jobContent1 = client.getJobContent(jobId1);
 

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -1570,7 +1570,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             if (contextInfos != null)
                 genericInfos = getMapWithFirstValues(contextInfos.getQueryParameters());
 
-            WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space);
+            WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space, sessionId);
             jobId = workflowSubmitter.submit(tmpWorkflowStream, jobVariables, genericInfos);
         }
 
@@ -1609,7 +1609,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             if (contextInfos != null)
                 genericInfos = getMapWithFirstValues(contextInfos.getQueryParameters());
 
-            WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space);
+            WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space, sessionId);
             jobId = workflowSubmitter.submit(tmpWorkflowStream, jobVariables, genericInfos);
         }
 
@@ -1669,7 +1669,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                 if (contextInfos != null)
                     genericInfos = getMapWithFirstValues(contextInfos.getQueryParameters());
 
-                WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space);
+                WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space, sessionId);
                 jobId = workflowSubmitter.submit(tmpWorkflowStream, jobVariables, genericInfos);
             }
 
@@ -1762,7 +1762,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                 genericInfos = getMapWithFirstValues(contextInfos.getQueryParameters());
             }
 
-            WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space);
+            WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space, sessionId);
             newJobId = workflowSubmitter.submit(tmpWorkflowStream, jobVariables, genericInfos);
         }
         return mapper.map(newJobId, JobIdData.class);
@@ -1777,7 +1777,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
             String jobXml = scheduler.getJobContent(JobIdImpl.makeJobId(jobId));
             Job job;
             try (InputStream tmpWorkflowStream = IOUtils.toInputStream(jobXml, Charset.forName(FILE_ENCODING))) {
-                job = JobFactory.getFactory().createJob(tmpWorkflowStream, null, null, scheduler, space);
+                job = JobFactory.getFactory().createJob(tmpWorkflowStream, null, null, scheduler, space, sessionId);
             }
             WorkflowDescription workflowDescription = new WorkflowDescription();
             workflowDescription.setName(job.getName());
@@ -1801,7 +1801,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     public List<JobIdData> reSubmitAll(String sessionId, List<String> jobsId) throws RestException {
         Scheduler scheduler = checkAccess(sessionId, "/scheduler/jobs/resubmit");
         SchedulerSpaceInterface space = getSpaceInterface(sessionId);
-        WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space);
+        WorkflowSubmitter workflowSubmitter = new WorkflowSubmitter(scheduler, space, sessionId);
         List<JobIdData> newJobIds = new ArrayList<>(jobsId.size());
 
         for (String jobId : jobsId) {
@@ -2387,7 +2387,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                 }
             }
 
-            return ValidationUtil.validateJobDescriptor(tmpFile, jobVariables, scheduler, space);
+            return ValidationUtil.validateJobDescriptor(tmpFile, jobVariables, scheduler, space, sessionId);
         } catch (IOException e) {
             JobValidationData validation = new JobValidationData();
             validation.setErrorMessage("Cannot read from the job validation request.");
@@ -2422,7 +2422,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                 jobVariables = workflowVariablesTransformer.getWorkflowVariablesFromPathSegment(pathSegment);
             }
 
-            return ValidationUtil.validateJobDescriptor(tmpWorkflowFile, jobVariables, scheduler, space);
+            return ValidationUtil.validateJobDescriptor(tmpWorkflowFile, jobVariables, scheduler, space, sessionId);
 
         } catch (JobCreationRestException | IOException e) {
             JobValidationData validation = new JobValidationData();
@@ -2466,7 +2466,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             }
 
-            return ValidationUtil.validateJobDescriptor(tmpWorkflowFile, jobVariables, scheduler, space);
+            return ValidationUtil.validateJobDescriptor(tmpWorkflowFile, jobVariables, scheduler, space, sessionId);
 
         } catch (JobCreationRestException | IOException e) {
             JobValidationData validation = new JobValidationData();

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/WorkflowSubmitter.java
@@ -61,9 +61,12 @@ public class WorkflowSubmitter {
 
     private SchedulerSpaceInterface space;
 
-    public WorkflowSubmitter(Scheduler scheduler, SchedulerSpaceInterface space) {
+    private String sessionId;
+
+    public WorkflowSubmitter(Scheduler scheduler, SchedulerSpaceInterface space, String sessionId) {
         this.scheduler = scheduler;
         this.space = space;
+        this.sessionId = sessionId;
     }
 
     /**
@@ -121,7 +124,12 @@ public class WorkflowSubmitter {
 
     private Job createJobObject(InputStream workflowStream, Map<String, String> jobVariables,
             Map<String, String> jobGenericInfos) throws JobCreationException {
-        return JobFactory.getFactory().createJob(workflowStream, jobVariables, jobGenericInfos, scheduler, space);
+        return JobFactory.getFactory().createJob(workflowStream,
+                                                 jobVariables,
+                                                 jobGenericInfos,
+                                                 scheduler,
+                                                 space,
+                                                 sessionId);
     }
 
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/util/ValidationUtil.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/util/ValidationUtil.java
@@ -86,17 +86,17 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobValidationData;
 public class ValidationUtil {
 
     public static JobValidationData validateJobDescriptor(File jobDescFile, Map<String, String> jobVariables,
-            Scheduler scheduler, SchedulerSpaceInterface space) {
-        return validateJob(jobDescFile.getAbsolutePath(), jobVariables, scheduler, space);
+            Scheduler scheduler, SchedulerSpaceInterface space, String sessionId) {
+        return validateJob(jobDescFile.getAbsolutePath(), jobVariables, scheduler, space, sessionId);
     }
 
     public static JobValidationData validateJob(String jobFilePath, Map<String, String> jobVariables,
-            Scheduler scheduler, SchedulerSpaceInterface space) {
+            Scheduler scheduler, SchedulerSpaceInterface space, String sessionId) {
         JobValidationData data = new JobValidationData();
         Job job = null;
         try {
             JobFactory factory = JobFactory.getFactory();
-            job = factory.createJob(jobFilePath, jobVariables, null, scheduler, space);
+            job = factory.createJob(jobFilePath, jobVariables, null, scheduler, space, sessionId);
 
             if (job instanceof TaskFlowJob) {
                 fillUpdatedVariables((TaskFlowJob) job, data);

--- a/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
+++ b/rest/rest-server/src/test/java/functionaltests/RestSchedulerTagTest.java
@@ -98,7 +98,7 @@ public class RestSchedulerTagTest extends AbstractRestFuncTestCase {
 
     private JobId submitJob(String filename) throws Exception {
         File jobFile = new File(this.getClass().getResource("config/" + filename).toURI());
-        WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler, space);
+        WorkflowSubmitter submitter = new WorkflowSubmitter(scheduler, space, null);
         JobId id;
         try (InputStream jobStream = new FileInputStream(jobFile)) {
             id = submitter.submit(jobStream, new HashMap<String, String>(), null);

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -210,10 +210,10 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
-    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws NotConnectedException, UnknownJobException, PermissionException, JobCreationException,
-            SubmissionClosedException {
-        return _getScheduler().reSubmit(currentJobId, jobVariables, jobGenericInfos);
+    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
+            String sessionId) throws NotConnectedException, UnknownJobException, PermissionException,
+            JobCreationException, SubmissionClosedException {
+        return _getScheduler().reSubmit(currentJobId, jobVariables, jobGenericInfos, sessionId);
     }
 
     @Override

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -663,9 +663,9 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      * @throws UnknownJobException if <code>currentJobId</code> does not correspond to any submitted job
      * @throws PermissionException if user cannot access job with <code>currentJobId</code>
      */
-    JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws NotConnectedException, UnknownJobException, PermissionException, JobCreationException,
-            SubmissionClosedException;
+    JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
+            String sessionId) throws NotConnectedException, UnknownJobException, PermissionException,
+            JobCreationException, SubmissionClosedException;
 
     /**
      * Get the result for the given jobId.<br>

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/JobFactory.java
@@ -175,11 +175,12 @@ public abstract class JobFactory {
      * @param genericInfos map of job submission generic infos
      * @param scheduler the Scheduler instance for validating jobs to access third-party credentials
      * @param space the SchedulerSpaceInterface instance for validating jobs to access data spaces files
+     * @param sessionId current session for validating jobs with CATALOG_OBJECT variables
      * @return a Job instance created with the given XML file
      * @throws JobCreationException if an exception occurred during job creation
      */
     public abstract Job createJob(String filePath, Map<String, String> variables, Map<String, String> genericInfos,
-            Scheduler scheduler, SchedulerSpaceInterface space) throws JobCreationException;
+            Scheduler scheduler, SchedulerSpaceInterface space, String sessionId) throws JobCreationException;
 
     /**
      * Creates a job using the given job descriptor.
@@ -211,7 +212,7 @@ public abstract class JobFactory {
             Map<String, String> genericInfos) throws JobCreationException;
 
     public abstract Job createJob(InputStream workflowStream, Map<String, String> variables,
-            Map<String, String> genericInfos, Scheduler scheduler, SchedulerSpaceInterface space)
+            Map<String, String> genericInfos, Scheduler scheduler, SchedulerSpaceInterface space, String sessionId)
             throws JobCreationException;
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -161,7 +161,7 @@ public class StaxJobFactory extends JobFactory {
     public Job createJob(String filePath, Map<String, String> replacementVariables,
             Map<String, String> replacementGenericInfos) throws JobCreationException {
         try {
-            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, null, null);
+            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, null, null, null);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -171,10 +171,15 @@ public class StaxJobFactory extends JobFactory {
 
     @Override
     public Job createJob(String filePath, Map<String, String> replacementVariables,
-            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space)
-            throws JobCreationException {
+            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) throws JobCreationException {
         try {
-            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, scheduler, space);
+            return createJob(new File(filePath),
+                             replacementVariables,
+                             replacementGenericInfos,
+                             scheduler,
+                             space,
+                             sessionId);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -191,7 +196,7 @@ public class StaxJobFactory extends JobFactory {
     public Job createJob(URI filePath, Map<String, String> replacementVariables,
             Map<String, String> replacementGenericInfos) throws JobCreationException {
         try {
-            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, null, null);
+            return createJob(new File(filePath), replacementVariables, replacementGenericInfos, null, null, null);
         } catch (JobCreationException jce) {
             throw jce;
         } catch (Exception e) {
@@ -207,19 +212,20 @@ public class StaxJobFactory extends JobFactory {
     @Override
     public Job createJob(InputStream workflowStream, Map<String, String> replacementVariables,
             Map<String, String> replacementGenericInfos) throws JobCreationException {
-        return createJob(workflowStream, replacementVariables, replacementGenericInfos, null, null);
+        return createJob(workflowStream, replacementVariables, replacementGenericInfos, null, null, null);
     }
 
     @Override
     public Job createJob(InputStream workflowStream, Map<String, String> replacementVariables,
-            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space)
-            throws JobCreationException {
+            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) throws JobCreationException {
         try {
             return createJobFromInputStream(workflowStream,
                                             replacementVariables,
                                             replacementGenericInfos,
                                             scheduler,
-                                            space);
+                                            space,
+                                            sessionId);
         } catch (JobCreationException jce) {
             jce.pushTag(XMLTags.JOB.getXMLName());
             throw jce;
@@ -229,8 +235,8 @@ public class StaxJobFactory extends JobFactory {
     }
 
     private Job createJob(File file, Map<String, String> replacementVariables,
-            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space)
-            throws JobCreationException {
+            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) throws JobCreationException {
         try {
             if (!file.exists()) {
                 throw new FileNotFoundException("This file has not been found: " + file.getAbsolutePath());
@@ -241,7 +247,8 @@ public class StaxJobFactory extends JobFactory {
                                                 replacementVariables,
                                                 replacementGenericInfos,
                                                 scheduler,
-                                                space);
+                                                space,
+                                                sessionId);
             }
         } catch (JobCreationException jce) {
             jce.pushTag(XMLTags.JOB.getXMLName());
@@ -252,8 +259,8 @@ public class StaxJobFactory extends JobFactory {
     }
 
     private Job createJobFromInputStream(InputStream jobInputStream, Map<String, String> replacementVariables,
-            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space)
-            throws JobCreationException, IOException, XMLStreamException {
+            Map<String, String> replacementGenericInfos, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) throws JobCreationException, IOException, XMLStreamException {
         long t0 = System.currentTimeMillis();
         byte[] bytes = ValidationUtil.getInputStreamBytes(jobInputStream);
         String md5Job = DigestUtils.md5Hex(bytes);
@@ -301,7 +308,7 @@ public class StaxJobFactory extends JobFactory {
             t3 = System.currentTimeMillis();
         }
         long t4 = System.currentTimeMillis();
-        validate((TaskFlowJob) job, scheduler, space);
+        validate((TaskFlowJob) job, scheduler, space, sessionId);
         long t5 = System.currentTimeMillis();
         long d1 = t1 - t0;
         long d2 = t2 - t1;
@@ -342,7 +349,7 @@ public class StaxJobFactory extends JobFactory {
     /*
      * Validate the given job descriptor
      */
-    private TaskFlowJob validate(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space)
+    private TaskFlowJob validate(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space, String sessionId)
             throws JobCreationException {
         Map<String, JobValidatorService> factories;
         try {
@@ -356,7 +363,7 @@ public class StaxJobFactory extends JobFactory {
         try {
 
             for (JobValidatorService factory : factories.values()) {
-                updatedJob = factory.validateJob(updatedJob, scheduler, space);
+                updatedJob = factory.validateJob(updatedJob, scheduler, space, sessionId);
             }
         } catch (JobValidationException e) {
             fillUpdatedVariables(e, job);

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/JobValidatorService.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/JobValidatorService.java
@@ -72,10 +72,11 @@ public interface JobValidatorService {
      * @param job job object to validate
      * @param scheduler scheduler instance which can give the access to the third-party credentials
      * @param space SchedulerSpaceInterface instance which can give the access to check data space files
+     * @param sessionId current session for validating jobs with CATALOG_OBJECT variables
      * @return if the validator eventually made some modifications to the job, return a new version
      * @throws JobValidationException if the job is not valid
      */
-    TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space)
+    TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space, String sessionId)
             throws JobValidationException;
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
@@ -54,21 +54,21 @@ public class DefaultModelJobValidatorServiceProvider implements JobValidatorServ
 
     @Override
     public TaskFlowJob validateJob(TaskFlowJob job) throws JobValidationException {
-        return validateJob(job, null, null);
+        return validateJob(job, null, null, null);
     }
 
     @Override
-    public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space)
-            throws JobValidationException {
+    public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) throws JobValidationException {
 
-        ModelValidatorContext context = new ModelValidatorContext(job, scheduler, space);
+        ModelValidatorContext context = new ModelValidatorContext(job, scheduler, space, sessionId);
 
         for (JobVariable jobVariable : job.getVariables().values()) {
             checkVariableFormat(null, jobVariable, context);
             context.updateJobWithContext(job);
         }
         for (Task task : job.getTasks()) {
-            context = new ModelValidatorContext(task, scheduler, space);
+            context = new ModelValidatorContext(task, scheduler, space, sessionId);
             for (TaskVariable taskVariable : task.getVariables().values()) {
                 checkVariableFormat(task, taskVariable, context);
                 context.updateTaskWithContext(task);

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/ModelValidatorContext.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/ModelValidatorContext.java
@@ -27,7 +27,6 @@ package org.ow2.proactive.scheduler.common.job.factories.spi.model;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -58,20 +57,23 @@ public class ModelValidatorContext {
 
     private final SchedulerSpaceInterface space;
 
+    private final String sessionId;
+
     private String variableName;
 
     // container for job and task variables
     private SpELVariables spELVariables;
 
-    public ModelValidatorContext(StandardEvaluationContext context, Scheduler scheduler,
-            SchedulerSpaceInterface space) {
+    public ModelValidatorContext(StandardEvaluationContext context, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) {
         this.spelContext = context;
         this.scheduler = scheduler;
         this.space = space;
+        this.sessionId = sessionId;
     }
 
     public ModelValidatorContext(Map<String, Serializable> variablesValues, Map<String, String> models,
-            Set<String> groupNames, Scheduler scheduler, SchedulerSpaceInterface space) {
+            Set<String> groupNames, Scheduler scheduler, SchedulerSpaceInterface space, String sessionId) {
         spELVariables = new SpELVariables(variablesValues, models, groupNames);
         spelContext = new StandardEvaluationContext(spELVariables);
         spelContext.setTypeLocator(new RestrictedTypeLocator());
@@ -79,9 +81,10 @@ public class ModelValidatorContext {
         spelContext.addPropertyAccessor(new RestrictedPropertyAccessor());
         this.scheduler = scheduler;
         this.space = space;
+        this.sessionId = sessionId;
     }
 
-    public ModelValidatorContext(Task task, Scheduler scheduler, SchedulerSpaceInterface space) {
+    public ModelValidatorContext(Task task, Scheduler scheduler, SchedulerSpaceInterface space, String sessionId) {
         this(task.getVariables().values().stream().collect(LinkedHashMap<String, Serializable>::new,
                                                            (m, v) -> m.put(v.getName(), v.getValue()),
                                                            LinkedHashMap<String, Serializable>::putAll),
@@ -90,7 +93,8 @@ public class ModelValidatorContext {
                                                            LinkedHashMap<String, String>::putAll),
              getGroups(task.getVariables()),
              scheduler,
-             space);
+             space,
+             sessionId);
 
     }
 
@@ -107,7 +111,8 @@ public class ModelValidatorContext {
         return groups;
     }
 
-    public ModelValidatorContext(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space) {
+    public ModelValidatorContext(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) {
         this(job.getVariables().values().stream().collect(LinkedHashMap<String, Serializable>::new,
                                                           (m, v) -> m.put(v.getName(), v.getValue()),
                                                           LinkedHashMap<String, Serializable>::putAll),
@@ -116,25 +121,26 @@ public class ModelValidatorContext {
                                                           LinkedHashMap<String, String>::putAll),
              getGroups(job.getVariables()),
              scheduler,
-             space);
+             space,
+             sessionId);
 
     }
 
     public ModelValidatorContext(StandardEvaluationContext context) {
-        this(context, null, null);
+        this(context, null, null, null);
     }
 
     public ModelValidatorContext(Map<String, Serializable> variablesValues, Map<String, String> models,
             Set<String> groupNames) {
-        this(variablesValues, models, groupNames, null, null);
+        this(variablesValues, models, groupNames, null, null, null);
     }
 
     public ModelValidatorContext(Task task) {
-        this(task, null, null);
+        this(task, null, null, null);
     }
 
     public ModelValidatorContext(TaskFlowJob job) {
-        this(job, null, null);
+        this(job, null, null, null);
     }
 
     public StandardEvaluationContext getSpELContext() {
@@ -163,6 +169,10 @@ public class ModelValidatorContext {
 
     public void setVariableName(String variableName) {
         this.variableName = variableName;
+    }
+
+    public String getSessionId() {
+        return sessionId;
     }
 
     /**

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidator.java
@@ -79,8 +79,7 @@ public class CatalogObjectValidator implements Validator<String> {
         }
         try {
             if (!exist(parameterValue, context.getSessionId())) {
-                throw new ValidationException(String.format("Catalog object [%s] does not exist or cannot be accessed.",
-                                                            parameterValue));
+                throw new ValidationException(String.format("Catalog object [%s] does not exist.", parameterValue));
             }
         } catch (PermissionException e) {
             throw new ValidationException(String.format("Access to catalog object [%s] is not authorized.",

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/stax/StaxJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/stax/StaxJobValidatorServiceProvider.java
@@ -83,7 +83,8 @@ public class StaxJobValidatorServiceProvider implements JobValidatorService {
     }
 
     @Override
-    public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space) {
+    public TaskFlowJob validateJob(TaskFlowJob job, Scheduler scheduler, SchedulerSpaceInterface space,
+            String sessionId) {
         // validate any job
         return job;
     }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -271,11 +271,11 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
 
     @Override
     @ImmediateService
-    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws NotConnectedException, UnknownJobException, PermissionException, JobCreationException,
-            SubmissionClosedException {
+    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
+            String sessionId) throws NotConnectedException, UnknownJobException, PermissionException,
+            JobCreationException, SubmissionClosedException {
         checkSchedulerConnection();
-        return uischeduler.reSubmit(currentJobId, jobVariables, jobGenericInfos);
+        return uischeduler.reSubmit(currentJobId, jobVariables, jobGenericInfos, sessionId);
     }
 
     @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -380,13 +380,14 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
-    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws NotConnectedException, UnknownJobException, PermissionException, JobCreationException,
-            SubmissionClosedException {
+    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
+            String sessionId) throws NotConnectedException, UnknownJobException, PermissionException,
+            JobCreationException, SubmissionClosedException {
         renewSession();
         return client.reSubmit(currentJobId,
                                addGlobalVariables(jobVariables),
-                               addGlobalGenericInfoAndParentJobId(jobGenericInfos));
+                               addGlobalGenericInfoAndParentJobId(jobGenericInfos),
+                               sessionId);
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -519,15 +519,16 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
      */
     @Override
     @ImmediateService
-    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws NotConnectedException, UnknownJobException, PermissionException, JobCreationException,
-            SubmissionClosedException {
+    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
+            String sessionId) throws NotConnectedException, UnknownJobException, PermissionException,
+            JobCreationException, SubmissionClosedException {
         final String jobContent = getJobContent(currentJobId);
         final Job job = JobFactory.getFactory().createJob(IOUtils.toInputStream(jobContent, Charset.forName("UTF-8")),
                                                           jobVariables,
                                                           jobGenericInfos,
                                                           this,
-                                                          this);
+                                                          this,
+                                                          sessionId);
         return submit(job);
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowReSubmission.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/TestWorkflowReSubmission.java
@@ -50,9 +50,8 @@ public class TestWorkflowReSubmission extends SchedulerFunctionalTestWithRestart
 
         JobId jobId = schedulerHelper.submitJob(new File(jobDescriptor.toURI()).getAbsolutePath());
 
-        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId,
-                                                                        Collections.emptyMap(),
-                                                                        Collections.emptyMap());
+        JobId jobId1 = schedulerHelper.getSchedulerInterface()
+                                      .reSubmit(jobId, Collections.emptyMap(), Collections.emptyMap(), null);
 
         schedulerHelper.waitForEventJobFinished(jobId);
         schedulerHelper.waitForEventJobFinished(jobId1);
@@ -70,7 +69,7 @@ public class TestWorkflowReSubmission extends SchedulerFunctionalTestWithRestart
 
         JobId jobId = schedulerHelper.submitJob(new File(jobDescriptor.toURI()).getAbsolutePath());
 
-        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, null, null);
+        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, null, null, null);
 
         schedulerHelper.waitForEventJobFinished(jobId);
         schedulerHelper.waitForEventJobFinished(jobId1);
@@ -90,7 +89,7 @@ public class TestWorkflowReSubmission extends SchedulerFunctionalTestWithRestart
 
         Map<String, String> vars = new HashMap<>();
         vars.put("x", "50");
-        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, vars, null);
+        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, vars, null, null);
 
         schedulerHelper.waitForEventJobFinished(jobId);
         schedulerHelper.waitForEventJobFinished(jobId1);
@@ -111,7 +110,7 @@ public class TestWorkflowReSubmission extends SchedulerFunctionalTestWithRestart
 
         Map<String, String> info = new HashMap<>();
         info.put("x", "50");
-        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, null, info);
+        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, null, info, null);
 
         schedulerHelper.waitForEventJobFinished(jobId);
         schedulerHelper.waitForEventJobFinished(jobId1);
@@ -132,7 +131,7 @@ public class TestWorkflowReSubmission extends SchedulerFunctionalTestWithRestart
 
         Map<String, String> vars = new HashMap<>();
         vars.put("x", "50");
-        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, vars, vars);
+        JobId jobId1 = schedulerHelper.getSchedulerInterface().reSubmit(jobId, vars, vars, null);
 
         schedulerHelper.waitForEventJobFinished(jobId);
         schedulerHelper.waitForEventJobFinished(jobId1);

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -540,13 +540,13 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
-    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos)
-            throws NotConnectedException, UnknownJobException, PermissionException, JobCreationException,
-            SubmissionClosedException {
+    public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
+            String sessionId) throws NotConnectedException, UnknownJobException, PermissionException,
+            JobCreationException, SubmissionClosedException {
         if (schedulerProxy == null) {
             throw new NotConnectedException("Not connected to the scheduler.");
         }
-        return schedulerProxy.reSubmit(currentJobId, jobVariables, jobGenericInfos);
+        return schedulerProxy.reSubmit(currentJobId, jobVariables, jobGenericInfos, sessionId);
     }
 
     @Override


### PR DESCRIPTION
Now PA:CATALOG_OBJECT variable value should exist in the catalog to be validated during workflow submission. (The existence is not checked during workflow design.)

To acheieve this goal `sessionId` is added in ModelValidatorContext (consequently, in the scheduling interface), since it's needed to check catalog object existence.