### PR TITLE
SchedulingMethodImpl: parallelize createExecution

### DIFF
--- a/config/rm/settings.ini
+++ b/config/rm/settings.ini
@@ -151,6 +151,9 @@ pa.rm.node.db.operations.delay=500
 #
 pa.rm.nodes.db.operations.update.synchronous=true
 
+# maximum length of in expressions in the database
+pa.rm.db.items.max.size=1000
+
 # Defines if  the runtime (RT) have to be killed when the resource manager (RM) is shutdown.
 pa.rm.shutdown.kill.rt=true
 

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -145,12 +145,12 @@ pa.scheduler.core.starttask.timeout=20000
 # Maximum number of threads used for the start task action. This property define the number of blocking resources
 # until the scheduling loop will block as well.
 # As it is related to the number of nodes, this property also define the number of threads used to terminate taskLauncher
-pa.scheduler.core.starttask.threadnumber=20
+pa.scheduler.core.starttask.threadnumber=100
 
 # Maximum number of threads used to send events to clients. This property defines the number of clients
 # than can block at the same time. If this number is reached, every clients won't receive events until
 # a thread unlock.
-pa.scheduler.core.listener.threadnumber=20
+pa.scheduler.core.listener.threadnumber=100
 
 # List of the scripts paths to execute at scheduler start. Paths are separated by a ';'.
 pa.scheduler.startscripts.paths=tools/LoadPackages.groovy

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
@@ -320,6 +320,8 @@ public enum PAResourceManagerProperties implements PACommonProperties {
      */
     RM_NODES_DB_SYNCHRONOUS_UPDATES("pa.rm.nodes.db.operations.update.synchronous", PropertyType.BOOLEAN, "true"),
 
+    RM_DB_ITEMS_MAX_SIZE("pa.rm.db.items.max.size", PropertyType.INTEGER, "1000"),
+
     /**
      * Defines whether all the resources of the deployed cloud instances
      * should be destroyed along with the nodes termination when the scheduler 
@@ -345,7 +347,7 @@ public enum PAResourceManagerProperties implements PACommonProperties {
     /**
      * Defines the buffer size used in asynchronous appenders
      */
-    LOG4J_ASYNC_APPENDER_BUFFER_SIZE("pa.log4j.async.appender.buffer.size", PropertyType.INTEGER, "10000"),
+    LOG4J_ASYNC_APPENDER_BUFFER_SIZE("pa.log4j.async.appender.buffer.size", PropertyType.INTEGER, "50000"),
 
     /**
      * Defines the AsynchFileAppender flush timeout

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMNodeData.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/db/RMNodeData.java
@@ -51,7 +51,8 @@ import org.ow2.proactive.resourcemanager.rmnode.RMNode;
                 @NamedQuery(name = "deleteAllRMNodeDataFromNodeSource", query = "delete from RMNodeData where nodeSource.name=:name"),
                 @NamedQuery(name = "getAllRMNodeData", query = "from RMNodeData"),
                 @NamedQuery(name = "getRMNodeDataByNameAndUrl", query = "from RMNodeData where name=:name and nodeUrl=:url"),
-                @NamedQuery(name = "getRMNodeDataByNodeSource", query = "from RMNodeData where nodeSource.name=:name") })
+                @NamedQuery(name = "getRMNodeDataByNodeSource", query = "from RMNodeData where nodeSource.name=:name"),
+                @NamedQuery(name = "updateMultipleRMNodeStatus", query = "update RMNodeData node set node.state = :nodeState, node.stateChangeTime = :stateChangeTime where node.nodeUrl in (:nodeUrls)") })
 @Table(name = "RMNodeData")
 public class RMNodeData implements Serializable {
 

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/AbstractRMNode.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/AbstractRMNode.java
@@ -374,4 +374,9 @@ public abstract class AbstractRMNode implements RMNode, Serializable {
     public void setUsageInfo(Map<String, String> usageInfo) {
         this.usageInfo = usageInfo;
     }
+
+    @Override
+    public void setStateChangeTime(long time) {
+        this.stateChangeTime = time;
+    }
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNode.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNode.java
@@ -375,4 +375,6 @@ public interface RMNode extends Comparable<RMNode> {
     Set<String> getNodeTags();
 
     void setNodeTags(Set<String> tags);
+
+    void setStateChangeTime(long time);
 }

--- a/rm/rm-server/src/test/java/functionaltests/db/NodeHistoryTest.java
+++ b/rm/rm-server/src/test/java/functionaltests/db/NodeHistoryTest.java
@@ -70,6 +70,8 @@ public class NodeHistoryTest {
         NodeHistory expected = createNodeHistory(1);
 
         dbManager.saveNodeHistory(expected);
+        // save node history is asynchronous
+        Thread.sleep(1000);
 
         List<?> rows = dbManager.executeSqlQuery("from NodeHistory");
         Assert.assertEquals(1, rows.size());
@@ -85,6 +87,8 @@ public class NodeHistoryTest {
         NodeHistory expected2 = createNodeHistory(2);
 
         dbManager.saveNodeHistory(expected2);
+        // save node history is asynchronous
+        Thread.sleep(1000);
 
         List<?> rows = dbManager.executeSqlQuery("from NodeHistory");
         Assert.assertEquals(2, rows.size());

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -136,12 +136,12 @@ public enum PASchedulerProperties implements PACommonProperties {
 
     /** Maximum number of threads used for the start task action. This property defines the number of blocking resources
      * until the scheduling loop will block as well.*/
-    SCHEDULER_STARTTASK_THREADNUMBER("pa.scheduler.core.starttask.threadnumber", PropertyType.INTEGER, "20"),
+    SCHEDULER_STARTTASK_THREADNUMBER("pa.scheduler.core.starttask.threadnumber", PropertyType.INTEGER, "100"),
 
     /** Maximum number of threads used to send events to clients. This property defines the number of clients
      * than can block at the same time. If this number is reached, every clients won't receive events until
      * a thread unlock. */
-    SCHEDULER_LISTENERS_THREADNUMBER("pa.scheduler.core.listener.threadnumber", PropertyType.INTEGER, "20"),
+    SCHEDULER_LISTENERS_THREADNUMBER("pa.scheduler.core.listener.threadnumber", PropertyType.INTEGER, "100"),
 
     /** List of the scripts paths to execute at scheduler start. Paths are separated by a ';'. */
     SCHEDULER_STARTSCRIPTS_PATHS("pa.scheduler.startscripts.paths", PropertyType.LIST),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -87,7 +87,7 @@ import com.google.common.collect.Lists;
                 @NamedQuery(name = "deleteJobDataInBulk", query = "delete from JobData where id in (:jobIdList)"),
                 @NamedQuery(name = "checkJobExistence", query = "select id from JobData where id = :id"),
                 @NamedQuery(name = "getChildrenCount", query = "select childrenCount from JobData where id = :id"),
-                @NamedQuery(name = "getParentIds", query = "select parentId from JobData where id in :ids and parentId IS NOT NULL"),
+                @NamedQuery(name = "getParentIds", query = "select parentId from JobData where id in (:ids) and parentId IS NOT NULL"),
                 @NamedQuery(name = "countJobDataFinished", query = "select count (*) from JobData where status = 3"),
                 @NamedQuery(name = "countJobData", query = "select count (*) from JobData"),
                 @NamedQuery(name = "findUsersWithJobs", query = "select owner, tenant, count(owner), max(submittedTime) from JobData group by owner, tenant"),
@@ -109,8 +109,8 @@ import com.google.common.collect.Lists;
                                                                      "numberOfFailedTasks = :numberOfFailedTasks, numberOfFaultyTasks = :numberOfFaultyTasks, " +
                                                                      "numberOfInErrorTasks = :numberOfInErrorTasks, inErrorTime = :inErrorTime, lastUpdatedTime = :lastUpdatedTime " +
                                                                      "where id = :jobId"),
-                @NamedQuery(name = "updateJobDataRemovedTime", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in :ids"),
-                @NamedQuery(name = "updateJobDataRemovedTimeInBulk", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in :jobIdList"),
+                @NamedQuery(name = "updateJobDataRemovedTime", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in (:ids)"),
+                @NamedQuery(name = "updateJobDataRemovedTimeInBulk", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in (:jobIdList)"),
                 @NamedQuery(name = "updateJobDataSetJobToBeRemoved", query = "update JobData set toBeRemoved = :toBeRemoved, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "updateJobDataPriority", query = "update JobData set priority = :priority, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "increaseJobDataChildrenCount", query = "update JobData set childrenCount = childrenCount+1, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/TaskData.java
@@ -102,7 +102,7 @@ import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
 
 
 @Entity
-@NamedQueries({ @NamedQuery(name = "deleteTaskDataInBulk", query = "delete from TaskData where id.jobId in :jobIdList"),
+@NamedQueries({ @NamedQuery(name = "deleteTaskDataInBulk", query = "delete from TaskData where id.jobId in (:jobIdList)"),
                 @NamedQuery(name = "countTaskData", query = "select count (*) from TaskData"),
                 @NamedQuery(name = "countTaskDataOwnerNull", query = "select count (*) from TaskData where owner is null"),
                 @NamedQuery(name = "setOwnerInTaskDataIfNull", query = "update TaskData task set task.owner = (select job.owner from JobData job where job.id = task.id.jobId)"),
@@ -158,9 +158,9 @@ import org.ow2.proactive.topology.descriptor.TopologyDescriptor;
                                                                      "where task.id.jobId = :jobId " +
                                                                      "and task.taskStatus = org.ow2.proactive.scheduler.common.task.TaskStatus.IN_ERROR "),
                 @NamedQuery(name = "updateTaskDataJobScripts", query = "update TaskData set envScript = null, preScript = null, postScript = null,flowScript = null," +
-                                                                       "cleanScript = null  where id.jobId in :ids"),
+                                                                       "cleanScript = null  where id.jobId in (:ids)"),
                 @NamedQuery(name = "updateTaskDataJobScriptsInBulk", query = "update TaskData set envScript = null, preScript = null, postScript = null,flowScript = null," +
-                                                                             "cleanScript = null  where id.jobId in :jobIdList"),
+                                                                             "cleanScript = null  where id.jobId in (:jobIdList)"),
                 @NamedQuery(name = "updateTaskDataStatusToPending", query = "update TaskData task set task.taskStatus = :taskStatus " +
                                                                             "where task.jobData = :job"),
                 @NamedQuery(name = "updateTaskDataTaskRestarted", query = "update TaskData set taskStatus = :taskStatus, " +

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -320,7 +320,7 @@ public abstract class InternalJob extends JobState {
      */
     public void startDataSpaceApplication(NamingService namingService, List<InternalTask> tasks) {
         if (taskDataSpaceApplications == null) {
-            taskDataSpaceApplications = new HashMap<>();
+            taskDataSpaceApplications = new ConcurrentHashMap<>();
         }
 
         UserCredentials userCredentials = getUserCredentials();
@@ -328,13 +328,12 @@ public abstract class InternalJob extends JobState {
         for (InternalTask internalTask : tasks) {
             long taskId = internalTask.getId().longValue();
 
+            String appId = internalTask.getId().toString();
+            TaskDataSpaceApplication taskDataSpaceApplication = new TaskDataSpaceApplication(appId, namingService);
+
             // reuse the already configured dataspaceApplication
             // if a task restart due to a failure for instance
-            if (!taskDataSpaceApplications.containsKey(taskId)) {
-                String appId = internalTask.getId().toString();
-                TaskDataSpaceApplication taskDataSpaceApplication = new TaskDataSpaceApplication(appId, namingService);
-
-                taskDataSpaceApplications.put(taskId, taskDataSpaceApplication);
+            if (taskDataSpaceApplications.putIfAbsent(taskId, taskDataSpaceApplication) == null) {
 
                 taskDataSpaceApplication.startDataSpaceApplication(getInputSpace(),
                                                                    getOutputSpace(),

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/threading/TimeoutThreadPoolExecutorTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/threading/TimeoutThreadPoolExecutorTest.java
@@ -49,9 +49,9 @@ public class TimeoutThreadPoolExecutorTest extends ProActiveTestClean {
 
     @Before
     public void init() {
-        executor = TimeoutThreadPoolExecutor.newFixedThreadPool(1,
-                                                                new NamedThreadFactory("TestTimeoutThreadPoolExecutor",
-                                                                                       false));
+        executor = TimeoutThreadPoolExecutor.newCachedThreadPool(1,
+                                                                 new NamedThreadFactory("TestTimeoutThreadPoolExecutor",
+                                                                                        false));
     }
 
     @After


### PR DESCRIPTION
- use the existing thread pool to run createExecution(s) in parallel
- start the database application and deploy the task launcher outside of a job lock (to deploy launchers in parallel for multiple tasks of the same job)

Also, in RMCore, allow setting multiple nodes as busy and use it in SelectionManager