### PR TITLE
Fix variable order when replacement variables order differs from the …

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/StaxJobFactory.java
@@ -560,6 +560,11 @@ public class StaxJobFactory extends JobFactory {
                         commonPropertiesHolder.getUnresolvedVariables().putAll(unresolvedJobVariablesMap);
                         Map<String, JobVariable> jobVariablesMap = replaceVariablesInJobVariablesMap(unresolvedJobVariablesMap,
                                                                                                      submittedJobVariables);
+                        // For each variable present in the workflow, remove first the entry in commonPropertiesHolder before replacing
+                        // this is to ensure preserving the order of variables defined in the workflow
+                        for (String key : jobVariablesMap.keySet()) {
+                            commonPropertiesHolder.getVariables().remove(key);
+                        }
                         commonPropertiesHolder.getVariables().putAll(jobVariablesMap);
 
                     } else if (XMLTags.COMMON_GENERIC_INFORMATION.matches(current)) {

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/TestStaxJobFactory.java
@@ -190,6 +190,26 @@ public class TestStaxJobFactory {
     }
 
     @Test
+    public void testCreateJobShouldPreserveVariablesOrderInTheWorkflowWhenReplacementVariablesAreProvided()
+            throws Exception {
+        GlobalVariablesParser.setConfigurationPath(GlobalVariablesParserTest.class.getResource("/org/ow2/proactive/scheduler/common/job/factories/globalvariables/global_variables_default.xml")
+                                                                                  .toExternalForm());
+        GlobalVariablesParser.getInstance().reloadFilters();
+        // Add replacement variables in reverse order from the workflow
+        Map<String, String> replacementVariables = new LinkedHashMap<>();
+        for (int i = 6; i > 0; i--) {
+            replacementVariables.put("var_" + i, "value_" + i);
+        }
+        Job job = factory.createJob(jobDescriptorVariableOrder, replacementVariables, null);
+        // Ensure that the final order is the workflow order
+        int index = 1;
+        for (String variable : job.getVariables().keySet()) {
+            assertEquals("var_" + index, variable);
+            index++;
+        }
+    }
+
+    @Test
     public void testCreateJobWithNoVariablesShouldReferenceGlobalVariablesAndGenericInfo() throws Exception {
         Job testScriptJob = factory.createJob(jobDescriptorNoVariablesUri);
         assertNotNull(testScriptJob.getVariables().get("globalVar"));


### PR DESCRIPTION
…workflow

In that case, the workflow variable order must take precedence.