### PR TITLE
Better handling of workflow names containing variables

### DIFF
--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -140,6 +140,7 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.dto.*;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.*;
 
 import com.google.common.io.Closer;
+import com.google.common.net.UrlEscapers;
 
 
 public class SchedulerClient extends ClientBase implements ISchedulerClient {
@@ -911,8 +912,9 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
             Map<String, String> variables, Map<String, String> genericInfo)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
 
-        HttpGet httpGet = new HttpGet(catalogRestURL + "/buckets/" + bucketName + "/resources/" + workflowName +
-                                      "/raw");
+        HttpGet httpGet = new HttpGet(catalogRestURL + "/buckets/" +
+                                      UrlEscapers.urlPathSegmentEscaper().escape(bucketName) + "/resources/" +
+                                      UrlEscapers.urlPathSegmentEscaper().escape(workflowName) + "/raw");
         return submitFromCatalog(httpGet, variables, genericInfo);
 
     }
@@ -943,9 +945,15 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
 
         Optional<String> revision = getRevisionFromCalledWorkflow(calledWorkflow);
 
-        HttpGet httpGet = new HttpGet(catalogRestURL + "/buckets/" + getBucketFromCalledWorkflow(calledWorkflow) +
-                                      "/resources/" + getNameFromCalledWorkflow(calledWorkflow) +
-                                      revision.map(r -> "/revisions/" + r).orElse("") + "/raw");
+        HttpGet httpGet = new HttpGet(catalogRestURL + "/buckets/" +
+                                      UrlEscapers.urlPathSegmentEscaper()
+                                                 .escape(getBucketFromCalledWorkflow(calledWorkflow)) +
+                                      "/resources/" +
+                                      UrlEscapers.urlPathSegmentEscaper()
+                                                 .escape(getNameFromCalledWorkflow(calledWorkflow)) +
+                                      revision.map(r -> "/revisions/" + UrlEscapers.urlPathSegmentEscaper().escape(r))
+                                              .orElse("") +
+                                      "/raw");
 
         return this.submitFromCatalog(httpGet, variables, genericInfo);
     }

--- a/rm/rm-server/src/test/java/functionaltests/execremote/TestExecRemote.java
+++ b/rm/rm-server/src/test/java/functionaltests/execremote/TestExecRemote.java
@@ -196,6 +196,7 @@ public final class TestExecRemote extends RMFunctionalTest {
                 }
 
                 String output = res.getOutput();
+                System.out.println("Script output: " + output);
 
                 assertTrue("The script output must contains " + valueToEcho, output.contains(valueToEcho));
             }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/validator/CatalogObjectValidator.java
@@ -42,6 +42,8 @@ import org.ow2.proactive.scheduler.common.job.factories.spi.model.exceptions.Val
 import org.ow2.proactive.scheduler.common.job.factories.spi.model.factory.BaseParserValidator;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 
+import com.google.common.net.UrlEscapers;
+
 
 /**
  * @author ActiveEon Team
@@ -113,9 +115,14 @@ public class CatalogObjectValidator implements Validator<String> {
         String url;
         // catalogObjectValue is already checked (with the regular expression) to have either 2 to 3 parts (bucketName/objectName[/revision]) after split
         if (splitCatalog.length == 2) {
-            url = String.format(CATALOG_URL_WITHOUT_REVISION, splitCatalog[0], splitCatalog[1]);
+            url = String.format(CATALOG_URL_WITHOUT_REVISION,
+                                UrlEscapers.urlPathSegmentEscaper().escape(splitCatalog[0]),
+                                UrlEscapers.urlPathSegmentEscaper().escape(splitCatalog[1]));
         } else if (splitCatalog.length == 3) {
-            url = String.format(CATALOG_URL_WITH_REVISION, splitCatalog[0], splitCatalog[1], splitCatalog[2]);
+            url = String.format(CATALOG_URL_WITH_REVISION,
+                                UrlEscapers.urlPathSegmentEscaper().escape(splitCatalog[0]),
+                                UrlEscapers.urlPathSegmentEscaper().escape(splitCatalog[1]),
+                                UrlEscapers.urlPathSegmentEscaper().escape(splitCatalog[2]));
         } else {
             throw new ValidationException("Expected value should match the format: bucketName/objectName[/revision]");
         }


### PR DESCRIPTION
 - in SchedulerClient.submitFromCatalog, escape path segments
 - in PA:CATALOG_OBJECT_MODEL, escape path segments