### PR TITLE
Recover global job variables and generic info on scheduler restart

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/CheckEligibleTaskDescriptorScript.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/CheckEligibleTaskDescriptorScript.java
@@ -102,6 +102,7 @@ public class CheckEligibleTaskDescriptorScript {
         }
 
         return (scriptContent != null) && (scriptContent.contains(SchedulerConstants.SCHEDULER_CLIENT_BINDING_NAME) ||
+                                           scriptContent.contains(SchedulerConstants.RM_CLIENT_BINDING_NAME) ||
                                            scriptContent.contains(SchedulerConstants.DS_GLOBAL_API_BINDING_NAME) ||
                                            scriptContent.contains(SchedulerConstants.DS_USER_API_BINDING_NAME));
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -242,7 +242,7 @@ public class SchedulerStarter {
         if (commandLine.hasOption(OPTION_NO_REST)) {
             System.setProperty(REST_DISABLED_PROPERTY, "true");
             PASchedulerProperties.JETTY_STARTED.updateProperty("true");
-        } else if (PASchedulerProperties.SCHEDULER_REST_URL.isSet()) {
+        } else {
             PASchedulerProperties.JETTY_STARTED.updateProperty("false");
         }
 


### PR DESCRIPTION
 - these structures are used in schedulerapi binding to ensure that submitted values for global variables and generic info are transmitted to sub workflows
 - additionally, fixed an issue with usage of JETTY_STARTED, and in CheckEligibleTaskDescriptorScript