### PR TITLE
Upgrade jetty version

### DIFF
--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -105,7 +105,9 @@ public enum WebProperties implements PACommonProperties {
 
     WEB_IDLE_TIMEOUT("web.idle_timeout", PropertyType.INTEGER, "60000"),
 
-    WEB_REQUEST_HEADER_SIZE("web.request_header_size", PropertyType.INTEGER, "8192"),
+    WEB_REQUEST_HEADER_SIZE("web.request_header_size", PropertyType.INTEGER, "16384"),
+
+    WEB_RESPONSE_HEADER_SIZE("web.response_header_size", PropertyType.INTEGER, "16384"),
 
     WEB_REDIRECT_HTTP_TO_HTTPS("web.redirect_http_to_https", PropertyType.BOOLEAN, "false"),
 

--- a/config/web/settings.ini
+++ b/config/web/settings.ini
@@ -9,8 +9,9 @@ web.max_threads=400
 # timeout on http requests, default to 1 minute, can be increased to handle long requests
 web.idle_timeout=60000
 
-# Maximum request header size. This value can be increased in case of HTTP 414 errors.
-web.request_header_size=8192
+# Maximum request and response header sizes. These values can be increased in case of HTTP 414 errors.
+web.request_header_size=16384
+web.response_header_size=16384
 
 # port to use to deploy web applications
 web.http.port=8080

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/utils/Zipper.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/client/utils/Zipper.java
@@ -28,6 +28,7 @@ package org.ow2.proactive_grid_cloud_portal.scheduler.client.utils;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.*;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -113,7 +114,7 @@ public class Zipper {
                 FileObject[] fos = rootObject.findFiles(selector);
 
                 for (FileObject fo : fos) {
-                    listFiles.add(new File(fo.getName().getPath()));
+                    listFiles.add(new File(new URI(fo.getName().getURI())));
                 }
             } catch (Exception e) {
                 logger.error("An error occurred while zipping files: ", e);

--- a/rest/rest-cli/build.gradle
+++ b/rest/rest-cli/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testCompile project(':scheduler:scheduler-api')
 
     testCompile 'com.eclipsesource.minimal-json:minimal-json:0.9.4'
-    testCompile 'org.eclipse.jetty:jetty-server:9.2.29.v20191105'
+    testCompile 'org.eclipse.jetty:jetty-server:9.4.50.v20221201'
 }
 
 task('functionalTest', type: Test).configure functionalTestConfiguration

--- a/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/ErrorCases.java
+++ b/rest/rest-cli/src/test/java/org/ow2/proactive_grid_cloud_portal/cli/ErrorCases.java
@@ -71,7 +71,7 @@ public class ErrorCases {
         skipIfHeadlessEnvironment();
         server = new Server();
 
-        SslContextFactory sslContextFactory = new SslContextFactory();
+        SslContextFactory sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setKeyStorePath(ErrorCases.class.getResource("keystore").getPath());
         sslContextFactory.setKeyStorePassword("activeeon");
 

--- a/rest/rest-client/build.gradle
+++ b/rest/rest-client/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     compile 'org.apache.httpcomponents:httpclient:4.5.13'
     compile 'org.apache.httpcomponents:httpmime:4.5.13'
-    compile 'org.atmosphere:wasync:2.1.2'
+    compile 'org.atmosphere:wasync:2.1.7'
 
     compile project(":common:common-api")
     compile project(':common:common-http')

--- a/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
+++ b/rest/rest-client/src/test/java/functionaltests/DataTransferTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Random;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,6 +95,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
 
         File tmpFile = tmpDir.newFile(TEMP_FILE_TMP_NAME);
         Files.write(randomFileContents(), tmpFile);
+        Assert.assertTrue(tmpFile.exists() && tmpFile.isFile());
 
         // use standard client
         IDataSpaceClient client = clientInstance();
@@ -122,8 +124,10 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         File tmpFolder = tmpDir.newFolder(testFolderName);
         File subFolder = new File(tmpFolder, subFolderName);
         subFolder.mkdirs();
+        Assert.assertTrue(subFolder.exists() && subFolder.isDirectory());
         File tmpFile = new File(subFolder, TEMP_FILE_TMP_NAME);
         Files.write(randomFileContents(), tmpFile);
+        Assert.assertTrue(tmpFile.exists() && tmpFile.isFile());
 
         // use standard client
         IDataSpaceClient client = clientInstance();
@@ -158,6 +162,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
             throws Exception {
         File tmpZipFile = tmpDir.newFile(archiveFileName);
         FileUtils.copyInputStreamToFile(archiveFileSource.openStream(), tmpZipFile);
+        Assert.assertTrue(tmpZipFile.exists() && tmpZipFile.isFile());
 
         // use standard client
         IDataSpaceClient client = clientInstance();
@@ -183,6 +188,8 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         TestFilesToUploadCreator testFiles = new TestFilesToUploadCreator().invoke();
         File tempTextFile = testFiles.getTempTextFile();
         File tempFile = testFiles.getTempFile();
+        Assert.assertTrue(tempTextFile.exists() && tempTextFile.isFile());
+        Assert.assertTrue(tempFile.exists() && tempFile.isFile());
 
         // use standard client
         IDataSpaceClient client = clientInstance();
@@ -211,6 +218,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         TestFilesToUploadCreator testFiles = new TestFilesToUploadCreator().invoke();
         File tempTextFile = testFiles.getTempTextFile();
         File tempFile = testFiles.getTempFile();
+        Assert.assertTrue(tempTextFile.exists() && tempTextFile.isFile());
 
         // use standard client
         IDataSpaceClient client = clientInstance();
@@ -241,6 +249,7 @@ public class DataTransferTest extends AbstractRestFuncTestCase {
         TestFilesToUploadCreator testFiles = new TestFilesToUploadCreator().invoke();
         File tempTextFile = testFiles.getTempTextFile();
         File tempFile = testFiles.getTempFile();
+        Assert.assertTrue(tempFile.exists() && tempFile.isFile());
 
         // use standard client
         IDataSpaceClient client = clientInstance();

--- a/rest/rest-server/build.gradle
+++ b/rest/rest-server/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile 'com.netiq:websockify:1.7-proactive'
     compile 'io.netty:netty:3.10.6.Final'
 
-    compile 'org.atmosphere:atmosphere-runtime:2.3.4'
+    compile 'org.atmosphere:atmosphere-runtime:2.4.33'
 
     compile project(":scheduler:scheduler-client")
     compile project(":rm:rm-client")
@@ -54,7 +54,7 @@ dependencies {
     testCompile 'org.jboss.resteasy:tjws:3.0.26.Final'
 
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.eclipse.jetty:jetty-client:9.2.29.v20191105'
+    testCompile 'org.eclipse.jetty:jetty-client:9.4.50.v20221201'
     testCompile 'org.zeroturnaround:zt-zip:1.13'
 
     testCompile 'com.fasterxml.jackson.core:jackson-core:2.7.9'
@@ -62,10 +62,11 @@ dependencies {
 
     testCompile project (':common:common-api').sourceSets.test.output
 
-    runtime 'org.eclipse.jetty.websocket:websocket-server:9.2.29.v20191105'
-    runtime 'org.eclipse.jetty:jetty-webapp:9.2.29.v20191105'
-    runtime 'org.eclipse.jetty:jetty-util:9.2.29.v20191105'
-    runtime 'org.eclipse.jetty:jetty-rewrite:9.2.29.v20191105'
+    runtime 'org.eclipse.jetty.websocket:websocket-server:9.4.50.v20221201'
+    runtime 'org.eclipse.jetty:jetty-webapp:9.4.50.v20221201'
+    runtime 'org.eclipse.jetty:jetty-util:9.4.50.v20221201'
+    runtime 'org.eclipse.jetty:jetty-client:9.4.50.v20221201'
+    runtime 'org.eclipse.jetty:jetty-rewrite:9.4.50.v20221201'
 
     runtime "org.objectweb.proactive:programming-extension-pamr:${programmingVersion}"
 }

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 
     compile 'org.fusesource.jdbm:jdbm:2.0.1'
 
-    compile 'org.eclipse.jetty:jetty-webapp:9.2.29.v20191105'
-    compile 'org.eclipse.jetty:jetty-rewrite:9.2.29.v20191105'
-    compile 'org.eclipse.jetty:jetty-util:9.2.29.v20191105'
+    compile 'org.eclipse.jetty:jetty-webapp:9.4.50.v20221201'
+    compile 'org.eclipse.jetty:jetty-rewrite:9.4.50.v20221201'
+    compile 'org.eclipse.jetty:jetty-util:9.4.50.v20221201'
     compile "org.objectweb.proactive:programming-core:${programmingVersion}"
 
     compile project(':common:common-api')

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/utils/PCAProxyRuleTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/utils/PCAProxyRuleTest.java
@@ -102,7 +102,7 @@ public class PCAProxyRuleTest {
         HttpURI requestUri = new HttpURI(target);
         when(request.getMethod()).thenReturn(method.asString());
         when(request.getHeader(HttpHeaders.REFERER)).thenReturn(referer);
-        when(request.getUri()).thenReturn(requestUri);
+        when(request.getHttpURI()).thenReturn(requestUri);
         ArgumentCaptor<String> redirectString = ArgumentCaptor.forClass(String.class);
         when(response.encodeRedirectURL(anyString())).then(returnsFirstArg());
         String newTarget = rule.matchAndApply(target, request, response);


### PR DESCRIPTION
 - upgraded also atmosphere framework to be compatible with jetty 9.4
 - implement necessary api changes
 - add property to control response header size, and increase default request header size
 - prevent LinkageError issues in cloud-automation-service when manipulating jetty api