### PR TITLE
Add filters to rm rest models

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/RMRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/RMRestInterface.java
@@ -253,34 +253,45 @@ public interface RMRestInterface {
      * List of registered node hosts as variable model.
      *
      * Returns a workflow variable model string containing the list of registered hosts in the resource manager
+     * @param name a <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">regular expression</a> which will accept hosts based on their name. Example: <code>host.*</code>
      * @return a model containing the list of hosts, including an empty name. e.g. PA:LIST(,hostname1,hostname2)
      */
     @GET
     @Path("model/hosts")
     @Produces({ MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON })
-    String getModelHosts() throws PermissionRestException;
+    String getModelHosts(@QueryParam("name") String name) throws PermissionRestException;
 
     /**
      * list of node sources as variable model.
      *
-     * Returns a workflow variable model string containing the list of registered node sources in the resource manager
+     * Returns a workflow variable model string containing the list of deployed node sources in the resource manager
+     *
+     * @param name a <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">regular expression</a> which will accept node sources based on their name. Example: <code>Internal_.*</code>
+     *
+     * @param infrastructure node source infrastructure type. All node sources whose infrastructure name contains the given type will be returned.
+     *             For example: <code>Local</code> will return all node sources with a <i>LocalInfrastructure</i>, <code>Azure</code> will return all node sources with <i>AzureInfrastructure</i> or <i>AzureVMScaleSetInfrastructure</i> types. See <a href="https://doc.activeeon.com/latest/admin/ProActiveAdminGuide.html#_node_source_infrastructures">Node Source Infrastructures</a> for a complete list of infrastructure types.
+     * @param policy node source policy type. All node sources whose policy name contains the given type will be returned.
+     *             For example: <code>Static</code> will return all node sources with a <i>StaticPolicy</i>, <code>Dynamic</code> will return all node sources with <i>DynamicPolicy</i>. See <a href="https://doc.activeeon.com/latest/admin/ProActiveAdminGuide.html#_node_source_policies">Node Source Policies</a> for a complete list of policy types.
+     *
      * @return a model containing the list of node sources name, including an empty name and the default node source e.g. PA:LIST(,Default,LocalNodes)
      */
     @GET
     @Path("model/nodesources")
     @Produces({ MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON })
-    String getModelNodeSources() throws PermissionRestException;
+    String getModelNodeSources(@QueryParam("name") String name, @QueryParam("infrastructure") String infrastructure,
+            @QueryParam("policy") String policy) throws PermissionRestException;
 
     /**
      * List of registered tokens as variable model.
      *
      * Returns a workflow variable model string containing the list of registered tokens in the resource manager
+     * @param name a <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">regular expression</a> which will accept tokens based on their name. Example: <code>token.*</code>
      * @return a model containing the list of tokens, including an empty name. e.g. PA:LIST(,token1,token2)
      */
     @GET
     @Path("model/tokens")
     @Produces({ MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON })
-    String getModelTokens() throws PermissionRestException;
+    String getModelTokens(@QueryParam("name") String name) throws PermissionRestException;
 
     /**
      * Check Resource Manager availability.

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/ExceptionMappers.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/ExceptionMappers.java
@@ -28,6 +28,7 @@ package org.ow2.proactive_grid_cloud_portal.webapp;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.security.KeyException;
+import java.util.regex.PatternSyntaxException;
 
 import javax.security.auth.login.LoginException;
 import javax.ws.rs.NotFoundException;
@@ -229,6 +230,13 @@ public class ExceptionMappers {
     }
 
     public static class LabelValidationRestExceptionMapper extends BaseExceptionMapper<LabelValidationRestException> {
+        @Override
+        protected int getErrorCode() {
+            return HttpURLConnection.HTTP_BAD_REQUEST;
+        }
+    }
+
+    public static class PatternSyntaxRestExceptionMapper extends BaseExceptionMapper<PatternSyntaxException> {
         @Override
         protected int getErrorCode() {
             return HttpURLConnection.HTTP_BAD_REQUEST;

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/RestRuntime.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/RestRuntime.java
@@ -124,6 +124,7 @@ public class RestRuntime {
         dispatcher.registerProvider(ExceptionMappers.LabelNotFoundRestExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.LabelConflictRestExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.LabelValidationRestExceptionMapper.class);
+        dispatcher.registerProvider(ExceptionMappers.PatternSyntaxRestExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.SchedulerRestExceptionExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.NotFoundExceptionMapper.class);
         dispatcher.registerProvider(ExceptionMappers.SubmissionClosedRestExceptionExceptionMapper.class);

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMNodeSourceEvent.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMNodeSourceEvent.java
@@ -66,6 +66,10 @@ public class RMNodeSourceEvent extends RMEvent {
     /** string representation of the status of node source */
     private String nodeSourceStatus;
 
+    private String infrastructureType;
+
+    private String policyType;
+
     /**
      * ProActive Empty constructor.
      */
@@ -77,19 +81,23 @@ public class RMNodeSourceEvent extends RMEvent {
      * Used to represent the resource manager state @see RMInitialState.
      */
     public RMNodeSourceEvent(String nodeSourceName, String nodeSourceDescription,
-            LinkedHashMap<String, String> additionalInformation, String nodeSourceAdmin, String nodeSourceStatus) {
+            LinkedHashMap<String, String> additionalInformation, String nodeSourceAdmin, String nodeSourceStatus,
+            String infrastructureType, String policyType) {
         this.nodeSourceName = nodeSourceName;
         this.nodeSourceDescription = nodeSourceDescription;
         this.additionalInformation = new LinkedHashMap<>(additionalInformation);
         this.nodeSourceAdmin = nodeSourceAdmin;
         this.nodeSourceStatus = nodeSourceStatus;
+        this.infrastructureType = infrastructureType;
+        this.policyType = policyType;
     }
 
     /**
      * Creates an RMNodesourceEvent object.
      */
     public RMNodeSourceEvent(RMEventType type, String initiator, String nodeSourceName, String nodeSourceDescription,
-            LinkedHashMap<String, String> additionalInformation, String nodeSourceAdmin, String nodeSourceStatus) {
+            LinkedHashMap<String, String> additionalInformation, String nodeSourceAdmin, String nodeSourceStatus,
+            String infrastructureType, String policyType) {
         super(type);
         this.initiator = initiator;
         this.nodeSourceName = nodeSourceName;
@@ -97,6 +105,8 @@ public class RMNodeSourceEvent extends RMEvent {
         this.additionalInformation = new LinkedHashMap<>(additionalInformation);
         this.nodeSourceAdmin = nodeSourceAdmin;
         this.nodeSourceStatus = nodeSourceStatus;
+        this.infrastructureType = infrastructureType;
+        this.policyType = policyType;
     }
 
     // for testing purpose RMinitialStateTest
@@ -192,5 +202,13 @@ public class RMNodeSourceEvent extends RMEvent {
     // for the sake of resteasy mapping
     public String getNodeSourceDescription() {
         return nodeSourceDescription;
+    }
+
+    public String getInfrastructureType() {
+        return infrastructureType;
+    }
+
+    public String getPolicyType() {
+        return policyType;
     }
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1742,7 +1742,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                             nodeSourceToRemove.getDescription(),
                                                             nodeSourceToRemove.getAdditionalInformation(),
                                                             nodeSourceToRemove.getAdministrator().getName(),
-                                                            NodeSourceStatus.NODES_UNDEPLOYED.toString()));
+                                                            NodeSourceStatus.NODES_UNDEPLOYED.toString(),
+                                                            nodeSourceToRemove.getDescriptor().getInfrastructureType(),
+                                                            nodeSourceToRemove.getDescriptor().getPolicyType()));
 
             // asynchronously delegate the removal process to the node source
             nodeSourceToRemove.shutdown(this.caller);
@@ -1817,7 +1819,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                               nodeSource.getDescription(),
                                                               nodeSource.getAdditionalInformation(),
                                                               descriptor.getProvider().getName(),
-                                                              nodeSource.getStatus().toString()));
+                                                              nodeSource.getStatus().toString(),
+                                                              descriptor.getInfrastructureType(),
+                                                              descriptor.getPolicyType()));
     }
 
     // ----------------------------------------------------------------------
@@ -2232,7 +2236,10 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                                        nodeSource.getDescription(),
                                                                        nodeSource.getAdditionalInformation(),
                                                                        nodeSourceAdministratorName,
-                                                                       nodeSourceStatus.toString());
+                                                                       nodeSourceStatus.toString(),
+                                                                       nodeSource.getDescriptor()
+                                                                                 .getInfrastructureType(),
+                                                                       nodeSource.getDescriptor().getPolicyType());
 
                 if (nodeSourceCanBeRemoved(nodeSourceName)) {
                     logger.info(NODE_SOURCE_STRING + nodeSourceName + HAS_BEEN_SUCCESSFULLY +
@@ -2563,7 +2570,10 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                                   nodeSourceToRemove.getDescription(),
                                                                   nodeSourceToRemove.getAdditionalInformation(),
                                                                   nodeSourceToRemove.getAdministrator().getName(),
-                                                                  nodeSourceToRemove.getStatus().toString()));
+                                                                  nodeSourceToRemove.getStatus().toString(),
+                                                                  nodeSourceToRemove.getDescriptor()
+                                                                                    .getInfrastructureType(),
+                                                                  nodeSourceToRemove.getDescriptor().getPolicyType()));
         }
     }
 
@@ -2585,7 +2595,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                             nodeSourceToRemove.getDescription(),
                                                             nodeSourceToRemove.getAdditionalInformation(),
                                                             nodeSourceToRemove.getAdministrator().getName(),
-                                                            status.toString()));
+                                                            status.toString(),
+                                                            nodeSourceToRemove.getDescriptor().getInfrastructureType(),
+                                                            nodeSourceToRemove.getDescriptor().getPolicyType()));
 
             // asynchronously delegate the removal process to the node source
             nodeSourceToRemove.shutdown(this.caller);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -643,7 +643,9 @@ public class NodeSource implements InitActive, RunActive {
                                                                   this.getDescription(),
                                                                   this.additionalInformation,
                                                                   this.administrator.getName(),
-                                                                  this.getStatus().toString()));
+                                                                  this.getStatus().toString(),
+                                                                  this.getDescriptor().getInfrastructureType(),
+                                                                  this.getDescriptor().getPolicyType()));
         }
     }
 
@@ -1097,6 +1099,8 @@ public class NodeSource implements InitActive, RunActive {
                                      getDescription(),
                                      this.additionalInformation,
                                      this.administrator.getName(),
-                                     this.getStatus().toString());
+                                     this.getStatus().toString(),
+                                     this.descriptor.getInfrastructureType(),
+                                     this.descriptor.getPolicyType());
     }
 }


### PR DESCRIPTION
Allows filtering:
 - node sources based on infrastructure type or name regular expression
 - hosts (name regular expression)
 - tokens (name regular expression)