### PR TITLE
Add tenant filtering

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
@@ -45,6 +45,12 @@ public class UserData implements Serializable {
 
     private Set<String> groups;
 
+    private String tenant;
+
+    private boolean filterByTenant;
+
+    private boolean allTenantPermission;
+
     public String getUserName() {
         return userName;
     }
@@ -59,5 +65,29 @@ public class UserData implements Serializable {
 
     public void setGroups(Set<String> groups) {
         this.groups = groups;
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
+    }
+
+    public boolean isFilterByTenant() {
+        return filterByTenant;
+    }
+
+    public void setFilterByTenant(boolean filterByTenant) {
+        this.filterByTenant = filterByTenant;
+    }
+
+    public boolean isAllTenantPermission() {
+        return allTenantPermission;
+    }
+
+    public void setAllTenantPermission(boolean allTenantPermission) {
+        this.allTenantPermission = allTenantPermission;
     }
 }

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPProperties.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/LDAPProperties.java
@@ -79,6 +79,12 @@ public class LDAPProperties {
     /** the attribute in the group entry that matches the jaas' group name */
     public static final String LDAP_GROUPNAME_ATTR = "pa.ldap.group.name.attr";
 
+    /**
+     * the attribute in the user entry that defines the tenant
+     * If not defined, no tenant will be associated with the user, or tenant will be defined using the fallback method
+     **/
+    public static final String LDAP_TENANT_ATTR = "pa.ldap.tenant.attr";
+
     /** authentication method used to connect to LDAP : none, simple or a SASL method */
     public static final String LDAP_AUTHENTICATION_METHOD = "pa.ldap.authentication.method";
 
@@ -117,6 +123,10 @@ public class LDAPProperties {
     /** group fall back property, check user group membership group file if user is not found in corresponding LDAP group.
      * true or false */
     public static final String FALLBACK_GROUP_MEMBERSHIP = "pa.ldap.group.membership.fallback";
+
+    /** tenant fall back property, check user tenant membership tenant file if user is not found in LDAP or if tenant LDAP attribute is not defined.
+     * true or false */
+    public static final String FALLBACK_TENANT_MEMBERSHIP = "pa.ldap.tenant.membership.fallback";
 
     /* ***************************************************************************** */
     /* ***************************************************************************** */

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/PAMLoginModule.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/PAMLoginModule.java
@@ -162,6 +162,7 @@ public abstract class PAMLoginModule extends FileLoginModule implements Loggable
             subject.getPrincipals().add(new UserNamePrincipal(username));
             resetFailedAttempt(username);
             super.groupMembershipFromFile(username);
+            super.tenantMembershipFromFile(username);
             return true;
         } else {
             logger.info("PAM authentication failed for user " + username + ": " + answer);

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/principals/TenantPrincipal.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/principals/TenantPrincipal.java
@@ -1,0 +1,35 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.authentication.principals;
+
+public class TenantPrincipal extends IdentityPrincipal {
+
+    private static final long serialVersionUID = 1L;
+
+    public TenantPrincipal(String name) {
+        super(name);
+    }
+}

--- a/config/authentication/ldap.cfg
+++ b/config/authentication/ldap.cfg
@@ -58,6 +58,9 @@ pa.ldap.group.filter=(&(objectclass=groupOfUniqueNames)(uniqueMember=%s))
 # the attribute in the group entry that matches the jaas' group name
 pa.ldap.group.name.attr=cn
 
+# the attribute in the user entry that will represent the tenant name
+# pa.ldap.tenant.attr=
+
 # authentication method used to connect to LDAP : none (for anonymous connection), simple or a SASL method
 pa.ldap.authentication.method=none
 
@@ -112,3 +115,8 @@ pa.ldap.authentication.fallback=false
 # if user is not found in its corresponding requested LDAP group.
 # true or false.
 pa.ldap.group.membership.fallback=false
+
+# check user tenant membership in tenant file (as performed in FileLogin method)
+# if tenant attribute is not defined or is empty for the corresponding requested LDAP user.
+# true or false.
+pa.ldap.tenant.membership.fallback=false

--- a/config/authentication/tenant.cfg
+++ b/config/authentication/tenant.cfg
@@ -1,0 +1,16 @@
+# Configuration file containing the definition of tenants
+# A tenant is a collection of user groups
+# Syntax for group/tenant association is group_name:tenant_name
+# Note: a user cannot belong to multiple tenants. If a conflict would appear, only the first tenant picked in the configuration will be chosen.
+#
+# Tenants can be used to restrict jobs viewed by a user to only jobs submitted by users belonging to the same tenant
+# In order to enable it, in config/scheduler/settings.ini, the setting pa.scheduler.core.tenant.filter must be set to 'true'
+
+# example tenants definition below:
+
+# citizen-ds:citizens
+# expert-ds:experts
+# scheduleradmins:admins
+# guests:others
+# nsadmins:others
+#

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -406,6 +406,15 @@ pa.scheduler.core.defaultloginfilename=config/authentication/login.cfg
 # else, the path is absolute, so the path is directly interpreted
 pa.scheduler.core.defaultgroupfilename=config/authentication/group.cfg
 
+# Tenant file name for file authentication method
+# If this file path is relative, the path is evaluated from the Scheduler dir (ie application's root dir)
+# with the variable defined below : pa.scheduler.home.
+# else, the path is absolute, so the path is directly interpreted
+pa.scheduler.core.defaulttenantfilename=config/authentication/tenant.cfg
+
+# If enabled, filter jobs according to user tenant
+pa.scheduler.core.tenant.filter=false
+
 # Property that define the method that have to be used for logging users to the Scheduler
 # It can be one of the following values:
 #	- "SchedulerFileLoginMethod" to use file login and group management

--- a/config/security.java.policy-server
+++ b/config/security.java.policy-server
@@ -166,6 +166,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.resumeJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeStartAt";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogsByTag ";
@@ -410,6 +411,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
+    permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodeTokens";
@@ -711,6 +713,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.resumeJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeStartAt";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogsByTag ";

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -214,7 +214,7 @@ public interface SchedulerRestInterface {
             @QueryParam("childJobs") @DefaultValue("true") boolean childJobs,
             @QueryParam("jobName") @DefaultValue("") String jobName,
             @QueryParam("projectName") @DefaultValue("") String projectName,
-            @QueryParam("userName") @DefaultValue("") String userName,
+            @QueryParam("userName") @DefaultValue("") String userName, @QueryParam("tenant") String tenant,
             @QueryParam("parentId") @DefaultValue("-1") Long parentId, @QueryParam("sortParams") String sortParams)
             throws RestException;
 

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerClientExample.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/SchedulerClientExample.java
@@ -110,6 +110,7 @@ public class SchedulerClientExample {
                                                                                        null,
                                                                                        null,
                                                                                        null,
+                                                                                       null,
                                                                                        null);
         Map<Long, ArrayList<UserJobData>> map = page.getMap();
         System.out.println(map);

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
@@ -67,6 +67,8 @@ public class JobInfoData implements java.io.Serializable {
 
     private String jobOwner;
 
+    private String tenant;
+
     private String projectName;
 
     private boolean toBeRemoved = false;
@@ -175,6 +177,14 @@ public class JobInfoData implements java.io.Serializable {
 
     public void setJobOwner(String jobOwner) {
         this.jobOwner = jobOwner;
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     public String getProjectName() {

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobStateData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobStateData.java
@@ -38,6 +38,8 @@ public class JobStateData {
 
     private String owner;
 
+    private String tenant;
+
     private JobInfoData jobInfo;
 
     private String projectName;
@@ -68,6 +70,14 @@ public class JobStateData {
 
     public void setOwner(String owner) {
         this.owner = owner;
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     public JobInfoData getJobInfo() {
@@ -109,8 +119,8 @@ public class JobStateData {
     @Override
     public String toString() {
         return "JobStateData{" + "name='" + name + '\'' + ", priority='" + priority + '\'' + ", owner='" + owner +
-               '\'' + ", jobInfo=" + jobInfo + ", projectName='" + projectName + '\'' + ", tasks=" + tasks +
-               ", genericInformation=" + genericInformation + '}';
+               '\'' + ", tenant='" + tenant + '\'' + ", jobInfo=" + jobInfo + ", projectName='" + projectName + '\'' +
+               ", tasks=" + tasks + ", genericInformation=" + genericInformation + '}';
     }
 
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobUsageData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobUsageData.java
@@ -34,6 +34,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class JobUsageData {
     private String owner;
 
+    private String tenant;
+
     private String project;
 
     private String jobId;
@@ -59,6 +61,14 @@ public class JobUsageData {
 
     public void setOwner(String owner) {
         this.owner = owner;
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     public String getProject() {

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/SchedulerUserData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/SchedulerUserData.java
@@ -36,6 +36,8 @@ public class SchedulerUserData {
 
     private Set<String> groups;
 
+    private String tenant;
+
     private String username;
 
     private long connectionTime;
@@ -59,6 +61,10 @@ public class SchedulerUserData {
 
     public String getUsername() {
         return username;
+    }
+
+    public String getTenant() {
+        return tenant;
     }
 
     public long getConnectionTime() {
@@ -85,6 +91,10 @@ public class SchedulerUserData {
         this.username = username;
     }
 
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
+    }
+
     public void setConnectionTime(long connectionTime) {
         this.connectionTime = connectionTime;
     }
@@ -107,8 +117,8 @@ public class SchedulerUserData {
 
     @Override
     public String toString() {
-        return "SchedulerUserData{" + "hostName='" + hostName + '\'' + ", username='" + username + '\'' +
-               ", connectionTime=" + connectionTime + ", lastSubmitTime=" + lastSubmitTime + ", submitNumber=" +
-               submitNumber + '}';
+        return "SchedulerUserData{" + "hostName='" + hostName + '\'' + ", username='" + username + '\'' + ", groups='" +
+               groups + "\'" + ", tenant='" + tenant + "\'" + ", connectionTime=" + connectionTime +
+               ", lastSubmitTime=" + lastSubmitTime + ", submitNumber=" + submitNumber + '}';
     }
 }

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommand.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommand.java
@@ -101,6 +101,7 @@ public class ListJobCommand extends AbstractCommand implements Command {
                                                                                             null,
                                                                                             null,
                                                                                             null,
+                                                                                            null,
                                                                                             null);
         Map<Long, ArrayList<UserJobData>> stateMap = page.getMap();
         List<UserJobData> jobs = stateMap.values().iterator().next();

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/StringUtility.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/StringUtility.java
@@ -255,6 +255,8 @@ public final class StringUtility {
               .append(jobState.getName())
               .append("\tOWNER: ")
               .append(jobState.getOwner())
+              .append("\tTENANT: ")
+              .append(jobState.getTenant())
               .append("\tSTATUS: ")
               .append(jobState.getJobInfo().getStatus())
               .append("\t#TASKS: ")

--- a/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommandTest.java
+++ b/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/cmd/sched/ListJobCommandTest.java
@@ -105,6 +105,7 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
@@ -119,6 +120,7 @@ public class ListJobCommandTest {
                                     true,
                                     true,
                                     true,
+                                    null,
                                     null,
                                     null,
                                     null,
@@ -152,13 +154,27 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
         new ListJobCommand("limit=" + offset, "from=" + index).execute(currentContextMock);
 
         Mockito.verify(schedulerRestInterfaceMock)
-               .revisionAndJobsInfo("sessionid", index, 1, false, true, true, true, true, null, null, null, null, null);
+               .revisionAndJobsInfo("sessionid",
+                                    index,
+                                    1,
+                                    false,
+                                    true,
+                                    true,
+                                    true,
+                                    true,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null);
 
     }
 
@@ -188,13 +204,27 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
         new ListJobCommand("limit=" + offset, "from=" + index).execute(currentContextMock);
 
         Mockito.verify(schedulerRestInterfaceMock)
-               .revisionAndJobsInfo("sessionid", index, 3, false, true, true, true, true, null, null, null, null, null);
+               .revisionAndJobsInfo("sessionid",
+                                    index,
+                                    3,
+                                    false,
+                                    true,
+                                    true,
+                                    true,
+                                    true,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null);
     }
 
     @Test
@@ -223,6 +253,7 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
@@ -237,6 +268,7 @@ public class ListJobCommandTest {
                                     true,
                                     true,
                                     true,
+                                    null,
                                     null,
                                     null,
                                     null,
@@ -271,6 +303,7 @@ public class ListJobCommandTest {
                                                                     null,
                                                                     null,
                                                                     null,
+                                                                    null,
                                                                     null))
                .thenReturn(page);
 
@@ -285,6 +318,7 @@ public class ListJobCommandTest {
                                     true,
                                     true,
                                     true,
+                                    null,
                                     null,
                                     null,
                                     null,

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -339,6 +339,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
                                                                                                            criteria.getJobName(),
                                                                                                            criteria.getProjectName(),
                                                                                                            criteria.getUserName(),
+                                                                                                           criteria.getTenant(),
                                                                                                            criteria.getParentId(),
                                                                                                            sortParams);
             List<UserJobData> userJobs = userJobsAllRevisions.getMap().values().iterator().next();
@@ -1333,6 +1334,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         JobId newJobId = JobIdImpl.makeJobId(jobId);
         jobInfoImpl.setJobId(newJobId);
         jobInfoImpl.setJobOwner(jobInfoData.getJobOwner());
+        jobInfoImpl.setTenant(jobInfoData.getTenant());
         jobInfoImpl.setProjectName(jobInfoData.getProjectName());
         jobInfoImpl.setFinishedTime(jobInfoData.getFinishedTime());
         jobInfoImpl.setRemovedTime(jobInfoData.getRemovedTime());

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
@@ -69,6 +69,7 @@ public class DataUtility {
         impl.setChildrenCount(d.getChildrenCount());
         impl.setFinishedTime(d.getFinishedTime());
         impl.setJobOwner(d.getJobOwner());
+        impl.setTenant(d.getTenant());
         impl.setNumberOfFinishedTasks(d.getNumberOfFinishedTasks());
         impl.setNumberOfPendingTasks(d.getNumberOfPendingTasks());
         impl.setNumberOfRunningTasks(d.getNumberOfRunningTasks());
@@ -150,6 +151,7 @@ public class DataUtility {
 
     public static JobUsage jobUsage(JobUsageData d) {
         JobUsage impl = new JobUsage(d.getOwner(),
+                                     d.getTenant(),
                                      d.getProject(),
                                      d.getJobId(),
                                      d.getJobName(),
@@ -194,6 +196,8 @@ public class DataUtility {
         for (SchedulerUserData sud : dataList) {
             schedulerUserInfos.add(new SchedulerUserInfo(sud.getHostName(),
                                                          sud.getUsername(),
+                                                         sud.getGroups(),
+                                                         sud.getTenant(),
                                                          sud.getConnectionTime(),
                                                          sud.getLastSubmitTime(),
                                                          sud.getSubmitNumber()));
@@ -204,6 +208,7 @@ public class DataUtility {
     public static UserIdentification userIdentification(SchedulerUserData d) {
         return new UserIdentificationImpl(d.getUsername(),
                                           d.getGroups(),
+                                          d.getTenant(),
                                           d.getSubmitNumber(),
                                           d.getHostName(),
                                           d.getConnectionTime(),

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
@@ -53,6 +53,8 @@ public class JobInfoImpl implements JobInfo {
 
     private String jobOwner;
 
+    private String tenant;
+
     private String projectName;
 
     private int totalNumberOfTasks = 0;
@@ -128,6 +130,15 @@ public class JobInfoImpl implements JobInfo {
     @Override
     public String getJobOwner() {
         return jobOwner;
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     public void setProjectName(String projectName) {

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobStateImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobStateImpl.java
@@ -82,6 +82,11 @@ public class JobStateImpl extends JobState {
     }
 
     @Override
+    public String getTenant() {
+        return jobStateData.getTenant();
+    }
+
+    @Override
     public List<TaskState> getTasks() {
         Map<String, TaskStateData> taskStateMap = jobStateData.getTasks();
         List<TaskState> taskStateList = new ArrayList<>(taskStateMap.size());

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
@@ -37,6 +37,8 @@ public class UserIdentificationImpl extends UserIdentification {
 
     private Set<String> groups;
 
+    private String tenant;
+
     private int submitNumber;
 
     private String hostName;
@@ -51,7 +53,7 @@ public class UserIdentificationImpl extends UserIdentification {
 
     }
 
-    public UserIdentificationImpl(String username, Set<String> groups, int submitNumber, String hostName,
+    public UserIdentificationImpl(String username, Set<String> groups, String tenant, int submitNumber, String hostName,
             long connectionTime, long lastSubmitTime, boolean myEventsOnly) {
         this.username = username;
         this.groups = groups;
@@ -60,6 +62,7 @@ public class UserIdentificationImpl extends UserIdentification {
         this.connectionTime = connectionTime;
         this.lastSubmitTime = lastSubmitTime;
         this.myEventsOnly = myEventsOnly;
+        this.tenant = tenant;
     }
 
     @Override
@@ -70,6 +73,16 @@ public class UserIdentificationImpl extends UserIdentification {
     @Override
     public Set<String> getGroups() {
         return groups;
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    @Override
+    public boolean isAllTenantPermission() {
+        return false;
     }
 
     @Override
@@ -108,6 +121,10 @@ public class UserIdentificationImpl extends UserIdentification {
 
     public void setGroups(Set<String> groups) {
         this.groups = groups;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     public void setSubmitNumber(int submitNumber) {

--- a/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/SchedulerClientTest.java
@@ -337,6 +337,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
                                                                   "",
                                                                   "",
                                                                   "",
+                                                                  null,
                                                                   new Long(-1));
         List defaultSortOrder = Collections.singletonList(new SortParameter<>(JobSortParameter.ID, SortOrder.ASC));
         List<JobInfo> allJobInfos = client.getJobs(0, 1000, allJobsCriteria, defaultSortOrder).getList();
@@ -393,6 +394,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
                                                                   "",
                                                                   "",
                                                                   "",
+                                                                  null,
                                                                   new Long(-1));
         SortParameter jobNameDescOrder = new SortParameter<>(JobSortParameter.NAME, SortOrder.DESC);
         SortParameter jobIdAscOrder = new SortParameter<>(JobSortParameter.ID, SortOrder.ASC);
@@ -420,6 +422,7 @@ public class SchedulerClientTest extends AbstractRestFuncTestCase {
                                                                                       "",
                                                                                       "myProjectB",
                                                                                       "",
+                                                                                      null,
                                                                                       new Long(-1));
         List<JobInfo> jobsList3 = client.getJobs(0,
                                                  4,

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -229,7 +229,16 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             Page<JobInfo> page = s.getJobs(index,
                                            limit,
-                                           new JobFilterCriteria(false, true, true, true, true, null, null, null, null),
+                                           new JobFilterCriteria(false,
+                                                                 true,
+                                                                 true,
+                                                                 true,
+                                                                 true,
+                                                                 null,
+                                                                 null,
+                                                                 null,
+                                                                 null,
+                                                                 null),
                                            DEFAULT_JOB_SORT_PARAMS);
 
             List<String> ids = new ArrayList<>(page.getList().size());
@@ -309,7 +318,16 @@ public class SchedulerStateRest implements SchedulerRestInterface {
 
             Page<JobInfo> page = s.getJobs(index,
                                            limit,
-                                           new JobFilterCriteria(false, true, true, true, true, null, null, null, null),
+                                           new JobFilterCriteria(false,
+                                                                 true,
+                                                                 true,
+                                                                 true,
+                                                                 true,
+                                                                 null,
+                                                                 null,
+                                                                 null,
+                                                                 null,
+                                                                 null),
                                            DEFAULT_JOB_SORT_PARAMS);
             List<UserJobData> userJobInfoList = new ArrayList<>(page.getList().size());
             for (JobInfo jobInfo : page.getList()) {
@@ -343,7 +361,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     @Override
     public RestMapPage<Long, ArrayList<UserJobData>> revisionAndJobsInfo(String sessionId, int index, int limit,
             boolean myJobs, boolean pending, boolean running, boolean finished, boolean childJobs, String jobName,
-            String projectName, String userName, Long parentId, String sortParams) throws RestException {
+            String projectName, String tenant, String userName, Long parentId, String sortParams) throws RestException {
         try {
             Scheduler s = checkAccess(sessionId, "revisionjobsinfo?index=" + index + "&limit=" + limit);
             String user = sessionStore.get(sessionId).getUserName();
@@ -371,6 +389,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
                                                                  jobName,
                                                                  projectName,
                                                                  userName,
+                                                                 tenant,
                                                                  parentId),
                                            sortParameterList);
             List<JobInfo> jobsInfo = page.getList();

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/DozerMappingTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/DozerMappingTest.java
@@ -139,6 +139,11 @@ public class DozerMappingTest {
             }
 
             @Override
+            public String getTenant() {
+                return null;
+            }
+
+            @Override
             public JobType getType() {
                 return null;
             }

--- a/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
+++ b/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
@@ -160,6 +160,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.resumeJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeStartAt";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogsByTag ";
@@ -661,6 +662,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.resumeJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.killJob";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeJobPriority";
+    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.changeStartAt";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getJobServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogs";
     permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.getTaskServerLogsByTag ";

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
@@ -138,6 +138,9 @@ public enum PAResourceManagerProperties implements PACommonProperties {
     /** Resource Manager group file name */
     RM_GROUP_FILE("pa.rm.defaultgroupfilename", PropertyType.STRING, "config/authentication/group.cfg"),
 
+    /** Resource Manager tenant file name */
+    RM_TENANT_FILE("pa.rm.defaulttenantfilename", PropertyType.STRING, "config/authentication/tenant.cfg"),
+
     /** Name of the JMX MBean for the RM */
     RM_JMX_CONNECTOR_NAME("pa.rm.jmx.connectorname", PropertyType.STRING, "JMXRMAgent"),
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/Client.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/Client.java
@@ -42,6 +42,7 @@ import org.objectweb.proactive.core.mop.Proxy;
 import org.objectweb.proactive.core.mop.StubObject;
 import org.ow2.proactive.authentication.crypto.Credentials;
 import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
+import org.ow2.proactive.authentication.principals.TenantPrincipal;
 import org.ow2.proactive.authentication.principals.UserNamePrincipal;
 import org.ow2.proactive.resourcemanager.core.history.UserHistory;
 
@@ -131,6 +132,15 @@ public class Client implements Serializable {
             answer.add(principal.getName());
         }
         return answer;
+    }
+
+    public String getTenant() {
+        Set<TenantPrincipal> tenantPrincipals = subject.getPrincipals(TenantPrincipal.class);
+        if (tenantPrincipals != null && tenantPrincipals.size() > 0) {
+            return tenantPrincipals.iterator().next().getName();
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMFileLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMFileLoginModule.java
@@ -74,6 +74,21 @@ public class RMFileLoginModule extends FileLoginModule {
         return groupFile;
     }
 
+    /**
+     * Returns tenant file name from resource manager configuration file
+     */
+    @Override
+    protected String getTenantFileName() {
+        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
     @Override
     protected PrivateKey getPrivateKey() throws KeyException {
         return Credentials.getPrivateKey(PAResourceManagerProperties.getAbsolutePath(PAResourceManagerProperties.RM_AUTH_PRIVKEY_PATH.getValueAsString()));

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMLDAPLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMLDAPLoginModule.java
@@ -93,6 +93,21 @@ public class RMLDAPLoginModule extends LDAPLoginModule {
         return groupFile;
     }
 
+    /**
+     * Returns tenant file name from resource manager configuration file
+     */
+    @Override
+    protected String getTenantFileName() {
+        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
     @Override
     protected PrivateKey getPrivateKey() throws KeyException {
         return Credentials.getPrivateKey(PAResourceManagerProperties.getAbsolutePath(PAResourceManagerProperties.RM_AUTH_PRIVKEY_PATH.getValueAsString()));

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMPAMLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMPAMLoginModule.java
@@ -73,6 +73,21 @@ public class RMPAMLoginModule extends PAMLoginModule {
     }
 
     /**
+     * Returns tenant file name from resource manager configuration file
+     */
+    @Override
+    protected String getTenantFileName() {
+        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
+    /**
      * Returns logger used for authentication
      */
     public Logger getLogger() {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -3068,6 +3068,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         UserData userData = new UserData();
         userData.setUserName(caller.getName());
         userData.setGroups(caller.getGroups());
+        userData.setTenant(caller.getTenant());
         return userData;
     }
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/AccessType.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/AccessType.java
@@ -61,6 +61,8 @@ public class AccessType implements Serializable {
 
     public static final String TOKEN_ACCESS_TYPE = "tokens";
 
+    public static final String TENANT_ACCESS_TYPE = "tenants";
+
     public static final AccessType ME = new AccessType("ME");
 
     @Deprecated
@@ -83,6 +85,8 @@ public class AccessType implements Serializable {
     private String[] includedGroups = null;
 
     private String[] excludedGroups = null;
+
+    private String[] includedTenants = null;
 
     private String[] tokens;
 
@@ -123,6 +127,7 @@ public class AccessType implements Serializable {
             ArrayList<String> excludedUsers = new ArrayList<>();
             ArrayList<String> includedGroups = new ArrayList<>();
             ArrayList<String> excludedGroups = new ArrayList<>();
+            ArrayList<String> includedTenants = new ArrayList<>();
             ArrayList<String> tokens = new ArrayList<>();
 
             for (String s : semicolon) {
@@ -152,6 +157,9 @@ public class AccessType implements Serializable {
                                 excludedGroups.add(value.replaceFirst("!", ""));
                             }
                             break;
+                        case TENANT_ACCESS_TYPE:
+                            includedTenants.add(value);
+                            break;
                         case TOKEN_ACCESS_TYPE:
                             tokens.add(value);
                             break;
@@ -167,12 +175,15 @@ public class AccessType implements Serializable {
                 accessType.includedGroups = includedGroups.toArray(new String[0]);
             if (!excludedGroups.isEmpty())
                 accessType.excludedGroups = excludedGroups.toArray(new String[0]);
+            if (!includedTenants.isEmpty())
+                accessType.includedTenants = includedTenants.toArray(new String[0]);
             if (!tokens.isEmpty())
                 accessType.tokens = tokens.toArray(new String[0]);
 
             if (accessType.includedUsers == null && accessType.excludedUsers == null &&
-                accessType.includedGroups == null && accessType.excludedGroups == null && accessType.tokens == null) {
-                throw new IllegalArgumentException("Not able to retrieve any users/groups/tokens " + type);
+                accessType.includedGroups == null && accessType.excludedGroups == null &&
+                accessType.includedTenants == null && accessType.tokens == null) {
+                throw new IllegalArgumentException("Not able to retrieve any users/groups/tenants/tokens " + type);
             }
         }
 
@@ -223,6 +234,11 @@ public class AccessType implements Serializable {
         if (excludedGroups != null) {
             for (String group : excludedGroups) {
                 identities.add(new ExcludedGroupNamePrincipal(group));
+            }
+        }
+        if (includedTenants != null) {
+            for (String tenant : includedTenants) {
+                identities.add(new TenantPrincipal(tenant));
             }
         }
         if (tokens != null) {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/NodeSourcePolicy.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/policy/NodeSourcePolicy.java
@@ -70,11 +70,11 @@ public abstract class NodeSourcePolicy implements NodeSourcePlugin {
     protected NodeSource nodeSource;
 
     // Users who can get nodes for computations from this node source
-    @Configurable(description = "ME|users=name1,name2;groups=group1,group2;tokens=t1,t2|ALL", sectionSelector = 1)
+    @Configurable(description = "ME|users=name1,name2;groups=group1,group2;tenants=tenant1,tenant2;tokens=t1,t2|ALL", sectionSelector = 1)
     private AccessType userAccessType = AccessType.ALL;
 
     // Users who can add/remove nodes to/from this node source
-    @Configurable(description = "ME|users=name1,name2;groups=group1,group2|ALL", sectionSelector = 1)
+    @Configurable(description = "ME|users=name1,name2;groups=group1,group2;tenants=tenant1,tenant2|ALL", sectionSelector = 1)
     private AccessType providerAccessType = AccessType.ME;
 
     private Map<String, String> meta = new HashMap<>();

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/JobFilterCriteria.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/JobFilterCriteria.java
@@ -49,10 +49,12 @@ public class JobFilterCriteria implements Serializable {
 
     private final String userName;
 
+    private final String tenant;
+
     private final Long parentId;
 
     public JobFilterCriteria(boolean myJobsOnly, boolean pending, boolean running, boolean finished, boolean childJobs,
-            String jobName, String projectName, String userName, Long parentId) {
+            String jobName, String projectName, String userName, String tenant, Long parentId) {
         this.myJobsOnly = myJobsOnly;
         this.pending = pending;
         this.running = running;
@@ -61,6 +63,7 @@ public class JobFilterCriteria implements Serializable {
         this.jobName = jobName;
         this.projectName = projectName;
         this.userName = userName;
+        this.tenant = tenant;
         this.parentId = parentId;
     }
 
@@ -94,6 +97,10 @@ public class JobFilterCriteria implements Serializable {
 
     public String getUserName() {
         return userName;
+    }
+
+    public String getTenant() {
+        return tenant;
     }
 
     public Long getParentId() {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/TaskFilterCriteria.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/TaskFilterCriteria.java
@@ -34,7 +34,7 @@ import org.ow2.proactive.db.SortParameter;
 
 
 /**
- * Default values for the embedded criterias are the following:
+ * Default values for the embedded criteria are the following:
  * <ul>
  *     <li>no tag filtering</li>
  *     <li>no dates filtering</li>
@@ -56,6 +56,8 @@ public class TaskFilterCriteria implements Serializable {
     private int limit = 0;
 
     private String user = null;
+
+    private String tenant = null;
 
     private boolean running = true;
 
@@ -135,6 +137,14 @@ public class TaskFilterCriteria implements Serializable {
 
     public void setUser(String user) {
         this.user = user;
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     public List<SortSpecifierContainer> getSortParameters() {
@@ -230,6 +240,14 @@ public class TaskFilterCriteria implements Serializable {
          */
         public TFCBuilder user(String user) {
             criterias.setUser(user);
+            return this;
+        }
+
+        /**
+         * Default value is <code>null</code> (no user specific filtering)
+         */
+        public TFCBuilder tenant(String tenant) {
+            criterias.setTenant(tenant);
             return this;
         }
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
@@ -62,6 +62,13 @@ public interface JobInfo extends Serializable {
     String getJobOwner();
 
     /**
+     * Return the tenant associated with the job owner
+     *
+     * @return the tenant associated with the job owner or null if no tenant is associated
+     */
+    String getTenant();
+
+    /**
      * Returns the project name associated with this job
      * @return project name
      */

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
@@ -440,6 +440,13 @@ public abstract class JobState extends Job implements Comparable<JobState> {
     public abstract String getOwner();
 
     /**
+     * To get the owner of the job.
+     *
+     * @return the owner of the job.
+     */
+    public abstract String getTenant();
+
+    /**
      * Get the toBeRemoved property.
      * If this method returns true, this job is about to be removed from scheduler.
      *

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
@@ -86,6 +86,19 @@ public abstract class UserIdentification implements Serializable, Comparable<Use
     public abstract Set<String> getGroups();
 
     /**
+     *
+     * @return
+     */
+    public abstract boolean isAllTenantPermission();
+
+    /**
+     * Return the tenant associated with the current user, or null if no tenant is associated
+     *
+     * @return user tenant
+     */
+    public abstract String getTenant();
+
+    /**
      * Get the number of submit for this user.
      * 
      * @return the number of submit for this user.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/usage/JobUsage.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/usage/JobUsage.java
@@ -45,6 +45,8 @@ import org.objectweb.proactive.annotation.PublicAPI;
 public class JobUsage implements Serializable {
     private final String owner;
 
+    private final String tenant;
+
     private final String project;
 
     private final String jobId;
@@ -61,9 +63,10 @@ public class JobUsage implements Serializable {
 
     private final Long parentId;
 
-    public JobUsage(String owner, String project, String jobId, String jobName, long jobDuration, String status,
-            long submittedTime, Long parentId) {
+    public JobUsage(String owner, String tenant, String project, String jobId, String jobName, long jobDuration,
+            String status, long submittedTime, Long parentId) {
         this.owner = owner;
+        this.tenant = tenant;
         this.project = project;
         this.jobId = jobId;
         this.jobName = jobName;
@@ -87,6 +90,10 @@ public class JobUsage implements Serializable {
 
     public String getOwner() {
         return owner;
+    }
+
+    public String getTenant() {
+        return tenant;
     }
 
     public String getProject() {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -192,6 +192,12 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Group default filename */
     SCHEDULER_GROUP_FILENAME("pa.scheduler.core.defaultgroupfilename", PropertyType.STRING, "config/authentication/group.cfg"),
 
+    /** Tenant default filename */
+    SCHEDULER_TENANT_FILENAME("pa.scheduler.core.defaulttenantfilename", PropertyType.STRING, "config/authentication/tenant.cfg"),
+
+    /** If enabled, filter jobs according to user tenant */
+    SCHEDULER_TENANT_FILTER("pa.scheduler.core.tenant.filter", PropertyType.BOOLEAN, "false"),
+
     /** Property that define the method that have to be used for logging users to the Scheduler */
     SCHEDULER_LOGIN_METHOD("pa.scheduler.core.authentication.loginMethod", PropertyType.STRING, "SchedulerFileLoginMethod"),
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/job/SchedulerUserInfo.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/job/SchedulerUserInfo.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.scheduler.job;
 
 import java.io.Serializable;
+import java.util.Set;
 
 import org.objectweb.proactive.annotation.PublicAPI;
 
@@ -37,16 +38,22 @@ public class SchedulerUserInfo implements Serializable {
 
     private final String username;
 
+    private final Set<String> groups;
+
+    private final String tenant;
+
     private final long connectionTime;
 
     private final long lastSubmitTime;
 
     private final int submitNumber;
 
-    public SchedulerUserInfo(String hostName, String username, long connectionTime, long lastSubmitTime,
-            int submitNumber) {
+    public SchedulerUserInfo(String hostName, String username, Set<String> groups, String tenant, long connectionTime,
+            long lastSubmitTime, int submitNumber) {
         this.hostName = hostName;
         this.username = username;
+        this.groups = groups;
+        this.tenant = tenant;
         this.connectionTime = connectionTime;
         this.lastSubmitTime = lastSubmitTime;
         this.submitNumber = submitNumber;
@@ -58,6 +65,14 @@ public class SchedulerUserInfo implements Serializable {
 
     public String getUsername() {
         return username;
+    }
+
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    public String getTenant() {
+        return tenant;
     }
 
     public long getConnectionTime() {

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -66,6 +66,8 @@ public class ClientJobState extends JobState {
 
     private String owner;
 
+    private String tenant;
+
     private JobType type;
 
     private Map<TaskId, TaskState> tasks;
@@ -86,6 +88,7 @@ public class ClientJobState extends JobState {
         // converting internal job into a light job descriptor
         jobInfo = (JobInfoImpl) jobState.getJobInfo();
         owner = jobState.getOwner();
+        tenant = jobState.getTenant();
         type = jobState.getType();
 
         this.name = jobState.getName();
@@ -202,6 +205,11 @@ public class ClientJobState extends JobState {
     @Override
     public String getOwner() {
         return owner;
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
     }
 
     @Override

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
@@ -61,6 +61,8 @@ public class JobInfoImpl implements JobInfo {
 
     private String owner;
 
+    private String tenant;
+
     private String projectName;
 
     /** job submitted time */
@@ -165,6 +167,7 @@ public class JobInfoImpl implements JobInfo {
     public JobInfoImpl(JobInfoImpl jobInfo) {
         this.jobId = jobInfo.getJobId();
         this.owner = jobInfo.owner;
+        this.tenant = jobInfo.tenant;
         this.projectName = jobInfo.getProjectName();
         this.submittedTime = jobInfo.getSubmittedTime();
         this.startTime = jobInfo.getStartTime();
@@ -214,6 +217,15 @@ public class JobInfoImpl implements JobInfo {
 
     public void setJobOwner(String owner) {
         this.owner = owner;
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     @Override

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/permissions/TenantAllAccessPermission.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/permissions/TenantAllAccessPermission.java
@@ -1,0 +1,36 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.permissions;
+
+import org.ow2.proactive.permissions.ClientPermission;
+
+
+/**
+ * If pa.scheduler.core.tenant.filter is enabled, this permission allows a user to view all jobs,
+ * regardless of which tenant the user belongs to.
+ */
+public class TenantAllAccessPermission extends ClientPermission {
+}

--- a/scheduler/scheduler-client/src/test/java/functionaltests/job/serialization/ClientJobStateSerializationTest.java
+++ b/scheduler/scheduler-client/src/test/java/functionaltests/job/serialization/ClientJobStateSerializationTest.java
@@ -130,6 +130,11 @@ public class ClientJobStateSerializationTest {
         }
 
         @Override
+        public String getTenant() {
+            return null;
+        }
+
+        @Override
         public JobType getType() {
             return null;
         }

--- a/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobStateTest.java
+++ b/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobStateTest.java
@@ -198,6 +198,11 @@ public class ClientJobStateTest {
             }
 
             @Override
+            public String getTenant() {
+                return null;
+            }
+
+            @Override
             public JobType getType() {
                 return null;
             }
@@ -236,6 +241,11 @@ public class ClientJobStateTest {
         @Override
         public String getOwner() {
             return "testOwnder";
+        }
+
+        @Override
+        public String getTenant() {
+            return null;
         }
 
         @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerFileLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerFileLoginModule.java
@@ -77,6 +77,23 @@ public class SchedulerFileLoginModule extends FileLoginModule {
         return groupFile;
     }
 
+    /**
+     * Returns tenant file name from scheduler configuration file
+     *
+     * @return tenant file name from scheduler configuration file
+     */
+    @Override
+    protected String getTenantFileName() {
+        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
     @Override
     protected PrivateKey getPrivateKey() throws KeyException {
         return Credentials.getPrivateKey(PASchedulerProperties.getAbsolutePath(PASchedulerProperties.SCHEDULER_AUTH_PRIVKEY_PATH.getValueAsString()));

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerLDAPLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerLDAPLoginModule.java
@@ -91,6 +91,23 @@ public class SchedulerLDAPLoginModule extends LDAPLoginModule {
         return groupFile;
     }
 
+    /**
+     * Returns tenant file name from scheduler configuration file
+     *
+     * @return tenant file name from scheduler configuration file
+     */
+    @Override
+    protected String getTenantFileName() {
+        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
     @Override
     protected PrivateKey getPrivateKey() throws KeyException {
         return Credentials.getPrivateKey(PASchedulerProperties.getAbsolutePath(PASchedulerProperties.SCHEDULER_AUTH_PRIVKEY_PATH.getValueAsString()));

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerPAMLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerPAMLoginModule.java
@@ -75,6 +75,23 @@ public class SchedulerPAMLoginModule extends PAMLoginModule {
         return groupFile;
     }
 
+    /**
+     * Returns tenant file name from scheduler configuration file
+     *
+     * @return tenant file name from scheduler configuration file
+     */
+    @Override
+    protected String getTenantFileName() {
+        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
     @Override
     protected PrivateKey getPrivateKey() throws KeyException {
         return Credentials.getPrivateKey(PASchedulerProperties.getAbsolutePath(PASchedulerProperties.SCHEDULER_AUTH_PRIVKEY_PATH.getValueAsString()));

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -25,42 +25,7 @@
  */
 package org.ow2.proactive.scheduler.core;
 
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSIONS_TO_GET_THE_LOGS_OF_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_ADD_EXTERNAL_ENDPOINT_URL_TO_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_DETACH_SERVICE_TO_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_DO_THIS_OPERATION;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_ENABLE_VISE_THIS_TASK;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_FINISH_THIS_TASK;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_FREEZE_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_GET_TASK_IDS;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_GET_TASK_STATES;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THE_RESULT_OF_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THE_TASK_LOGS_OF_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THE_TASK_RESULT_OF_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_GET_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_KILL_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_KILL_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_KILL_THIS_TASK;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_LISTEN_THE_LOG_OF_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_LIST_THIRD_PARTY_CREDENTIALS_IN_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_PAUSE_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_PAUSE_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_PREEMPT_THIS_TASK;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_PUT_THIRD_PARTY_CREDENTIALS_IN_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_REGISTER_SERVICE_TO_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_RELOAD_POLICY_CONFIGURATION;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_REMOVE_EXTERNAL_ENDPOINT_URL_TO_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_REMOVE_THIRD_PARTY_CREDENTIALS_FROM_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_REMOVE_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_RESTART_IN_ERROR_TASKS_IN_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_RESTART_THIS_TASK;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_RESUME_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_RESUME_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_SEND_SIGNALS_TO_THIS_JOB;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_SHUTDOWN_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_START_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_STOP_THE_SCHEDULER;
-import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.YOU_DO_NOT_HAVE_PERMISSION_TO_SUBMIT_A_JOB;
+import static org.ow2.proactive.scheduler.core.SchedulerFrontendState.*;
 
 import java.io.*;
 import java.net.URI;
@@ -177,6 +142,8 @@ import org.ow2.proactive.scheduler.util.ServerJobAndTaskLogs;
 import org.ow2.proactive.utils.NodeSet;
 import org.ow2.proactive.utils.PAExecutors;
 import org.ow2.proactive.utils.Tools;
+
+import com.google.common.base.Strings;
 
 
 /**
@@ -1690,13 +1657,21 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
         boolean myJobsOnly = filterCriteria.isMyJobsOnly();
 
         String user = filterCriteria.getUserName();
+        String tenant = filterCriteria.getTenant();
         if (myJobsOnly) {
             user = ident.getUsername();
+        }
+        boolean isExplicitTenantFilter = !Strings.isNullOrEmpty(tenant);
+        if (PASchedulerProperties.SCHEDULER_TENANT_FILTER.getValueAsBoolean() && !ident.isAllTenantPermission()) {
+            // overwrite tenant filter if the user only has access to his own tenant
+            tenant = ident.getTenant();
         }
 
         Page<JobInfo> jobsInfo = dbManager.getJobs(offset,
                                                    limit,
                                                    user,
+                                                   tenant,
+                                                   isExplicitTenantFilter,
                                                    filterCriteria.isPending(),
                                                    filterCriteria.isRunning(),
                                                    filterCriteria.isFinished(),
@@ -1867,12 +1842,18 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
     public Page<TaskId> getTaskIds(String taskTag, long from, long to, boolean mytasks, Set<TaskStatus> taskStatuses,
             int offset, int limit) throws NotConnectedException, PermissionException {
         String userName = null;
-        String tmpUserName = frontendState.checkPermission("getTaskIds", YOU_DO_NOT_HAVE_PERMISSION_TO_GET_TASK_IDS)
-                                          .getUsername();
+        UserIdentificationImpl userIdentification = frontendState.checkPermission("getTaskIds",
+                                                                                  YOU_DO_NOT_HAVE_PERMISSION_TO_GET_TASK_IDS);
+        String tmpUserName = userIdentification.getUsername();
+        String tenant = null;
         if (mytasks) {
             userName = tmpUserName;
         }
-        Page<TaskInfo> pTaskInfo = dbManager.getTasks(from, to, taskTag, offset, limit, userName, taskStatuses);
+        if (PASchedulerProperties.SCHEDULER_TENANT_FILTER.getValueAsBoolean() &&
+            !userIdentification.isAllTenantPermission()) {
+            tenant = userIdentification.getTenant();
+        }
+        Page<TaskInfo> pTaskInfo = dbManager.getTasks(from, to, taskTag, offset, limit, userName, tenant, taskStatuses);
         List<TaskId> lTaskId = new ArrayList<>(pTaskInfo.getList().size());
         for (TaskInfo taskInfo : pTaskInfo.getList()) {
             if (checkJobPermissionMethod(taskInfo.getJobId().value(), "getTaskIds")) {
@@ -1889,11 +1870,16 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
             throws NotConnectedException, PermissionException {
 
         String userName = null;
-        String tmpUserName = frontendState.checkPermission("getTaskStates",
-                                                           YOU_DO_NOT_HAVE_PERMISSION_TO_GET_TASK_STATES)
-                                          .getUsername();
+        UserIdentificationImpl userIdentification = frontendState.checkPermission("getTaskStates",
+                                                                                  YOU_DO_NOT_HAVE_PERMISSION_TO_GET_TASK_STATES);
+        String tmpUserName = userIdentification.getUsername();
+        String tenant = null;
         if (mytasks) {
             userName = tmpUserName;
+        }
+        if (PASchedulerProperties.SCHEDULER_TENANT_FILTER.getValueAsBoolean() &&
+            !userIdentification.isAllTenantPermission()) {
+            tenant = userIdentification.getTenant();
         }
         Page<TaskState> page = dbManager.getTaskStates(from,
                                                        to,
@@ -1901,6 +1887,7 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
                                                        offset,
                                                        limit,
                                                        userName,
+                                                       tenant,
                                                        statusFilter,
                                                        sortParams);
         for (Iterator<TaskState> it = page.getList().iterator(); it.hasNext();) {
@@ -2012,7 +1999,11 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
      */
     @Override
     @ImmediateService
-    public boolean changeStartAt(JobId jobId, String startAt) {
+    public boolean changeStartAt(JobId jobId, String startAt)
+            throws UnknownJobException, NotConnectedException, PermissionException {
+        frontendState.checkPermissions("changeStartAt",
+                                       frontendState.getIdentifiedJob(jobId),
+                                       YOU_DO_NOT_HAVE_PERMISSION_TO_CHANGE_THE_START_AT_VALUE_OF_THIS_JOB);
         return schedulingService.changeStartAt(jobId, startAt);
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBJobDataParameters.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBJobDataParameters.java
@@ -46,6 +46,10 @@ public class DBJobDataParameters {
 
     private final String user;
 
+    private final String tenant;
+
+    private final boolean isExplicitTenantFilter;
+
     private final boolean pending;
 
     private final boolean running;
@@ -64,12 +68,14 @@ public class DBJobDataParameters {
 
     private final Set<JobStatus> status;
 
-    DBJobDataParameters(int offset, int limit, String user, boolean pending, boolean running, boolean finished,
-            boolean childJobs, String jobName, String projectName, Long parentId,
-            List<SortParameter<JobSortParameter>> sortParameters) {
+    DBJobDataParameters(int offset, int limit, String user, String tenant, boolean isExplicitTenantFilter,
+            boolean pending, boolean running, boolean finished, boolean childJobs, String jobName, String projectName,
+            Long parentId, List<SortParameter<JobSortParameter>> sortParameters) {
         this.offset = offset;
         this.limit = limit;
         this.user = user;
+        this.tenant = tenant;
+        this.isExplicitTenantFilter = isExplicitTenantFilter;
         this.pending = pending;
         this.running = running;
         this.finished = finished;
@@ -103,6 +109,14 @@ public class DBJobDataParameters {
 
     public String getUser() {
         return user;
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public boolean isExplicitTenantFilter() {
+        return isExplicitTenantFilter;
     }
 
     public boolean isChildJobs() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBTaskDataParameters.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBTaskDataParameters.java
@@ -52,6 +52,8 @@ public class DBTaskDataParameters {
 
     private String user;
 
+    private String tenant;
+
     private Set<TaskStatus> status;
 
     private SortSpecifierContainer sortParams;
@@ -61,9 +63,10 @@ public class DBTaskDataParameters {
         this.sortParams = new SortSpecifierContainer();
     }
 
-    DBTaskDataParameters(String user, String tag, long from, long to, int offset, int limit, Set<TaskStatus> statuses,
-            SortSpecifierContainer sortParams) {
+    DBTaskDataParameters(String user, String tenant, String tag, long from, long to, int offset, int limit,
+            Set<TaskStatus> statuses, SortSpecifierContainer sortParams) {
         this.user = user;
+        this.tenant = tenant;
         this.tag = tag;
         this.from = from;
         this.to = to;
@@ -83,6 +86,18 @@ public class DBTaskDataParameters {
 
     public boolean hasUser() {
         return !Strings.isNullOrEmpty(user);
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
+    }
+
+    public boolean hasTenant() {
+        return !Strings.isNullOrEmpty(tenant);
     }
 
     public String getTag() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -188,7 +188,8 @@ import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
                                        @Index(name = "TASK_DATA_TASK_ID_JOB", columnList = "TASK_ID_JOB"),
                                        @Index(name = "TASK_DATA_TASK_ID_TASK", columnList = "TASK_ID_TASK"),
                                        @Index(name = "TASK_DATA_TASK_NAME", columnList = "TASK_NAME"),
-                                       @Index(name = "TASK_DATA_OWNER", columnList = "OWNER") })
+                                       @Index(name = "TASK_DATA_OWNER", columnList = "OWNER"),
+                                       @Index(name = "TASK_DATA_TENANT", columnList = "TENANT") })
 public class TaskData {
 
     private static final String SCRIPT_TASK = "SCRIPT_TASK";
@@ -226,6 +227,8 @@ public class TaskData {
     private String taskName;
 
     private String owner;
+
+    private String tenant;
 
     private String tag;
 
@@ -536,6 +539,7 @@ public class TaskData {
 
         taskData.setId(taskId);
         taskData.setOwner(jobRuntimeData.getOwner());
+        taskData.setTenant(jobRuntimeData.getTenant());
         taskData.setDescription(task.getDescription());
         taskData.setTag(task.getTag());
         taskData.setParallelEnvironment(task.getParallelEnvironment());
@@ -921,6 +925,15 @@ public class TaskData {
 
     public void setOwner(String owner) {
         this.owner = owner;
+    }
+
+    @Column(name = "TENANT")
+    public String getTenant() {
+        return tenant;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
     }
 
     @Column(name = "TYPE", nullable = false, updatable = false)

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/IdentifiedJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/IdentifiedJob.java
@@ -33,6 +33,7 @@ import org.ow2.proactive.authentication.principals.UserNamePrincipal;
 import org.ow2.proactive.permissions.PrincipalPermission;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 
 
 /**
@@ -103,11 +104,11 @@ public class IdentifiedJob implements Serializable {
     }
 
     /**
-     * Check if the given user identification can managed this job.
+     * Check if the given user identification can manage this job.
      *
      * @param userId
      *            the user identification to check.
-     * @return true if userId has permission to managed this job.
+     * @return true if userId has permission to manage this job.
      */
     public boolean hasRight(UserIdentificationImpl userId) {
         if (userIdentification == null) {
@@ -124,6 +125,21 @@ public class IdentifiedJob implements Serializable {
             return false;
         }
 
+        return true;
+    }
+
+    /**
+     * Check if the given user identification has access to this job according to the tenant policy.
+     *
+     * @param userId
+     *            the user identification to check.
+     * @return true if userId has permission to access this job.
+     */
+    public boolean hasTenantAccess(UserIdentificationImpl userId) {
+        // check tenant permission
+        if (PASchedulerProperties.SCHEDULER_TENANT_FILTER.getValueAsBoolean() && !userId.isAllTenantPermission()) {
+            return userIdentification.getTenant() == null || userIdentification.getTenant().equals(userId.getTenant());
+        }
         return true;
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -1219,6 +1219,23 @@ public abstract class InternalJob extends JobState {
     }
 
     /**
+     * @see org.ow2.proactive.scheduler.common.job.JobState#getTenant()
+     */
+    @Override
+    public String getTenant() {
+        return jobInfo.getTenant();
+    }
+
+    /**
+     * To set the tenant of this job owner.
+     *
+     * @param tenant the tenant to set.
+     */
+    public void setTenant(String tenant) {
+        this.jobInfo.setTenant(tenant);
+    }
+
+    /**
      * Get the credentials for this job
      *
      * @return the credentials for this job

--- a/scheduler/scheduler-server/src/test/java/functionaltests/api/TestLoadJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/api/TestLoadJobs.java
@@ -322,7 +322,7 @@ public class TestLoadJobs extends SchedulerFunctionalTestNoRestart {
 
     private JobFilterCriteria criteria(boolean myJobsOnly, boolean pending, boolean running, boolean finished,
             boolean childJobs) {
-        return new JobFilterCriteria(myJobsOnly, pending, running, finished, childJobs, null, null, null, null);
+        return new JobFilterCriteria(myJobsOnly, pending, running, finished, childJobs, null, null, null, null, null);
     }
 
     private JobFilterCriteria criteria(boolean myJobsOnly, boolean pending, boolean running, boolean finished,
@@ -335,6 +335,7 @@ public class TestLoadJobs extends SchedulerFunctionalTestNoRestart {
                                      jobName,
                                      projectName,
                                      userName,
+                                     null,
                                      parentId);
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
@@ -108,6 +108,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -122,6 +124,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -136,6 +140,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -151,6 +157,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -166,6 +174,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -180,6 +190,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -194,6 +206,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -208,6 +222,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -222,6 +238,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -237,6 +255,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         jobs = dbManager.getJobs(0,
                                  10,
                                  null,
+                                 null,
+                                 false,
                                  true,
                                  true,
                                  true,
@@ -302,7 +322,8 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         List<SortParameter<JobSortParameter>> sortParameters = new ArrayList<>();
         sortParameters.add(new SortParameter<>(JobSortParameter.ID, SortOrder.ASC));
 
-        jobs = dbManager.getJobs(5, 1, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(5, 1, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         JobInfo jobInfo = jobs.get(0);
         Assert.assertEquals("6", jobInfo.getJobId().value());
         Assert.assertEquals(JobStatus.FINISHED, jobInfo.getStatus());
@@ -314,89 +335,225 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         Assert.assertEquals(JobPriority.NORMAL, jobInfo.getPriority());
         Assert.assertEquals(DEFAULT_USER_NAME, jobInfo.getJobOwner());
 
-        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 10, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 1, 2, 3, 4, 5, 6, 7);
         Assert.assertEquals(2, jobs.get(0).getChildrenCount());
 
-        jobs = dbManager.getJobs(-1, -1, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(-1, -1, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 1, 2, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(-1, 5, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(-1, 5, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 1, 2, 3, 4, 5);
 
-        jobs = dbManager.getJobs(2, -1, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(2, -1, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(0, 0, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 0, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 1, 2, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(0, 1, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 1, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 1);
 
-        jobs = dbManager.getJobs(0, 3, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 3, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 1, 2, 3);
 
-        jobs = dbManager.getJobs(1, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(1, 10, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 2, 3, 4, 5, 6, 7);
 
-        jobs = dbManager.getJobs(5, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(5, 10, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 6, 7);
 
-        jobs = dbManager.getJobs(6, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(6, 10, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 7);
 
-        jobs = dbManager.getJobs(7, 10, null, true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(7, 10, null, null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, true, true, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 true,
+                                 true,
+                                 true,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 1, 3, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, "user1", true, true, true, true, null, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 10, "user1", null, false, true, true, true, true, null, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 2);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, false, false, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 true,
+                                 false,
+                                 false,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 1);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, true, false, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 false,
+                                 true,
+                                 false,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 3);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, false, true, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 false,
+                                 false,
+                                 true,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, true, true, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 false,
+                                 true,
+                                 true,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 3, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, false, true, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 true,
+                                 false,
+                                 true,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 1, 4, 6, 7);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, true, true, false, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 true,
+                                 true,
+                                 false,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 1, 3);
 
-        jobs = dbManager.getJobs(0, 10, DEFAULT_USER_NAME, false, false, false, true, null, null, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 DEFAULT_USER_NAME,
+                                 null,
+                                 false,
+                                 false,
+                                 false,
+                                 false,
+                                 true,
+                                 null,
+                                 null,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs);
 
-        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, jobName, null, null, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 10, null, null, false, true, true, true, true, jobName, null, null, sortParameters)
+                        .getList();
         checkJobs(jobs, 2);
 
-        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, projectName, null, sortParameters)
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 null,
+                                 null,
+                                 false,
+                                 true,
+                                 true,
+                                 true,
+                                 true,
+                                 null,
+                                 projectName,
+                                 null,
+                                 sortParameters)
                         .getList();
         checkJobs(jobs, 1, 3);
 
-        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, 1L, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 10, null, null, false, true, true, true, true, null, null, 1L, sortParameters)
+                        .getList();
         checkJobs(jobs, 2, 3);
 
-        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, jobName, null, 1L, sortParameters).getList();
+        jobs = dbManager.getJobs(0, 10, null, null, false, true, true, true, true, jobName, null, 1L, sortParameters)
+                        .getList();
         checkJobs(jobs, 2);
 
-        jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, projectName, 1L, sortParameters).getList();
+        jobs = dbManager.getJobs(0,
+                                 10,
+                                 null,
+                                 null,
+                                 false,
+                                 true,
+                                 true,
+                                 true,
+                                 true,
+                                 null,
+                                 projectName,
+                                 1L,
+                                 sortParameters)
+                        .getList();
         checkJobs(jobs, 3);
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/jmx/SchedulerRuntimeDataMBeanTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/jmx/SchedulerRuntimeDataMBeanTest.java
@@ -103,6 +103,7 @@ public class SchedulerRuntimeDataMBeanTest extends SchedulerFunctionalTestNoRest
                                                                                            null,
                                                                                            null,
                                                                                            null,
+                                                                                           null,
                                                                                            null),
                                                                      null)
                                                             .getList();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
@@ -243,21 +243,23 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
         initExpectedResults("testGetTotalJobsCount-Job", "TEST-TAG");
 
         // default parameters
-        actualJobPage = dbManager.getJobs(0, 0, null, true, true, true, true, null, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 0, null, null, false, true, true, true, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, no user, no pending, no running, no finished
-        actualJobPage = dbManager.getJobs(0, 0, null, false, false, false, true, null, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 0, null, null, false, false, false, false, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished
-        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, null, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 0, "admin", null, false, true, true, true, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished, jobName = "testGetTotalJobsCount-Job"
         actualJobPage = dbManager.getJobs(0,
                                           0,
                                           "admin",
+                                          null,
+                                          false,
                                           true,
                                           true,
                                           true,
@@ -269,19 +271,55 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished, jobName = "testGetTotal"
-        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, "testGetTotal", null, null, null);
+        actualJobPage = dbManager.getJobs(0,
+                                          0,
+                                          "admin",
+                                          null,
+                                          false,
+                                          true,
+                                          true,
+                                          true,
+                                          true,
+                                          "testGetTotal",
+                                          null,
+                                          null,
+                                          null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
 
         // no pagination, user = "admin", pending, running, finished, jobName = "invalid_job_name"
-        actualJobPage = dbManager.getJobs(0, 0, "admin", true, true, true, true, "invalid_job_name", null, null, null);
+        actualJobPage = dbManager.getJobs(0,
+                                          0,
+                                          "admin",
+                                          null,
+                                          false,
+                                          true,
+                                          true,
+                                          true,
+                                          true,
+                                          "invalid_job_name",
+                                          null,
+                                          null,
+                                          null);
         assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
 
         // no pagination, user = "invalid_user", pending, no running, finished
-        actualJobPage = dbManager.getJobs(0, 0, "invalid_user", true, true, true, true, null, null, null, null);
+        actualJobPage = dbManager.getJobs(0,
+                                          0,
+                                          "invalid_user",
+                                          null,
+                                          false,
+                                          true,
+                                          true,
+                                          true,
+                                          true,
+                                          null,
+                                          null,
+                                          null,
+                                          null);
         assertEquals("Incorrect jobs total number", 0, actualJobPage.getSize());
 
         // pagination [0,5[, user = "admin", pending, running, finished
-        actualJobPage = dbManager.getJobs(0, 5, "admin", true, true, true, true, null, null, null, null);
+        actualJobPage = dbManager.getJobs(0, 5, "admin", null, false, true, true, true, true, null, null, null, null);
         assertEquals("Incorrect jobs total number", nbJobs, actualJobPage.getSize());
     }
 
@@ -424,7 +462,19 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
 
         dbManager.updateJobAndTasksState(job);
 
-        Page<JobInfo> jobs = dbManager.getJobs(0, 10, null, true, true, true, true, null, null, null, null);
+        Page<JobInfo> jobs = dbManager.getJobs(0,
+                                               10,
+                                               null,
+                                               null,
+                                               false,
+                                               true,
+                                               true,
+                                               true,
+                                               true,
+                                               null,
+                                               null,
+                                               null,
+                                               null);
 
         assertThat(jobs.getSize()).isEqualTo(1);
 
@@ -441,6 +491,7 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
                                                         null,
                                                         0,
                                                         10,
+                                                        null,
                                                         null,
                                                         taskStatuses(true, true, true),
                                                         new SortSpecifierContainer());
@@ -469,6 +520,7 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
                                                         null,
                                                         0,
                                                         10,
+                                                        null,
                                                         null,
                                                         taskStatuses(true, true, true),
                                                         new SortSpecifierContainer());
@@ -545,6 +597,7 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
                                   criterias.getOffset(),
                                   criterias.getLimit(),
                                   criterias.getUser(),
+                                  criterias.getTenant(),
                                   taskStatuses(criterias.isPending(), criterias.isRunning(), criterias.isFinished()));
     }
 
@@ -555,6 +608,7 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
                                        criterias.getOffset(),
                                        criterias.getLimit(),
                                        criterias.getUser(),
+                                       criterias.getTenant(),
                                        taskStatuses(criterias.isPending(),
                                                     criterias.isRunning(),
                                                     criterias.isFinished()),

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -1354,7 +1354,7 @@ public class SchedulerTHelper {
 
     public void cleanJobs() throws Exception {
         Scheduler userInt = getSchedulerInterface();
-        JobFilterCriteria criteria = new JobFilterCriteria(false, true, true, true, true, null, null, null, null);
+        JobFilterCriteria criteria = new JobFilterCriteria(false, true, true, true, true, null, null, null, null, null);
         List<JobInfo> jobs = userInt.getJobs(0,
                                              1000,
                                              criteria,

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/common/job/JobStateTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/common/job/JobStateTest.java
@@ -109,6 +109,11 @@ public class JobStateTest extends ProActiveTestClean {
             }
 
             @Override
+            public String getTenant() {
+                return null;
+            }
+
+            @Override
             public JobType getType() {
                 return null;
             }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendStateTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendStateTest.java
@@ -80,7 +80,7 @@ public class SchedulerFrontendStateTest extends ProActiveTestClean {
 
         // create a bunch of active sessions, they will be removed in 1s
         for (int i = 0; i < 100; i++) {
-            UserIdentificationImpl identification = new UserIdentificationImpl("john");
+            UserIdentificationImpl identification = new UserIdentificationImpl("john", (String) null);
             identification.setHostName("localhost");
             schedulerFrontendState.connect(new UniqueID("abc" + i), identification, null);
         }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendTest.java
@@ -108,7 +108,7 @@ public class SchedulerFrontendTest extends ProActiveTestClean {
      */
     @Test
     public void testConnection() throws KeyException, AlreadyConnectedException {
-        schedulerFrontend.connect(new UniqueID(), new UserIdentificationImpl("admin"), null);
+        schedulerFrontend.connect(new UniqueID(), new UserIdentificationImpl("admin", (String) null), null);
 
         Mockito.verify(spacesSupport, times(1)).registerUserSpace("admin", null);
     }


### PR DESCRIPTION
 - tenants can be defined through a configuration file or a ldap attribute
 - a scheduler property allows to enable/disable job filtering by tenant.
 - allow filtering by tenant in revisionAndJobsInfo
 - allow node source restriction by tenants