### PR TITLE
Fix for Node source permissions lost after scheduler kill

### DIFF
--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1628,6 +1628,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         NodeSource nodeSource = this.createNodeSourceInstance(nodeSourceDescriptor);
 
         this.definedNodeSources.put(nodeSourceDescriptor.getName(), nodeSource);
+        this.emitNodeSourceEvent(nodeSource, RMEventType.NODESOURCE_DEFINED);
 
         if (nodeSourceDescriptor.getStatus().equals(NodeSourceStatus.NODES_DEPLOYED)) {
             NodeSource nodeSourceToDeploy = this.createNodeSourceInstance(nodeSourceDescriptor);
@@ -1657,6 +1658,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                              nodeSourcePolicyStub);
 
             this.deployedNodeSources.put(nodeSourceName, nodeSourceStub);
+            this.emitNodeSourceEvent(nodeSourceStub, RMEventType.NODESOURCE_CREATED);
         } else {
             this.nodesRecoveryManager.logRecoveryAbortedReason(nodeSourceName, "This node source is undeployed");
         }
@@ -2011,7 +2013,14 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
 
         final List<RMNodeSourceEvent> nodeSourceEvents = new ArrayList<>(this.definedNodeSources.values()
                                                                                                 .stream()
-                                                                                                .map(NodeSource::createNodeSourceEvent)
+                                                                                                .map(ns -> {
+                                                                                                    if (deployedNodeSources.containsKey(ns.getName())) {
+                                                                                                        return PAFuture.getFutureValue(deployedNodeSources.get(ns.getName())
+                                                                                                                                                          .createNodeSourceEvent());
+                                                                                                    } else {
+                                                                                                        return ns.createNodeSourceEvent();
+                                                                                                    }
+                                                                                                })
                                                                                                 .collect(Collectors.toList()));
 
         long eventCounter = 0;

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -250,6 +250,10 @@ public class NodeSource implements InitActive, RunActive {
                                              .orElse(new LinkedHashMap<>());
     }
 
+    public AccessType getNodeUserAccessType() {
+        return nodeUserAccessType;
+    }
+
     public static void initThreadPools() {
         if (threadPoolHolder == null) {
             try {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMDeployingNode.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMDeployingNode.java
@@ -372,6 +372,11 @@ public final class RMDeployingNode extends AbstractRMNode {
         return false;
     }
 
+    @Override
+    public void setProtectedByToken(boolean protectedByToken) {
+
+    }
+
     public RMDeployingNode updateOnNodeSource() {
         return nodeSource.update(this);
     }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNode.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNode.java
@@ -352,6 +352,8 @@ public interface RMNode extends Comparable<RMNode> {
      */
     boolean isProtectedByToken();
 
+    void setProtectedByToken(boolean protectedByToken);
+
     void addToken(String token);
 
     void removeToken(String token);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNodeImpl.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNodeImpl.java
@@ -489,6 +489,7 @@ public class RMNodeImpl extends AbstractRMNode {
         return protectedByToken;
     }
 
+    @Override
     public void setProtectedByToken(boolean protectedByToken) {
         this.protectedByToken = protectedByToken;
     }

--- a/rm/rm-server/src/test/java/functionaltests/RegressionTestSuite.java
+++ b/rm/rm-server/src/test/java/functionaltests/RegressionTestSuite.java
@@ -34,6 +34,7 @@ import functionaltests.nodesource.TestLocalInfrastructureTimeSlotPolicy;
 import functionaltests.nodesource.TestNodeSourceThreadPool;
 import functionaltests.nodesource.TestSSHInfrastructureV2RestartDownNodesPolicy;
 import functionaltests.nodesrecovery.NodesRecoveryPropertyTest;
+import functionaltests.nodesrecovery.RecoverDefaultInfrastructureTest;
 import functionaltests.nodesrecovery.RecoverLocalInfrastructureTest;
 import functionaltests.nodesrecovery.RecoverSSHInfrastructureV2Test;
 import functionaltests.nonblockingcore.NonBlockingCoreTest;
@@ -44,9 +45,10 @@ import functionaltests.selectionscript.SelectionScriptTimeOutTest;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ NonBlockingCoreTest.class, TestNSNodesPermissions.class, SelectionScriptTimeOutTest.class,
                       RecoverLocalInfrastructureTest.class, RecoverSSHInfrastructureV2Test.class,
-                      TestLocalInfrastructureCronPolicy.class, TestLocalInfrastructureTimeSlotPolicy.class,
-                      TestSSHInfrastructureV2RestartDownNodesPolicy.class, NodesRecoveryPropertyTest.class,
-                      NodesHouseKeepingPropertiesTest.class, TestNodeSourceThreadPool.class })
+                      RecoverDefaultInfrastructureTest.class, TestLocalInfrastructureCronPolicy.class,
+                      TestLocalInfrastructureTimeSlotPolicy.class, TestSSHInfrastructureV2RestartDownNodesPolicy.class,
+                      NodesRecoveryPropertyTest.class, NodesHouseKeepingPropertiesTest.class,
+                      TestNodeSourceThreadPool.class })
 
 /**
  * @author ActiveEon Team

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/rmnode/AbstractRMNodeTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/rmnode/AbstractRMNodeTest.java
@@ -340,6 +340,11 @@ public class AbstractRMNodeTest {
         }
 
         @Override
+        public void setProtectedByToken(boolean protectedByToken) {
+
+        }
+
+        @Override
         public int compareTo(RMNode o) {
             return 0;
         }


### PR DESCRIPTION
 - recover nodes isProtectedByTokens status during recovery
 - correctly collect deployed node source description in RMInitialState
 - Add node recovery test for default infrastructure/