### PR TITLE
install.sh configure network protocol

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ChangeHttpConfiguration.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/ChangeHttpConfiguration.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.cli.*;
 import org.apache.commons.io.IOUtils;
 import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.ow2.proactive.utils.OperatingSystem;
 import org.ow2.proactive.utils.Tools;
 import org.ow2.proactive.web.WebProperties;
 
@@ -109,6 +110,16 @@ public class ChangeHttpConfiguration {
             if (changeHttpConfiguration(args)) {
                 log("Applied configuration: scheme=" + (isHttps ? "https" : "http") + " hostname=" +
                     configuredHostname + " port=" + port);
+                switch (OperatingSystem.resolveOrError(System.getProperty("os.name")).getFamily()) {
+                    case LINUX:
+                    case UNIX:
+                        log(newline +
+                            "NOTE: if ProActive is installed as a service under /etc/init.d/proactive-scheduler,");
+                        log("1) Edit this file and set PROTOCOL=" + (isHttps ? "https" : "http") + ", PORT=" + port +
+                            ", and eventually ALIAS=" + configuredHostname);
+                        log("2) Run the command \"sudo systemctl daemon-reload\"");
+                }
+
             }
         } catch (ChangeHttpConfigurationException e) {
             System.err.println("ERROR : " + e.getMessage());


### PR DESCRIPTION
Also:
   - copy automatically the jre/lib/security/cacerts file from the previous installation if the java version did not change. Prints a warning if not.
   - in ChangeHttpConfiguration prints a notice message on linux to manually apply changes when ProActive is installed as a service.