### PR TITLE
Disable some models validations when variable is hidden

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/DefaultModelJobValidatorServiceProvider.java
@@ -138,7 +138,7 @@ public class DefaultModelJobValidatorServiceProvider implements JobValidatorServ
             context.setVariableName(variable.getName());
 
             try {
-                new ModelValidator(model).validate(variable.getValue(), context);
+                new ModelValidator(model).validate(variable.getValue(), context, variable.isHidden());
             } catch (Exception e) {
                 throw new JobValidationException((task != null ? "Task '" + task.getName() + "': " : "") +
                                                  "Variable '" + variable.getName() + "': Model " + variable.getModel() +

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/BaseParserValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/BaseParserValidator.java
@@ -157,17 +157,18 @@ public abstract class BaseParserValidator<T> implements ParserValidator<T> {
         return groupsFound;
     }
 
+    // Used in tests only
     @Override
     public T parseAndValidate(String parameterValue)
             throws ConversionException, ValidationException, ModelSyntaxException {
-        return parseAndValidate(parameterValue, null);
+        return parseAndValidate(parameterValue, null, false);
     }
 
     @Override
-    public T parseAndValidate(String parameterValue, ModelValidatorContext context)
+    public T parseAndValidate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
             throws ConversionException, ValidationException, ModelSyntaxException {
         Converter<T> converter = createConverter(model);
-        return createValidator(model, converter).validate(converter.convert(parameterValue), context);
+        return createValidator(model, converter).validate(converter.convert(parameterValue), context, isVariableHidden);
     }
 
     public static String ignoreCaseRegexp(String matcher) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ParserValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ParserValidator.java
@@ -48,11 +48,12 @@ public interface ParserValidator<T> {
      *
      * @param parameterValue value to parse and validate
      * @param context a context for this validation
+     * @param isVariableHidden true if the variable is hidden
      * @return a converted value
      * @throws ConversionException if an error occurred during the conversion
      * @throws ValidationException if an error occurred during the validation
      */
-    T parseAndValidate(String parameterValue, ModelValidatorContext context)
+    T parseAndValidate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
             throws ConversionException, ValidationException, ModelSyntaxException;
 
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/AcceptAllValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/AcceptAllValidator.java
@@ -36,7 +36,8 @@ public class AcceptAllValidator<T> implements Validator<T> {
     }
 
     @Override
-    public T validate(T parameterValue, ModelValidatorContext context) throws ValidationException {
+    public T validate(T parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         // accept all values
         return parameterValue;
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CRONValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CRONValidator.java
@@ -39,7 +39,8 @@ public class CRONValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         try {
             (new Predictor(parameterValue)).nextMatchingDate();
         } catch (InvalidPatternException e) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidator.java
@@ -74,15 +74,17 @@ public class CatalogObjectValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         Pattern pattern = Pattern.compile(CATALOG_OBJECT_MODEL_REGEXP);
         Matcher matcher = pattern.matcher(parameterValue);
         if (!(parameterValue.matches(CATALOG_OBJECT_MODEL_REGEXP) && matcher.find())) {
             throw new ValidationException("Expected value should match regular expression " + pattern.pattern() +
                                           " , received " + parameterValue);
         }
-        if (context == null || context.getSessionId() == null || context.getSessionId().isEmpty()) {
-            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog).
+        if (context == null || context.getSessionId() == null || context.getSessionId().isEmpty() || isVariableHidden) {
+            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog)
+            // or the variable may be hidden.
             // In this case, we don't have the access of the scheduler global dataspace, so the validity check is passed.
             logger.debug(String.format("Validity of the variable value [%s] is skipped because access to the catalog is disabled.",
                                        parameterValue));

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CredentialValidator.java
@@ -43,9 +43,11 @@ public class CredentialValidator implements Validator<String> {
     private static final Logger logger = Logger.getLogger(CredentialValidator.class);
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
-        if (context == null || context.getScheduler() == null) {
-            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog).
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
+        if (context == null || context.getScheduler() == null || isVariableHidden) {
+            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog)
+            // or the variable may be hidden
             // In this case, we don't have the access of the third-party credentials, so the validity check is passed.
             logger.debug(String.format("Can't check the validity of the variable value, because missing the access to the scheduler third-party credentials",
                                        parameterValue));

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/EncryptionValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/EncryptionValidator.java
@@ -37,7 +37,8 @@ public class EncryptionValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         if (parameterValue != null && parameterValue.startsWith(PropertyDecrypter.ENCRYPTION_PREFIX)) {
             // validating value already encrypted
             try {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/GlobalFileValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/GlobalFileValidator.java
@@ -39,9 +39,11 @@ public class GlobalFileValidator implements Validator<String> {
     private static final Logger logger = Logger.getLogger(GlobalFileValidator.class);
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
-        if (context == null || context.getSpace() == null) {
-            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog).
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
+        if (context == null || context.getSpace() == null || isVariableHidden) {
+            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog)
+            // or the variable may be hidden.
             // In this case, we don't have the access of the scheduler global dataspace, so the validity check is passed.
             logger.debug(String.format("Can't check the validity of the variable value [%s], because missing the access to the scheduler global data space",
                                        parameterValue));

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/GlobalFolderValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/GlobalFolderValidator.java
@@ -39,9 +39,11 @@ public class GlobalFolderValidator implements Validator<String> {
     private static final Logger logger = Logger.getLogger(GlobalFolderValidator.class);
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
-        if (context == null || context.getSpace() == null) {
-            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog).
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
+        if (context == null || context.getSpace() == null || isVariableHidden) {
+            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog)
+            // or the variable may be hidden.
             // In this case, we don't have the access of the scheduler global dataspace, so the validity check is passed.
             logger.debug(String.format("Can't check the validity of the variable value [%s], because missing the access to the scheduler global data space",
                                        parameterValue));

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/JSONValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/JSONValidator.java
@@ -44,7 +44,8 @@ public class JSONValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
 
         try {
             final JsonParser parser = new ObjectMapper().getJsonFactory().createJsonParser(parameterValue);

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ListValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ListValidator.java
@@ -44,7 +44,8 @@ public class ListValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         if (!listItems.contains(parameterValue)) {
             throw new ValidationException("Expected value should be one of " + listItems + ", received '" +
                                           parameterValue + "'");

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ModelValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ModelValidator.java
@@ -57,11 +57,12 @@ public class ModelValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         try {
             ParserValidator<?> validator = createParserValidator();
             if (validator != null) {
-                validator.parseAndValidate(parameterValue, context);
+                validator.parseAndValidate(parameterValue, context, isVariableHidden);
             }
             return parameterValue;
         } catch (Exception e) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/NotEmptyValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/NotEmptyValidator.java
@@ -37,7 +37,8 @@ import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.Val
 public class NotEmptyValidator implements Validator<String> {
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         if (StringUtils.isBlank(parameterValue)) {
             throw new ValidationException("Expected value should not be blank.");
         }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/OptionalValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/OptionalValidator.java
@@ -42,12 +42,13 @@ public class OptionalValidator<T> implements Validator<T> {
     }
 
     @Override
-    public T validate(T parameterValue, ModelValidatorContext context) throws ValidationException {
+    public T validate(T parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         // When the parameter value is not provided, it's validated. Otherwise, use its proper validator
         if (parameterValue == null || StringUtils.isBlank(parameterValue.toString())) {
             return parameterValue;
         } else {
-            return validator.validate(parameterValue, context);
+            return validator.validate(parameterValue, context, isVariableHidden);
         }
     }
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RangeValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RangeValidator.java
@@ -52,7 +52,8 @@ public class RangeValidator<T extends Comparable<T>> implements Validator<T> {
     }
 
     @Override
-    public T validate(T parameterValue, ModelValidatorContext context) throws ValidationException {
+    public T validate(T parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         if (!range.contains(parameterValue)) {
             throw new ValidationException("Expected value should be in range " + range.toString() + ", received " +
                                           parameterValue);

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RegexpValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RegexpValidator.java
@@ -40,7 +40,8 @@ public class RegexpValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
 
         if (!pattern.matcher(parameterValue).matches()) {
             throw new ValidationException("Expected value should match regular expression " + pattern.pattern() +

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidator.java
@@ -44,7 +44,8 @@ public class SpelValidator implements Validator<String> {
     }
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         try {
             context.getSpELContext().setVariable("value", parameterValue);
             // register true / false functions

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URIValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URIValidator.java
@@ -39,7 +39,8 @@ import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.Val
 public class URIValidator implements Validator<String> {
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         try {
             return new URI(parameterValue).toString();
         } catch (URISyntaxException e) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URLValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URLValidator.java
@@ -39,7 +39,8 @@ import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.Val
 public class URLValidator implements Validator<String> {
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
         try {
             return new URL(parameterValue).toString();
         } catch (MalformedURLException e) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/UserFileValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/UserFileValidator.java
@@ -39,9 +39,11 @@ public class UserFileValidator implements Validator<String> {
     private static final Logger logger = Logger.getLogger(UserFileValidator.class);
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
-        if (context == null || context.getSpace() == null) {
-            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog).
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
+        if (context == null || context.getSpace() == null || isVariableHidden) {
+            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog)
+            // or the variable may be hidden.
             // In this case, we don't have the access of the scheduler user dataspace, so the validity check is passed.
             logger.debug(String.format("Can't check the validity of the variable value [%s], because missing the access to the scheduler user data space",
                                        parameterValue));

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/UserFolderValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/UserFolderValidator.java
@@ -39,9 +39,11 @@ public class UserFolderValidator implements Validator<String> {
     private static final Logger logger = Logger.getLogger(UserFolderValidator.class);
 
     @Override
-    public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
-        if (context == null || context.getSpace() == null) {
-            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog).
+    public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+            throws ValidationException {
+        if (context == null || context.getSpace() == null || isVariableHidden) {
+            // Sometimes the workflow is parsed and checked without scheduler instance (e.g., submitted from catalog)
+            // or the variable may be hidden.
             // In this case, we don't have the access of the scheduler user dataspace, so the validity check is passed.
             logger.debug(String.format("Can't check the validity of the variable value [%s], because missing the access to the scheduler user data space",
                                        parameterValue));

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/Validator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/Validator.java
@@ -37,8 +37,9 @@ public interface Validator<T> {
      *
      * @param parameterValue the value to check.
      * @param context a context object, if needed by the validator
+     * @param isVariableHidden true is the variable is hidden
      * @return the unmodified parameterValue if validation is successful
      * @throws ValidationException if the parameter value is invalid.
      */
-    T validate(T parameterValue, ModelValidatorContext context) throws ValidationException;
+    T validate(T parameterValue, ModelValidatorContext context, boolean isVariableHidden) throws ValidationException;
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/GlobalFileParserValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/GlobalFileParserValidatorTest.java
@@ -65,14 +65,14 @@ public class GlobalFileParserValidatorTest {
     public void testThatValidGlobalFileIsOk() throws ModelSyntaxException, ValidationException, ConversionException {
         String value = existGlobalFilePath;
         GlobalFileParserValidator parserValidator = new GlobalFileParserValidator(ModelType.GLOBAL_FILE.name());
-        Assert.assertEquals(value, parserValidator.parseAndValidate(value, context));
+        Assert.assertEquals(value, parserValidator.parseAndValidate(value, context, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatInvalidGlobalFileThrowException()
             throws ModelSyntaxException, ValidationException, ConversionException {
         GlobalFileParserValidator parserValidator = new GlobalFileParserValidator(ModelType.GLOBAL_FILE.name());
-        parserValidator.parseAndValidate(notExistGlobalFilePath, context);
+        parserValidator.parseAndValidate(notExistGlobalFilePath, context, false);
     }
 
     @Test(expected = ValidationException.class)
@@ -80,7 +80,7 @@ public class GlobalFileParserValidatorTest {
             throws ModelSyntaxException, ValidationException, ConversionException {
         String value = "";
         GlobalFileParserValidator parserValidator = new GlobalFileParserValidator(ModelType.GLOBAL_FILE.name());
-        parserValidator.parseAndValidate(value, context);
+        parserValidator.parseAndValidate(value, context, false);
     }
 
     // when context is not specified, the parserValidator is expected to not check global file existence.
@@ -89,7 +89,7 @@ public class GlobalFileParserValidatorTest {
             throws ModelSyntaxException, ValidationException, ConversionException {
         String value = "";
         GlobalFileParserValidator parserValidator = new GlobalFileParserValidator(ModelType.GLOBAL_FILE.name());
-        Assert.assertEquals(value, parserValidator.parseAndValidate(value, null));
+        Assert.assertEquals(value, parserValidator.parseAndValidate(value, null, false));
     }
 
     @Test(expected = ModelSyntaxException.class)

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/OptionalParserValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/OptionalParserValidatorTest.java
@@ -147,7 +147,7 @@ public class OptionalParserValidatorTest {
     public void testThatValidValueIsOK(ModelType type, String model, String value, Object expectedParsedValue)
             throws ModelSyntaxException, ValidationException, ConversionException {
         ParserValidator<String> parserValidator = new OptionalParserValidator<>(model, type);
-        Object parsedValue = parserValidator.parseAndValidate(value, context);
+        Object parsedValue = parserValidator.parseAndValidate(value, context, false);
         Assert.assertEquals(String.format("When parsing the variable (model '%s', value '%s'), get the parsed value '%s' instead of expected '%s'",
                                           type,
                                           value,
@@ -160,7 +160,7 @@ public class OptionalParserValidatorTest {
     public void testThatValidHiddenValueIsOK() throws ModelSyntaxException, ValidationException, ConversionException {
         String model = ModelType.HIDDEN.name() + ModelValidator.OPTIONAL_VARIABLE_SUFFIX;
         ParserValidator<String> parserValidator = new OptionalParserValidator<>(model, ModelType.HIDDEN);
-        String parsedValue = parserValidator.parseAndValidate("pwd", context);
+        String parsedValue = parserValidator.parseAndValidate("pwd", context, false);
         Assert.assertTrue(parsedValue.startsWith("ENC("));
         Assert.assertTrue(parsedValue.endsWith(")"));
     }
@@ -205,7 +205,7 @@ public class OptionalParserValidatorTest {
             throws ModelSyntaxException, ValidationException, ConversionException {
         String value = " ";
         ParserValidator<String> parserValidator = new OptionalParserValidator<>(model, type);
-        Assert.assertNull(parserValidator.parseAndValidate(value, context));
+        Assert.assertNull(parserValidator.parseAndValidate(value, context, false));
     }
 
     public void testThatBlankValueIsOK(ModelType type)
@@ -375,7 +375,7 @@ public class OptionalParserValidatorTest {
     public void testThatInvalidValueThrowException(ModelType type, String model, String invalidValue)
             throws ModelSyntaxException, ValidationException, ConversionException {
         ParserValidator<String> parserValidator = new OptionalParserValidator<>(model, type);
-        parserValidator.parseAndValidate(invalidValue, context);
+        parserValidator.parseAndValidate(invalidValue, context, false);
     }
 
     public void testThatInvalidValueThrowException(ModelType type, String invalidValue)

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/UserFileParserValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/UserFileParserValidatorTest.java
@@ -65,14 +65,14 @@ public class UserFileParserValidatorTest {
     public void testThatValidUserFileIsOK() throws ModelSyntaxException, ValidationException, ConversionException {
         String value = existUserFilePath;
         UserFileParserValidator parserValidator = new UserFileParserValidator(ModelType.USER_FILE.name());
-        Assert.assertEquals(value, parserValidator.parseAndValidate(value, context));
+        Assert.assertEquals(value, parserValidator.parseAndValidate(value, context, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatInvalidUserFileThrowException()
             throws ModelSyntaxException, ValidationException, ConversionException {
         UserFileParserValidator parserValidator = new UserFileParserValidator(ModelType.USER_FILE.name());
-        parserValidator.parseAndValidate(notExistUserFilePath, context);
+        parserValidator.parseAndValidate(notExistUserFilePath, context, false);
     }
 
     @Test(expected = ValidationException.class)
@@ -80,7 +80,7 @@ public class UserFileParserValidatorTest {
             throws ModelSyntaxException, ValidationException, ConversionException {
         String value = "";
         UserFileParserValidator parserValidator = new UserFileParserValidator(ModelType.USER_FILE.name());
-        parserValidator.parseAndValidate(value, context);
+        parserValidator.parseAndValidate(value, context, false);
     }
 
     // when context is not specified, the parserValidator is expected to not check user file existence.
@@ -89,7 +89,7 @@ public class UserFileParserValidatorTest {
             throws ModelSyntaxException, ValidationException, ConversionException {
         String value = "";
         UserFileParserValidator parserValidator = new UserFileParserValidator(ModelType.USER_FILE.name());
-        Assert.assertEquals(value, parserValidator.parseAndValidate(value, null));
+        Assert.assertEquals(value, parserValidator.parseAndValidate(value, null, false));
     }
 
     @Test(expected = ModelSyntaxException.class)

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/AcceptAllValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/AcceptAllValidatorTest.java
@@ -35,6 +35,6 @@ public class AcceptAllValidatorTest {
     @Test
     public void testAcceptAll() throws ValidationException {
         String value = "my value";
-        Assert.assertEquals(value, new AcceptAllValidator<String>().validate(value, null));
+        Assert.assertEquals(value, new AcceptAllValidator<String>().validate(value, null, false));
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CRONValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CRONValidatorTest.java
@@ -35,12 +35,12 @@ public class CRONValidatorTest {
     @Test
     public void testCRONOK() throws ValidationException {
         String value = "* * * * *";
-        Assert.assertEquals(value, new CRONValidator().validate(value, null));
+        Assert.assertEquals(value, new CRONValidator().validate(value, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testCRONKO() throws ValidationException {
         String value = " * * * *";
-        new CRONValidator().validate(value, null);
+        new CRONValidator().validate(value, null, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidatorTest.java
@@ -39,54 +39,54 @@ public class CatalogObjectValidatorTest {
     @Test
     public void testCatalogObjectOKWithoutRevisionNumber() throws ValidationException {
         String value = "bucket_1/object10";
-        Assert.assertEquals(value, new CatalogObjectValidator().validate(value, null));
+        Assert.assertEquals(value, new CatalogObjectValidator().validate(value, null, false));
     }
 
     @Test
     public void testCatalogObjectOKWithRevisionNumber() throws ValidationException {
         String value = "bucket_1/object10/1539310165443";
-        Assert.assertEquals(value, new CatalogObjectValidator().validate(value, null));
+        Assert.assertEquals(value, new CatalogObjectValidator().validate(value, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testCatalogObjectWithEmptyValue() throws ValidationException {
         String value = "";
-        new CatalogObjectValidator().validate(value, null);
+        new CatalogObjectValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testCatalogObjectWithInvalidValue1() throws ValidationException {
         String value = " bucket_1/";
-        new CatalogObjectValidator().validate(value, null);
+        new CatalogObjectValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testCatalogObjectWithInvalidValue2() throws ValidationException {
         String value = " bucket_1";
-        new CatalogObjectValidator().validate(value, null);
+        new CatalogObjectValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testCatalogObjectWithShortRevisionNumber() throws ValidationException {
         String value = " bucket_1/object10/123445";
-        new CatalogObjectValidator().validate(value, null);
+        new CatalogObjectValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testCatalogObjectKOWithInvalidRevisionNumber() throws ValidationException {
         String value = " bucket_1/object10/123445ddd";
-        new CatalogObjectValidator().validate(value, null);
+        new CatalogObjectValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testCatalogObjectKOWithNoRevisionNumber() throws ValidationException {
         String value = " bucket_1/object10/";
-        new CatalogObjectValidator().validate(value, null);
+        new CatalogObjectValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testCatalogObjectKOWithLongRevisionNumber() throws ValidationException {
         String value = " bucket_1/object10/153931016544335";
-        new CatalogObjectValidator().validate(value, null);
+        new CatalogObjectValidator().validate(value, null, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/EncryptionValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/EncryptionValidatorTest.java
@@ -54,7 +54,7 @@ public class EncryptionValidatorTest {
     public void testEncryptedReadOK() throws ValidationException {
         String value = "some_data";
         String encryptedValue = PropertyDecrypter.encryptData(value);
-        Assert.assertEquals(encryptedValue, new EncryptionValidator().validate(encryptedValue, context));
+        Assert.assertEquals(encryptedValue, new EncryptionValidator().validate(encryptedValue, context, false));
     }
 
     @Test(expected = ValidationException.class)
@@ -63,13 +63,13 @@ public class EncryptionValidatorTest {
         String encryptedValue = PropertyDecrypter.ENCRYPTION_PREFIX +
                                 PropertyDecrypter.getDefaultEncryptor().encrypt(value) + "blabla" +
                                 PropertyDecrypter.ENCRYPTION_SUFFIX;
-        new EncryptionValidator().validate(encryptedValue, context);
+        new EncryptionValidator().validate(encryptedValue, context, false);
     }
 
     @Test
     public void testEncryptedWriteOK() throws ValidationException {
         String value = "some_data";
-        String encryptedValue = new EncryptionValidator().validate(value, context);
+        String encryptedValue = new EncryptionValidator().validate(value, context, false);
         // decrypt returned string, which uses ENC(crypted_data) format
         Assert.assertEquals(value, PropertyDecrypter.decryptData(encryptedValue));
 

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/GlobalFileValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/GlobalFileValidatorTest.java
@@ -63,19 +63,19 @@ public class GlobalFileValidatorTest {
     public void testThatExistGlobalFileIsOK() throws ValidationException {
         GlobalFileValidator validator = new GlobalFileValidator();
         String value = existGlobalFilePath;
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatNotExistGlobalFileThrowException() throws ValidationException {
         GlobalFileValidator validator = new GlobalFileValidator();
-        validator.validate(notExistGlobalFilePath, context);
+        validator.validate(notExistGlobalFilePath, context, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testThatEmptyGlobalFileThrowException() throws ValidationException {
         GlobalFileValidator validator = new GlobalFileValidator();
         String value = "";
-        validator.validate(value, context);
+        validator.validate(value, context, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/JSONValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/JSONValidatorTest.java
@@ -39,48 +39,48 @@ public class JSONValidatorTest {
     @Test
     public void testJSONOKSimple() throws ValidationException {
         String value = "{\"type\": \"string\"}";
-        Assert.assertEquals(value, new JSONValidator().validate(value, null));
+        Assert.assertEquals(value, new JSONValidator().validate(value, null, false));
     }
 
     @Test
     public void testJSONOKMultiple() throws ValidationException {
         String value = "{\n" + "  \"type\": \"string\", \n" + "  \"minLength\": 3,\n" + "  \"maxLength\": 7\n" + "}";
-        Assert.assertEquals(value, new JSONValidator().validate(value, null));
+        Assert.assertEquals(value, new JSONValidator().validate(value, null, false));
     }
 
     @Test
     public void testJSONWithEmptyValue() throws ValidationException {
         String value = "{}";
-        new JSONValidator().validate(value, null);
+        new JSONValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testJSONWithInvalidValue1() throws ValidationException {
         String value = "{\n" + "  type: \"string\", \n" + "}";
-        new JSONValidator().validate(value, null);
+        new JSONValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testJSONWithInvalidValue2() throws ValidationException {
         String value = "[\n" + "  \"type\": \"string\", \n" + "]";
-        new JSONValidator().validate(value, null);
+        new JSONValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testJSONWithInvalidValue3() throws ValidationException {
         String value = "{\n" + "    123 : \"Variable1\"\n";
-        new JSONValidator().validate(value, null);
+        new JSONValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testJSONWithInvalidValue4() throws ValidationException {
         String value = "\"test\" : 123";
-        new JSONValidator().validate(value, null);
+        new JSONValidator().validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testJSONWithInvalidValue5() throws ValidationException {
         String value = "{\n" + "  \"test\" : 62GE\n" + "}";
-        new JSONValidator().validate(value, null);
+        new JSONValidator().validate(value, null, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ListValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ListValidatorTest.java
@@ -39,27 +39,27 @@ public class ListValidatorTest {
     @Test
     public void testListOK() throws Exception {
         ListValidator validator = new ListValidator(listMembers);
-        Assert.assertEquals("1", validator.validate("1", null));
-        Assert.assertEquals("2", validator.validate("2", null));
-        Assert.assertEquals("3", validator.validate("3", null));
+        Assert.assertEquals("1", validator.validate("1", null, false));
+        Assert.assertEquals("2", validator.validate("2", null, false));
+        Assert.assertEquals("3", validator.validate("3", null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testListWrongValue() throws Exception {
         ListValidator validator = new ListValidator(listMembers);
-        validator.validate("4", null);
+        validator.validate("4", null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testListEmptyValue() throws Exception {
         ListValidator validator = new ListValidator(listMembers);
-        validator.validate("", null);
+        validator.validate("", null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testListNullValue() throws Exception {
         ListValidator validator = new ListValidator(listMembers);
-        validator.validate(null, null);
+        validator.validate(null, null, false);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ModelValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/ModelValidatorTest.java
@@ -38,14 +38,14 @@ public class ModelValidatorTest {
     public void testModelValidatorNotHandled() throws ValidationException {
         ModelValidator validator = new ModelValidator("Unknown");
         String parameterValue = "Any Value";
-        Assert.assertEquals(parameterValue, validator.validate(parameterValue, null));
+        Assert.assertEquals(parameterValue, validator.validate(parameterValue, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testModelValidatorValidPrefixButUnknownType() throws ValidationException {
         ModelValidator validator = new ModelValidator(ModelValidator.PREFIX + "Unknown");
         String parameterValue = "Any Value";
-        validator.validate(parameterValue, null);
+        validator.validate(parameterValue, null, false);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -169,7 +169,7 @@ public class ModelValidatorTest {
         ModelValidator validator = new ModelValidator(ModelValidator.PREFIX + "Unknown" +
                                                       ModelValidator.OPTIONAL_VARIABLE_SUFFIX);
         String parameterValue = "Any Value";
-        validator.validate(parameterValue, null);
+        validator.validate(parameterValue, null, false);
     }
 
     @Test

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/NotEmptyValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/NotEmptyValidatorTest.java
@@ -40,41 +40,41 @@ public class NotEmptyValidatorTest {
     public void testNotEmptyStringOK() throws ValidationException {
         NotEmptyValidator validator = new NotEmptyValidator();
         String value = "string foo";
-        Assert.assertEquals(value, validator.validate(value, null));
+        Assert.assertEquals(value, validator.validate(value, null, false));
     }
 
     @Test
     public void testNotEmptyStringWithSpacesOK() throws ValidationException {
         NotEmptyValidator validator = new NotEmptyValidator();
         String value = " abc ";
-        Assert.assertEquals(value, validator.validate(value, null));
+        Assert.assertEquals(value, validator.validate(value, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testEmptyStringDisallowed() throws ValidationException {
         NotEmptyValidator validator = new NotEmptyValidator();
         String value = "";
-        validator.validate(value, null);
+        validator.validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testNullStringDisallowed() throws ValidationException {
         NotEmptyValidator validator = new NotEmptyValidator();
         String value = null;
-        validator.validate(value, null);
+        validator.validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testBlankStringDisallowed() throws ValidationException {
         NotEmptyValidator validator = new NotEmptyValidator();
         String value = "      ";
-        validator.validate(value, null);
+        validator.validate(value, null, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testTabStringDisallowed() throws ValidationException {
         NotEmptyValidator validator = new NotEmptyValidator();
         String value = "\t";
-        validator.validate(value, null);
+        validator.validate(value, null, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/OptionalValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/OptionalValidatorTest.java
@@ -52,109 +52,110 @@ public class OptionalValidatorTest {
     public void testThatOnlyBlankValidatorValidateBlankValue() throws Exception {
         String blank = " ";
         OptionalValidator<String> onlyBlankValidator = new OptionalValidator<>(new DisallowAllValidator());
-        Assert.assertEquals(blank, onlyBlankValidator.validate(blank, null));
+        Assert.assertEquals(blank, onlyBlankValidator.validate(blank, null, false));
     }
 
     @Test
     public void testThatOnlyBlankValidatorValidateEmptyValue() throws Exception {
         String blank = "";
         OptionalValidator<String> onlyBlankValidator = new OptionalValidator<>(new DisallowAllValidator());
-        Assert.assertEquals(blank, onlyBlankValidator.validate(blank, null));
+        Assert.assertEquals(blank, onlyBlankValidator.validate(blank, null, false));
     }
 
     @Test
     public void testThatOnlyBlankValidatorValidateTabValue() throws Exception {
         String blank = "\t";
         OptionalValidator<String> onlyBlankValidator = new OptionalValidator<>(new DisallowAllValidator());
-        Assert.assertEquals(blank, onlyBlankValidator.validate(blank, null));
+        Assert.assertEquals(blank, onlyBlankValidator.validate(blank, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatOnlyBlankValidatorThrowExceptionForNotBlankValue() throws Exception {
         String notBlank = " any string ";
         OptionalValidator<String> onlyBlankValidator = new OptionalValidator<>(new DisallowAllValidator());
-        onlyBlankValidator.validate(notBlank, null);
+        onlyBlankValidator.validate(notBlank, null, false);
     }
 
     @Test
     public void testThatOptionalURLValidatorValidateBlankValue() throws Exception {
         String blank = "  ";
         OptionalValidator<String> optionalURLValidator = new OptionalValidator<>(new URLValidator());
-        Assert.assertEquals(blank, optionalURLValidator.validate(blank, null));
+        Assert.assertEquals(blank, optionalURLValidator.validate(blank, null, false));
     }
 
     @Test
     public void testThatOptionalURLValidatorValidateValidURL() throws Exception {
         String validURL = "http://mysite?myparam=1";
         OptionalValidator<String> optionalURLValidator = new OptionalValidator<>(new URLValidator());
-        Assert.assertEquals(validURL, optionalURLValidator.validate(validURL, null));
+        Assert.assertEquals(validURL, optionalURLValidator.validate(validURL, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatOptionalURLValidatorThrowExceptionForInvalidURL() throws Exception {
         String invalidURL = "unknown://mysite.com";
         OptionalValidator<String> optionalURLValidator = new OptionalValidator<>(new URLValidator());
-        optionalURLValidator.validate(invalidURL, null);
+        optionalURLValidator.validate(invalidURL, null, false);
     }
 
     @Test
     public void testThatOptionalURIValidatorValidateBlankValue() throws Exception {
         String blank = "  ";
         OptionalValidator<String> optionalURIValidator = new OptionalValidator<>(new URIValidator());
-        Assert.assertEquals(blank, optionalURIValidator.validate(blank, null));
+        Assert.assertEquals(blank, optionalURIValidator.validate(blank, null, false));
     }
 
     @Test
     public void testThatOptionalURIValidatorValidateValidURI() throws Exception {
         String validURI = "c:/toto";
         OptionalValidator<String> optionalURIValidator = new OptionalValidator<>(new URIValidator());
-        Assert.assertEquals(validURI, optionalURIValidator.validate(validURI, null));
+        Assert.assertEquals(validURI, optionalURIValidator.validate(validURI, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatOptionalURIValidatorThrowExceptionForInvalidURI() throws Exception {
         String invalidURI = "invalid%uri";
         OptionalValidator<String> optionalURIValidator = new OptionalValidator<>(new URIValidator());
-        optionalURIValidator.validate(invalidURI, null);
+        optionalURIValidator.validate(invalidURI, null, false);
     }
 
     @Test
     public void testThatOptionalGlobalFileValidatorValidateBlankValue() throws Exception {
         String blank = "  ";
         OptionalValidator<String> optionalGlobalFileValidator = new OptionalValidator<>(new GlobalFileValidator());
-        Assert.assertEquals(blank, optionalGlobalFileValidator.validate(blank, null));
+        Assert.assertEquals(blank, optionalGlobalFileValidator.validate(blank, null, false));
     }
 
     @Test
     public void testThatOptionalGlobalFileValidatorValidateExistGlobalFile() throws Exception {
         OptionalValidator<String> optionalGlobalFileValidator = new OptionalValidator<>(new GlobalFileValidator());
         Assert.assertEquals(existGlobalFilePath,
-                            optionalGlobalFileValidator.validate(existGlobalFilePath, mockContext()));
+                            optionalGlobalFileValidator.validate(existGlobalFilePath, mockContext(), false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatOptionalGlobalFileValidatorThrowExceptionForNotExistGlobalFile() throws Exception {
         OptionalValidator<String> optionalGlobalFileValidator = new OptionalValidator<>(new GlobalFileValidator());
-        optionalGlobalFileValidator.validate(notExistGlobalFilePath, mockContext());
+        optionalGlobalFileValidator.validate(notExistGlobalFilePath, mockContext(), false);
     }
 
     @Test
     public void testThatOptionalUserFileValidatorValidateBlankValue() throws Exception {
         String blank = "  ";
         OptionalValidator<String> optionalUserFileValidator = new OptionalValidator<>(new UserFileValidator());
-        Assert.assertEquals(blank, optionalUserFileValidator.validate(blank, null));
+        Assert.assertEquals(blank, optionalUserFileValidator.validate(blank, null, false));
     }
 
     @Test
     public void testThatOptionalUserFileValidatorValidateExistUserFile() throws Exception {
         OptionalValidator<String> optionalUserFileValidator = new OptionalValidator<>(new UserFileValidator());
-        Assert.assertEquals(existUserFilePath, optionalUserFileValidator.validate(existUserFilePath, mockContext()));
+        Assert.assertEquals(existUserFilePath,
+                            optionalUserFileValidator.validate(existUserFilePath, mockContext(), false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatOptionalUserFileValidatorThrowExceptionForNotExistUserFile() throws Exception {
         OptionalValidator<String> optionalUserFileValidator = new OptionalValidator<>(new UserFileValidator());
-        optionalUserFileValidator.validate(notExistUserFilePath, mockContext());
+        optionalUserFileValidator.validate(notExistUserFilePath, mockContext(), false);
     }
 
     public ModelValidatorContext mockContext() throws NotConnectedException, PermissionException {
@@ -170,7 +171,8 @@ public class OptionalValidatorTest {
 
     static class DisallowAllValidator implements Validator<String> {
         @Override
-        public String validate(String parameterValue, ModelValidatorContext context) throws ValidationException {
+        public String validate(String parameterValue, ModelValidatorContext context, boolean isVariableHidden)
+                throws ValidationException {
             throw new ValidationException();
         }
     }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RangeValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RangeValidatorTest.java
@@ -42,22 +42,22 @@ public class RangeValidatorTest {
     public void testRangeAny() throws Exception {
         int value = 10;
         RangeValidator<Integer> validator = new RangeValidator<>();
-        Assert.assertEquals(value, (int) validator.validate(value, null));
+        Assert.assertEquals(value, (int) validator.validate(value, null, false));
     }
 
     @Test
     public void testRangeGreaterThanOK() throws Exception {
         int value = 10;
         RangeValidator<Integer> validator = new RangeValidator<>(value);
-        Assert.assertEquals(value + 1, (int) validator.validate(value + 1, null));
-        Assert.assertEquals(value, (int) validator.validate(value, null));
+        Assert.assertEquals(value + 1, (int) validator.validate(value + 1, null, false));
+        Assert.assertEquals(value, (int) validator.validate(value, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testRangeGreaterThanKO() throws Exception {
         int value = 10;
         RangeValidator<Integer> validator = new RangeValidator<>(value);
-        validator.validate(value - 1, null);
+        validator.validate(value - 1, null, false);
     }
 
     @Test
@@ -65,10 +65,10 @@ public class RangeValidatorTest {
         int minValue = 10;
         int maxValue = 20;
         RangeValidator<Integer> validator = new RangeValidator<>(minValue, maxValue);
-        Assert.assertEquals(minValue, (int) validator.validate(minValue, null));
-        Assert.assertEquals(maxValue, (int) validator.validate(maxValue, null));
-        Assert.assertEquals(minValue + 1, (int) validator.validate(minValue + 1, null));
-        Assert.assertEquals(maxValue - 1, (int) validator.validate(maxValue - 1, null));
+        Assert.assertEquals(minValue, (int) validator.validate(minValue, null, false));
+        Assert.assertEquals(maxValue, (int) validator.validate(maxValue, null, false));
+        Assert.assertEquals(minValue + 1, (int) validator.validate(minValue + 1, null, false));
+        Assert.assertEquals(maxValue - 1, (int) validator.validate(maxValue - 1, null, false));
     }
 
     @Test(expected = ValidationException.class)
@@ -76,10 +76,10 @@ public class RangeValidatorTest {
         int minValue = 10;
         int maxValue = 20;
         RangeValidator<Integer> validator = new RangeValidator<>(minValue, maxValue);
-        validator.validate(minValue - 1, null);
-        Assert.assertEquals(maxValue, (int) validator.validate(maxValue, null));
-        Assert.assertEquals(minValue + 1, (int) validator.validate(minValue + 1, null));
-        Assert.assertEquals(maxValue - 1, (int) validator.validate(minValue - 1, null));
+        validator.validate(minValue - 1, null, false);
+        Assert.assertEquals(maxValue, (int) validator.validate(maxValue, null, false));
+        Assert.assertEquals(minValue + 1, (int) validator.validate(minValue + 1, null, false));
+        Assert.assertEquals(maxValue - 1, (int) validator.validate(minValue - 1, null, false));
     }
 
     @Test(expected = ValidationException.class)
@@ -87,6 +87,6 @@ public class RangeValidatorTest {
         int minValue = 10;
         int maxValue = 20;
         RangeValidator<Integer> validator = new RangeValidator<>(minValue, maxValue);
-        validator.validate(maxValue + 1, null);
+        validator.validate(maxValue + 1, null, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RegexpValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/RegexpValidatorTest.java
@@ -38,14 +38,14 @@ public class RegexpValidatorTest {
     public void testRegexpOK() throws ValidationException {
         RegexpValidator validator = new RegexpValidator("[a-zA-Z]+");
         String value = "MyString";
-        Assert.assertEquals(value, validator.validate(value, null));
+        Assert.assertEquals(value, validator.validate(value, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testRegexpKO() throws ValidationException {
         RegexpValidator validator = new RegexpValidator("[a-zA-Z]+");
         String value = "MyString123";
-        validator.validate(value, null);
+        validator.validate(value, null, false);
     }
 
     @Test(expected = PatternSyntaxException.class)

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/SpelValidatorTest.java
@@ -68,126 +68,126 @@ public class SpelValidatorTest {
     public void testSpelOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'");
         String value = "MyString";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test
     public void testSpelValidVariableOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("s(valid = true) + s('Hello World')");
         String value = "MyString";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelValidVariableKO() throws ValidationException {
         SpelValidator validator = new SpelValidator("s(valid = false) + s('Hello World')");
         String value = "MyString";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelKO() throws ValidationException {
         SpelValidator validator = new SpelValidator("#value == 'MyString'");
         String value = "MyString123";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test
     public void testSpelUseTrueFunction() throws ValidationException {
         SpelValidator validator = new SpelValidator("t('hello world')");
         String value = "MyString";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUseFalseFunction() throws ValidationException {
         SpelValidator validator = new SpelValidator("f('bad world')");
         String value = "MyString";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test
     public void testSpelUseTempVariable() throws ValidationException {
         SpelValidator validator = new SpelValidator("t(temp = {1,2,3}) && temp.size() == 3");
         String value = "MyString";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test
     public void testSpelUseTempMap() throws ValidationException {
         SpelValidator validator = new SpelValidator("t(tempMap['a'] = 1) && t(tempMap['b'] = 2) && (tempMap['b'] > tempMap['a'])");
         String value = "MyString";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test
     public void testSpelMathOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.Math).random() instanceof T(Double)");
         String value = "true";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test
     public void testSpelXmlOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(javax.xml.parsers.DocumentBuilderFactory).newInstance().newDocumentBuilder().parse(new org.xml.sax.InputSource(new java.io.StringReader('<employee id=\"101\"><name>toto</name><title>tata</title></employee>'))).getElementsByTagName('name').item(0).getTextContent() instanceof T(String)");
         String value = "toto";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test
     public void testSpelJSONOK() throws ValidationException {
         SpelValidator validator = new SpelValidator("new org.codehaus.jackson.map.ObjectMapper().readTree('{\"var\": \"value\"}').get('var').getTextValue() instanceof T(String)");
         String value = "value";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test
     public void testSpelJSONOK2() throws ValidationException {
         SpelValidator validator = new SpelValidator("new org.json.simple.parser.JSONParser().parse('{\"var\": \"value\"}').get('var').toString() instanceof T(String)");
         String value = "value";
-        Assert.assertEquals(value, validator.validate(value, validatorContext));
+        Assert.assertEquals(value, validator.validate(value, validatorContext, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType() throws ValidationException {
         SpelValidator validator = new SpelValidator("new x.y.z.Object().toString() instanceof T(String)");
         String value = "value";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType2() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.Runtime).getRuntime().exec('hostname').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType3() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.System).getenv('HOME').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedType4() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(org.apache.commons.lang3.time.DateUtils).toCalendar('01/01/2000') instanceof T(Date)");
         String value = "true";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedMethod() throws ValidationException {
         SpelValidator validator = new SpelValidator("(new java.lang.String()).getClass().forName('java.lang.Runtime').getDeclaredMethod('getRuntime').invoke(null).exec('hostname').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testSpelUnauthorizedAttribute() throws ValidationException {
         SpelValidator validator = new SpelValidator("T(java.lang.String).class.forName('java.lang.Runtime').getDeclaredMethod('getRuntime').invoke(null).exec('hostname').waitFor() instanceof T(Integer)");
         String value = "MyString123";
-        validator.validate(value, validatorContext);
+        validator.validate(value, validatorContext, false);
     }
 
     @Test
@@ -195,7 +195,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String):false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var1"));
     }
 
@@ -204,7 +204,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(models['var1'] = 'changed_model1') instanceof T(String):false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertEquals("changed_model1", context.getSpELVariables().getModels().get("var1"));
     }
 
@@ -213,7 +213,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?hideVar('var1'):false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertTrue(context.getSpELVariables().getHiddenVariables().get("var1"));
         Assert.assertNull(context.getSpELVariables().getHiddenVariables().get("var2"));
     }
@@ -223,7 +223,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?showVar('var1'):false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertFalse(context.getSpELVariables().getHiddenVariables().get("var1"));
         Assert.assertNull(context.getSpELVariables().getHiddenVariables().get("var2"));
     }
@@ -233,7 +233,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?hideGroup('group2'):false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertTrue(context.getSpELVariables().getHiddenGroups().get("group2"));
         Assert.assertNull(context.getSpELVariables().getHiddenVariables().get("group1"));
     }
@@ -243,7 +243,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?showGroup('group2'):false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertFalse(context.getSpELVariables().getHiddenGroups().get("group2"));
         Assert.assertNull(context.getSpELVariables().getHiddenVariables().get("group1"));
     }
@@ -254,7 +254,7 @@ public class SpelValidatorTest {
         String value = "MyString123";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
         try {
-            validator.validate(value, context);
+            validator.validate(value, context, false);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof ValidationException);
@@ -268,7 +268,7 @@ public class SpelValidatorTest {
         String value = "MyString123";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
         try {
-            validator.validate(value, context);
+            validator.validate(value, context, false);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof ValidationException);
@@ -281,7 +281,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString' ? (variables['var4'] == null ? (variables['var4'] = 'toto1') instanceof T(String) : true) : false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var4"));
     }
 
@@ -290,7 +290,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString' ? (variables['var2'] == null ? (variables['var2'] = 'toto1') instanceof T(String) : true) : false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createJob());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertEquals("value2", context.getSpELVariables().getVariables().get("var2"));
     }
 
@@ -299,7 +299,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(variables['var1'] = 'toto1') instanceof T(String) : false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createTask());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertEquals("toto1", context.getSpELVariables().getVariables().get("var1"));
     }
 
@@ -308,7 +308,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?(models['var1'] = 'changed_model1') instanceof T(String) : false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createTask());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertEquals("changed_model1", context.getSpELVariables().getModels().get("var1"));
     }
 
@@ -318,7 +318,7 @@ public class SpelValidatorTest {
         String value = "MyString123";
         ModelValidatorContext context = new ModelValidatorContext(createTask());
         try {
-            validator.validate(value, context);
+            validator.validate(value, context, false);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof ValidationException);
@@ -332,7 +332,7 @@ public class SpelValidatorTest {
         String value = "MyString123";
         ModelValidatorContext context = new ModelValidatorContext(createTask());
         try {
-            validator.validate(value, context);
+            validator.validate(value, context, false);
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof ValidationException);
@@ -345,7 +345,7 @@ public class SpelValidatorTest {
         SpelValidator validator = new SpelValidator("#value == 'MyString'?hideVar('var1'):false");
         String value = "MyString";
         ModelValidatorContext context = new ModelValidatorContext(createTask());
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
         Assert.assertTrue(context.getSpELVariables().getHiddenVariables().get("var1"));
         Assert.assertNull(context.getSpELVariables().getHiddenVariables().get("var2"));
     }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URIValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URIValidatorTest.java
@@ -36,13 +36,13 @@ public class URIValidatorTest {
     public void testThatValidURIIsOK() throws ValidationException {
         URIValidator validator = new URIValidator();
         String value = "c:/toto";
-        Assert.assertEquals(value, validator.validate(value, null));
+        Assert.assertEquals(value, validator.validate(value, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatInvalidURIThrowException() throws ValidationException {
         URIValidator validator = new URIValidator();
         String value = "\\&¨^¨$ù%";
-        validator.validate(value, null);
+        validator.validate(value, null, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URLValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/URLValidatorTest.java
@@ -36,13 +36,13 @@ public class URLValidatorTest {
     public void testThatValidURLIsOK() throws ValidationException {
         URLValidator validator = new URLValidator();
         String value = "http://mysite?myparam=1";
-        Assert.assertEquals(value, validator.validate(value, null));
+        Assert.assertEquals(value, validator.validate(value, null, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatInvalidURLThrowException() throws ValidationException {
         URLValidator validator = new URLValidator();
         String value = "unknown://mysite.com";
-        validator.validate(value, null);
+        validator.validate(value, null, false);
     }
 }

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/UserFileValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/UserFileValidatorTest.java
@@ -63,19 +63,19 @@ public class UserFileValidatorTest {
     public void testThatExistUserFileIsOk() throws ValidationException {
         UserFileValidator validator = new UserFileValidator();
         String value = existUserFilePath;
-        Assert.assertEquals(value, validator.validate(value, context));
+        Assert.assertEquals(value, validator.validate(value, context, false));
     }
 
     @Test(expected = ValidationException.class)
     public void testThatNotExistUserFileThrowException() throws ValidationException {
         UserFileValidator validator = new UserFileValidator();
-        validator.validate(notExistUserFilePath, context);
+        validator.validate(notExistUserFilePath, context, false);
     }
 
     @Test(expected = ValidationException.class)
     public void testThatEmptyUserFileThrowException() throws ValidationException {
         UserFileValidator validator = new UserFileValidator();
         String value = "";
-        validator.validate(value, context);
+        validator.validate(value, context, false);
     }
 }


### PR DESCRIPTION
When the variable is hidden, validation is disabled for models PA:CATALOG_OBJECT, PA:USER_FILE, PA:GLOBAL_FILE, PA:USER_FOLDER, PA:GLOBAL_FOLDER and PA:CREDENTIAL.

Disabling is mandatory for these models, as they require the user to select a file, credential or catalog object, which is not possible when the variable is hidden. Other models take default values which are required to be valid whether the variable is visible or not.