### PR TITLE
improve readAccount transaction management

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/GroupByStatusSortOrder.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/GroupByStatusSortOrder.java
@@ -62,8 +62,8 @@ public class GroupByStatusSortOrder extends Order {
                " when " + column + " = " + JobStatus.PENDING.ordinal() + " then 0 " +
                // running, stalled, paused then
                " when " + column + " = " + JobStatus.RUNNING.ordinal() + " then 1 " + " when " + column + " = " +
-               JobStatus.STALLED.ordinal() + " then 1 " + " when " + column + " = " + JobStatus.PAUSED.ordinal() +
-               " then 1 " +
+               JobStatus.STALLED.ordinal() + " then 1 " + " when " + column + " = " + JobStatus.IN_ERROR.ordinal() +
+               " then 1 " + " when " + column + " = " + JobStatus.PAUSED.ordinal() + " then 1 " +
                // and the rest (killed, finished, etc)
                " else 2 end " + (ascending ? " asc" : " desc");
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -37,12 +37,7 @@ import java.util.stream.Collectors;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.hibernate.Criteria;
-import org.hibernate.FetchMode;
-import org.hibernate.HibernateException;
-import org.hibernate.Query;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.hibernate.*;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.criterion.CriteriaSpecification;
@@ -769,6 +764,25 @@ public class SchedulerDBManager {
     }
 
     public SchedulerAccount readAccount(final String username) {
+
+        int pendingJobsCount = getPendingJobsCount(username);
+        int stalledJobsCount = getStalledJobsCount(username);
+        int runningJobsCount = getRunningJobsCount(username);
+        int pausedJobsCount = getPausedJobsCount(username);
+        int inErrorJobsCount = getInErrorJobsCount(username);
+        int failedJobsCount = getFailedJobsCount(username);
+        int cancelledJobsCount = getCanceledJobsCount(username);
+        int killedJobsCount = getKilledJobsCount(username);
+        int finishedJobsCount = getFinishedJobsCount(username);
+
+        int pendingTasksCount = getTaskCountForUser(TaskStatus.PENDING_TASKS, username);
+        int currentTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.RUNNING), username);
+        int pastTasksCount = getTaskCountForUser(TaskStatus.FINISHED_TASKS, username);
+        int pausedTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.PAUSED), username);
+        int faultyTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.FAULTY), username);
+        int failedTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.FAILED), username);
+        int inErrorTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.IN_ERROR), username);
+
         return executeReadOnlyTransaction(session -> {
             Query tasksQuery = session.getNamedQuery("readAccountTasks").setParameter("username", username);
 
@@ -782,14 +796,6 @@ public class SchedulerDBManager {
             } else {
                 taskDuration = 0L;
             }
-
-            int pendingTasksCount = getTaskCountForUser(TaskStatus.PENDING_TASKS, username);
-            int currentTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.RUNNING), username);
-            int pastTasksCount = getTaskCountForUser(TaskStatus.FINISHED_TASKS, username);
-            int pausedTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.PAUSED), username);
-            int faultyTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.FAULTY), username);
-            int failedTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.FAILED), username);
-            int inErrorTasksCount = getTaskCountForUser(Collections.singleton(TaskStatus.IN_ERROR), username);
 
             Query jobQuery = session.getNamedQuery("readAccountJobs").setParameter("username", username);
 
@@ -817,15 +823,15 @@ public class SchedulerDBManager {
                                    .faultyTasksCount(faultyTasksCount)
                                    .failedJobsCount(failedTasksCount)
                                    .inErrorTasksCount(inErrorTasksCount)
-                                   .pendingJobsCount(getPendingJobsCount(username))
-                                   .stalledJobsCount(getStalledJobsCount(username))
-                                   .runningJobsCount(getRunningJobsCount(username))
-                                   .pausedJobsCount(getPausedJobsCount(username))
-                                   .inErrorJobsCount(getInErrorJobsCount(username))
-                                   .failedJobsCount(getFailedJobsCount(username))
-                                   .canceledJobsCount(getCanceledJobsCount(username))
-                                   .killedJobsCount(getKilledJobsCount(username))
-                                   .finishedJobsCount(getFinishedJobsCount(username))
+                                   .pendingJobsCount(pendingJobsCount)
+                                   .stalledJobsCount(stalledJobsCount)
+                                   .runningJobsCount(runningJobsCount)
+                                   .pausedJobsCount(pausedJobsCount)
+                                   .inErrorJobsCount(inErrorJobsCount)
+                                   .failedJobsCount(failedJobsCount)
+                                   .canceledJobsCount(cancelledJobsCount)
+                                   .killedJobsCount(killedJobsCount)
+                                   .finishedJobsCount(finishedJobsCount)
                                    .build();
         });
     }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -125,7 +125,7 @@ import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
                                                                 "where task.id.jobId in (:ids)"),
                 @NamedQuery(name = "loadJobsTasks", query = "from TaskData as task " + "where task.id.jobId in (:ids)"),
                 @NamedQuery(name = "readAccountTasks", query = "select count(*), sum(task.finishedTime) - sum(task.startTime) from TaskData task " +
-                                                               "where task.finishedTime > 0 and task.owner = :username"),
+                                                               "where task.finishedTime > 0 and task.startTime > 0 and task.owner = :username"),
                 @NamedQuery(name = "updateTaskData", query = "update TaskData task set task.taskStatus = :taskStatus, " +
                                                              "task.numberOfExecutionLeft = :numberOfExecutionLeft, " +
                                                              "task.numberOfExecutionOnFailureLeft = :numberOfExecutionOnFailureLeft, " +

--- a/tools/install_base.sh
+++ b/tools/install_base.sh
@@ -195,6 +195,8 @@ init_and_ignores()
     OLD_PWD=$(pwd)
     cd "$PA_DIR"
     git init
+    # necessary for recent git versions
+    git config --global --add safe-directory "$PA_DIR" || true
     git config user.email "support@activeeon.com"
     git config user.name "proactive"
     echo '


### PR DESCRIPTION
readAcount was starting multiple transactions within an existing transaction.

This was leading to database deadlocks (at least on HSQLDB, possibly on other databases)

Also, in this change:
 - install_base.sh : add safe configuration for (necessary for recent git versions)
 - TaskData : fix get total tasks duration query
 - GroupByStatusSortOrder: fix the IN-ERROR status order