### PR TITLE
Allow to kill pending tasks

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/TaskResultCreator.java
@@ -92,7 +92,10 @@ public class TaskResultCreator {
     }
 
     public TaskResultImpl getEmptyTaskResult(InternalTask task, Throwable exception, TaskLogs output) {
-        return new TaskResultImpl(task.getId(), exception, output, System.currentTimeMillis() - task.getStartTime());
+        return new TaskResultImpl(task.getId(),
+                                  exception,
+                                  output,
+                                  task.getStartTime() > 0 ? System.currentTimeMillis() - task.getStartTime() : 0);
     }
 
     private Map<String, byte[]> getPropagatedVariables(SchedulerDBManager dbManager,

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/descriptor/JobDescriptorImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/descriptor/JobDescriptorImpl.java
@@ -270,6 +270,10 @@ public class JobDescriptorImpl implements JobDescriptor {
         }
 
         EligibleTaskDescriptorImpl oldEnd = (EligibleTaskDescriptorImpl) runningTasks.get(initiator);
+        if (oldEnd == null) {
+            // can occur if a task is killed
+            oldEnd = (EligibleTaskDescriptorImpl) eligibleTasks.get(initiator);
+        }
         EligibleTaskDescriptorImpl newStart = acc.get(target.getId());
         EligibleTaskDescriptorImpl newEnd = acc.get(newInit.getId());
 
@@ -362,6 +366,10 @@ public class JobDescriptorImpl implements JobDescriptor {
     public void doIf(TaskId initiator, TaskId branchStart, TaskId branchEnd, TaskId ifJoin, TaskId elseTarget,
             List<InternalTask> elseTasks) {
         EligibleTaskDescriptorImpl init = (EligibleTaskDescriptorImpl) runningTasks.get(initiator);
+        if (init == null) {
+            // can occur if a task is killed
+            init = (EligibleTaskDescriptorImpl) eligibleTasks.get(initiator);
+        }
         EligibleTaskDescriptorImpl start = (EligibleTaskDescriptorImpl) branchTasks.get(branchStart);
         EligibleTaskDescriptorImpl end = null;
         EligibleTaskDescriptorImpl join = null;
@@ -571,6 +579,13 @@ public class JobDescriptorImpl implements JobDescriptor {
 
         if (getInternal().getType() == JobType.TASKSFLOW) {
             TaskDescriptor taskToTerminate = currentTasks.get(taskId);
+            if (taskToTerminate == null && !inErrorTask) {
+                // occurs when a task is killed in pending state
+                taskToTerminate = eligibleTasks.remove(taskId);
+                if (taskToTerminate != null) {
+                    runningTasks.put(taskId, taskToTerminate);
+                }
+            }
 
             if (taskToTerminate != null) {
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestLoadJobsPagination.java
@@ -338,7 +338,7 @@ public class TestLoadJobsPagination extends BaseSchedulerDBTest {
         task = startTask(job, job.getITasks().get(0));
         dbManager.jobTaskStarted(job, task, true, null);
         TaskResultImpl result = new TaskResultImpl(null, new TestResult(0, "result"), null, 0);
-        job.terminateTask(false, task.getId(), null, null, result);
+        job.terminateTask(InternalJob.FinishTaskStatus.NORMAL, task.getId(), null, null, result);
         job.terminate();
         dbManager.updateAfterTaskFinished(job, task, new TaskResultImpl(null, new TestResult(0, "result"), null, 0));
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReadSchedulerAccount.java
@@ -197,7 +197,7 @@ public class TestReadSchedulerAccount extends BaseSchedulerDBTest {
 
         InternalTask task = job.getTask(taskName);
         TaskResultImpl res = new TaskResultImpl(null, "ok", null, 0);
-        job.terminateTask(false, task.getId(), null, null, res);
+        job.terminateTask(InternalJob.FinishTaskStatus.NORMAL, task.getId(), null, null, res);
         if (job.isFinished()) {
             job.terminate();
         }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReportingQueries.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestReportingQueries.java
@@ -261,7 +261,7 @@ public class TestReportingQueries extends BaseSchedulerDBTest {
 
         InternalTask task = job.getTask(taskName);
         TaskResultImpl res = new TaskResultImpl(null, "ok", null, 0);
-        job.terminateTask(false, task.getId(), null, null, res);
+        job.terminateTask(InternalJob.FinishTaskStatus.NORMAL, task.getId(), null, null, res);
         if (job.isFinished()) {
             job.terminate();
         }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs.java
@@ -67,7 +67,11 @@ public class TestRestoreWorkflowJobs extends BaseSchedulerDBTest {
         TaskResultImpl result = new TaskResultImpl(mainTask.getId(), "ok", null, 0);
         FlowAction action = new FlowAction(FlowActionType.REPLICATE);
         action.setDupNumber(2);
-        ChangedTasksInfo changesInfo = job.terminateTask(false, mainTask.getId(), null, action, result);
+        ChangedTasksInfo changesInfo = job.terminateTask(InternalJob.FinishTaskStatus.NORMAL,
+                                                         mainTask.getId(),
+                                                         null,
+                                                         action,
+                                                         result);
 
         dbManager.updateAfterWorkflowTaskFinished(job, changesInfo, result);
 
@@ -100,7 +104,11 @@ public class TestRestoreWorkflowJobs extends BaseSchedulerDBTest {
         dbManager.jobTaskStarted(job, mainTask, true, null);
 
         TaskResultImpl result = new TaskResultImpl(mainTask.getId(), "ok", null, 0);
-        ChangedTasksInfo changesInfo = job.terminateTask(false, mainTask.getId(), null, null, result);
+        ChangedTasksInfo changesInfo = job.terminateTask(InternalJob.FinishTaskStatus.NORMAL,
+                                                         mainTask.getId(),
+                                                         null,
+                                                         null,
+                                                         result);
         job.setStatus(JobStatus.FINISHED);
 
         dbManager.updateAfterWorkflowTaskFinished(job, changesInfo, result);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs2.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestRestoreWorkflowJobs2.java
@@ -61,7 +61,11 @@ public class TestRestoreWorkflowJobs2 extends BaseSchedulerDBTest {
         action.setDupNumber(1);
         action.setTarget("B");
         action.setTargetElse("C");
-        ChangedTasksInfo changesInfo = job.terminateTask(false, mainTask.getId(), null, action, result);
+        ChangedTasksInfo changesInfo = job.terminateTask(InternalJob.FinishTaskStatus.NORMAL,
+                                                         mainTask.getId(),
+                                                         null,
+                                                         action,
+                                                         result);
 
         dbManager.updateAfterWorkflowTaskFinished(job, changesInfo, result);
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestUsageData.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestUsageData.java
@@ -132,7 +132,7 @@ public class TestUsageData extends BaseSchedulerDBTest {
     private void finishTask(InternalJob job, InternalTask task) throws Exception {
         Thread.sleep(10);
         TaskResultImpl res = new TaskResultImpl(null, "ok", null, 42);
-        job.terminateTask(false, task.getId(), null, null, res);
+        job.terminateTask(InternalJob.FinishTaskStatus.NORMAL, task.getId(), null, null, res);
         if (job.isFinished()) {
             job.terminate();
         }

--- a/scheduler/scheduler-server/src/test/java/functionaltests/job/TagTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/job/TagTest.java
@@ -125,7 +125,11 @@ public class TagTest extends ProActiveTest {
         if (script != null) {
             action = task.getFlowScript().execute().getResult();
         }
-        job.terminateTask(false, task.getId(), schedulerStateUpdateMock, action, resultMock);
+        job.terminateTask(InternalJob.FinishTaskStatus.NORMAL,
+                          task.getId(),
+                          schedulerStateUpdateMock,
+                          action,
+                          resultMock);
         System.out.println("executed " + task.getName() + " -> " + getTaskNameList(true));
     }
 

--- a/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/service/SchedulerDBManagerTest.java
@@ -632,7 +632,11 @@ public class SchedulerDBManagerTest extends BaseServiceTest {
         for (InternalTask task : finishedJob.getITasks()) {
             TaskResultImpl result = new TaskResultImpl(task.getId(), "ok", null, 0);
             FlowAction action = new FlowAction(FlowActionType.CONTINUE);
-            ChangedTasksInfo changesInfo = finishedJob.terminateTask(false, task.getId(), null, action, result);
+            ChangedTasksInfo changesInfo = finishedJob.terminateTask(InternalJob.FinishTaskStatus.NORMAL,
+                                                                     task.getId(),
+                                                                     null,
+                                                                     action,
+                                                                     result);
             task.setFinishedTime(finishedTime);
             dbManager.updateAfterWorkflowTaskFinished(finishedJob, changesInfo, result);
         }


### PR DESCRIPTION
 - ensure that the control flow behaves normally after the kill
 - unrelated: fix cumulated core time calculation in pauseJob and finishInErrorTask