### PR TITLE
Filter varying generic info from the jobCache key

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerConstants.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/SchedulerConstants.java
@@ -139,6 +139,9 @@ public class SchedulerConstants {
     /** Generic information containing the parent job id */
     public static final String PARENT_JOB_ID = "PARENT_JOB_ID";
 
+    /** Generic information used by the job planner as the next execution schedule */
+    public static final String NEXT_EXECUTION = "next.execution";
+
     /** Generic information containing the bucket name */
     public static final String BUCKET_NAME = "bucketName";
 


### PR DESCRIPTION
Generic info such as START_AT, PARENT_JOB_ID or next.execution varies at each job execution.

In the current state, the jobCache was being filled rapidly from job planner submissions due to the next.execution generic info varying at each submission.

This change remove these generic info when calculating the md5 key and reinsert them after retrieving the job from the cache.