### PR TITLE
Improve start_at scheduling

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -158,6 +158,9 @@ pa.scheduler.startscripts.paths=tools/LoadPackages.groovy
 # Size of parsed workflow cache, used to optimize workflow submission time
 pa.scheduler.stax.job.cache=5000
 
+# Size of the cache used to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds)
+pa.scheduler.startat.cache=5000
+
 #-------------------------------------------------------
 #----------------   JOBS PROPERTIES   ------------------
 #-------------------------------------------------------

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -149,6 +149,9 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Size of parsed workflow cache, used to optimize workflow submission time */
     SCHEDULER_STAX_JOB_CACHE("pa.scheduler.stax.job.cache", PropertyType.INTEGER, "5000"),
 
+    /** size of the cache used to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds) **/
+    SCHEDULER_STARTAT_CACHE("pa.scheduler.startat.cache", PropertyType.INTEGER, "5000"),
+
     /* ***************************************************************** */
     /* ********************** AUTHENTICATION PROPERTIES **************** */
     /* ***************************************************************** */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -1284,11 +1284,11 @@ public class SchedulingService {
         }
     }
 
-    protected void sleepSchedulingThread() throws InterruptedException {
+    public void sleepSchedulingThread() throws InterruptedException {
         schedulingThread.sleepSchedulingThread();
     }
 
-    protected void wakeUpSchedulingThread() {
+    public void wakeUpSchedulingThread() {
         schedulingThread.wakeUpSchedulingThread();
     }
 


### PR DESCRIPTION
 - A task or job using START_AT is delayed for scheduling until the scheduling loop cycle coming right after the START_AT date.
 - Unfortunately, the scheduling loop may be sleeping at that moment, this produces a delay between 1 and 10 seconds.

 In order to remove this delay, thanks to a scheduled executor, we will now wake the scheduling thread when a start_at date expires.
 A LRU cache is used to ensure that a single runnable will be submitted to the executor for any given task or job.