### PR TITLE
Add QOSFilter to throttle node.jar downloads

### DIFF
--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -103,13 +103,21 @@ public enum WebProperties implements PACommonProperties {
 
     WEB_MAX_THREADS("web.max_threads", PropertyType.INTEGER, "400"),
 
-    WEB_IDLE_TIMEOUT("web.idle_timeout", PropertyType.INTEGER, "60000"),
+    WEB_IDLE_TIMEOUT("web.idle_timeout", PropertyType.INTEGER, "120000"),
 
     WEB_REQUEST_HEADER_SIZE("web.request_header_size", PropertyType.INTEGER, "16384"),
 
     WEB_RESPONSE_HEADER_SIZE("web.response_header_size", PropertyType.INTEGER, "16384"),
 
     WEB_REDIRECT_HTTP_TO_HTTPS("web.redirect_http_to_https", PropertyType.BOOLEAN, "false"),
+
+    WEB_QOS_FILTER_ENABLED("web.qos.filter.enabled", PropertyType.BOOLEAN, "true"),
+
+    WEB_QOS_FILTER_CONTEXT("web.qos.filter.context", PropertyType.STRING, "/rest"),
+
+    WEB_QOS_FILTER_PATHS("web.qos.filter.paths", PropertyType.LIST, "/node.jar"),
+
+    WEB_QOS_FILTER_MAX_REQUESTS("web.qos.filter.max.requests", PropertyType.INTEGER, "1"),
 
     WEB_X_FRAME_OPTIONS("web.x_frame_options", PropertyType.STRING, "SAMEORIGIN"),
 

--- a/config/log/server.properties
+++ b/config/log/server.properties
@@ -34,6 +34,7 @@ log4j.logger.org.ow2.proactive.utils.JettyStarter=INFO, CONSOLE
 # Logs from REST server
 log4j.logger.org.ow2.proactive_grid_cloud_portal=INFO
 log4j.logger.org.ow2.proactive_grid_cloud_portal.webapp.NoVncSecuredTargetResolver=DEBUG
+log4j.logger.org.eclipse.jetty.servlets.QoSFilter=DEBUG
 
 log4j.logger.proactive=WARN
 log4j.logger.proactive.pamr.router=INFO

--- a/config/web/settings.ini
+++ b/config/web/settings.ini
@@ -6,12 +6,23 @@ web.deploy=true
 # the maximum number of threads in Jetty for parallel request processing
 web.max_threads=400
 
-# timeout on http requests, default to 1 minute, can be increased to handle long requests
-web.idle_timeout=60000
+# timeout on http requests, default to 2 minute, can be increased to handle long requests
+web.idle_timeout=120000
 
 # Maximum request and response header sizes. These values can be increased in case of HTTP 414 errors.
 web.request_header_size=16384
 web.response_header_size=16384
+
+# Configuration of the quality of service filter.
+web.qos.filter.enabled=true
+# Context of the filter, defaults to the /rest microservice
+web.qos.filter.context=/rest
+# A comma-separated list of path specification, relative to the context microservice, on which a quality of service filter will be applied
+# The path specification accepts wildcards.
+web.qos.filter.paths=/node.jar
+# No more than web.qos.filter.max.requests requests can run in parallel at the same time for each element of the list.
+# Pending requests will wait for web.idle_timeout milliseconds. After this timeout, an error 503 Service Unavailable with be triggered.
+web.qos.filter.max.requests=1
 
 # port to use to deploy web applications
 web.http.port=8080

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile 'org.eclipse.jetty:jetty-webapp:9.4.50.v20221201'
     compile 'org.eclipse.jetty:jetty-rewrite:9.4.50.v20221201'
     compile 'org.eclipse.jetty:jetty-util:9.4.50.v20221201'
+    compile 'org.eclipse.jetty:jetty-servlets:9.4.50.v20221201'
     compile "org.objectweb.proactive:programming-core:${programmingVersion}"
 
     compile project(':common:common-api')


### PR DESCRIPTION
The filter ensures that a single download occurs at any given time. Any subsequent download request will wait for completion of the first request, up to 2 minutes.

The filter is configurable through config/web/settings.ini