### PR TITLE
Thread leak issue in ExtendedSchedulerPolicy

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
@@ -65,12 +65,12 @@ public class ExtendedSchedulerPolicy extends DefaultPolicy {
 
     public static final String GENERIC_INFORMATION_KEY_START_AT = "START_AT";
 
-    private ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1,
-                                                                                   new NamedThreadFactory("ExtendedSchedulerPolicyExecutor",
-                                                                                                          true,
-                                                                                                          2));
+    private static ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1,
+                                                                                          new NamedThreadFactory("ExtendedSchedulerPolicyExecutor",
+                                                                                                                 true,
+                                                                                                                 2));
 
-    private final Map<String, Boolean> startAtCache = Collections.synchronizedMap(new LRUMap<>(PASchedulerProperties.SCHEDULER_STARTAT_CACHE.getValueAsInt()));
+    private static final Map<String, Boolean> startAtCache = Collections.synchronizedMap(new LRUMap<>(PASchedulerProperties.SCHEDULER_STARTAT_CACHE.getValueAsInt()));
 
     /*
      * Utilize 'startAt' generic info and filter any tasks that should not be scheduled for current

--- a/tools/install_base.sh
+++ b/tools/install_base.sh
@@ -694,6 +694,7 @@ if ls $PA_ROOT/default/addons/*.jar > /dev/null 2>&1; then
         OLD_VERSION=$(compute-version $OLD_PADIR)
         if [[ "$OLD_VERSION" != "$NEW_VERSION" ]]; then
            rm -f  $PA_ROOT/default/addons/*$OLD_VERSION*.jar
+           rm -f  $PA_ROOT/default/addons/*/*$OLD_VERSION*.jar
         fi
     fi
     # display the list of addons in the new installation


### PR DESCRIPTION
 - make ScheduledThreadPoolExecutor static to avoid multiple instanciation
 - improve SchedulingThread by using a CountDownLatch, this allows other threads to notify SchedulingThread without acquiring a lock

Also, in install_base.sh, delete previous version jars in subfolders of the addons directory