### PR TITLE
SchedulerFrontend : improve insertVisualization performance

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -2397,13 +2397,11 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
 
         if (checkJobPermissionMethod(jobid, "enableRemoteVisualization")) {
             try {
-                JobInfo jobInfoState = frontendState.getJobState(jobInfo.getJobId()).getJobInfo();
+                JobInfo jobInfoState = frontendState.getJobInfo(jobInfo.getJobId());
                 jobInfo.setVisualizationConnectionStrings(jobInfoState.getVisualizationConnectionStrings());
                 jobInfo.setVisualizationIcons(jobInfoState.getVisualizationIcons());
-            } catch (PermissionException e) {
-                logger.debug("Could not add visualization info for job " + jobInfo.getJobId(), e);
-            } catch (UnknownJobException | NotConnectedException e1) {
-                logger.warn("Could not add visualization info for job " + jobInfo.getJobId(), e1);
+            } catch (UnknownJobException e) {
+                logger.warn("Could not add visualization info for job " + jobInfo.getJobId(), e);
             }
         }
         return jobInfo;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -942,6 +942,28 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         });
     }
 
+    JobInfo getJobInfo(JobId jobId) throws UnknownJobException {
+        return Lambda.withLock(stateReadLock, () -> {
+            ClientJobState jobState = getClientJobState(jobId);
+            if (jobState == null) {
+                throw new UnknownJobException(jobId);
+            }
+            JobInfo jobInfoCopy;
+            try {
+                jobState.readLock();
+                try {
+                    jobInfoCopy = (JobInfo) ProActiveMakeDeepCopy.WithProActiveObjectStream.makeDeepCopy(jobState.getJobInfo());
+                } catch (Exception e) {
+                    logger.error("Error when copying job state", e);
+                    throw new IllegalStateException(e);
+                }
+            } finally {
+                jobState.readUnlock();
+            }
+            return jobInfoCopy;
+        });
+    }
+
     JobState getJobState(JobId jobId) throws NotConnectedException, UnknownJobException, PermissionException {
         return Lambda.withLock(stateReadLock, () -> {
             ClientJobState jobState = getClientJobState(jobId);


### PR DESCRIPTION
Do not use the full job state when retrieving visualization info, but the much lighter JobInfo instead.