### PR TITLE
Decrease the stax job cache size

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -156,7 +156,7 @@ pa.scheduler.core.listener.threadnumber=100
 pa.scheduler.startscripts.paths=tools/LoadPackages.groovy
 
 # Size of parsed workflow cache, used to optimize workflow submission time
-pa.scheduler.stax.job.cache=5000
+pa.scheduler.stax.job.cache=1000
 
 # Size of the cache used to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds)
 pa.scheduler.startat.cache=5000

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/selection/SelectionManager.java
@@ -391,7 +391,7 @@ public abstract class SelectionManager {
         } catch (NotConnectedException e) {
             // client has disconnected during getNodes request
             logger.warn(e.getMessage(), e);
-            return null;
+            return new NodeSet();
         }
 
         if (logger.isInfoEnabled()) {

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -147,7 +147,7 @@ public enum PASchedulerProperties implements PACommonProperties {
     SCHEDULER_STARTSCRIPTS_PATHS("pa.scheduler.startscripts.paths", PropertyType.LIST),
 
     /** Size of parsed workflow cache, used to optimize workflow submission time */
-    SCHEDULER_STAX_JOB_CACHE("pa.scheduler.stax.job.cache", PropertyType.INTEGER, "5000"),
+    SCHEDULER_STAX_JOB_CACHE("pa.scheduler.stax.job.cache", PropertyType.INTEGER, "1000"),
 
     /** size of the cache used to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds) **/
     SCHEDULER_STARTAT_CACHE("pa.scheduler.startat.cache", PropertyType.INTEGER, "5000"),


### PR DESCRIPTION
The cache can use too much memory on machines with small RAM capacity.

Also, avoid returning null in SelectionManager