### PR TITLE
SchedulerDBManager:fix issues arising after hibernate upgrade 2

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -1703,7 +1703,10 @@ public class SchedulerDBManager {
                    .setParameter("totalNumberOfTasks", jobInfo.getTotalNumberOfTasks())
                    .setParameter("lastUpdatedTime", new Date().getTime())
                    .setParameter("resultMap", ObjectByteConverter.mapOfSerializableToByteArray(job.getResultMap()))
-                   .setParameter("preciousTasks", ObjectByteConverter.serializeList(jobInfo.getPreciousTasks()))
+                   // the following distinction is necessary as hsqldb has some issue with its hibernate dialect without visible fix
+                   .setParameter("preciousTasks",
+                                 IS_HSQLDB ? ObjectByteConverter.serializeList(jobInfo.getPreciousTasks())
+                                           : jobInfo.getPreciousTasks())
                    .setParameter("jobId", jobId)
                    .executeUpdate();
 
@@ -1792,8 +1795,10 @@ public class SchedulerDBManager {
                                .setParameter("lastUpdatedTime", new Date().getTime())
                                .setParameter("resultMap",
                                              ObjectByteConverter.mapOfSerializableToByteArray(job.getResultMap()))
+                               // the following distinction is necessary as hsqldb has some issue with its hibernate dialect without visible fix
                                .setParameter("preciousTasks",
-                                             ObjectByteConverter.serializeList(job.getPreciousTasksFinished()))
+                                             IS_HSQLDB ? ObjectByteConverter.serializeList(job.getPreciousTasksFinished())
+                                                       : job.getPreciousTasksFinished())
                                .setParameter("jobId", jobId)
                                .executeUpdate();
 
@@ -1881,8 +1886,10 @@ public class SchedulerDBManager {
                                         .setParameter("lastUpdatedTime", new Date().getTime())
                                         .setParameter("resultMap",
                                                       ObjectByteConverter.mapOfSerializableToByteArray(job.getResultMap()))
+                                        // the following distinction is necessary as hsqldb has some issue with its hibernate dialect without visible fix
                                         .setParameter("preciousTasks",
-                                                      ObjectByteConverter.serializeList(job.getPreciousTasksFinished()))
+                                                      IS_HSQLDB ? ObjectByteConverter.serializeList(job.getPreciousTasksFinished())
+                                                                : job.getPreciousTasksFinished())
                                         .setParameter("jobId", jobId)
                                         .executeUpdate();
                     if (result != 0) {
@@ -2162,7 +2169,10 @@ public class SchedulerDBManager {
                    .setParameter("numberOfInErrorTasks", jobInfo.getNumberOfInErrorTasks())
                    .setParameter("lastUpdatedTime", new Date().getTime())
                    .setParameter("resultMap", ObjectByteConverter.mapOfSerializableToByteArray(job.getResultMap()))
-                   .setParameter("preciousTasks", ObjectByteConverter.serializeList(job.getPreciousTasksFinished()))
+                   // the following distinction is necessary as hsqldb has some issue with its hibernate dialect without visible fix
+                   .setParameter("preciousTasks",
+                                 IS_HSQLDB ? ObjectByteConverter.serializeList(job.getPreciousTasksFinished())
+                                           : job.getPreciousTasksFinished())
                    .setParameter("jobId", jobId)
                    .executeUpdate();
 


### PR DESCRIPTION
 - handle preciousTasks query parameter differently for HSQLDB and other databases