### PR TITLE
Add submit multiple jobs

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -59,22 +59,10 @@ import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.ow2.proactive.authentication.UserData;
 import org.ow2.proactive.scheduler.common.SortSpecifierContainer;
+import org.ow2.proactive.scheduler.common.job.JobIdDataAndError;
 import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
 import org.ow2.proactive_grid_cloud_portal.common.dto.PermissionForm;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobIdData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobInfoData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobResultData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobStateData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobUsageData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.JobValidationData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.RestMapPage;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.RestPage;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerStatusData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.SchedulerUserData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskResultData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.TaskStateData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.UserJobData;
-import org.ow2.proactive_grid_cloud_portal.scheduler.dto.WorkflowDescription;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.*;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.LogForwardingRestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
@@ -1563,6 +1551,22 @@ public interface SchedulerRestInterface {
             @PathParam("path") PathSegment pathSegment, Map<String, String> jsonBody, @Context UriInfo contextInfos)
             throws JobCreationRestException, NotConnectedRestException, PermissionRestException,
             SubmissionClosedRestException, IOException;
+
+    /**
+     * Submits a list of workflows to the scheduler from a list of workflow URLs
+     *
+     * @param sessionId
+     *            a valid session id
+     * @param jsonBody
+     *            a list of workflows. Each element must contain an url, a set of variables and generic information
+     * @return the list of objects containing, for each workflow a <code>jobid</code> if submission was successful, or the error description if an error occurred.
+     */
+    @POST
+    @Path("{path:jobs}/body/multi")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    List<JobIdDataAndError> multipleSubmitFromUrls(@HeaderParam("sessionid") String sessionId,
+            List<WorkflowUrlData> jsonBody) throws NotConnectedRestException;
 
     /**
      * Pushes a file from the local file system into the given DataSpace

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/WorkflowUrlData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/WorkflowUrlData.java
@@ -1,0 +1,78 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.scheduler.dto;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.objectweb.proactive.annotation.PublicAPI;
+
+
+/**
+ * An object representing a workflow submission by url
+ */
+@PublicAPI
+public class WorkflowUrlData implements Serializable {
+
+    /**
+     * Url of the workflow that will be fetched
+     */
+    private String workflowUrl;
+
+    /**
+     * variables values set at submission
+     */
+    private Map<String, String> variables;
+
+    /**
+     * generic information values set at submission
+     */
+    private Map<String, String> genericInformation;
+
+    public String getWorkflowUrl() {
+        return workflowUrl;
+    }
+
+    public void setWorkflowUrl(String workflowUrl) {
+        this.workflowUrl = workflowUrl;
+    }
+
+    public Map<String, String> getVariables() {
+        return variables;
+    }
+
+    public void setVariables(Map<String, String> variables) {
+        this.variables = variables;
+    }
+
+    public Map<String, String> getGenericInformation() {
+        return genericInformation;
+    }
+
+    public void setGenericInformation(Map<String, String> genericInformation) {
+        this.genericInformation = genericInformation;
+    }
+}

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ISchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ISchedulerClient.java
@@ -42,8 +42,10 @@ import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
 import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobIdDataAndError;
 import org.ow2.proactive.scheduler.common.job.JobResult;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.WorkflowUrlData;
 
 
 /**
@@ -381,6 +383,17 @@ public interface ISchedulerClient extends Scheduler {
     JobId submitFromCatalog(String catalogRestURL, String calledWorkflow, Map<String, String> variables,
             Map<String, String> genericInfo)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException;
+
+    /**
+     * Submit a list of jobs to the scheduler from a list of catalogRestURL, variables and generic information.
+     *
+     * @param workflowUrlDataList list of objects containing workflow submission data
+     * @return a list of job ids of the submitted jobs and errors when jobs could not be submitted
+     * @throws NotConnectedException
+     * @throws PermissionException
+     */
+    List<JobIdDataAndError> multipleSubmitFromUrls(List<WorkflowUrlData> workflowUrlDataList)
+            throws NotConnectedException, PermissionException;
 
     /**
      * Returns <tt>true</tt>, if the scheduler has finished the execution of the

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerRestWorkflowFromCatalogExecutionTest.java
@@ -98,7 +98,7 @@ public class SchedulerRestWorkflowFromCatalogExecutionTest extends RestTestServe
     @Test
     public void testWhenSubmittingConcurrentlyUsingAValidWfContentUrlAllValidJobIdsMustBeRetrieved() throws Exception {
         Integer NRO_THREADS = 100;
-        doAnswer(invocation -> new JobIdImpl(currentJobId++, "job")).when(scheduler).submit(Matchers.any());
+        doAnswer(invocation -> new JobIdImpl(currentJobId++, "job")).when(scheduler).submit(Matchers.any(Job.class));
 
         final AtomicInteger successfullySubmitted = new AtomicInteger(0);
         Runnable runnable = () -> {

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -57,13 +57,7 @@ import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
-import org.ow2.proactive.scheduler.common.job.Job;
-import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.job.JobResult;
-import org.ow2.proactive.scheduler.common.job.JobState;
-import org.ow2.proactive.scheduler.common.job.JobVariable;
-import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
+import org.ow2.proactive.scheduler.common.job.*;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -88,6 +82,7 @@ import org.ow2.proactive.scheduler.smartproxy.common.AwaitedTask;
 import org.ow2.proactive.scheduler.smartproxy.common.SchedulerEventListenerExtended;
 import org.ow2.proactive.utils.Tools;
 import org.ow2.proactive_grid_cloud_portal.common.FileType;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.WorkflowUrlData;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -225,6 +220,11 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
+    public List<JobIdDataAndError> submit(List<Job> jobs) throws NotConnectedException {
+        return _getScheduler().submit(jobs);
+    }
+
+    @Override
     public JobId submit(File job)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
         return _getScheduler().submit(job);
@@ -310,6 +310,12 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
             Map<String, String> genericInfo)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
         return _getScheduler().submitFromCatalog(catalogRestURL, calledWorkflow, variables, genericInfo);
+    }
+
+    @Override
+    public List<JobIdDataAndError> multipleSubmitFromUrls(List<WorkflowUrlData> workflowUrlDataList)
+            throws NotConnectedException, PermissionException {
+        return _getScheduler().multipleSubmitFromUrls(workflowUrlDataList);
     }
 
     @Override

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/common/util/RMProxyUserInterface.java
@@ -455,7 +455,7 @@ public class RMProxyUserInterface extends RMListenerProxy implements ResourceMan
     }
 
     @Override
-    public boolean areNodesRecoverable(NodeSet nodes) {
+    public Map<String, Boolean> areNodesRecoverable(NodeSet nodes) {
         return target.areNodesRecoverable(nodes);
     }
 

--- a/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
+++ b/rm/rm-client/src/main/java/org/ow2/proactive/resourcemanager/frontend/ResourceManager.java
@@ -573,9 +573,9 @@ public interface ResourceManager {
      * of a crash
      *
      * @param nodes the node set to verify
-     * @return whether all nodes in the node set are recoverable
+     * @return a map containing recoverable status for each node of the node set
      */
-    boolean areNodesRecoverable(NodeSet nodes);
+    Map<String, Boolean> areNodesRecoverable(NodeSet nodes);
 
     /**
      * Set the amount of nodes currently needed by the resource manager

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -3122,19 +3122,21 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
     }
 
     @Override
-    public boolean areNodesRecoverable(NodeSet nodes) {
+    public Map<String, Boolean> areNodesRecoverable(NodeSet nodes) {
+        Map<String, Boolean> answer = new HashMap<>(nodes.size());
         Set<String> nodesURL = nodes.getAllNodesUrls();
 
         for (String nodeURL : nodesURL) {
             RMNode rmNode = allNodes.get(nodeURL);
             if (rmNode == null || !rmNode.getNodeSource().nodesRecoverable()) {
-                logger.debug("RMNode corresponding to URL " + nodeURL + " is not recoverable");
-                return false;
+                logger.trace("RMNode corresponding to URL " + nodeURL + " is not recoverable");
+                answer.put(nodeURL, false);
+            } else {
+                logger.trace("RMNode corresponding to URL " + nodeURL + " is recoverable");
+                answer.put(nodeURL, true);
             }
         }
-
-        logger.debug("All given nodes are recoverable");
-        return true;
+        return answer;
     }
 
     @Override

--- a/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchChachedFileAppender.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/AsynchChachedFileAppender.java
@@ -33,6 +33,10 @@ import org.apache.log4j.RollingFileAppender;
 import org.apache.log4j.spi.LoggingEvent;
 
 
+/**
+ * @deprecated AsynchFileAppender has now an appender cache mechanism
+ */
+@Deprecated
 public class AsynchChachedFileAppender extends AsynchFileAppender {
 
     private static final Logger LOGGER = Logger.getLogger(AsynchChachedFileAppender.class);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/FileAppender.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/FileAppender.java
@@ -72,10 +72,7 @@ public abstract class FileAppender extends WriterAppender {
         }
         try {
             File file = new File(fileName);
-            if (!file.exists()) {
-                FileUtils.forceMkdirParent(file);
-                FileUtils.touch(file);
-            }
+            FileUtils.forceMkdirParent(file);
 
             appender = new RollingFileAppender(getLayout(), fileName, true);
             appender.setMaxBackupIndex(1);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/MultipleFileAppender.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/utils/appenders/MultipleFileAppender.java
@@ -41,7 +41,7 @@ import org.apache.log4j.spi.LoggingEvent;
  * to all the tasks files.
  *
  */
-public class MultipleFileAppender extends SynchFileAppender {
+public class MultipleFileAppender extends AsynchFileAppender {
 
     public static final String FILE_NAMES = "filenames";
 
@@ -51,7 +51,7 @@ public class MultipleFileAppender extends SynchFileAppender {
         if (value != null) {
             Collection<String> names = (Collection<String>) value;
             for (String fileName : names) {
-                append(fileName, event);
+                super.append(fileName, event);
             }
         }
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -46,6 +46,7 @@ import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
 import org.ow2.proactive.scheduler.common.job.Job;
 import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobIdDataAndError;
 import org.ow2.proactive.scheduler.common.job.JobInfo;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
 import org.ow2.proactive.scheduler.common.job.JobResult;
@@ -681,6 +682,15 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials {
      */
     JobId submit(Job job)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException;
+
+    /**
+     * Submit multiple jobs
+     *
+     * @param jobs a list of jobs to submit
+     * @return a list of objects containing, for each job, a job id or any error occurring during job submission
+     * @throws NotConnectedException
+     */
+    List<JobIdDataAndError> submit(List<Job> jobs) throws NotConnectedException;
 
     /**
      *

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobIdDataAndError.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobIdDataAndError.java
@@ -1,0 +1,154 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.common.job;
+
+import java.io.Serializable;
+
+import org.objectweb.proactive.annotation.PublicAPI;
+import org.ow2.proactive.scheduler.common.SchedulerConstants;
+
+
+/**
+ * An object representing a job submission
+ *
+ * it contains a job id if the submission was successful or
+ * the description of an error whenever an error occurred
+ */
+@PublicAPI
+public class JobIdDataAndError implements Serializable {
+
+    /**
+     * id of the job if submission was successful or -1 if not
+     */
+    private long id;
+
+    /**
+     * Name of the job if submission was successful or "NOT SET" if not
+     */
+    private String readableName;
+
+    /**
+     * Error message, if the submission did not succeed
+     */
+    private String errorMessage;
+
+    /**
+     * complete error stack trace if the submission did not succeed
+     */
+    private String stackTrace;
+
+    /**
+     * true if the submission did not succeed
+     */
+    private boolean isError;
+
+    /**
+     * true if the submission did not succeed because the workflow content could not be retrieved
+     */
+    private boolean isFetchError;
+
+    public JobIdDataAndError() {
+
+    }
+
+    public JobIdDataAndError(String errorMessage, String stackTrace) {
+        this(-1L, SchedulerConstants.JOB_DEFAULT_NAME, errorMessage, stackTrace, false);
+    }
+
+    public JobIdDataAndError(String errorMessage, String stackTrace, boolean isFetchError) {
+        this(-1L, SchedulerConstants.JOB_DEFAULT_NAME, errorMessage, stackTrace, isFetchError);
+    }
+
+    public JobIdDataAndError(long id, String readableName) {
+        this(id, readableName, null, null, false);
+    }
+
+    public JobIdDataAndError(long id, String readableName, String errorMessage, String stackTrace) {
+        this(id, readableName, errorMessage, stackTrace, false);
+    }
+
+    public JobIdDataAndError(long id, String readableName, String errorMessage, String stackTrace,
+            boolean isFetchError) {
+        this.id = id;
+        this.readableName = readableName;
+        this.errorMessage = errorMessage;
+        this.stackTrace = stackTrace;
+        this.isFetchError = isFetchError;
+        if (errorMessage != null || stackTrace != null) {
+            this.isError = true;
+        } else {
+            this.isError = false;
+        }
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getReadableName() {
+        return readableName;
+    }
+
+    public void setReadableName(String readableName) {
+        this.readableName = readableName;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(String stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    public boolean isError() {
+        return isError;
+    }
+
+    public void setError(boolean error) {
+        isError = error;
+    }
+
+    public boolean isFetchError() {
+        return isFetchError;
+    }
+
+    public void setFetchError(boolean fetchError) {
+        isFetchError = fetchError;
+    }
+}

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -68,13 +68,7 @@ import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
-import org.ow2.proactive.scheduler.common.job.Job;
-import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.job.JobPriority;
-import org.ow2.proactive.scheduler.common.job.JobResult;
-import org.ow2.proactive.scheduler.common.job.JobState;
-import org.ow2.proactive.scheduler.common.job.JobVariable;
+import org.ow2.proactive.scheduler.common.job.*;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
@@ -269,6 +263,12 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable {
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException {
         checkSchedulerConnection();
         return uischeduler.submit(job);
+    }
+
+    @Override
+    public List<JobIdDataAndError> submit(List<Job> jobs) throws NotConnectedException {
+        checkSchedulerConnection();
+        return uischeduler.submit(jobs);
     }
 
     @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -63,13 +63,7 @@ import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
-import org.ow2.proactive.scheduler.common.job.Job;
-import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.job.JobPriority;
-import org.ow2.proactive.scheduler.common.job.JobResult;
-import org.ow2.proactive.scheduler.common.job.JobState;
-import org.ow2.proactive.scheduler.common.job.JobVariable;
+import org.ow2.proactive.scheduler.common.job.*;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
 import org.ow2.proactive.scheduler.common.task.TaskState;
@@ -82,6 +76,7 @@ import org.ow2.proactive.scheduler.rest.ISchedulerClient;
 import org.ow2.proactive.scheduler.rest.SchedulerClient;
 import org.ow2.proactive.scheduler.signal.SignalApiException;
 import org.ow2.proactive.scheduler.task.utils.Decrypter;
+import org.ow2.proactive_grid_cloud_portal.scheduler.dto.WorkflowUrlData;
 
 import com.google.common.collect.Maps;
 
@@ -381,6 +376,12 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
+    public List<JobIdDataAndError> submit(List<Job> jobs) throws NotConnectedException {
+        renewSession();
+        return client.submit(jobs);
+    }
+
+    @Override
     public JobId reSubmit(JobId currentJobId, Map<String, String> jobVariables, Map<String, String> jobGenericInfos,
             String sessionId) throws NotConnectedException, UnknownJobException, PermissionException,
             JobCreationException, SubmissionClosedException {
@@ -526,6 +527,17 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
                                         calledWorkflow,
                                         addGlobalVariables(variables),
                                         addGlobalGenericInfoAndParentJobId(genericInfo));
+    }
+
+    @Override
+    public List<JobIdDataAndError> multipleSubmitFromUrls(List<WorkflowUrlData> workflowUrlDataList)
+            throws NotConnectedException, PermissionException {
+        renewSession();
+        for (WorkflowUrlData urlData : workflowUrlDataList) {
+            urlData.setVariables(addGlobalVariables(urlData.getVariables()));
+            urlData.setGenericInformation(addGlobalGenericInfoAndParentJobId(urlData.getGenericInformation()));
+        }
+        return client.multipleSubmitFromUrls(workflowUrlDataList);
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -583,7 +583,7 @@ class LiveJobs {
         return terminationData;
     }
 
-    void taskStarted(InternalJob job, InternalTask task, TaskLauncher launcher) {
+    void taskStarted(InternalJob job, InternalTask task, TaskLauncher launcher, String taskLauncherNodeUrl) {
         JobData jobData = checkJobAccess(job.getId());
         if (jobData == null) {
             throw new IllegalStateException("Job " + job.getId() + " does not exist");
@@ -611,7 +611,7 @@ class LiveJobs {
 
         // set the different informations on task
         job.startTask(task);
-        dbManager.jobTaskStarted(job, task, firstTaskStarted);
+        dbManager.jobTaskStarted(job, task, firstTaskStarted, taskLauncherNodeUrl);
 
         listener.taskStateUpdated(job.getOwner(),
                                   new NotificationData<TaskInfo>(SchedulerEvent.TASK_PENDING_TO_RUNNING,

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/ExecuterInformationData.java
@@ -66,16 +66,10 @@ public class ExecuterInformationData implements Serializable {
 
     private String hostName;
 
-    public ExecuterInformationData(long taskId, ExecuterInformation executerInformation) {
+    public ExecuterInformationData(long taskId, ExecuterInformation executerInformation, String taskLauncherNodeUrl) {
         this.taskId = taskId;
         if (executerInformation != null) {
-            if (executerInformation.getLauncher() != null) {
-                try {
-                    taskLauncherNodeUrl = PAActiveObject.getUrl(executerInformation.getLauncher());
-                } catch (Exception e) {
-                    logger.warn("TaskLauncher node URL could not be retrieved for task " + taskId);
-                }
-            }
+            this.taskLauncherNodeUrl = taskLauncherNodeUrl;
             nodes = executerInformation.getNodes();
             nodeName = executerInformation.getNodeName();
             hostName = executerInformation.getHostName();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -1156,7 +1156,8 @@ public class SchedulerDBManager {
         });
     }
 
-    public void jobTaskStarted(final InternalJob job, final InternalTask task, final boolean taskStatusToPending) {
+    public void jobTaskStarted(final InternalJob job, final InternalTask task, final boolean taskStatusToPending,
+            String taskLauncherNodeUrl) {
         executeReadWriteTransaction((SessionWork<Void>) session -> {
             long jobId = jobId(job);
 
@@ -1176,7 +1177,8 @@ public class SchedulerDBManager {
             TaskInfo taskInfo = task.getTaskInfo();
 
             ExecuterInformationData executerInfo = new ExecuterInformationData(taskId.getTaskId(),
-                                                                               task.getExecuterInformation());
+                                                                               task.getExecuterInformation(),
+                                                                               taskLauncherNodeUrl);
 
             session.getNamedQuery("updateTaskDataTaskStarted")
                    .setParameter("taskStatus", taskInfo.getStatus())

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxy.java
@@ -203,12 +203,12 @@ public class RMProxy {
         }
     }
 
-    public boolean areNodesRecoverable(NodeSet nodes) {
+    public Map<String, Boolean> areNodesRecoverable(NodeSet nodes) {
         if (proxyActiveObject != null) {
             return proxyActiveObject.areNodesRecoverable(nodes);
         } else {
             logger.warn("Didn't find RM to check whether nodes are recoverable");
-            return false;
+            return null;
         }
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
@@ -360,7 +360,7 @@ public class RMProxyActiveObject {
     }
 
     @ImmediateService
-    public boolean areNodesRecoverable(NodeSet nodes) {
+    public Map<String, Boolean> areNodesRecoverable(NodeSet nodes) {
         return rm.areNodesRecoverable(nodes);
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/JobLogger.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/JobLogger.java
@@ -114,7 +114,7 @@ public class JobLogger {
 
     public void flush(JobId id) {
         updateMdcWithTaskLogFilename(id);
-        logger.debug(PREFIX + id + " closing logger");
+        logger.debug(PREFIX + id + " flushing logger");
         for (Appender appender : (List<Appender>) Collections.list(logger.getAllAppenders())) {
             if (appender instanceof AsynchFileAppender) {
                 ((AsynchFileAppender) appender).flush();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerTasksStateRecoverIntegrationTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/SchedulerTasksStateRecoverIntegrationTest.java
@@ -50,7 +50,7 @@ public class SchedulerTasksStateRecoverIntegrationTest extends BaseSchedulerDBTe
 
         job.start();
         startTask(job, task);
-        dbManager.jobTaskStarted(job, task, true);
+        dbManager.jobTaskStarted(job, task, true, null);
 
         SchedulerStateRecoverHelper recoverHelper = new SchedulerStateRecoverHelper(dbManager);
 
@@ -67,7 +67,7 @@ public class SchedulerTasksStateRecoverIntegrationTest extends BaseSchedulerDBTe
         task = job.getTask("task1");
 
         startTask(job, task);
-        dbManager.jobTaskStarted(job, task, true);
+        dbManager.jobTaskStarted(job, task, true, null);
 
         job.newWaitingTask();
         job.reStartTask(task);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestJobRuntimeData.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestJobRuntimeData.java
@@ -76,7 +76,7 @@ public class TestJobRuntimeData extends BaseSchedulerDBTest {
         InternalTask internalTask = startTask(runtimeData, runtimeData.getITasks().get(0));
 
         System.out.println("Update started task data");
-        dbManager.jobTaskStarted(runtimeData, internalTask, false);
+        dbManager.jobTaskStarted(runtimeData, internalTask, false, null);
 
         System.out.println("Load internal job");
         runtimeData = loadInternalJob(true, runtimeData.getId());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
@@ -101,7 +101,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
 
         job5.start();
         InternalTask taskJob5 = startTask(job5, job5.getITasks().get(0));
-        dbManager.jobTaskStarted(job5, taskJob5, true);
+        dbManager.jobTaskStarted(job5, taskJob5, true, null);
 
         List<JobInfo> jobs;
 
@@ -268,7 +268,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         job = defaultSubmitJob(createJob(null, null, projectName, 1L));
         job.start();
         task = startTask(job, job.getITasks().get(0));
-        dbManager.jobTaskStarted(job, task, true);
+        dbManager.jobTaskStarted(job, task, true, null);
 
         // killed job - 4
         job = defaultSubmitJob(createJob());
@@ -282,7 +282,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         job = defaultSubmitJob(createJob());
         job.start();
         task = startTask(job, job.getITasks().get(0));
-        dbManager.jobTaskStarted(job, task, true);
+        dbManager.jobTaskStarted(job, task, true, null);
         TaskResultImpl result = new TaskResultImpl(null, new TestResult(0, "result"), null, 0);
         job.terminateTask(false, task.getId(), null, null, result);
         job.terminate();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadSchedulerClientState.java
@@ -69,7 +69,7 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
 
         job.start();
         startTask(job, task1);
-        dbManager.jobTaskStarted(job, task1, true);
+        dbManager.jobTaskStarted(job, task1, true, null);
 
         TaskResultImpl result = new TaskResultImpl(null, new TestResult(1, "res1"), null, 1000);
         terminateTask(job, task1, result);
@@ -94,7 +94,7 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
         InternalTask task2 = job.getTask("task2");
 
         startTask(job, task2);
-        dbManager.jobTaskStarted(job, task2, false);
+        dbManager.jobTaskStarted(job, task2, false, null);
 
         expectedJob = job(job.getId(), JobStatus.STALLED)
                                                          .withFinished(task("task1", TaskStatus.FINISHED)
@@ -108,7 +108,7 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
         task2 = job.getTask("task2");
 
         startTask(job, task2);
-        dbManager.jobTaskStarted(job, task2, false);
+        dbManager.jobTaskStarted(job, task2, false, null);
         terminateTask(job, task2, result);
         dbManager.updateAfterTaskFinished(job, task2, result);
 
@@ -148,9 +148,9 @@ public class TestLoadSchedulerClientState extends BaseSchedulerDBTest {
 
         job.start();
         startTask(job, task1);
-        dbManager.jobTaskStarted(job, task1, true);
+        dbManager.jobTaskStarted(job, task1, true, null);
         startTask(job, task2);
-        dbManager.jobTaskStarted(job, task2, false);
+        dbManager.jobTaskStarted(job, task2, false, null);
 
         // task 2 finished with error, stop job
         Set<TaskId> ids = job.failed(task2.getId(), JobStatus.CANCELED);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
@@ -134,7 +134,7 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
         // task1 started
         job1.start();
         startTask(job1, job1.getTask("task1"));
-        dbManager.jobTaskStarted(job1, job1.getTask("task1"), true);
+        dbManager.jobTaskStarted(job1, job1.getTask("task1"), true, null);
         accountData.pendingJobsCount--;
         accountData.runningJobsCount++;
         accountData.pendingTasksCount--;
@@ -156,11 +156,11 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
 
         // task2 and task3 started
         startTask(job1, job1.getTask("task2"));
-        dbManager.jobTaskStarted(job1, job1.getTask("task2"), true);
+        dbManager.jobTaskStarted(job1, job1.getTask("task2"), true, null);
         accountData.pendingTasksCount--;
         accountData.currentTasksCount++;
         startTask(job1, job1.getTask("task3"));
-        dbManager.jobTaskStarted(job1, job1.getTask("task3"), true);
+        dbManager.jobTaskStarted(job1, job1.getTask("task3"), true, null);
         accountData.pendingTasksCount--;
         accountData.currentTasksCount++;
         accountData.runningJobsCount++;

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReportingQueries.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReportingQueries.java
@@ -90,7 +90,7 @@ public class TestReportingQueries extends BaseSchedulerDBTest {
         // job1: task1 started
         job1.start();
         startTask(job1, job1.getTask("task1"));
-        dbManager.jobTaskStarted(job1, job1.getTask("task1"), true);
+        dbManager.jobTaskStarted(job1, job1.getTask("task1"), true, null);
         checkNumberOfHosts(job1, 1);
 
         checkJobPendingTime(job1);
@@ -109,7 +109,7 @@ public class TestReportingQueries extends BaseSchedulerDBTest {
         // job2: task1 started
         job2.start();
         startTask(job2, job2.getTask("task1"));
-        dbManager.jobTaskStarted(job2, job2.getTask("task1"), true);
+        dbManager.jobTaskStarted(job2, job2.getTask("task1"), true, null);
 
         checkMeanPendingTime(job1, job2);
         checkMeanTaskRunningTime(job2);
@@ -117,9 +117,9 @@ public class TestReportingQueries extends BaseSchedulerDBTest {
 
         // job1: task2 and task3 started
         startTask(job1, job1.getTask("task2"));
-        dbManager.jobTaskStarted(job1, job1.getTask("task2"), false);
+        dbManager.jobTaskStarted(job1, job1.getTask("task2"), false, null);
         startTask(job1, job1.getTask("task3"));
-        dbManager.jobTaskStarted(job1, job1.getTask("task3"), false);
+        dbManager.jobTaskStarted(job1, job1.getTask("task3"), false, null);
 
         checkMeanTaskPendingTime(job1);
         checkMeanTaskRunningTime(job1);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs.java
@@ -62,7 +62,7 @@ public class TestRestoreWorkflowJobs extends BaseSchedulerDBTest {
         job.start();
         InternalTask mainTask = job.getTask("T");
         startTask(job, mainTask);
-        dbManager.jobTaskStarted(job, mainTask, true);
+        dbManager.jobTaskStarted(job, mainTask, true, null);
 
         TaskResultImpl result = new TaskResultImpl(mainTask.getId(), "ok", null, 0);
         FlowAction action = new FlowAction(FlowActionType.REPLICATE);
@@ -97,7 +97,7 @@ public class TestRestoreWorkflowJobs extends BaseSchedulerDBTest {
         job.start();
         InternalTask mainTask = job.getTask("T");
         startTask(job, mainTask);
-        dbManager.jobTaskStarted(job, mainTask, true);
+        dbManager.jobTaskStarted(job, mainTask, true, null);
 
         TaskResultImpl result = new TaskResultImpl(mainTask.getId(), "ok", null, 0);
         ChangedTasksInfo changesInfo = job.terminateTask(false, mainTask.getId(), null, null, result);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs2.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs2.java
@@ -54,7 +54,7 @@ public class TestRestoreWorkflowJobs2 extends BaseSchedulerDBTest {
         job.start();
         InternalTask mainTask = job.getTask("A");
         startTask(job, mainTask);
-        dbManager.jobTaskStarted(job, mainTask, true);
+        dbManager.jobTaskStarted(job, mainTask, true, null);
 
         TaskResultImpl result = new TaskResultImpl(mainTask.getId(), "ok", null, 0);
         FlowAction action = new FlowAction(FlowActionType.IF);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestTaskRuntimeData.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestTaskRuntimeData.java
@@ -96,7 +96,7 @@ public class TestTaskRuntimeData extends BaseSchedulerDBTest {
         internalJob.start();
         InternalTask task = startTask(internalJob, internalJob.getTask("task1"));
         System.out.println("Job started");
-        dbManager.jobTaskStarted(internalJob, task, true);
+        dbManager.jobTaskStarted(internalJob, task, true, null);
 
         internalJob = loadInternalJob(true, internalJob.getId());
         Assert.assertEquals(TaskStatus.RUNNING, internalJob.getTask("task1").getStatus());

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestUsageData.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestUsageData.java
@@ -125,7 +125,7 @@ public class TestUsageData extends BaseSchedulerDBTest {
 
     protected InternalTask startTask(InternalJob job, InternalTask task) throws Exception {
         super.startTask(job, task);
-        dbManager.jobTaskStarted(job, task, false);
+        dbManager.jobTaskStarted(job, task, false, null);
         return task;
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/BaseServiceTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/BaseServiceTest.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.mockito.Mockito;
+import org.objectweb.proactive.core.node.Node;
 import org.objectweb.proactive.core.node.NodeFactory;
 import org.ow2.proactive.scheduler.common.JobDescriptor;
 import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
@@ -88,8 +89,12 @@ public class BaseServiceTest extends ProActiveTest {
     void taskStarted(JobDescriptor jobDesc, EligibleTaskDescriptor taskDesc) throws Exception {
         InternalTask task = ((EligibleTaskDescriptorImpl) taskDesc).getInternal();
         TaskLauncher launcher = Mockito.mock(TaskLauncher.class);
+        Node defaultNode = NodeFactory.getDefaultNode();
         task.setExecuterInformation(new ExecuterInformation(launcher, NodeFactory.getDefaultNode()));
-        service.taskStarted(((JobDescriptorImpl) jobDesc).getInternal(), task, launcher);
+        service.taskStarted(((JobDescriptorImpl) jobDesc).getInternal(),
+                            task,
+                            launcher,
+                            defaultNode.getNodeInformation().getURL());
     }
 
     public static InternalJob createJob(TaskFlowJob job) throws Exception {

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
@@ -384,7 +384,7 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
             j.setStartTime(100L);
             for (InternalTask t : j.getITasks()) {
                 t.setStartTime(100L);
-                dbManager.jobTaskStarted(j, t, true);
+                dbManager.jobTaskStarted(j, t, true, null);
             }
         }
 

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/LiveJobsTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/LiveJobsTest.java
@@ -195,7 +195,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask(tid.getReadableName()), null);
+        liveJobs.taskStarted(job, job.getTask(tid.getReadableName()), null, null);
     }
 
     @Test(timeout = 60000)
@@ -391,7 +391,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
 
         assertThat(internalTask.getMaxNumberOfExecutionOnFailure(), is(5));
         assertThat(internalTask.getTaskInfo().getNumberOfExecutionOnFailureLeft(), is(5));
@@ -425,7 +425,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
 
         assertThat(internalTask.getMaxNumberOfExecutionOnFailure(), is(0));
         assertThat(internalTask.getTaskInfo().getNumberOfExecutionOnFailureLeft(), is(0));
@@ -455,7 +455,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
         assertThat(liveJobs.canPingTask(liveJobs.getRunningTasks().iterator().next()), is(true));
     }
 
@@ -483,7 +483,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
 
         TaskResultImpl result = new TaskResultImpl(taskId, new Exception(), null, 330);
 
@@ -521,7 +521,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
 
         TaskResultImpl result = new TaskResultImpl(taskId, new Exception(), null, 330);
 
@@ -569,7 +569,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
 
         TaskResultImpl result = new TaskResultImpl(taskId, new Exception());
 
@@ -611,7 +611,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
 
         TaskResultImpl result = new TaskResultImpl(taskId, new Exception());
         liveJobs.taskTerminatedWithResult(taskId, result);
@@ -648,7 +648,7 @@ public class LiveJobsTest extends ProActiveTestClean {
         job.setTasks(tasksList);
         liveJobs.jobSubmitted(job);
         liveJobs.lockJobsToSchedule(false);
-        liveJobs.taskStarted(job, job.getTask("task-name"), null);
+        liveJobs.taskStarted(job, job.getTask("task-name"), null, null);
 
         TaskResultImpl result = new TaskResultImpl(taskId, new Exception());
         liveJobs.taskTerminatedWithResult(taskId, result);

--- a/scheduler/scheduler-smartproxy-common/src/main/java/org/ow2/proactive/scheduler/smartproxy/common/AbstractSmartProxy.java
+++ b/scheduler/scheduler-smartproxy-common/src/main/java/org/ow2/proactive/scheduler/smartproxy/common/AbstractSmartProxy.java
@@ -52,7 +52,6 @@ import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.SchedulerEventListener;
 import org.ow2.proactive.scheduler.common.SchedulerState;
 import org.ow2.proactive.scheduler.common.SchedulerStatus;
-import org.ow2.proactive.scheduler.common.SortSpecifierContainer;
 import org.ow2.proactive.scheduler.common.TaskDescriptor;
 import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
 import org.ow2.proactive.scheduler.common.exception.JobCreationException;
@@ -62,15 +61,7 @@ import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
-import org.ow2.proactive.scheduler.common.job.Job;
-import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.job.JobPriority;
-import org.ow2.proactive.scheduler.common.job.JobResult;
-import org.ow2.proactive.scheduler.common.job.JobState;
-import org.ow2.proactive.scheduler.common.job.JobStatus;
-import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
-import org.ow2.proactive.scheduler.common.job.UserIdentification;
+import org.ow2.proactive.scheduler.common.job.*;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskInfo;
@@ -965,6 +956,8 @@ public abstract class AbstractSmartProxy<T extends JobTracker> implements Schedu
 
     public abstract JobId submit(Job job)
             throws NotConnectedException, PermissionException, SubmissionClosedException, JobCreationException;
+
+    public abstract List<JobIdDataAndError> submit(List<Job> jobs) throws NotConnectedException;
 
     @Override
     public JobResult getJobResult(String jobId) throws NotConnectedException, PermissionException, UnknownJobException {

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -73,12 +73,7 @@ import org.ow2.proactive.scheduler.common.exception.SchedulerException;
 import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
 import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
 import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
-import org.ow2.proactive.scheduler.common.job.Job;
-import org.ow2.proactive.scheduler.common.job.JobId;
-import org.ow2.proactive.scheduler.common.job.JobInfo;
-import org.ow2.proactive.scheduler.common.job.JobState;
-import org.ow2.proactive.scheduler.common.job.JobVariable;
-import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
+import org.ow2.proactive.scheduler.common.job.*;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskResult;
@@ -92,8 +87,6 @@ import org.ow2.proactive.scheduler.smartproxy.common.AbstractSmartProxy;
 import org.ow2.proactive.scheduler.smartproxy.common.AwaitedJob;
 import org.ow2.proactive.scheduler.smartproxy.common.AwaitedTask;
 import org.ow2.proactive.scheduler.smartproxy.common.SchedulerEventListenerExtended;
-
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 
 /**
@@ -539,6 +532,15 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
         }
 
         return schedulerProxy.submit(job);
+    }
+
+    @Override
+    public List<JobIdDataAndError> submit(List<Job> jobs) throws NotConnectedException {
+        if (schedulerProxy == null) {
+            throw new NotConnectedException("Not connected to the scheduler.");
+        }
+
+        return schedulerProxy.submit(jobs);
     }
 
     @Override


### PR DESCRIPTION
 - SchedulerRestInterface: multipleSubmitFromUrls
 - Scheduler: submit list of jobs
 - SchedulerClient: multipleSubmitFromUrl
 etc

 Additional parts of this commit:
 - improved SchedulingMethodImpl performance using factorization of some operations that can be done once instead of for each task to be launched. Use caches when possible
 - improved SubmitHandler concurrency by ensuring that frontendState is notified as soon as the job is started