### PR TITLE
Fix deadlock in SchedulerFrontendState

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -1462,6 +1462,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
 
     @Override
     public void taskStateUpdated(String owner, NotificationData<TaskInfo> notification) {
+        boolean sendNotification = false;
         ClientJobState jobState = getClientJobState(notification.getData().getJobId());
         if (jobState != null) {
             try {
@@ -1475,7 +1476,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
                     case TASK_SKIPPED:
                     case TASK_REPLICATED:
                     case TASK_IN_ERROR_TO_FINISHED:
-                        dispatchTaskStateUpdated(owner, notification);
+                        sendNotification = true;
                         break;
                     case TASK_PROGRESS:
                     case TASK_VISU_ACTIVATED:
@@ -1484,7 +1485,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
                         // already finished.
                         // so if task is not finished, send event
                         if (notification.getData().getFinishedTime() <= 0) {
-                            dispatchTaskStateUpdated(owner, notification);
+                            sendNotification = true;
                         }
                         break;
                     default:
@@ -1494,6 +1495,9 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
             } finally {
                 jobState.writeUnlock();
             }
+        }
+        if (sendNotification) {
+            dispatchTaskStateUpdated(owner, notification);
         }
     }
 


### PR DESCRIPTION
A deadlock occurred because taskStateUpdated kept a lock on a ClientJobState instance while waiting for an available lock inside dispatchTaskStateUpdated.

The fix is to move dispatchTaskStateUpdated outside, thus releasing the client job state lock before notifications are dispatched.