### PR TITLE
RunAsUser feature

### DIFF
--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProgressFileReader.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProgressFileReader.java
@@ -112,10 +112,10 @@ public class ProgressFileReader implements ProgressFileReaderInterface {
 
         try {
             Files.createDirectories(progressFileDir);
-            ForkerUtils.setSharedExecutablePermissions(progressFileDir.toFile());
+            ForkerUtils.getInstance().setSharedExecutablePermissions(progressFileDir.toFile());
             progressFile = progressFileDir.resolve(progressFileName);
             Files.createFile(progressFile);
-            ForkerUtils.setSharedPermissions(progressFile.toFile());
+            ForkerUtils.getInstance().setSharedPermissions(progressFile.toFile());
         } catch (FileAlreadyExistsException e) {
             // ignore file already exists exception
         }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProgressFileReaderPoller.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/ProgressFileReaderPoller.java
@@ -120,12 +120,12 @@ public class ProgressFileReaderPoller implements ProgressFileReaderInterface {
         progressFileDir = workingDir.toPath().resolve(PROGRESS_FILE_DIR);
 
         Files.createDirectories(progressFileDir);
-        ForkerUtils.setSharedExecutablePermissions(progressFileDir.toFile());
+        ForkerUtils.getInstance().setSharedExecutablePermissions(progressFileDir.toFile());
         progressFile = progressFileDir.resolve(progressFileName);
         if (!Files.exists(progressFile)) {
             Files.createFile(progressFile);
         }
-        ForkerUtils.setSharedPermissions(progressFile.toFile());
+        ForkerUtils.getInstance().setSharedPermissions(progressFile.toFile());
 
         logger.debug("Progress file '" + progressFile + "' created");
     }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextSerializer.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextSerializer.java
@@ -54,7 +54,7 @@ public class TaskContextSerializer implements Serializable {
             objectOutputStream.writeObject(context);
         }
         if (context.isRunAsUser()) {
-            ForkerUtils.setSharedPermissions(file);
+            ForkerUtils.getInstance().setSharedPermissions(file);
         }
         return file;
     }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractor.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/context/TaskContextVariableExtractor.java
@@ -51,6 +51,8 @@ public class TaskContextVariableExtractor implements Serializable {
 
     private final String ERROR_READING_VARIABLES = "Error reading variables from task context!";
 
+    private final String ERROR_READING_CREDENTIALS = "Error reading third-party-credentials from task context!";
+
     private static final Logger logger = Logger.getLogger(TaskContextVariableExtractor.class);
 
     private final ForkedTaskVariablesManager forkedTaskVariablesManager = new ForkedTaskVariablesManager();
@@ -78,7 +80,7 @@ public class TaskContextVariableExtractor implements Serializable {
         try {
             thirdPartyCredentials = forkedTaskVariablesManager.extractThirdPartyCredentials(taskContext);
         } catch (Exception e) {
-            logger.error(ERROR_READING_VARIABLES, e);
+            logger.error(ERROR_READING_CREDENTIALS, e);
         }
 
         HashMap<String, Serializable> systemEnvironmentVariables = new HashMap<String, Serializable>(System.getenv());
@@ -86,6 +88,10 @@ public class TaskContextVariableExtractor implements Serializable {
         systemEnvironmentVariables.putAll(thirdPartyCredentials);
 
         return VariableSubstitutor.filterAndUpdate(forkEnvironment.getSystemEnvironment(), systemEnvironmentVariables);
+    }
+
+    public Map<String, String> extractThirdPartyCredentials(TaskContext taskContext) {
+        return forkedTaskVariablesManager.extractThirdPartyCredentials(taskContext);
     }
 
     /**

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreator.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/ForkedProcessBuilderCreator.java
@@ -50,6 +50,12 @@ public class ForkedProcessBuilderCreator implements Serializable {
 
     private final ForkEnvironmentScriptExecutor forkEnvironmentScriptExecutor = new ForkEnvironmentScriptExecutor();
 
+    private final transient ForkerUtils forkerUtils;
+
+    public ForkedProcessBuilderCreator() {
+        forkerUtils = ForkerUtils.getInstance();
+    }
+
     /**
      * Creates a process builder for a given task context.
      *
@@ -121,11 +127,11 @@ public class ForkedProcessBuilderCreator implements Serializable {
         OSProcessBuilder processBuilder;
         if (context.isRunAsUser()) {
             addExecutionPermissionToScripts();
-            ForkerUtils.setSharedExecutablePermissions(workingDir);
-            processBuilder = ForkerUtils.getOSProcessBuilderFactory(nativeScriptPath)
-                                        .getBuilder(ForkerUtils.checkConfigAndGetUser(context.getDecrypter()));
+            forkerUtils.setSharedExecutablePermissions(workingDir);
+            processBuilder = forkerUtils.getOSProcessBuilderFactory(nativeScriptPath)
+                                        .getBuilder(forkerUtils.checkConfigAndGetUser(context));
         } else {
-            processBuilder = ForkerUtils.getOSProcessBuilderFactory(nativeScriptPath).getBuilder();
+            processBuilder = forkerUtils.getOSProcessBuilderFactory(nativeScriptPath).getBuilder();
         }
         return processBuilder;
     }

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
@@ -164,7 +164,7 @@ public class ForkedTaskVariablesManager implements Serializable {
         return isDockerWindows2Linux ? ForkEnvironment.convertToLinuxPath(uri) : uri;
     }
 
-    public Map<String, String> extractThirdPartyCredentials(TaskContext container) throws Exception {
+    public Map<String, String> extractThirdPartyCredentials(TaskContext container) {
         try {
             Map<String, String> thirdPartyCredentials = new HashMap<>();
             if (container.getDecrypter() != null) {
@@ -172,7 +172,7 @@ public class ForkedTaskVariablesManager implements Serializable {
             }
             return thirdPartyCredentials;
         } catch (Exception e) {
-            throw new Exception("Could read encrypted third party credentials", e);
+            throw new RuntimeException("Could not read encrypted third party credentials", e);
         }
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
@@ -247,7 +247,9 @@ import functionaltests.workflow.variables.Test_SCHEDULING_2034;
                       TestSubmitJobWithPartiallyUnaccessibleDataSpaces.class,
                       TestSubmitJobWithUnaccessibleDataSpaces.class, TestTaskRestartOnNodeFailure.class,
                       TestTasksCompleteAfterSelectiontimeout.class, TestUnauthorizedScripts.class,
-                      TestVariablesPropagation.class, EDFPolicyTest.class, EDFPolicyExtendedTest.class })
+                      TestVariablesPropagation.class, EDFPolicyTest.class, EDFPolicyExtendedTest.class,
+                      TestRunAsMeLinuxPwd.class, TestRunAsMeLinuxKey.class, TestRunAsMeLinuxNone.class,
+                      TestRunAsMeWindows.class })
 
 /**
  * @author ActiveEon Team

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxNone.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxNone.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.resourcemanager.RMFactory;
 import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -84,6 +85,22 @@ public class TestRunAsMeLinuxNone extends TestRunAsMe {
                                                                   .createJob(new File(jobDescriptor.toURI()).getAbsolutePath()),
                                                         false,
                                                         true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+
+    @Test
+    public void testRunAsUser() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        Job job = JobFactory.getFactory().createJob(new File(jobDescriptor.toURI()).getAbsolutePath());
+        job.addGenericInformation(ForkerUtils.RUNAS_USER_GENERIC_INFO, username);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler, job, false, true);
 
         for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
             if (entry.getKey().contains("RunAsMeTask")) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxPwd.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeLinuxPwd.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.resourcemanager.RMFactory;
 import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -84,6 +85,41 @@ public class TestRunAsMeLinuxPwd extends TestRunAsMe {
                                                                   .createJob(new File(jobDescriptor.toURI()).getAbsolutePath()),
                                                         false,
                                                         true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+
+    @Test
+    public void testRunAsUser() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        Job job = JobFactory.getFactory().createJob(new File(jobDescriptor.toURI()).getAbsolutePath());
+        job.addGenericInformation(ForkerUtils.RUNAS_USER_GENERIC_INFO, username);
+        job.addGenericInformation(ForkerUtils.RUNAS_PWD_GENERIC_INFO, password);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler, job, false, true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+
+    @Test
+    public void testRunAsUserCreds() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        Job job = JobFactory.getFactory().createJob(new File(jobDescriptor.toURI()).getAbsolutePath());
+        job.addGenericInformation(ForkerUtils.RUNAS_USER_GENERIC_INFO, username);
+        job.addGenericInformation(ForkerUtils.RUNAS_PWD_CRED_GENERIC_INFO, username);
+        scheduler.putThirdPartyCredential(username, password);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler, job, false, true);
 
         for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
             if (entry.getKey().contains("RunAsMeTask")) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeWindows.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/runasme/TestRunAsMeWindows.java
@@ -42,6 +42,7 @@ import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.resourcemanager.RMFactory;
 import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.factories.JobFactory;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -115,6 +116,41 @@ public class TestRunAsMeWindows extends TestRunAsMe {
                                                                   .createJob(new File(jobDescriptor.toURI()).getAbsolutePath()),
                                                         false,
                                                         true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+
+    @Test
+    public void testRunAsUserPwd() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        Job job = JobFactory.getFactory().createJob(new File(jobDescriptor.toURI()).getAbsolutePath());
+        job.addGenericInformation(ForkerUtils.RUNAS_USER_GENERIC_INFO, username);
+        job.addGenericInformation(ForkerUtils.RUNAS_PWD_GENERIC_INFO, password);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler, job, false, true);
+
+        for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
+            if (entry.getKey().contains("RunAsMeTask")) {
+                Assert.assertTrue("RunAsMe task should display in the logs the correct system user",
+                                  entry.getValue().getOutput().getStdoutLogs().contains(username));
+            }
+        }
+    }
+
+    @Test
+    public void testRunAsUserPwdCreds() throws Exception {
+        // connect to the scheduler using the runasme account
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface(username, password, null);
+        Job job = JobFactory.getFactory().createJob(new File(jobDescriptor.toURI()).getAbsolutePath());
+        job.addGenericInformation(ForkerUtils.RUNAS_USER_GENERIC_INFO, username);
+        job.addGenericInformation(ForkerUtils.RUNAS_PWD_CRED_GENERIC_INFO, username);
+        scheduler.putThirdPartyCredential(username, password);
+        JobId jobid = schedulerHelper.testJobSubmission(scheduler, job, false, true);
 
         for (Map.Entry<String, TaskResult> entry : scheduler.getJobResult(jobid).getAllResults().entrySet()) {
             if (entry.getKey().contains("RunAsMeTask")) {


### PR DESCRIPTION
Extra configurations for RunAsMe, through generic information.

Possible to change the runasme method for a task (PWD, KEY or NONE)
Possible to define the system account that will run the task
Possible to define the user domain
Possible to define the password via generic information or 3rd-party credentials
Possible to define the ssh key via generic information or 3rd-party credentials