### PR TITLE
Improve getJobs performance

### DIFF
--- a/config/hsqldb-server.properties
+++ b/config/hsqldb-server.properties
@@ -2,7 +2,7 @@
 # ProActive Workflows and Scheduling with the default embedded
 # database, namely HSQLDB, in server mode.
 
-server.catalogs.option_line=create=true;hsqldb.tx=mvcc;hsqldb.applog=0;hsqldb.sqllog=0;hsqldb.write_delay=false;hsqldb.lob_file_scale=1
+server.catalogs.option_line=create=true;hsqldb.tx=mvcc;hsqldb.applog=0;hsqldb.sqllog=0;hsqldb.write_delay=false;hsqldb.lob_file_scale=1;sql.nulls_order=false
 
 # See HSQLDB configuration (table 14.1) for a description of
 # the following properties:

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -74,11 +74,8 @@ import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.log4j.Logger;
@@ -1348,7 +1345,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         jobInfoImpl.setNumberOfFaultyTasks(jobInfoData.getNumberOfFaultyTasks());
         jobInfoImpl.setTotalNumberOfTasks(jobInfoData.getTotalNumberOfTasks());
         jobInfoImpl.setJobPriority(JobPriority.findPriority(jobInfoData.getPriority().toString()));
-        jobInfoImpl.setJobStatus(JobStatus.findPriority(jobInfoData.getStatus().toString()));
+        jobInfoImpl.setJobStatus(JobStatus.findStatus(jobInfoData.getStatus().toString()));
         if (jobInfoData.isToBeRemoved())
             jobInfoImpl.setToBeRemoved();
         jobInfoImpl.setGenericInformation(jobInfoData.getGenericInformation());

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -186,7 +186,7 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     protected static final List<SortParameter<JobSortParameter>> DEFAULT_JOB_SORT_PARAMS = Arrays.asList(new SortParameter<>(JobSortParameter.STATE,
-                                                                                                                             SortOrder.ASC),
+                                                                                                                             SortOrder.DESC),
                                                                                                          new SortParameter<>(JobSortParameter.ID,
                                                                                                                              SortOrder.DESC));
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
@@ -56,6 +56,12 @@ import org.ow2.proactive.scheduler.task.SchedulerVars;
 @PublicAPI
 public abstract class JobState extends Job implements Comparable<JobState> {
 
+    public static int PENDING_RANK = 2;
+
+    public static int RUNNING_RANK = 1;
+
+    public static int FINISHED_RANK = 0;
+
     /** Used to sort by id */
     public static final int SORT_BY_ID = 1;
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobStatus.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobStatus.java
@@ -25,6 +25,8 @@
  */
 package org.ow2.proactive.scheduler.common.job;
 
+import static org.ow2.proactive.scheduler.common.job.JobState.*;
+
 import org.objectweb.proactive.annotation.PublicAPI;
 
 
@@ -37,64 +39,68 @@ import org.objectweb.proactive.annotation.PublicAPI;
  */
 @PublicAPI
 public enum JobStatus implements java.io.Serializable {
+
     /**
      * The job is waiting to be scheduled.
      */
-    PENDING("Pending", true),
+    PENDING("Pending", true, PENDING_RANK),
     /**
      * The job is running. Actually at least one of its task has been scheduled.
      */
-    RUNNING("Running", true),
+    RUNNING("Running", true, RUNNING_RANK),
     /**
      * The job has been launched but no task are currently running.
      */
-    STALLED("Stalled", true),
+    STALLED("Stalled", true, RUNNING_RANK),
     /**
      * The job is finished. Every tasks are finished.
      */
-    FINISHED("Finished", false),
+    FINISHED("Finished", false, FINISHED_RANK),
     /**
      * The job is paused waiting for user to resume it.
      */
-    PAUSED("Paused", true),
+    PAUSED("Paused", true, RUNNING_RANK),
     /**
      * The job has been canceled due to user exception and order.
      * This status runs when a user exception occurs in a task
      * and when the user has asked to cancel On exception.
      */
-    CANCELED("Canceled", false),
+    CANCELED("Canceled", false, FINISHED_RANK),
     /**
      * The job has failed. One or more tasks have failed (due to resources failure).
      * There is no more executionOnFailure left for a task.
      */
-    FAILED("Failed", false),
+    FAILED("Failed", false, FINISHED_RANK),
     /**
      * The job has been killed by a user..
      * Nothing can be done anymore on this job expect read execution informations
      * such as output, time, etc...
      */
-    KILLED("Killed", false),
+    KILLED("Killed", false, FINISHED_RANK),
     /**
      * The job has at least one in-error task and in-error tasks are the last, among others,
      * which have changed their state (i.e. Job status is depicted by the last action).
      */
-    IN_ERROR("In-Error", true);
+    IN_ERROR("In-Error", true, RUNNING_RANK);
 
     /** The textual definition of the status */
     private final String definition;
 
     private final boolean jobAlive;
 
+    private final int rank;
+
     /**
      * Default constructor.
      * @param def the textual definition of the status.
      */
-    JobStatus(String def, boolean jobAlive) {
+    JobStatus(String def, boolean jobAlive, int rank) {
         definition = def;
         this.jobAlive = jobAlive;
+        this.rank = rank;
     }
 
-    public static JobStatus findPriority(String name) {
+    public static JobStatus findStatus(String name) {
 
         for (JobStatus jobStatus : JobStatus.values()) {
             if (name.equalsIgnoreCase(jobStatus.toString()))
@@ -118,4 +124,7 @@ public enum JobStatus implements java.io.Serializable {
         return jobAlive;
     }
 
+    public int getRank() {
+        return rank;
+    }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBJobDataParameters.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/DBJobDataParameters.java
@@ -32,7 +32,7 @@ import java.util.Set;
 
 import org.ow2.proactive.db.SortParameter;
 import org.ow2.proactive.scheduler.common.JobSortParameter;
-import org.ow2.proactive.scheduler.common.job.JobStatus;
+import org.ow2.proactive.scheduler.common.job.JobState;
 
 
 /**
@@ -66,7 +66,7 @@ public class DBJobDataParameters {
 
     private final List<SortParameter<JobSortParameter>> sortParameters;
 
-    private final Set<JobStatus> status;
+    private final Set<Integer> statusRanks;
 
     DBJobDataParameters(int offset, int limit, String user, String tenant, boolean isExplicitTenantFilter,
             boolean pending, boolean running, boolean finished, boolean childJobs, String jobName, String projectName,
@@ -85,17 +85,17 @@ public class DBJobDataParameters {
         this.parentId = parentId;
         this.sortParameters = sortParameters;
 
-        Set<JobStatus> newStatus = new HashSet<JobStatus>();
+        Set<Integer> newStatusRanks = new HashSet<Integer>();
         if (pending) {
-            newStatus.addAll(SchedulerDBManager.PENDING_JOB_STATUSES);
+            newStatusRanks.add(JobState.PENDING_RANK);
         }
         if (running) {
-            newStatus.addAll(SchedulerDBManager.RUNNING_JOB_STATUSES);
+            newStatusRanks.add(JobState.RUNNING_RANK);
         }
         if (finished) {
-            newStatus.addAll(SchedulerDBManager.FINISHED_JOB_STATUSES);
+            newStatusRanks.add(JobState.FINISHED_RANK);
         }
-        this.status = Collections.unmodifiableSet(newStatus);
+        this.statusRanks = Collections.unmodifiableSet(newStatusRanks);
 
     }
 
@@ -139,7 +139,7 @@ public class DBJobDataParameters {
         return sortParameters;
     }
 
-    public Set<JobStatus> getStatuses() {
-        return status;
+    public Set<Integer> getStatusRanks() {
+        return statusRanks;
     }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerStateRecoverHelper.java
@@ -73,6 +73,7 @@ public class SchedulerStateRecoverHelper {
 
     public RecoveredSchedulerState recover(long loadJobPeriod, RMProxy rmProxy, SchedulerStatus schedulerStatus) {
         dbManager.setTaskDataOwnerIfNull();
+        dbManager.setJobDataStatusRankIfNull();
         List<InternalJob> notFinishedJobs = dbManager.loadNotFinishedJobs(true);
 
         Vector<InternalJob> pendingJobs = new Vector<>();

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
@@ -247,7 +247,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  null,
                                  null,
                                  null,
-                                 sortParameters(new SortParameter<>(JobSortParameter.STATE, SortOrder.ASC),
+                                 sortParameters(new SortParameter<>(JobSortParameter.STATE, SortOrder.DESC),
                                                 new SortParameter<>(JobSortParameter.ID, SortOrder.ASC)))
                         .getList();
         checkJobs(jobs, 2, 4, 6, 3, 5, 1);
@@ -264,7 +264,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
                                  null,
                                  null,
                                  null,
-                                 sortParameters(new SortParameter<>(JobSortParameter.STATE, SortOrder.DESC),
+                                 sortParameters(new SortParameter<>(JobSortParameter.STATE, SortOrder.ASC),
                                                 new SortParameter<>(JobSortParameter.ID, SortOrder.ASC)))
                         .getList();
         checkJobs(jobs, 1, 3, 5, 2, 4, 6);


### PR DESCRIPTION
Add a statusRank column to JobData used to sort statuses (pending first, then all running states, then all finished states)

Bootstrap method to fill the statusRank column on startup for an existing older version database

Added indexes that benefit from both statusRank and jobId reverse sort
Added additional indexes for common use cases (myJobs, parentJobsOnly)

Added a custom hibernate interceptor for HSQLDB which uses indexes on ORDER BY columns only if the hint USING INDEX is appended to the query

Added the hsqldb option sql.nulls_order=false to let null values be sorted according to ASCENDING or DESCENDING order