### PR TITLE
Add list-metadata to list files in a directory with all their metadata

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
@@ -67,4 +67,13 @@ public class ListFile {
     public List<String> getFullListing() {
         return fullListing;
     }
+
+    @Override
+    public String toString() {
+        return "ListFile{" +
+                "directoryListing=" + directoryListing +
+                ", fileListing=" + fileListing +
+                ", fullListing=" + fullListing +
+                '}';
+    }
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
@@ -70,10 +70,7 @@ public class ListFile {
 
     @Override
     public String toString() {
-        return "ListFile{" +
-                "directoryListing=" + directoryListing +
-                ", fileListing=" + fileListing +
-                ", fullListing=" + fullListing +
-                '}';
+        return "ListFile{" + "directoryListing=" + directoryListing + ", fileListing=" + fileListing +
+               ", fullListing=" + fullListing + '}';
     }
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFile.java
@@ -35,6 +35,15 @@ public class ListFile {
 
     private List<String> fullListing;
 
+    public ListFile() {
+    }
+
+    public ListFile(ListFile listFile) {
+        this.directoryListing = listFile.directoryListing;
+        this.fileListing = listFile.fileListing;
+        this.fullListing = listFile.fullListing;
+    }
+
     public List<String> getDirectoryListing() {
         return directoryListing;
     }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
@@ -63,15 +63,15 @@ public class ListFileMetadata extends ListFile {
         types.put(filename, type);
     }
 
-    public void addPermissions(String filename, String permission) {
+    public void addPermission(String filename, String permission) {
         permissions.put(filename, permission);
     }
 
-    public void addLastModifiedDates(String filename, Date date) {
+    public void addLastModifiedDate(String filename, Date date) {
         lastModifiedDates.put(filename, date);
     }
 
-    public void addSizes(String filename, long size) {
+    public void addSize(String filename, long size) {
         sizes.put(filename, size);
     }
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
@@ -1,0 +1,77 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.dataspace.dto;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class ListFileMetadata extends ListFile {
+    private Map<String, String> types = new HashMap<>();
+
+    private Map<String, String> permissions = new HashMap<>();
+
+    private Map<String, Date> lastModifiedDates = new HashMap<>();
+
+    private Map<String, Long> sizes = new HashMap<>();
+
+    public ListFileMetadata(ListFile listFile) {
+        super(listFile);
+    }
+
+    public Map<String, String> getTypes() {
+        return types;
+    }
+
+    public Map<String, String> getPermissions() {
+        return permissions;
+    }
+
+    public Map<String, Date> getLastModifiedDates() {
+        return lastModifiedDates;
+    }
+
+    public Map<String, Long> getSizes() {
+        return sizes;
+    }
+
+    public void addType(String filename, String type) {
+        types.put(filename, type);
+    }
+
+    public void addPermissions(String filename, String permission) {
+        permissions.put(filename, permission);
+    }
+
+    public void addLastModifiedDates(String filename, Date date) {
+        lastModifiedDates.put(filename, date);
+    }
+
+    public void addSizes(String filename, long size) {
+        sizes.put(filename, size);
+    }
+}

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
@@ -39,6 +39,8 @@ public class ListFileMetadata extends ListFile {
 
     private Map<String, Long> sizes = new HashMap<>();
 
+    public ListFileMetadata() {}
+
     public ListFileMetadata(ListFile listFile) {
         super(listFile);
     }
@@ -73,5 +75,15 @@ public class ListFileMetadata extends ListFile {
 
     public void addSize(String filename, long size) {
         sizes.put(filename, size);
+    }
+
+    @Override
+    public String toString() {
+        return "ListFileMetadata{" +
+                "types=" + types +
+                ", permissions=" + permissions +
+                ", lastModifiedDates=" + lastModifiedDates +
+                ", sizes=" + sizes +
+                "} " + super.toString();
     }
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/dto/ListFileMetadata.java
@@ -39,7 +39,8 @@ public class ListFileMetadata extends ListFile {
 
     private Map<String, Long> sizes = new HashMap<>();
 
-    public ListFileMetadata() {}
+    public ListFileMetadata() {
+    }
 
     public ListFileMetadata(ListFile listFile) {
         super(listFile);
@@ -79,11 +80,7 @@ public class ListFileMetadata extends ListFile {
 
     @Override
     public String toString() {
-        return "ListFileMetadata{" +
-                "types=" + types +
-                ", permissions=" + permissions +
-                ", lastModifiedDates=" + lastModifiedDates +
-                ", sizes=" + sizes +
-                "} " + super.toString();
+        return "ListFileMetadata{" + "types=" + types + ", permissions=" + permissions + ", lastModifiedDates=" +
+               lastModifiedDates + ", sizes=" + sizes + "} " + super.toString();
     }
 }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
@@ -303,9 +303,10 @@ public class DataSpaceClient implements IDataSpaceClient {
     public ListFileMetadata listMetadata(IRemoteSource source) throws NotConnectedException, PermissionException {
         StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(source.getDataspace().value());
         ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
-                .httpEngine(httpEngine)
-                .build();
-        ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath()).queryParam("comp", "list-metadata");
+                                                           .httpEngine(httpEngine)
+                                                           .build();
+        ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath()).queryParam("comp",
+                                                                                                       "list-metadata");
 
         List<String> includes = source.getIncludes();
         if (includes != null && !includes.isEmpty()) {
@@ -323,7 +324,7 @@ public class DataSpaceClient implements IDataSpaceClient {
                     throw new NotConnectedException("User not authenticated or session timeout.");
                 } else {
                     throw new RuntimeException(String.format("Cannot list the specified location: %s",
-                            source.getPath()));
+                                                             source.getPath()));
                 }
             }
             return response.readEntity(ListFileMetadata.class);

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/DataSpaceClient.java
@@ -60,6 +60,7 @@ import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive.scheduler.rest.ISchedulerClient;
 import org.ow2.proactive.scheduler.rest.SchedulerClient;
 import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
+import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFileMetadata;
 import org.ow2.proactive_grid_cloud_portal.scheduler.client.SchedulerRestClient;
 
 import com.google.common.base.Throwables;
@@ -291,6 +292,41 @@ public class DataSpaceClient implements IDataSpaceClient {
                 }
             }
             return response.readEntity(ListFile.class);
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    @Override
+    public ListFileMetadata listMetadata(IRemoteSource source) throws NotConnectedException, PermissionException {
+        StringBuffer uriTmpl = (new StringBuffer()).append(restDataspaceUrl).append(source.getDataspace().value());
+        ResteasyClient client = new ResteasyClientBuilder().providerFactory(providerFactory)
+                .httpEngine(httpEngine)
+                .build();
+        ResteasyWebTarget target = client.target(uriTmpl.toString()).path(source.getPath()).queryParam("comp", "list-metadata");
+
+        List<String> includes = source.getIncludes();
+        if (includes != null && !includes.isEmpty()) {
+            target = target.queryParam("includes", includes.toArray(new Object[includes.size()]));
+        }
+        List<String> excludes = source.getExcludes();
+        if (excludes != null && !excludes.isEmpty()) {
+            target = target.queryParam("excludes", excludes.toArray(new Object[excludes.size()]));
+        }
+        Response response = null;
+        try {
+            response = target.request().header("sessionid", sessionId).get();
+            if (response.getStatus() != HttpURLConnection.HTTP_OK) {
+                if (response.getStatus() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                    throw new NotConnectedException("User not authenticated or session timeout.");
+                } else {
+                    throw new RuntimeException(String.format("Cannot list the specified location: %s",
+                            source.getPath()));
+                }
+            }
+            return response.readEntity(ListFileMetadata.class);
         } finally {
             if (response != null) {
                 response.close();

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/IDataSpaceClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ds/IDataSpaceClient.java
@@ -36,6 +36,7 @@ import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.task.dataspaces.RemoteSpace;
 import org.ow2.proactive_grid_cloud_portal.common.FileType;
 import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
+import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFileMetadata;
 
 
 public interface IDataSpaceClient {
@@ -84,6 +85,18 @@ public interface IDataSpaceClient {
      *             the specified location in the server
      */
     ListFile list(IRemoteSource source) throws NotConnectedException, PermissionException;
+
+    /**
+     * Returns a {@link ListFileMetadata} type object which contains the names and metadata of files
+     * and directories in the specified location of the <i>dataspace</i>.
+     *
+     * @throws NotConnectedException
+     *             if the client is not logged in or the session has expired
+     * @throws PermissionException
+     *             if the user does not have permission to upload the file to
+     *             the specified location in the server
+     */
+    ListFileMetadata listMetadata(IRemoteSource source) throws NotConnectedException, PermissionException;
 
     /**
      * Deletes the specified directory or the file from the <i>dataspace</i>.

--- a/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
@@ -49,9 +49,9 @@ import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.rest.ds.*;
 import org.ow2.proactive_grid_cloud_portal.common.FileType;
 import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
+import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFileMetadata;
 
 import com.google.common.io.Files;
-import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFileMetadata;
 
 
 public class DataTransferTest extends AbstractRestFuncTestCase {
@@ -563,7 +563,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         System.out.println("Full : " + foundFiles);
         assertEquals(3, foundFiles.size());
         assertArrayEquals(new String[] { TEMP_DIR_NAME, TEMP_FILE_TMP_PATH, TEMP_FILE_TXT_NAME },
-                foundFiles.toArray(new String[0]));
+                          foundFiles.toArray(new String[0]));
 
         System.out.println("Metadata: " + listFile);
         assertEquals("DIRECTORY", listFile.getTypes().get(TEMP_DIR_NAME));

--- a/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
@@ -752,13 +752,15 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
             srcTextFile = new File(srcDir, TEMP_FILE_TXT_NAME);
             Files.createParentDirs(srcTextFile);
             Files.write("some text ...".getBytes(), srcTextFile);
-            srcTextFile.setExecutable(false);
+            // make the file not executable for everyone
+            srcTextFile.setExecutable(false, false);
 
             File srcTempDir = new File(srcDir, TEMP_DIR_NAME);
             srcTempFile = new File(srcTempDir, TEMP_FILE_TMP_NAME);
             Files.createParentDirs(srcTempFile);
             Files.write(randomFileContents(), srcTempFile);
-            srcTempFile.setExecutable(true);
+            // make the file executable for everyone
+            srcTempFile.setExecutable(true, false);
             return this;
         }
     }

--- a/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
@@ -575,7 +575,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         assertEquals(Long.valueOf(13), listFile.getSizes().get(TEMP_FILE_TXT_NAME));
         assertTrue(listFile.getTypes().containsKey(TEMP_FILE_TMP_PATH));
         assertNotNull(listFile.getLastModifiedDates().get(TEMP_FILE_TMP_PATH));
-        assertEquals("rw-", listFile.getPermissions().get(TEMP_FILE_TMP_PATH));
+        assertEquals("rwx", listFile.getPermissions().get(TEMP_FILE_TMP_PATH));
         assertEquals(Long.valueOf(100), listFile.getSizes().get(TEMP_FILE_TMP_PATH));
     }
 
@@ -610,7 +610,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         System.out.println("Metadata: " + listFile);
         assertTrue(listFile.getTypes().containsKey(TEMP_FILE_TMP_PATH));
         assertNotNull(listFile.getLastModifiedDates().get(TEMP_FILE_TMP_PATH));
-        assertEquals("rw-", listFile.getPermissions().get(TEMP_FILE_TMP_PATH));
+        assertEquals("rwx", listFile.getPermissions().get(TEMP_FILE_TMP_PATH));
         assertEquals(Long.valueOf(100), listFile.getSizes().get(TEMP_FILE_TMP_PATH));
     }
 
@@ -752,11 +752,13 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
             srcTextFile = new File(srcDir, TEMP_FILE_TXT_NAME);
             Files.createParentDirs(srcTextFile);
             Files.write("some text ...".getBytes(), srcTextFile);
+            srcTextFile.setExecutable(false);
 
             File srcTempDir = new File(srcDir, TEMP_DIR_NAME);
             srcTempFile = new File(srcTempDir, TEMP_FILE_TMP_NAME);
             Files.createParentDirs(srcTempFile);
             Files.write(randomFileContents(), srcTempFile);
+            srcTempFile.setExecutable(true);
             return this;
         }
     }

--- a/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
@@ -76,6 +76,8 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
 
     static URL tgzFileUrl = DataTransferTest.class.getResource("/functionaltests/files/test2.tgz");
 
+    private boolean checkExecutable = true;
+
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
@@ -530,7 +532,12 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         assertEquals("rwx", listFile.getPermissions().get(TEMP_DIR_NAME));
         assertEquals("text/plain", listFile.getTypes().get(TEMP_FILE_TXT_NAME));
         assertNotNull(listFile.getLastModifiedDates().get(TEMP_FILE_TXT_NAME));
-        assertEquals("rw-", listFile.getPermissions().get(TEMP_FILE_TXT_NAME));
+        if (checkExecutable) {
+            assertEquals("rw-", listFile.getPermissions().get(TEMP_FILE_TXT_NAME));
+        } else {
+            // on some system (e.g., windows), File.setExecutable may be failed, in this case, we don't check its exec permission.
+            assertTrue(listFile.getPermissions().get(TEMP_FILE_TXT_NAME).contains("rw"));
+        }
         assertEquals(Long.valueOf(13), listFile.getSizes().get(TEMP_FILE_TXT_NAME));
     }
 
@@ -571,7 +578,12 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         assertEquals("rwx", listFile.getPermissions().get(TEMP_DIR_NAME));
         assertEquals("text/plain", listFile.getTypes().get(TEMP_FILE_TXT_NAME));
         assertNotNull(listFile.getLastModifiedDates().get(TEMP_FILE_TXT_NAME));
-        assertEquals("rw-", listFile.getPermissions().get(TEMP_FILE_TXT_NAME));
+        if (checkExecutable) {
+            assertEquals("rw-", listFile.getPermissions().get(TEMP_FILE_TXT_NAME));
+        } else {
+            // on some system (e.g., windows), File.setExecutable may be failed, in this case, we don't check its exec permission.
+            assertTrue(listFile.getPermissions().get(TEMP_FILE_TXT_NAME).contains("rw"));
+        }
         assertEquals(Long.valueOf(13), listFile.getSizes().get(TEMP_FILE_TXT_NAME));
         assertTrue(listFile.getTypes().containsKey(TEMP_FILE_TMP_PATH));
         assertNotNull(listFile.getLastModifiedDates().get(TEMP_FILE_TMP_PATH));
@@ -753,7 +765,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
             Files.createParentDirs(srcTextFile);
             Files.write("some text ...".getBytes(), srcTextFile);
             // make the file not executable for everyone
-            srcTextFile.setExecutable(false, false);
+            checkExecutable = srcTextFile.setExecutable(false, false);
 
             File srcTempDir = new File(srcDir, TEMP_DIR_NAME);
             srcTempFile = new File(srcTempDir, TEMP_FILE_TMP_NAME);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
@@ -117,16 +117,16 @@ public class FileSystem {
         List<String> fileList = Lists.newArrayList();
         List<String> fullList = Lists.newArrayList();
 
-        for (String filename : fileObjects.keySet()) {
-            FileType type = fileObjects.get(filename).getType();
+        for (String fileRelativePath : fileObjects.keySet()) {
+            FileType type = fileObjects.get(fileRelativePath).getType();
             switch (type) {
                 case FOLDER:
-                    dirList.add(filename);
-                    fullList.add(filename);
+                    dirList.add(fileRelativePath);
+                    fullList.add(fileRelativePath);
                     break;
                 case FILE:
-                    fileList.add(filename);
-                    fullList.add(filename);
+                    fileList.add(fileRelativePath);
+                    fullList.add(fileRelativePath);
                     break;
                 default:
                     throw new RuntimeException("Unknown : " + type);
@@ -181,18 +181,18 @@ public class FileSystem {
             throws FileSystemException {
         Map<String, FileObject> listFileObjects = listFileObjects(fo, includes, excludes);
         ListFileMetadata allFils = new ListFileMetadata(list(listFileObjects));
-        for (String dir : allFils.getDirectoryListing()) {
-            FileObject dirObject = listFileObjects.get(dir);
-            allFils.addType(dir, DIRECTORY_TYPE);
-            allFils.addLastModifiedDate(dir, new Date(dirObject.getContent().getLastModifiedTime()));
-            allFils.addPermission(dir, getPermissionsString(dirObject));
+        for (String dirRelativePath : allFils.getDirectoryListing()) {
+            FileObject dirObject = listFileObjects.get(dirRelativePath);
+            allFils.addType(dirRelativePath, DIRECTORY_TYPE);
+            allFils.addLastModifiedDate(dirRelativePath, new Date(dirObject.getContent().getLastModifiedTime()));
+            allFils.addPermission(dirRelativePath, getPermissionsString(dirObject));
         }
-        for (String file : allFils.getFileListing()) {
-            FileObject fileObject = listFileObjects.get(file);
-            allFils.addType(file, contentType(fileObject));
-            allFils.addLastModifiedDate(file, new Date(fileObject.getContent().getLastModifiedTime()));
-            allFils.addPermission(file, getPermissionsString(fileObject));
-            allFils.addSize(file, fileObject.getContent().getSize());
+        for (String fileRelativePath : allFils.getFileListing()) {
+            FileObject fileObject = listFileObjects.get(fileRelativePath);
+            allFils.addType(fileRelativePath, contentType(fileObject));
+            allFils.addLastModifiedDate(fileRelativePath, new Date(fileObject.getContent().getLastModifiedTime()));
+            allFils.addPermission(fileRelativePath, getPermissionsString(fileObject));
+            allFils.addSize(fileRelativePath, fileObject.getContent().getSize());
         }
         return allFils;
     }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
@@ -184,15 +184,15 @@ public class FileSystem {
         for (String dir : allFils.getDirectoryListing()) {
             FileObject dirObject = listFileObjects.get(dir);
             allFils.addType(dir, DIRECTORY_TYPE);
-            allFils.addLastModifiedDates(dir, new Date(dirObject.getContent().getLastModifiedTime()));
-            allFils.addPermissions(dir, getPermissionsString(dirObject));
+            allFils.addLastModifiedDate(dir, new Date(dirObject.getContent().getLastModifiedTime()));
+            allFils.addPermission(dir, getPermissionsString(dirObject));
         }
         for (String file : allFils.getFileListing()) {
             FileObject fileObject = listFileObjects.get(file);
             allFils.addType(file, contentType(fileObject));
-            allFils.addLastModifiedDates(file, new Date(fileObject.getContent().getLastModifiedTime()));
-            allFils.addPermissions(file, getPermissionsString(fileObject));
-            allFils.addSizes(file, fileObject.getContent().getSize());
+            allFils.addLastModifiedDate(file, new Date(fileObject.getContent().getLastModifiedTime()));
+            allFils.addPermission(file, getPermissionsString(fileObject));
+            allFils.addSize(file, fileObject.getContent().getSize());
         }
         return allFils;
     }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/FileSystem.java
@@ -33,7 +33,7 @@ import java.text.Collator;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,6 +48,7 @@ import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive_grid_cloud_portal.common.Session;
 import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFile;
+import org.ow2.proactive_grid_cloud_portal.dataspace.dto.ListFileMetadata;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -60,6 +61,8 @@ public class FileSystem {
     public static final String X_PROACTIVE_DS_TYPE = "x-proactive-ds-type";
 
     public static final String X_PROACTIVE_DS_PERMISSIONS = "x-proactive-ds-permissions";
+
+    public static final String DIRECTORY_TYPE = "DIRECTORY";
 
     private static final Collator COLLATOR = Collator.getInstance(Locale.getDefault());
 
@@ -105,36 +108,25 @@ public class FileSystem {
 
     public static ListFile list(FileObject fo, List<String> includes, List<String> excludes)
             throws FileSystemException {
-        fo.refresh();
+        return list(listFileObjects(fo, includes, excludes));
+    }
+
+    private static ListFile list(Map<String, FileObject> fileObjects) throws FileSystemException {
         ListFile answer = new ListFile();
         List<String> dirList = Lists.newArrayList();
         List<String> fileList = Lists.newArrayList();
         List<String> fullList = Lists.newArrayList();
-        List<FileObject> foundFileObjects = new LinkedList<>();
-        if (isNullOrEmpty(includes) && isNullOrEmpty(excludes)) {
-            fo.findFiles(Selectors.SELECT_CHILDREN, false, foundFileObjects);
-        } else {
-            FileSelector selector = new org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector(includes,
-                                                                                                                excludes);
-            fo.findFiles(selector, false, foundFileObjects);
-        }
 
-        for (FileObject child : foundFileObjects) {
-            FileType type = child.getType();
-            FileName childName = child.getName();
+        for (String filename : fileObjects.keySet()) {
+            FileType type = fileObjects.get(filename).getType();
             switch (type) {
                 case FOLDER:
-                    if (!child.equals(fo)) {
-                        // exclude root directory from the list
-                        String relativePath = fo.getName().getRelativeName(childName);
-                        dirList.add(relativePath);
-                        fullList.add(relativePath);
-                    }
+                    dirList.add(filename);
+                    fullList.add(filename);
                     break;
                 case FILE:
-                    String relativePath = fo.getName().getRelativeName(childName);
-                    fileList.add(relativePath);
-                    fullList.add(relativePath);
+                    fileList.add(filename);
+                    fullList.add(filename);
                     break;
                 default:
                     throw new RuntimeException("Unknown : " + type);
@@ -147,6 +139,27 @@ public class FileSystem {
         answer.setFileListing(fileList);
         answer.setFullListing(fullList);
         return answer;
+    }
+
+    private static Map<String, FileObject> listFileObjects(FileObject fo, List<String> includes, List<String> excludes)
+            throws FileSystemException {
+        fo.refresh();
+        List<FileObject> fileObjects = Lists.newArrayList();
+        Map<String, FileObject> result = new HashMap<>();
+        if (isNullOrEmpty(includes) && isNullOrEmpty(excludes)) {
+            fo.findFiles(Selectors.SELECT_CHILDREN, false, fileObjects);
+        } else {
+            FileSelector selector = new org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector(includes,
+                                                                                                                excludes);
+            fo.findFiles(selector, false, fileObjects);
+        }
+        for (FileObject file : fileObjects) {
+            if (!file.equals(fo)) { // exclude root directory from the list
+                String relativePath = fo.getName().getRelativeName(file.getName());
+                result.put(relativePath, file);
+            }
+        }
+        return result;
     }
 
     public static Map<String, Object> metadata(FileObject fo) throws FileSystemException {
@@ -164,8 +177,28 @@ public class FileSystem {
         return props;
     }
 
+    public static ListFileMetadata listMetadata(FileObject fo, List<String> includes, List<String> excludes)
+            throws FileSystemException {
+        Map<String, FileObject> listFileObjects = listFileObjects(fo, includes, excludes);
+        ListFileMetadata allFils = new ListFileMetadata(list(listFileObjects));
+        for (String dir : allFils.getDirectoryListing()) {
+            FileObject dirObject = listFileObjects.get(dir);
+            allFils.addType(dir, DIRECTORY_TYPE);
+            allFils.addLastModifiedDates(dir, new Date(dirObject.getContent().getLastModifiedTime()));
+            allFils.addPermissions(dir, getPermissionsString(dirObject));
+        }
+        for (String file : allFils.getFileListing()) {
+            FileObject fileObject = listFileObjects.get(file);
+            allFils.addType(file, contentType(fileObject));
+            allFils.addLastModifiedDates(file, new Date(fileObject.getContent().getLastModifiedTime()));
+            allFils.addPermissions(file, getPermissionsString(fileObject));
+            allFils.addSizes(file, fileObject.getContent().getSize());
+        }
+        return allFils;
+    }
+
     private static void fillDirProps(FileObject fo, Map<String, Object> properties) throws FileSystemException {
-        properties.put(X_PROACTIVE_DS_TYPE, "DIRECTORY");
+        properties.put(X_PROACTIVE_DS_TYPE, DIRECTORY_TYPE);
         properties.put("Last-Modified", new Date(fo.getContent().getLastModifiedTime()));
         properties.put(X_PROACTIVE_DS_PERMISSIONS, getPermissionsString(fo));
     }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspaceImpl.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/dataspace/RestDataspaceImpl.java
@@ -70,6 +70,8 @@ public class RestDataspaceImpl implements RestDataspace {
 
     public static final String GLOBAL = "global";
 
+    public static final String LIST_METADATA = "list-metadata";
+
     private static SessionStore sessions = SharedSessionStore.getInstance();
 
     @Override
@@ -129,6 +131,7 @@ public class RestDataspaceImpl implements RestDataspace {
             if (!Strings.isNullOrEmpty(component)) {
                 return componentResponse(component, fo, includes, excludes);
             }
+
             if (fo.getType() == FileType.FILE) {
                 if (VFSZipper.isZipFile(fo)) {
                     logger.debug(String.format("Retrieving file %s in %s", pathname, dataspace.toUpperCase()));
@@ -247,6 +250,8 @@ public class RestDataspaceImpl implements RestDataspace {
         switch (type) {
             case "list":
                 return Response.ok(FileSystem.list(fo, includes, excludes), MediaType.APPLICATION_JSON).build();
+            case LIST_METADATA:
+                return Response.ok(FileSystem.listMetadata(fo, includes, excludes), MediaType.APPLICATION_JSON).build();
             default:
                 return Response.status(Response.Status.BAD_REQUEST)
                                .entity(String.format("Unknown query parameter: comp=%s", type))


### PR DESCRIPTION
Add another component for the list request of dataspace to retrieve the full list of dirs and files in a directory with all their metadata.