### PR TITLE
Better handling of oracle varbinary columns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -395,7 +395,7 @@ class CustomCreateStartScripts extends CreateStartScripts {
         generator.mainClassName = getMainClassName()
 
         if (getApplicationName().equals("proactive-server")) {
-            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8", "-Dresteasy.allowGzip=true", "-Xms4g"]
+            generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8", "-Dresteasy.allowGzip=true", "-Doracle.jdbc.useFetchSizeWithLongColumn=true", "-Xms4g"]
         } else {
             generator.defaultJvmOpts = ["-server", "-Dfile.encoding=UTF-8"]
         }


### PR DESCRIPTION
This is to avoid java.sql.SQLException: Stream has already been closed errors when using oracle db