### PR TITLE
Force property decrypter initialization at scheduler start

### DIFF
--- a/dist/war/getstarted/index.html
+++ b/dist/war/getstarted/index.html
@@ -117,6 +117,8 @@
            title="Scheduler GraphQL Portal (requires being logged into any ProActive portal before using it)">Scheduler GraphQL API</a>,
         <a id="catalogUrlLink" href="catalog/swagger-ui.html" target=”_blank”
            title="Catalog REST Swagger API">Catalog API</a>,
+        <a id="catalogGraphQLLink" href="catalog/graphiql" target=”_blank”
+           title="Catalog GraphQL Portal (requires being logged into any ProActive portal before using it)">Catalog GraphQL API</a>,
         <a id="jobPlannerUrlLink" href="job-planner/swagger-ui.html" target=”_blank”
            title="Job Planner REST Swagger API">Job Planner API</a>,
         <a id="cloudAutomationUrlLink" href="cloud-automation-service/swagger-ui.html" target=”_blank”

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -64,6 +64,7 @@ import org.objectweb.proactive.extensions.pamr.router.Router;
 import org.objectweb.proactive.extensions.pamr.router.RouterConfig;
 import org.objectweb.proactive.utils.JVMPropertiesPreloader;
 import org.ow2.proactive.authentication.crypto.Credentials;
+import org.ow2.proactive.core.properties.PropertyDecrypter;
 import org.ow2.proactive.resourcemanager.RMFactory;
 import org.ow2.proactive.resourcemanager.authentication.RMAuthentication;
 import org.ow2.proactive.resourcemanager.common.RMConstants;
@@ -214,6 +215,8 @@ public class SchedulerStarter {
         }
 
         LOGGER.info("Activeeon ProActive version " + getSchedulerVersion());
+        // force initialize the property decrypter to avoid conflicts with microservices
+        PropertyDecrypter.encryptData("dummy");
 
         hsqldbServer = new SchedulerHsqldbStarter();
         hsqldbServer.startIfNeeded();


### PR DESCRIPTION
This is to prevent conflicts with microservices like catalog using the property decrypter.

Also, added Graphql catalog portal links in main page.