### PR TITLE
Allow empty PA:LIST model

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ListParserValidator.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ListParserValidator.java
@@ -42,7 +42,7 @@ public class ListParserValidator extends BaseParserValidator<String> {
     public static final String RIGHT_DELIMITER = ")";
 
     protected static final String LIST_REGEXP = "^" + ignoreCaseRegexp(ModelType.LIST.name()) + "\\" + LEFT_DELIMITER +
-                                                "([^)]+)" + "\\" + RIGHT_DELIMITER + "$";
+                                                "([^)]*)" + "\\" + RIGHT_DELIMITER + "$";
 
     public ListParserValidator(String model) throws ModelSyntaxException {
         super(model, ModelType.LIST, LIST_REGEXP);

--- a/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ListParserValidatorTest.java
+++ b/scheduler/scheduler-api/src/test/java/org/ow2/proactive/scheduler/common/job/factories/spi/model/factory/ListParserValidatorTest.java
@@ -50,6 +50,22 @@ public class ListParserValidatorTest {
                                                     VALID_MODEL_PARAMETER).parseAndValidate(VALID_VALUE));
     }
 
+    @Test
+    public void testListParserValidatorEmptyListOK()
+            throws ModelSyntaxException, ValidationException, ConversionException {
+        Assert.assertEquals("",
+                            new ListParserValidator(ModelType.LIST + ListParserValidator.LEFT_DELIMITER + "" +
+                                                    ListParserValidator.RIGHT_DELIMITER).parseAndValidate(""));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testListParserValidatorEmptyListKO()
+            throws ModelSyntaxException, ValidationException, ConversionException {
+        Assert.assertEquals(VALID_VALUE,
+                            new ListParserValidator(ModelType.LIST + ListParserValidator.LEFT_DELIMITER + "" +
+                                                    ListParserValidator.RIGHT_DELIMITER).parseAndValidate("invalid"));
+    }
+
     @Test(expected = ValidationException.class)
     public void testListParserValidatorKO() throws ModelSyntaxException, ValidationException, ConversionException {
         new ListParserValidator(ModelType.LIST + VALID_MODEL_PARAMETER).parseAndValidate(INVALID_VALUE);


### PR DESCRIPTION
Also, in rm dynamic models, return an empty PA:LIST when the node source, hosts or token list is empty.