### PR TITLE
Add children count to JobInfo

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -202,6 +202,8 @@ public interface SchedulerRestInterface {
      *             Include only jobs with a project name that starts with projectName (case in-sensitive)
      * @param userName
      *             Include only jobs with a user name that matches exactly with userName (case in-sensitive)
+     * @param parentId
+     *             Include only children jobs of the given parent job id. This parameter is ignored if childJobs is set to false
      * @param sortParams
      *            string containing sort directives. It must contain a comma separated list of sort parameters.
      *            A sort parameter can contain ID,STATE,OWNER,PRIORITY,NAME,SUBMIT_TIME,START_TIME,IN_ERROR_TIME,FINISH_TIME,TOTAL_TASKS,
@@ -224,7 +226,8 @@ public interface SchedulerRestInterface {
             @QueryParam("childJobs") @DefaultValue("true") boolean childJobs,
             @QueryParam("jobName") @DefaultValue("") String jobName,
             @QueryParam("projectName") @DefaultValue("") String projectName,
-            @QueryParam("userName") @DefaultValue("") String userName, @QueryParam("sortParams") String sortParams)
+            @QueryParam("userName") @DefaultValue("") String userName,
+            @QueryParam("parentId") @DefaultValue("-1") Long parentId, @QueryParam("sortParams") String sortParams)
             throws RestException;
 
     /**

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerClientExample.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerClientExample.java
@@ -109,6 +109,7 @@ public class SchedulerClientExample {
                                                                                        null,
                                                                                        null,
                                                                                        null,
+                                                                                       null,
                                                                                        null);
         Map<Long, ArrayList<UserJobData>> map = page.getMap();
         System.out.println(map);

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
@@ -93,6 +93,10 @@ public class JobInfoData implements java.io.Serializable {
 
     private List<String> preciousTasks;
 
+    private Long parentId = null;
+
+    private int childrenCount = 0;
+
     public void setToBeRemoved() {
         toBeRemoved = true;
     }
@@ -325,18 +329,34 @@ public class JobInfoData implements java.io.Serializable {
         this.preciousTasks = preciousTasks;
     }
 
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+    }
+
+    public int getChildrenCount() {
+        return childrenCount;
+    }
+
+    public void setChildrenCount(int childrenCount) {
+        this.childrenCount = childrenCount;
+    }
+
     @Override
     public String toString() {
         return "JobInfoData{ " + "startTime=" + startTime + ", finishedTime=" + finishedTime + ", submittedTime=" +
                submittedTime + ", removedTime=" + removedTime + ", status=" + status + ", jobId=" + jobId +
-               ", totalNumberOfTasks=" + totalNumberOfTasks + ", numberOfPendingTasks=" + numberOfPendingTasks +
-               ", numberOfRunningTasks=" + numberOfRunningTasks + ", numberOfFinishedTasks=" + numberOfFinishedTasks +
-               ", numberOfFailedTasks=" + numberOfFailedTasks + ", numberOfFaultyTasks=" + numberOfFaultyTasks +
-               ", numberOfInErrorTasks=" + numberOfInErrorTasks + ", priority=" + priority + ", jobOwner='" + jobOwner +
-               "', projectName='" + projectName + "', toBeRemoved=" + toBeRemoved + ", genericInformation=" +
-               genericInformation + ", variables=" + variables + ", signals=" + signals + ", detailedSignals=" +
-               detailedSignals + ", attachedServices=" + attachedServices + ", externalEndpointUrls=" +
-               externalEndpointUrls + " }";
+               ", parentId=" + parentId + ", childrenCount=" + childrenCount + ", totalNumberOfTasks=" +
+               totalNumberOfTasks + ", numberOfPendingTasks=" + numberOfPendingTasks + ", numberOfRunningTasks=" +
+               numberOfRunningTasks + ", numberOfFinishedTasks=" + numberOfFinishedTasks + ", numberOfFailedTasks=" +
+               numberOfFailedTasks + ", numberOfFaultyTasks=" + numberOfFaultyTasks + ", numberOfInErrorTasks=" +
+               numberOfInErrorTasks + ", priority=" + priority + ", jobOwner='" + jobOwner + "', projectName='" +
+               projectName + "', toBeRemoved=" + toBeRemoved + ", genericInformation=" + genericInformation +
+               ", variables=" + variables + ", signals=" + signals + ", detailedSignals=" + detailedSignals +
+               ", attachedServices=" + attachedServices + ", externalEndpointUrls=" + externalEndpointUrls + " }";
     }
 
 }

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommand.java
@@ -100,6 +100,7 @@ public class ListJobCommand extends AbstractCommand implements Command {
                                                                                             null,
                                                                                             null,
                                                                                             null,
+                                                                                            null,
                                                                                             null);
         Map<Long, ArrayList<UserJobData>> stateMap = page.getMap();
         List<UserJobData> jobs = stateMap.values().iterator().next();

--- a/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommandTest.java
+++ b/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommandTest.java
@@ -104,13 +104,26 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
         new ListJobCommand("limit=" + offset, "from=" + index).execute(currentContextMock);
 
         Mockito.verify(schedulerRestInterfaceMock)
-               .revisionAndJobsInfo("sessionid", index, 10, false, true, true, true, true, null, null, null, null);
+               .revisionAndJobsInfo("sessionid",
+                                    index,
+                                    10,
+                                    false,
+                                    true,
+                                    true,
+                                    true,
+                                    true,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null);
     }
 
     @Test
@@ -138,13 +151,14 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
         new ListJobCommand("limit=" + offset, "from=" + index).execute(currentContextMock);
 
         Mockito.verify(schedulerRestInterfaceMock)
-               .revisionAndJobsInfo("sessionid", index, 1, false, true, true, true, true, null, null, null, null);
+               .revisionAndJobsInfo("sessionid", index, 1, false, true, true, true, true, null, null, null, null, null);
 
     }
 
@@ -173,13 +187,14 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
         new ListJobCommand("limit=" + offset, "from=" + index).execute(currentContextMock);
 
         Mockito.verify(schedulerRestInterfaceMock)
-               .revisionAndJobsInfo("sessionid", index, 3, false, true, true, true, true, null, null, null, null);
+               .revisionAndJobsInfo("sessionid", index, 3, false, true, true, true, true, null, null, null, null, null);
     }
 
     @Test
@@ -207,13 +222,26 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
         new ListJobCommand("limit=" + offset, "from=" + index).execute(currentContextMock);
 
         Mockito.verify(schedulerRestInterfaceMock)
-               .revisionAndJobsInfo("sessionid", index, 10, false, true, true, true, true, null, null, null, null);
+               .revisionAndJobsInfo("sessionid",
+                                    index,
+                                    10,
+                                    false,
+                                    true,
+                                    true,
+                                    true,
+                                    true,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null);
 
     }
 
@@ -242,13 +270,26 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
         new ListJobCommand().execute(currentContextMock);
 
         Mockito.verify(schedulerRestInterfaceMock)
-               .revisionAndJobsInfo("sessionid", index, 10, false, true, true, true, true, null, null, null, null);
+               .revisionAndJobsInfo("sessionid",
+                                    index,
+                                    10,
+                                    false,
+                                    true,
+                                    true,
+                                    true,
+                                    true,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -1308,6 +1308,8 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         jobInfoImpl.setVisualizationIcons(jobInfoData.getVisualizationIcons());
         jobInfoImpl.setAttachedServices(jobInfoData.getAttachedServices());
         jobInfoImpl.setExternalEndpointUrls(jobInfoData.getExternalEndpointUrls());
+        jobInfoImpl.setParentId(jobInfoData.getParentId());
+        jobInfoImpl.setChildrenCount(jobInfoData.getChildrenCount());
         return jobInfoImpl;
     }
 

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
@@ -65,6 +65,8 @@ public class DataUtility {
     public static JobInfo toJobInfo(JobInfoData d) {
         JobInfoImpl impl = new JobInfoImpl();
         impl.setJobId(jobId(d.getJobId()));
+        impl.setParentId(d.getParentId());
+        impl.setChildrenCount(d.getChildrenCount());
         impl.setFinishedTime(d.getFinishedTime());
         impl.setJobOwner(d.getJobOwner());
         impl.setNumberOfFinishedTasks(d.getNumberOfFinishedTasks());

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
@@ -99,6 +99,10 @@ public class JobInfoImpl implements JobInfo {
 
     private List<String> preciousTasks;
 
+    private Long parentId;
+
+    private int childrenCount;
+
     public void setFinishedTime(long finishedTime) {
         this.finishedTime = finishedTime;
     }
@@ -385,5 +389,23 @@ public class JobInfoImpl implements JobInfo {
 
     public void setPreciousTasks(List<String> preciousTasks) {
         this.preciousTasks = preciousTasks;
+    }
+
+    @Override
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+    }
+
+    @Override
+    public int getChildrenCount() {
+        return childrenCount;
+    }
+
+    public void setChildrenCount(int childrenCount) {
+        this.childrenCount = childrenCount;
     }
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -219,7 +219,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             Page<JobInfo> page = s.getJobs(index,
                                            limit,
-                                           new JobFilterCriteria(false, true, true, true, true, null, null, null),
+                                           new JobFilterCriteria(false, true, true, true, true, null, null, null, null),
                                            DEFAULT_JOB_SORT_PARAMS);
 
             List<String> ids = new ArrayList<>(page.getList().size());
@@ -299,7 +299,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             Page<JobInfo> page = s.getJobs(index,
                                            limit,
-                                           new JobFilterCriteria(false, true, true, true, true, null, null, null),
+                                           new JobFilterCriteria(false, true, true, true, true, null, null, null, null),
                                            DEFAULT_JOB_SORT_PARAMS);
             List<UserJobData> userJobInfoList = new ArrayList<>(page.getList().size());
             for (JobInfo jobInfo : page.getList()) {
@@ -333,7 +333,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     @Override
     public RestMapPage<Long, ArrayList<UserJobData>> revisionAndJobsInfo(String sessionId, int index, int limit,
             boolean myJobs, boolean pending, boolean running, boolean finished, boolean childJobs, String jobName,
-            String projectName, String userName, String sortParams) throws RestException {
+            String projectName, String userName, Long parentId, String sortParams) throws RestException {
         try {
             Scheduler s = checkAccess(sessionId, "revisionjobsinfo?index=" + index + "&limit=" + limit);
             String user = sessionStore.get(sessionId).getUserName();
@@ -360,7 +360,8 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                                                                  childJobs,
                                                                  jobName,
                                                                  projectName,
-                                                                 userName),
+                                                                 userName,
+                                                                 parentId),
                                            sortParameterList);
             List<JobInfo> jobsInfo = page.getList();
             ArrayList<UserJobData> jobs = new ArrayList<>(jobsInfo.size());

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/JobFilterCriteria.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/JobFilterCriteria.java
@@ -49,8 +49,10 @@ public class JobFilterCriteria implements Serializable {
 
     private final String userName;
 
+    private final Long parentId;
+
     public JobFilterCriteria(boolean myJobsOnly, boolean pending, boolean running, boolean finished, boolean childJobs,
-            String jobName, String projectName, String userName) {
+            String jobName, String projectName, String userName, Long parentId) {
         this.myJobsOnly = myJobsOnly;
         this.pending = pending;
         this.running = running;
@@ -59,6 +61,7 @@ public class JobFilterCriteria implements Serializable {
         this.jobName = jobName;
         this.projectName = projectName;
         this.userName = userName;
+        this.parentId = parentId;
     }
 
     public boolean isMyJobsOnly() {
@@ -91,5 +94,9 @@ public class JobFilterCriteria implements Serializable {
 
     public String getUserName() {
         return userName;
+    }
+
+    public Long getParentId() {
+        return parentId;
     }
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
@@ -305,4 +305,16 @@ public interface JobInfo extends Serializable {
      * @return non-empty result map test
      */
     boolean isResultMapPresent();
+
+    /**
+     * Return the parent id of the job
+     * @return parent id of the job, or null if the job has no parent
+     */
+    Long getParentId();
+
+    /**
+     * Return the number of children jobs
+     * @return number of children jobs
+     */
+    int getChildrenCount();
 }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
@@ -146,6 +146,10 @@ public class JobInfoImpl implements JobInfo {
 
     private List<String> preciousTasks = new ArrayList<>();
 
+    private Long parentId = null;
+
+    private int childrenCount = 0;
+
     public JobInfoImpl() {
     }
 
@@ -196,6 +200,8 @@ public class JobInfoImpl implements JobInfo {
         this.externalEndpointUrls = jobInfo.getExternalEndpointUrls();
         this.resultMapPresent = jobInfo.isResultMapPresent();
         this.preciousTasks = jobInfo.getPreciousTasks();
+        this.parentId = jobInfo.getParentId();
+        this.childrenCount = jobInfo.getChildrenCount();
     }
 
     /**
@@ -580,5 +586,23 @@ public class JobInfoImpl implements JobInfo {
 
     public void setPreciousTasks(List<String> preciousTasks) {
         this.preciousTasks = preciousTasks;
+    }
+
+    @Override
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+    }
+
+    @Override
+    public int getChildrenCount() {
+        return childrenCount;
+    }
+
+    public void setChildrenCount(int childrenCount) {
+        this.childrenCount = childrenCount;
     }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -1645,6 +1645,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
                                                    filterCriteria.isChildJobs(),
                                                    filterCriteria.getJobName(),
                                                    filterCriteria.getProjectName(),
+                                                   filterCriteria.getParentId(),
                                                    sortParameters);
         /**
          * Add/inject to each JobInfo the list of signals used by the job, if they exist.

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -570,7 +570,8 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         jlogger.info(job.getId(),
                      "submitted: name '" + job.getName() + "', tasks '" + job.getTotalNumberOfTasks() + "', owner '" +
 
-                                  job.getOwner() + "'");
+                                  job.getOwner() + "'" +
+                                  (job.getParentId() != null ? ", parentJobId '" + job.getParentId() + "'" : ""));
         if (jlogger.isTraceEnabled()) {
             try {
                 jlogger.trace(job.getId(), job.display());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBJobDataParameters.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBJobDataParameters.java
@@ -58,12 +58,14 @@ public class DBJobDataParameters {
 
     private final String projectName;
 
+    private final Long parentId;
+
     private final List<SortParameter<JobSortParameter>> sortParameters;
 
     private final Set<JobStatus> status;
 
     DBJobDataParameters(int offset, int limit, String user, boolean pending, boolean running, boolean finished,
-            boolean childJobs, String jobName, String projectName,
+            boolean childJobs, String jobName, String projectName, Long parentId,
             List<SortParameter<JobSortParameter>> sortParameters) {
         this.offset = offset;
         this.limit = limit;
@@ -74,6 +76,7 @@ public class DBJobDataParameters {
         this.childJobs = childJobs;
         this.jobName = jobName;
         this.projectName = projectName;
+        this.parentId = parentId;
         this.sortParameters = sortParameters;
 
         Set<JobStatus> newStatus = new HashSet<JobStatus>();
@@ -112,6 +115,10 @@ public class DBJobDataParameters {
 
     public String getProjectName() {
         return projectName;
+    }
+
+    public Long getParentId() {
+        return parentId;
     }
 
     public List<SortParameter<JobSortParameter>> getSortParameters() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -86,6 +86,8 @@ import com.google.common.collect.Lists;
 @NamedQueries({ @NamedQuery(name = "setJobForRemoval", query = "update JobData set scheduledTimeForRemoval = :timeForRemoval, toBeRemoved = :toBeRemoved where id = :jobId"),
                 @NamedQuery(name = "deleteJobDataInBulk", query = "delete from JobData where id in (:jobIdList)"),
                 @NamedQuery(name = "checkJobExistence", query = "select id from JobData where id = :id"),
+                @NamedQuery(name = "getChildrenCount", query = "select childrenCount from JobData where id = :id"),
+                @NamedQuery(name = "getParentIds", query = "select parentId from JobData where id in :ids and parentId IS NOT NULL"),
                 @NamedQuery(name = "countJobDataFinished", query = "select count (*) from JobData where status = 3"),
                 @NamedQuery(name = "countJobData", query = "select count (*) from JobData"),
                 @NamedQuery(name = "findUsersWithJobs", query = "select owner, count(owner), max(submittedTime) from JobData group by owner"),
@@ -111,6 +113,8 @@ import com.google.common.collect.Lists;
                 @NamedQuery(name = "updateJobDataRemovedTimeInBulk", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in :jobIdList"),
                 @NamedQuery(name = "updateJobDataSetJobToBeRemoved", query = "update JobData set toBeRemoved = :toBeRemoved, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "updateJobDataPriority", query = "update JobData set priority = :priority, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
+                @NamedQuery(name = "increaseJobDataChildrenCount", query = "update JobData set childrenCount = childrenCount+1, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
+                @NamedQuery(name = "decreaseJobDataChildrenCount", query = "update JobData set childrenCount = childrenCount-1, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "updateJobDataAfterTaskFinished", query = "update JobData set status = :status, " +
                                                                              "finishedTime = :finishedTime, inErrorTime= :inErrorTime, numberOfPendingTasks = :numberOfPendingTasks, " +
                                                                              "numberOfFinishedTasks = :numberOfFinishedTasks, " +
@@ -150,6 +154,8 @@ public class JobData implements Serializable {
     private Long id;
 
     private Long parentId;
+
+    private Integer childrenCount;
 
     private List<TaskData> tasks;
 
@@ -235,6 +241,8 @@ public class JobData implements Serializable {
         jobInfo.setJobOwner(getOwner());
         jobInfo.setProjectName(getProjectName());
         jobInfo.setStatus(getStatus());
+        jobInfo.setParentId(getParentId());
+        jobInfo.setChildrenCount(getChildrenCount());
         jobInfo.setTotalNumberOfTasks(getTotalNumberOfTasks());
         jobInfo.setNumberOfPendingTasks(getNumberOfPendingTasks());
         jobInfo.setNumberOfRunningTasks(getNumberOfRunningTasks());
@@ -431,6 +439,18 @@ public class JobData implements Serializable {
 
     public void setParentId(Long parentId) {
         this.parentId = parentId;
+    }
+
+    @Column(name = "CHILDREN_COUNT", nullable = true)
+    public Integer getChildrenCount() {
+        if (childrenCount == null) {
+            return 0;
+        }
+        return childrenCount;
+    }
+
+    public void setChildrenCount(Integer childrenCount) {
+        this.childrenCount = childrenCount;
     }
 
     @Cascade(org.hibernate.annotations.CascadeType.ALL)

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
@@ -368,6 +368,7 @@ public class InternalJobFactory {
         jobToSet.setGenericInformation(job.getGenericInformation());
         //special behavior
         jobToSet.setPriority(job.getPriority());
+        jobToSet.setParentId(job.getParentId());
     }
 
     /**

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/TestLoadJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/TestLoadJobs.java
@@ -317,17 +317,25 @@ public class TestLoadJobs extends SchedulerFunctionalTestNoRestart {
     }
 
     private JobFilterCriteria criteria(boolean myJobsOnly, boolean pending, boolean running, boolean finished) {
-        return criteria(myJobsOnly, pending, running, finished, true, null, null, null);
+        return criteria(myJobsOnly, pending, running, finished, true, null, null, null, null);
     }
 
     private JobFilterCriteria criteria(boolean myJobsOnly, boolean pending, boolean running, boolean finished,
             boolean childJobs) {
-        return new JobFilterCriteria(myJobsOnly, pending, running, finished, childJobs, null, null, null);
+        return new JobFilterCriteria(myJobsOnly, pending, running, finished, childJobs, null, null, null, null);
     }
 
     private JobFilterCriteria criteria(boolean myJobsOnly, boolean pending, boolean running, boolean finished,
-            boolean childJobs, String jobName, String projectName, String userName) {
-        return new JobFilterCriteria(myJobsOnly, pending, running, finished, childJobs, jobName, projectName, userName);
+            boolean childJobs, String jobName, String projectName, String userName, Long parentId) {
+        return new JobFilterCriteria(myJobsOnly,
+                                     pending,
+                                     running,
+                                     finished,
+                                     childJobs,
+                                     jobName,
+                                     projectName,
+                                     userName,
+                                     parentId);
     }
 
 }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
@@ -49,8 +49,29 @@ import org.ow2.proactive.scheduler.task.internal.InternalTask;
 public class TestLoadJobsPagination extends BaseSchedulerDBTest {
 
     private TaskFlowJob createJob() throws Exception {
+        return createJob(null, null, null, null);
+    }
+
+    private TaskFlowJob createJob(String name, JobPriority priority, String projectName, Long parentId)
+            throws Exception {
         TaskFlowJob job = new TaskFlowJob();
-        job.setName(this.getClass().getSimpleName());
+        if (name != null) {
+            job.setName(name);
+        } else {
+            job.setName(this.getClass().getSimpleName());
+        }
+        if (projectName != null) {
+            job.setProjectName(projectName);
+        } else {
+            job.setProjectName(this.getClass().getSimpleName() + " project");
+        }
+        if (priority != null) {
+            job.setPriority(priority);
+        } else {
+            job.setPriority(JobPriority.NORMAL);
+        }
+
+        job.setParentId(parentId);
         job.setDescription("TestLoadJobsPagination desc");
         JavaTask task = new JavaTask();
         task.setExecutableClassName("className");
@@ -59,13 +80,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
     }
 
     private TaskFlowJob createJob(String name, JobPriority priority) throws Exception {
-        TaskFlowJob job = new TaskFlowJob();
-        job.setName(name);
-        job.setPriority(priority);
-        JavaTask task = new JavaTask();
-        task.setExecutableClassName("className");
-        job.addTask(task);
-        return job;
+        return createJob(name, priority, null, null);
     }
 
     @Test
@@ -99,6 +114,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  null,
                                  null,
+                                 null,
                                  sortParameters(new SortParameter<>(JobSortParameter.ID, SortOrder.ASC)))
                         .getList();
         checkJobs(jobs, 1, 2, 3, 4, 5, 6);
@@ -112,6 +128,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  null,
                                  null,
+                                 null,
                                  sortParameters(new SortParameter<>(JobSortParameter.ID, SortOrder.DESC)))
                         .getList();
         checkJobs(jobs, 6, 5, 4, 3, 2, 1);
@@ -123,6 +140,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  true,
                                  true,
+                                 null,
                                  null,
                                  null,
                                  sortParameters(new SortParameter<>(JobSortParameter.NAME, SortOrder.ASC),
@@ -139,6 +157,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  null,
                                  null,
+                                 null,
                                  sortParameters(new SortParameter<>(JobSortParameter.NAME, SortOrder.ASC),
                                                 new SortParameter<>(JobSortParameter.ID, SortOrder.DESC)))
                         .getList();
@@ -151,6 +170,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  true,
                                  true,
+                                 null,
                                  null,
                                  null,
                                  sortParameters(new SortParameter<>(JobSortParameter.OWNER, SortOrder.ASC)))
@@ -166,6 +186,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  null,
                                  null,
+                                 null,
                                  sortParameters(new SortParameter<>(JobSortParameter.OWNER, SortOrder.DESC)))
                         .getList();
         checkJobs(jobs, 6, 5, 4, 3, 2, 1);
@@ -177,6 +198,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  true,
                                  true,
+                                 null,
                                  null,
                                  null,
                                  sortParameters(new SortParameter<>(JobSortParameter.PRIORITY, SortOrder.ASC)))
@@ -192,6 +214,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  null,
                                  null,
+                                 null,
                                  sortParameters(new SortParameter<>(JobSortParameter.PRIORITY, SortOrder.DESC)))
                         .getList();
         checkJobs(jobs, 6, 5, 4, 3, 2, 1);
@@ -203,6 +226,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  true,
                                  true,
+                                 null,
                                  null,
                                  null,
                                  sortParameters(new SortParameter<>(JobSortParameter.STATE, SortOrder.ASC),
@@ -219,6 +243,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  true,
                                  null,
                                  null,
+                                 null,
                                  sortParameters(new SortParameter<>(JobSortParameter.STATE, SortOrder.DESC),
                                                 new SortParameter<>(JobSortParameter.ID, SortOrder.ASC)))
                         .getList();
@@ -226,18 +251,21 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
     }
 
     @Test
-    public void testPagingAndFilteting() throws Exception {
+    public void testPagingAndFiltering() throws Exception {
         InternalJob job;
         InternalTask task;
 
-        // pending job - 1
-        defaultSubmitJob(createJob());
+        String projectName = "project1";
+        String jobName = "job1";
 
-        // job for user1 - 2
-        defaultSubmitJob(createJob(), "user1");
+        // pending job with projectName - 1
+        defaultSubmitJob(createJob(null, null, projectName, null));
+
+        // job for user1 with jobName - 2
+        defaultSubmitJob(createJob(jobName, null, null, 1L), "user1");
 
         // running job - 3
-        job = defaultSubmitJob(createJob());
+        job = defaultSubmitJob(createJob(null, null, projectName, 1L));
         job.start();
         task = startTask(job, job.getITasks().get(0));
         dbManager.jobTaskStarted(job, task, true);
@@ -274,7 +302,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         List<SortParameter<JobSortParameter>> sortParameters = new ArrayList<>();
         sortParameters.add(new SortParameter<>(JobSortParameter.ID, SortOrder.ASC));
 
-        jobs = dbManager.getJobs(5, 1, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(5, 1, null, true, true, true, true, null, null, null, sortParameters).getList();
         JobInfo jobInfo = jobs.get(0);
         Assert.assertEquals("6", jobInfo.getJobId().value());
         Assert.assertEquals(JobStatus.FINISHED, jobInfo.getStatus());
@@ -286,73 +314,90 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         Assert.assertEquals(JobPriority.NORMAL, jobInfo.getPriority());
         Assert.assertEquals(DEFAULT_USER_NAME, jobInfo.getJobOwner());
 
-        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
+        checkJobs(jobs, 1, 2, 3, 4, 5, 6, 7);
+        Assert.assertEquals(2, jobs.get(0).getChildrenCount());
+
+        jobs = dbManager.getJobs(-1, -1, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 1, 2, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(-1, -1, null, true, true, true, true, null, null, sortParameters).getList();
-        checkJobs(jobs, 1, 2, 3, 4, 5, 6, 7);
-
-        jobs = dbManager.getJobs(-1, 5, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(-1, 5, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 1, 2, 3, 4, 5);
 
-        jobs = dbManager.getJobs(2, -1, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(2, -1, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(0, 0, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 0, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 1, 2, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(0, 1, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 1, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 1);
 
-        jobs = dbManager.getJobs(0, 3, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 3, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 1, 2, 3);
 
-        jobs = dbManager.getJobs(1, 10, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(1, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 2, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(5, 10, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(5, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 6, 7);
 
-        jobs = dbManager.getJobs(6, 10, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(6, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 7);
 
-        jobs = dbManager.getJobs(7, 10, null, true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(7, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, true, true, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, true, true, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs, 1, 3, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, "user1", true, true, true, true, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 10, "user1", true, true, true, true, null, null, null, sortParameters).getList();
         checkJobs(jobs, 2);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, false, false, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, false, false, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs, 1);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, true, false, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, true, false, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs, 3);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, false, true, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, false, true, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, true, true, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, true, true, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs, 3, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, false, true, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, false, true, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs, 1, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, true, false, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, true, false, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs, 1, 3);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, false, false, true, null, null, sortParameters)
+        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, false, false, true, null, null, null, sortParameters)
                         .getList();
         checkJobs(jobs);
+
+        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, jobName, null, null, sortParameters).getList();
+        checkJobs(jobs, 2);
+
+        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, projectName, null, sortParameters)
+                        .getList();
+        checkJobs(jobs, 1, 3);
+
+        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, 1L, sortParameters).getList();
+        checkJobs(jobs, 2, 3);
+
+        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, jobName, null, 1L, sortParameters).getList();
+        checkJobs(jobs, 2);
+
+        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, projectName, 1L, sortParameters).getList();
+        checkJobs(jobs, 3);
     }
 
     private List<SortParameter<JobSortParameter>> sortParameters(SortParameter<JobSortParameter>... params) {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/jmx/SchedulerRuntimeDataMBeanTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/jmx/SchedulerRuntimeDataMBeanTest.java
@@ -102,6 +102,7 @@ public class SchedulerRuntimeDataMBeanTest extends SchedulerFunctionalTestNoRest
                                                                                            true,
                                                                                            null,
                                                                                            null,
+                                                                                           null,
                                                                                            null),
                                                                      null)
                                                             .getList();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
@@ -243,15 +243,15 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
         initExpectedResults("testGetTotalJobsCount-Job", "TEST-TAG");
 
         // default parameters
-        actualJobPage = dbManager.getJobs(0, 0, null, true, true, true, true, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 0, null, true, true, true, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, no user, no pending, no running, no finished
-        actualJobPage = dbManager.getJobs(0, 0, null, false, false, false, true, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 0, null, false, false, false, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished
-        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished, jobName = "testGetTotalJobsCount-Job"
@@ -264,23 +264,24 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
                                           true,
                                           "testGetTotalJobsCount-Job",
                                           null,
+                                          null,
                                           null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished, jobName = "testGetTotal"
-        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, "testGetTotal", null, null);
+        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, "testGetTotal", null, null, null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished, jobName = "invalid_job_name"
-        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, "invalid_job_name", null, null);
+        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, "invalid_job_name", null, null, null);
         assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
 
         // no pagination, user = "invalid_user", pending, no running, finished
-        actualJobPage = dbManager.getJobs(0, 0, "invalid_user", true, true, true, true, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 0, "invalid_user", true, true, true, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
 
         // pagination [0,5[, user = "admin", pending, running, finished
-        actualJobPage = dbManager.getJobs(0, 5, "admin", true, true, true, true, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 5, "admin", true, true, true, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
     }
 
@@ -423,7 +424,7 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
 
         dbManager.updateJobAndTasksState(job);
 
-        Page<JobInfo> jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, null);
+        Page<JobInfo> jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, null, null);
 
         assertThat(jobs.getSize()).isEqualTo(1);
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -1354,7 +1354,7 @@ public class SchedulerTHelper {
 
     public void cleanJobs() throws Exception {
         Scheduler userInt = getSchedulerInterface();
-        JobFilterCriteria criteria = new JobFilterCriteria(false, true, true, true, true, null, null, null);
+        JobFilterCriteria criteria = new JobFilterCriteria(false, true, true, true, true, null, null, null, null);
         List<JobInfo> jobs = userInt.getJobs(0,
                                              1000,
                                              criteria,


### PR DESCRIPTION
 - when a job with a parentId is submitted, we increase the children count of the parent job
 - when a job with a parentId is removed, we decrease the children count of the parent job
 - also added the parentId to JobInfo
 - added a filter to revisionAndJobInfo endpoint, which allows to return all children of the given job
 - added db tests and rest client tests