### PR TITLE
Add domain information and control

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
@@ -47,6 +47,8 @@ public class UserData implements Serializable {
 
     private String tenant;
 
+    private String domain;
+
     private boolean filterByTenant;
 
     private boolean allTenantPermission;
@@ -87,6 +89,14 @@ public class UserData implements Serializable {
 
     public void setTenant(String tenant) {
         this.tenant = tenant;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
     }
 
     public boolean isFilterByTenant() {

--- a/common/common-api/src/main/java/org/ow2/proactive/core/properties/PACommonProperties.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/core/properties/PACommonProperties.java
@@ -107,12 +107,23 @@ public interface PACommonProperties {
 
     /**
      * Returns the value of this property as a List of strings.
+     * equivalent of getValueAsList(separator, false)
      *
      * @param separator the separator to use
      *
      * @return the list of values of this property.
      */
     List<String> getValueAsList(String separator);
+
+    /**
+     * Returns the value of this property as a List of strings.
+     *
+     * @param separator the separator to use
+     * @param allowEmpty allow empty values in the list
+     *
+     * @return the list of values of this property.
+     */
+    List<String> getValueAsList(String separator, boolean allowEmpty);
 
     /**
      * Return the type of the given properties.

--- a/common/common-api/src/main/java/org/ow2/proactive/core/properties/PACommonPropertiesHelper.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/core/properties/PACommonPropertiesHelper.java
@@ -185,7 +185,7 @@ public class PACommonPropertiesHelper {
      *
      * @return the list of values of this property.
      */
-    public synchronized List<String> getValueAsList(String key, PropertyType type, String separator,
+    public synchronized List<String> getValueAsList(String key, PropertyType type, String separator, boolean allowEmpty,
             String defaultValue) {
         if (type != PropertyType.LIST) {
             throw new IllegalArgumentException("Property " + key + " is not a " + PropertyType.LIST);
@@ -195,7 +195,7 @@ public class PACommonPropertiesHelper {
         if (valueString != null) {
             for (String val : valueString.split(Pattern.quote(separator))) {
                 val = val.trim();
-                if (val.length() > 0) {
+                if (allowEmpty || val.length() > 0) {
                     valueList.add(val);
                 }
             }

--- a/common/common-api/src/main/java/org/ow2/proactive/core/properties/PASharedProperties.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/core/properties/PASharedProperties.java
@@ -261,7 +261,12 @@ public enum PASharedProperties implements PACommonProperties {
 
     @Override
     public List<String> getValueAsList(String separator) {
-        return propertiesHelper.getValueAsList(key, type, separator, defaultValue);
+        return propertiesHelper.getValueAsList(key, type, separator, false, defaultValue);
+    }
+
+    @Override
+    public List<String> getValueAsList(String separator, boolean allowEmpty) {
+        return propertiesHelper.getValueAsList(key, type, separator, allowEmpty, defaultValue);
     }
 
     @Override

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/PAMLoginModule.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/PAMLoginModule.java
@@ -142,7 +142,7 @@ public abstract class PAMLoginModule extends FileLoginModule implements Loggable
      */
     protected boolean logUser(String username, String password) throws LoginException {
         try {
-            return super.logUser(username, password, false);
+            return super.logUser(username, password, null, false);
         } catch (LoginException ex) {
             return pamLogUser(username, password);
         }

--- a/common/common-client/src/main/java/org/ow2/proactive/authentication/principals/DomainNamePrincipal.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/authentication/principals/DomainNamePrincipal.java
@@ -1,0 +1,35 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.authentication.principals;
+
+public class DomainNamePrincipal extends IdentityPrincipal {
+
+    private static final long serialVersionUID = 1L;
+
+    public DomainNamePrincipal(String name) {
+        super(name);
+    }
+}

--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -334,7 +334,12 @@ public enum WebProperties implements PACommonProperties {
 
     @Override
     public List<String> getValueAsList(String separator) {
-        return propertiesHelper.getValueAsList(key, type, separator, defaultValue);
+        return propertiesHelper.getValueAsList(key, type, separator, false, defaultValue);
+    }
+
+    @Override
+    public List<String> getValueAsList(String separator, boolean allowEmpty) {
+        return propertiesHelper.getValueAsList(key, type, separator, allowEmpty, defaultValue);
     }
 
     @Override

--- a/config/rm/settings.ini
+++ b/config/rm/settings.ini
@@ -197,6 +197,8 @@ pa.rm.ldap.config.path=config/authentication/ldap.cfg
 # Multi-domain LDAP configuration
 # a comma-separated list of the pair domain_name:configuration_path
 # see comment above regarding file paths locations
+# domain names must be lowercase and must also be configured in pa.rm.allowed.domains
+
 # pa.rm.multi.ldap.config=domain1:config/authentication/ldap-domain1.cfg,domain2:config/authentication/ldap-domain2.cfg
 
 # Login file name for file authentication method
@@ -210,6 +212,18 @@ pa.rm.defaultloginfilename=config/authentication/login.cfg
 # with the variable defined below : pa.rm.home.
 # else, the path is absolute, so the path is directly interpreted
 pa.rm.defaultgroupfilename=config/authentication/group.cfg
+
+# Tenant file name for file authentication method
+# If this file path is relative, the path is evaluated from the resource manager dir (ie application's root dir)
+# with the variable defined below : pa.rm.home.
+# else, the path is absolute, so the path is directly interpreted
+pa.rm.defaulttenantfilename=config/authentication/tenant.cfg
+
+# List of domain names that can be used during a login (can be a list of windows domain names or a list of tenants in Multi-LDAP configuration)
+# This setting is interpreted by ProActive portals to show a selectable list of domains
+# Domain names should be lowercase
+# It is possible to allow both named domain and empty domain using the syntax pa.rm.allowed.domains=,domain1,domain2
+# pa.rm.allowed.domains=domain1,domain2
 
 #Property that define the method that have to be used for logging users to the resource manager
 #It can be one of the following values :

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -420,6 +420,12 @@ pa.scheduler.core.defaulttenantfilename=config/authentication/tenant.cfg
 # If enabled, filter jobs according to user tenant
 pa.scheduler.core.tenant.filter=false
 
+# List of domain names that can be used during a login (can be a list of windows domain names or a list of tenants in Multi-LDAP configuration)
+# This setting is interpreted by ProActive portals to show a selectable list of domains
+# Domain names should be lowercase
+# It is possible to allow both named domain and empty domain using the syntax pa.scheduler.allowed.domains=,domain1,domain2
+# pa.scheduler.allowed.domains=domain1,domain2
+
 # Property that define the method that have to be used for logging users to the Scheduler
 # It can be one of the following values:
 #	- "SchedulerFileLoginMethod" to use file login and group management

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/RMRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/RMRestInterface.java
@@ -98,6 +98,16 @@ public interface RMRestInterface {
     String getUrl();
 
     /**
+     * Returns the domains configured on the resource manager server.
+     *
+     * @return list of domains
+     */
+    @GET
+    @Path("domains")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<String> getDomains();
+
+    /**
      * Login with username/password.
      *
      * Log into the resource manager using an form containing 2 fields

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -89,6 +89,16 @@ public interface SchedulerRestInterface {
     String getUrl();
 
     /**
+     * Returns the domains configured on the scheduler server.
+     *
+     * @return list of domains
+     */
+    @GET
+    @Path("domains")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<String> getDomains();
+
+    /**
      * Returns the ids of the current jobs under a list of string.
      *
      * @param sessionId

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
@@ -69,6 +69,8 @@ public class JobInfoData implements java.io.Serializable {
 
     private String tenant;
 
+    private String domain;
+
     private String projectName;
 
     private String bucketName;
@@ -197,6 +199,14 @@ public class JobInfoData implements java.io.Serializable {
 
     public void setTenant(String tenant) {
         this.tenant = tenant;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
     }
 
     public String getProjectName() {

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobStateData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobStateData.java
@@ -40,6 +40,8 @@ public class JobStateData {
 
     private String tenant;
 
+    private String domain;
+
     private JobInfoData jobInfo;
 
     private String projectName;
@@ -78,6 +80,14 @@ public class JobStateData {
 
     public void setTenant(String tenant) {
         this.tenant = tenant;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
     }
 
     public JobInfoData getJobInfo() {

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/SchedulerUserData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/SchedulerUserData.java
@@ -38,6 +38,8 @@ public class SchedulerUserData {
 
     private String tenant;
 
+    private String domain;
+
     private String username;
 
     private long connectionTime;
@@ -65,6 +67,10 @@ public class SchedulerUserData {
 
     public String getTenant() {
         return tenant;
+    }
+
+    public String getDomain() {
+        return domain;
     }
 
     public long getConnectionTime() {
@@ -95,6 +101,10 @@ public class SchedulerUserData {
         this.tenant = tenant;
     }
 
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
     public void setConnectionTime(long connectionTime) {
         this.connectionTime = connectionTime;
     }
@@ -118,7 +128,7 @@ public class SchedulerUserData {
     @Override
     public String toString() {
         return "SchedulerUserData{" + "hostName='" + hostName + '\'' + ", username='" + username + '\'' + ", groups='" +
-               groups + "\'" + ", tenant='" + tenant + "\'" + ", connectionTime=" + connectionTime +
-               ", lastSubmitTime=" + lastSubmitTime + ", submitNumber=" + submitNumber + '}';
+               groups + "\'" + ", tenant='" + tenant + "\'" + ", domain='" + domain + "\'" + ", connectionTime=" +
+               connectionTime + ", lastSubmitTime=" + lastSubmitTime + ", submitNumber=" + submitNumber + '}';
     }
 }

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioInterface.java
@@ -96,6 +96,11 @@ public interface StudioInterface {
     UserData currentUserData(@HeaderParam("sessionid") String sessionId);
 
     @GET
+    @Path("domains")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<String> getDomains();
+
+    @GET
     @Path("workflows")
     List<Workflow> getWorkflows(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedRestException, IOException;

--- a/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/StringUtility.java
+++ b/rest/rest-cli/src/main/java/org/ow2/proactive_grid_cloud_portal/cli/utils/StringUtility.java
@@ -257,6 +257,8 @@ public final class StringUtility {
               .append(jobState.getOwner())
               .append("\tTENANT: ")
               .append(jobState.getTenant())
+              .append("\tDOMAIN: ")
+              .append(jobState.getDomain())
               .append("\tSTATUS: ")
               .append(jobState.getJobInfo().getStatus())
               .append("\t#TASKS: ")

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -1536,6 +1536,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         jobInfoImpl.setJobId(newJobId);
         jobInfoImpl.setJobOwner(jobInfoData.getJobOwner());
         jobInfoImpl.setTenant(jobInfoData.getTenant());
+        jobInfoImpl.setDomain(jobInfoData.getDomain());
         jobInfoImpl.setProjectName(jobInfoData.getProjectName());
         jobInfoImpl.setProjectName(jobInfoData.getProjectName());
         jobInfoImpl.setBucketName(jobInfoData.getBucketName());

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
@@ -72,6 +72,7 @@ public class DataUtility {
         impl.setFinishedTime(d.getFinishedTime());
         impl.setJobOwner(d.getJobOwner());
         impl.setTenant(d.getTenant());
+        impl.setDomain(d.getDomain());
         impl.setBucketName(d.getBucketName());
         impl.setNumberOfFinishedTasks(d.getNumberOfFinishedTasks());
         impl.setNumberOfPendingTasks(d.getNumberOfPendingTasks());
@@ -290,6 +291,7 @@ public class DataUtility {
         return new UserIdentificationImpl(d.getUsername(),
                                           d.getGroups(),
                                           d.getTenant(),
+                                          d.getDomain(),
                                           d.getSubmitNumber(),
                                           d.getHostName(),
                                           d.getConnectionTime(),

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
@@ -61,6 +61,8 @@ public class JobInfoImpl implements JobInfo {
 
     private String tenant;
 
+    private String domain;
+
     private String projectName;
 
     private String bucketName;
@@ -151,6 +153,15 @@ public class JobInfoImpl implements JobInfo {
 
     public void setTenant(String tenant) {
         this.tenant = tenant;
+    }
+
+    @Override
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
     }
 
     public void setProjectName(String projectName) {

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobStateImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobStateImpl.java
@@ -87,6 +87,11 @@ public class JobStateImpl extends JobState {
     }
 
     @Override
+    public String getDomain() {
+        return jobStateData.getDomain();
+    }
+
+    @Override
     public List<TaskState> getTasks() {
         Map<String, TaskStateData> taskStateMap = jobStateData.getTasks();
         List<TaskState> taskStateList = new ArrayList<>(taskStateMap.size());

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
@@ -39,6 +39,8 @@ public class UserIdentificationImpl extends UserIdentification {
 
     private String tenant;
 
+    private String domain;
+
     private int submitNumber;
 
     private String hostName;
@@ -53,8 +55,8 @@ public class UserIdentificationImpl extends UserIdentification {
 
     }
 
-    public UserIdentificationImpl(String username, Set<String> groups, String tenant, int submitNumber, String hostName,
-            long connectionTime, long lastSubmitTime, boolean myEventsOnly) {
+    public UserIdentificationImpl(String username, Set<String> groups, String tenant, String domain, int submitNumber,
+            String hostName, long connectionTime, long lastSubmitTime, boolean myEventsOnly) {
         this.username = username;
         this.groups = groups;
         this.submitNumber = submitNumber;
@@ -63,6 +65,7 @@ public class UserIdentificationImpl extends UserIdentification {
         this.lastSubmitTime = lastSubmitTime;
         this.myEventsOnly = myEventsOnly;
         this.tenant = tenant;
+        this.domain = domain;
     }
 
     @Override
@@ -78,6 +81,11 @@ public class UserIdentificationImpl extends UserIdentification {
     @Override
     public String getTenant() {
         return tenant;
+    }
+
+    @Override
+    public String getDomain() {
+        return domain;
     }
 
     @Override

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -87,6 +87,7 @@ import org.ow2.proactive.resourcemanager.common.event.dto.RMStateFull;
 import org.ow2.proactive.resourcemanager.common.util.RMListenerProxy;
 import org.ow2.proactive.resourcemanager.common.util.RMProxyUserInterface;
 import org.ow2.proactive.resourcemanager.core.jmx.RMJMXBeans;
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
 import org.ow2.proactive.resourcemanager.exception.RMActiveObjectCreationException;
 import org.ow2.proactive.resourcemanager.exception.RMException;
 import org.ow2.proactive.resourcemanager.exception.RMNodeException;
@@ -110,6 +111,8 @@ import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestExc
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
 import org.ow2.proactive_grid_cloud_portal.webapp.PortalConfiguration;
 import org.ow2.proactive_grid_cloud_portal.webapp.StatHistory;
+
+import com.google.common.collect.ImmutableList;
 
 
 public class RMRest implements RMRestInterface {
@@ -149,6 +152,21 @@ public class RMRest implements RMRestInterface {
     @Override
     public String getUrl() {
         return PortalConfiguration.RM_URL.getValueAsString();
+    }
+
+    @Override
+    public List<String> getDomains() {
+        if (PAResourceManagerProperties.RM_ALLOWED_DOMAINS.isSet()) {
+            return PAResourceManagerProperties.RM_ALLOWED_DOMAINS.getValueAsList(",", true);
+        }
+
+        // windows current machine domain
+        String currentMachineDomain = System.getenv("USERDOMAIN");
+        if (currentMachineDomain != null) {
+            return ImmutableList.of("", currentMachineDomain.toLowerCase());
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -125,6 +125,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -226,6 +227,21 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     @Override
     public String getUrl() {
         return PortalConfiguration.SCHEDULER_URL.getValueAsString();
+    }
+
+    @Override
+    public List<String> getDomains() {
+        if (PASchedulerProperties.SCHEDULER_ALLOWED_DOMAINS.isSet()) {
+            return PASchedulerProperties.SCHEDULER_ALLOWED_DOMAINS.getValueAsList(",", true);
+        }
+
+        // windows current machine domain
+        String currentMachineDomain = System.getenv("USERDOMAIN");
+        if (currentMachineDomain != null) {
+            return ImmutableList.of("", currentMachineDomain.toLowerCase());
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/studio/StudioRest.java
@@ -141,6 +141,11 @@ public class StudioRest implements StudioInterface {
     }
 
     @Override
+    public List<String> getDomains() {
+        return scheduler().getDomains();
+    }
+
+    @Override
     public List<Workflow> getWorkflows(String sessionId) throws NotConnectedRestException, IOException {
         String userName = getUserName(sessionId);
         logger.info("Reading workflows as " + userName);

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/PortalConfiguration.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/webapp/PortalConfiguration.java
@@ -258,7 +258,12 @@ public enum PortalConfiguration implements PACommonProperties {
 
     @Override
     public List<String> getValueAsList(String separator) {
-        return propertiesHelper.getValueAsList(key, type, separator, defaultValue);
+        return propertiesHelper.getValueAsList(key, type, separator, false, defaultValue);
+    }
+
+    @Override
+    public List<String> getValueAsList(String separator, boolean allowEmpty) {
+        return propertiesHelper.getValueAsList(key, type, separator, allowEmpty, defaultValue);
     }
 
     @Override

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/DozerMappingTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/DozerMappingTest.java
@@ -144,6 +144,11 @@ public class DozerMappingTest {
             }
 
             @Override
+            public String getDomain() {
+                return null;
+            }
+
+            @Override
             public JobType getType() {
                 return null;
             }

--- a/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestRenewLeaseForClientTest.java
+++ b/rest/rest-server/src/test/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRestRenewLeaseForClientTest.java
@@ -83,7 +83,8 @@ public class SchedulerStateRestRenewLeaseForClientTest extends RestTestServer {
                                                       "login",
                                                       "loginWithCredential",
                                                       "validate",
-                                                      "getUrl");
+                                                      "getUrl",
+                                                      "getDomains");
 
         Method[] methodsToTest = SchedulerRestInterface.class.getMethods();
         Object[][] data = new Object[methodsToTest.length][2];

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/core/properties/PAResourceManagerProperties.java
@@ -136,6 +136,8 @@ public enum PAResourceManagerProperties implements PACommonProperties {
      * Support for multi-ldap login configuration.
      * This property must be defined using a list of the following form:
      * domain1:path_to_domain1.cfg,domain2:path_to_domain2.cfg, etc
+     *
+     * domain names must be lowercase and must also be configured in pa.rm.allowed.domains
      */
     RM_MULTI_LDAP_CONFIG("pa.rm.multi.ldap.config", PropertyType.LIST),
 
@@ -147,6 +149,9 @@ public enum PAResourceManagerProperties implements PACommonProperties {
 
     /** Resource Manager tenant file name */
     RM_TENANT_FILE("pa.rm.defaulttenantfilename", PropertyType.STRING, "config/authentication/tenant.cfg"),
+
+    /** List of domain names that can be used during a login (can be a list of windows domain names or a list of tenants in Multi-LDAP configuration) **/
+    RM_ALLOWED_DOMAINS("pa.rm.allowed.domains", PropertyType.LIST),
 
     /** Name of the JMX MBean for the RM */
     RM_JMX_CONNECTOR_NAME("pa.rm.jmx.connectorname", PropertyType.STRING, "JMXRMAgent"),
@@ -559,7 +564,12 @@ public enum PAResourceManagerProperties implements PACommonProperties {
 
     @Override
     public List<String> getValueAsList(String separator) {
-        return propertiesHelper.getValueAsList(key, type, separator, defaultValue);
+        return propertiesHelper.getValueAsList(key, type, separator, false, defaultValue);
+    }
+
+    @Override
+    public List<String> getValueAsList(String separator, boolean allowEmpty) {
+        return propertiesHelper.getValueAsList(key, type, separator, allowEmpty, defaultValue);
     }
 
     @Override

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/Client.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/Client.java
@@ -41,6 +41,7 @@ import org.objectweb.proactive.core.body.request.Request;
 import org.objectweb.proactive.core.mop.Proxy;
 import org.objectweb.proactive.core.mop.StubObject;
 import org.ow2.proactive.authentication.crypto.Credentials;
+import org.ow2.proactive.authentication.principals.DomainNamePrincipal;
 import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
 import org.ow2.proactive.authentication.principals.TenantPrincipal;
 import org.ow2.proactive.authentication.principals.UserNamePrincipal;
@@ -141,6 +142,14 @@ public class Client implements Serializable {
         } else {
             return null;
         }
+    }
+
+    public String getDomain() {
+        Set<DomainNamePrincipal> domains = subject.getPrincipals(DomainNamePrincipal.class);
+        if (domains == null || domains.size() == 0) {
+            return null;
+        }
+        return domains.iterator().next().getName();
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMFileLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMFileLoginModule.java
@@ -25,9 +25,9 @@
  */
 package org.ow2.proactive.resourcemanager.authentication;
 
-import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.FileLoginModule;
@@ -48,15 +48,7 @@ public class RMFileLoginModule extends FileLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-
-        String loginFile = PAResourceManagerProperties.RM_LOGIN_FILE.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PAResourceManagerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return RMJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -64,14 +56,7 @@ public class RMFileLoginModule extends FileLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PAResourceManagerProperties.RM_GROUP_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PAResourceManagerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return RMJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -79,14 +64,12 @@ public class RMFileLoginModule extends FileLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
-        }
+        return RMJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return RMJaasConfigUtils.getConfiguredDomains();
     }
 
     @Override

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMJaasConfigUtils.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMJaasConfigUtils.java
@@ -1,0 +1,89 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.resourcemanager.authentication;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.ow2.proactive.resourcemanager.core.properties.PAResourceManagerProperties;
+
+
+public class RMJaasConfigUtils {
+
+    static String getLoginFileName() {
+
+        String loginFile = PAResourceManagerProperties.RM_LOGIN_FILE.getValueAsString();
+        //test that login file path is an absolute path or not
+        if (!(new File(loginFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            loginFile = PAResourceManagerProperties.getAbsolutePath(loginFile);
+        }
+
+        return loginFile;
+    }
+
+    static String getGroupFileName() {
+        String groupFile = PAResourceManagerProperties.RM_GROUP_FILE.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(groupFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            groupFile = PAResourceManagerProperties.getAbsolutePath(groupFile);
+        }
+
+        return groupFile;
+    }
+
+    static String getTenantFileName() {
+        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
+    static Set<String> getConfiguredDomains() {
+        if (PAResourceManagerProperties.RM_ALLOWED_DOMAINS.isSet()) {
+            return PAResourceManagerProperties.RM_ALLOWED_DOMAINS.getValueAsList(",")
+                                                                 .stream()
+                                                                 .map(domain -> domain.toLowerCase())
+                                                                 .collect(Collectors.toSet());
+        } else {
+            // windows current machine domain
+            String currentMachineDomain = System.getenv("USERDOMAIN");
+            if (currentMachineDomain != null) {
+                return Collections.singleton(currentMachineDomain.toLowerCase());
+            } else {
+                return new HashSet<>();
+            }
+        }
+    }
+}

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMLDAPLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMLDAPLoginModule.java
@@ -28,6 +28,7 @@ package org.ow2.proactive.resourcemanager.authentication;
 import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.LDAPLoginModule;
@@ -65,15 +66,7 @@ public class RMLDAPLoginModule extends LDAPLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-
-        String loginFile = PAResourceManagerProperties.RM_LOGIN_FILE.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PAResourceManagerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return RMJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -83,14 +76,7 @@ public class RMLDAPLoginModule extends LDAPLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PAResourceManagerProperties.RM_GROUP_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PAResourceManagerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return RMJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -98,14 +84,12 @@ public class RMLDAPLoginModule extends LDAPLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
-        }
+        return RMJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return RMJaasConfigUtils.getConfiguredDomains();
     }
 
     @Override

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMMultiLDAPLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMMultiLDAPLoginModule.java
@@ -28,9 +28,7 @@ package org.ow2.proactive.resourcemanager.authentication;
 import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.MultiLDAPLoginModule;
@@ -79,15 +77,7 @@ public class RMMultiLDAPLoginModule extends MultiLDAPLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-
-        String loginFile = PAResourceManagerProperties.RM_LOGIN_FILE.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PAResourceManagerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return RMJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -97,14 +87,7 @@ public class RMMultiLDAPLoginModule extends MultiLDAPLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PAResourceManagerProperties.RM_GROUP_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PAResourceManagerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return RMJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -112,14 +95,12 @@ public class RMMultiLDAPLoginModule extends MultiLDAPLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
-        }
+        return RMJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return RMJaasConfigUtils.getConfiguredDomains();
     }
 
     @Override

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMPAMLoginModule.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/authentication/RMPAMLoginModule.java
@@ -25,9 +25,9 @@
  */
 package org.ow2.proactive.resourcemanager.authentication;
 
-import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.PAMLoginModule;
@@ -46,15 +46,7 @@ public class RMPAMLoginModule extends PAMLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-
-        String loginFile = PAResourceManagerProperties.RM_LOGIN_FILE.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PAResourceManagerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return RMJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -62,14 +54,7 @@ public class RMPAMLoginModule extends PAMLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PAResourceManagerProperties.RM_GROUP_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PAResourceManagerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return RMJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -77,14 +62,12 @@ public class RMPAMLoginModule extends PAMLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PAResourceManagerProperties.RM_TENANT_FILE.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PAResourceManagerProperties.getAbsolutePath(tenantFile);
-        }
+        return RMJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return RMJaasConfigUtils.getConfiguredDomains();
     }
 
     /**

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -3365,6 +3365,7 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
         userData.setUserName(caller.getName());
         userData.setGroups(caller.getGroups());
         userData.setTenant(caller.getTenant());
+        userData.setDomain(caller.getDomain());
         return userData;
     }
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
@@ -69,6 +69,13 @@ public interface JobInfo extends Serializable {
     String getTenant();
 
     /**
+     * Return the domain associated with the job owner
+     *
+     * @return the domain associated with the job owner or null if no tenant is associated
+     */
+    String getDomain();
+
+    /**
      * Returns the project name associated with this job
      * @return project name
      */

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobState.java
@@ -481,11 +481,18 @@ public abstract class JobState extends Job implements Comparable<JobState> {
     public abstract String getOwner();
 
     /**
-     * To get the owner of the job.
+     * To get the tenant of the job owner.
      *
-     * @return the owner of the job.
+     * @return the tenant of the job owner.
      */
     public abstract String getTenant();
+
+    /**
+     * To get the domain name of the job.
+     *
+     * @return the domain name of the job owner.
+     */
+    public abstract String getDomain();
 
     /**
      * Get the toBeRemoved property.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
@@ -113,6 +113,13 @@ public abstract class UserIdentification implements Serializable, Comparable<Use
     public abstract String getTenant();
 
     /**
+     * Return the domain name associated with the current user, or null if no domain is associated
+     *
+     * @return user domain
+     */
+    public abstract String getDomain();
+
+    /**
      * Get the number of submit for this user.
      * 
      * @return the number of submit for this user.

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -176,6 +176,7 @@ public enum PASchedulerProperties implements PACommonProperties {
     SCHEDULER_AUTH_PUBKEY_PATH("pa.scheduler.auth.pubkey.path", PropertyType.STRING, "config/authentication/keys/pub.key"),
 
     /** a domain name (windows active directory) which can be configured globally at the scheduler level **/
+    /** Deprecated: consider using pa.scheduler.allowed.domains instead **/
     SCHEDULER_AUTH_GLOBAL_DOMAIN("pa.scheduler.auth.global.domain", PropertyType.STRING),
 
     /** 
@@ -190,6 +191,8 @@ public enum PASchedulerProperties implements PACommonProperties {
      * Support for multi-ldap login configuration.
      * This property must be defined using a list of the following form:
      * domain1:path_to_domain1.cfg,domain2:path_to_domain2.cfg, etc
+     *
+     * domain names must be lowercase and must also be configured in pa.scheduler.allowed.domains
      */
     SCHEDULER_MULTI_LDAP_CONFIG("pa.scheduler.multi.ldap.config", PropertyType.LIST),
 
@@ -201,6 +204,9 @@ public enum PASchedulerProperties implements PACommonProperties {
 
     /** Tenant default filename */
     SCHEDULER_TENANT_FILENAME("pa.scheduler.core.defaulttenantfilename", PropertyType.STRING, "config/authentication/tenant.cfg"),
+
+    /** List of domain names that can be used during a login (can be a list of windows domain names or a list of tenants in Multi-LDAP configuration) **/
+    SCHEDULER_ALLOWED_DOMAINS("pa.scheduler.allowed.domains", PropertyType.LIST),
 
     /** If enabled, filter jobs according to user tenant */
     SCHEDULER_TENANT_FILTER("pa.scheduler.core.tenant.filter", PropertyType.BOOLEAN, "false"),
@@ -720,7 +726,12 @@ public enum PASchedulerProperties implements PACommonProperties {
 
     @Override
     public List<String> getValueAsList(String separator) {
-        return propertiesHelper.getValueAsList(key, type, separator, defaultValue);
+        return propertiesHelper.getValueAsList(key, type, separator, false, defaultValue);
+    }
+
+    @Override
+    public List<String> getValueAsList(String separator, boolean allowEmpty) {
+        return propertiesHelper.getValueAsList(key, type, separator, allowEmpty, defaultValue);
     }
 
     /**

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -68,6 +68,8 @@ public class ClientJobState extends JobState {
 
     private String tenant;
 
+    private String domain;
+
     private JobType type;
 
     private Map<TaskId, TaskState> tasks;
@@ -89,6 +91,7 @@ public class ClientJobState extends JobState {
         jobInfo = (JobInfoImpl) jobState.getJobInfo();
         owner = jobState.getOwner();
         tenant = jobState.getTenant();
+        domain = jobState.getDomain();
         type = jobState.getType();
 
         this.name = jobState.getName();
@@ -211,6 +214,11 @@ public class ClientJobState extends JobState {
     @Override
     public String getTenant() {
         return tenant;
+    }
+
+    @Override
+    public String getDomain() {
+        return domain;
     }
 
     @Override

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
@@ -63,6 +63,8 @@ public class JobInfoImpl implements JobInfo {
 
     private String tenant;
 
+    private String domain;
+
     private String projectName;
 
     private String bucketName = null;
@@ -241,6 +243,14 @@ public class JobInfoImpl implements JobInfo {
 
     public void setTenant(String tenant) {
         this.tenant = tenant;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
     }
 
     @Override

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/UserIdentificationImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/UserIdentificationImpl.java
@@ -33,6 +33,7 @@ import java.util.TimerTask;
 
 import javax.security.auth.Subject;
 
+import org.ow2.proactive.authentication.principals.DomainNamePrincipal;
 import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
 import org.ow2.proactive.authentication.principals.TenantPrincipal;
 import org.ow2.proactive.authentication.principals.UserNamePrincipal;
@@ -87,13 +88,16 @@ public class UserIdentificationImpl extends UserIdentification {
      * @param username the user name.
      * @param tenant user tenant
      */
-    public UserIdentificationImpl(String username, String tenant) {
+    public UserIdentificationImpl(String username, String tenant, String domain) {
         this.username = username;
         this.connectionTime = System.currentTimeMillis();
         this.subject = new Subject();
         this.subject.getPrincipals().add(new UserNamePrincipal(username));
         if (tenant != null) {
             this.subject.getPrincipals().add(new TenantPrincipal(tenant));
+        }
+        if (domain != null) {
+            this.subject.getPrincipals().add(new DomainNamePrincipal(domain));
         }
     }
 
@@ -141,6 +145,15 @@ public class UserIdentificationImpl extends UserIdentification {
             return null;
         }
         return tenants.iterator().next().getName();
+    }
+
+    @Override
+    public String getDomain() {
+        Set<DomainNamePrincipal> domains = subject.getPrincipals(DomainNamePrincipal.class);
+        if (domains == null || domains.size() == 0) {
+            return null;
+        }
+        return domains.iterator().next().getName();
     }
 
     @Override

--- a/scheduler/scheduler-client/src/test/java/functionaltests/job/serialization/ClientJobStateSerializationTest.java
+++ b/scheduler/scheduler-client/src/test/java/functionaltests/job/serialization/ClientJobStateSerializationTest.java
@@ -135,6 +135,11 @@ public class ClientJobStateSerializationTest {
         }
 
         @Override
+        public String getDomain() {
+            return null;
+        }
+
+        @Override
         public JobType getType() {
             return null;
         }

--- a/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobStateTest.java
+++ b/scheduler/scheduler-client/src/test/java/org/ow2/proactive/scheduler/job/ClientJobStateTest.java
@@ -203,6 +203,11 @@ public class ClientJobStateTest {
             }
 
             @Override
+            public String getDomain() {
+                return null;
+            }
+
+            @Override
             public JobType getType() {
                 return null;
             }
@@ -245,6 +250,11 @@ public class ClientJobStateTest {
 
         @Override
         public String getTenant() {
+            return null;
+        }
+
+        @Override
+        public String getDomain() {
             return null;
         }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerFileLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerFileLoginModule.java
@@ -28,6 +28,9 @@ package org.ow2.proactive.scheduler.authentication;
 import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.FileLoginModule;
@@ -50,14 +53,7 @@ public class SchedulerFileLoginModule extends FileLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-        String loginFile = PASchedulerProperties.SCHEDULER_LOGIN_FILENAME.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PASchedulerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return SchedulerJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -67,14 +63,7 @@ public class SchedulerFileLoginModule extends FileLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PASchedulerProperties.SCHEDULER_GROUP_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PASchedulerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return SchedulerJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -84,14 +73,12 @@ public class SchedulerFileLoginModule extends FileLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
-        }
+        return SchedulerJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return SchedulerJaasConfigUtils.getConfiguredDomains();
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerJaasConfigUtils.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerJaasConfigUtils.java
@@ -1,0 +1,88 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.authentication;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+
+
+public class SchedulerJaasConfigUtils {
+
+    static String getLoginFileName() {
+        String loginFile = PASchedulerProperties.SCHEDULER_LOGIN_FILENAME.getValueAsString();
+        //test that login file path is an absolute path or not
+        if (!(new File(loginFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            loginFile = PASchedulerProperties.getAbsolutePath(loginFile);
+        }
+
+        return loginFile;
+    }
+
+    static String getGroupFileName() {
+        String groupFile = PASchedulerProperties.SCHEDULER_GROUP_FILENAME.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(groupFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            groupFile = PASchedulerProperties.getAbsolutePath(groupFile);
+        }
+
+        return groupFile;
+    }
+
+    static String getTenantFileName() {
+        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
+        //test that group file path is an absolute path or not
+        if (!(new File(tenantFile).isAbsolute())) {
+            //file path is relative, so we complete the path with the prefix RM_Home constant
+            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
+        }
+
+        return tenantFile;
+    }
+
+    static Set<String> getConfiguredDomains() {
+        if (PASchedulerProperties.SCHEDULER_ALLOWED_DOMAINS.isSet()) {
+            return PASchedulerProperties.SCHEDULER_ALLOWED_DOMAINS.getValueAsList(",")
+                                                                  .stream()
+                                                                  .map(domain -> domain.toLowerCase())
+                                                                  .collect(Collectors.toSet());
+        } else {
+            // windows current machine domain
+            String currentMachineDomain = System.getenv("USERDOMAIN");
+            if (currentMachineDomain != null) {
+                return Collections.singleton(currentMachineDomain.toLowerCase());
+            } else {
+                return new HashSet<>();
+            }
+        }
+    }
+}

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerLDAPLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerLDAPLoginModule.java
@@ -28,6 +28,9 @@ package org.ow2.proactive.scheduler.authentication;
 import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.LDAPLoginModule;
@@ -64,14 +67,7 @@ public class SchedulerLDAPLoginModule extends LDAPLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-        String loginFile = PASchedulerProperties.SCHEDULER_LOGIN_FILENAME.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PASchedulerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return SchedulerJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -81,14 +77,7 @@ public class SchedulerLDAPLoginModule extends LDAPLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PASchedulerProperties.SCHEDULER_GROUP_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PASchedulerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return SchedulerJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -98,14 +87,12 @@ public class SchedulerLDAPLoginModule extends LDAPLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
-        }
+        return SchedulerJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return SchedulerJaasConfigUtils.getConfiguredDomains();
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerMultiLDAPLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerMultiLDAPLoginModule.java
@@ -28,9 +28,7 @@ package org.ow2.proactive.scheduler.authentication;
 import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.MultiLDAPLoginModule;
@@ -77,14 +75,7 @@ public class SchedulerMultiLDAPLoginModule extends MultiLDAPLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-        String loginFile = PASchedulerProperties.SCHEDULER_LOGIN_FILENAME.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PASchedulerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return SchedulerJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -94,14 +85,7 @@ public class SchedulerMultiLDAPLoginModule extends MultiLDAPLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PASchedulerProperties.SCHEDULER_GROUP_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PASchedulerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return SchedulerJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -111,14 +95,12 @@ public class SchedulerMultiLDAPLoginModule extends MultiLDAPLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
-        }
+        return SchedulerJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return SchedulerJaasConfigUtils.getConfiguredDomains();
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerPAMLoginModule.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/authentication/SchedulerPAMLoginModule.java
@@ -28,6 +28,9 @@ package org.ow2.proactive.scheduler.authentication;
 import java.io.File;
 import java.security.KeyException;
 import java.security.PrivateKey;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.ow2.proactive.authentication.PAMLoginModule;
@@ -48,14 +51,7 @@ public class SchedulerPAMLoginModule extends PAMLoginModule {
      */
     @Override
     protected String getLoginFileName() {
-        String loginFile = PASchedulerProperties.SCHEDULER_LOGIN_FILENAME.getValueAsString();
-        //test that login file path is an absolute path or not
-        if (!(new File(loginFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            loginFile = PASchedulerProperties.getAbsolutePath(loginFile);
-        }
-
-        return loginFile;
+        return SchedulerJaasConfigUtils.getLoginFileName();
     }
 
     /**
@@ -65,14 +61,7 @@ public class SchedulerPAMLoginModule extends PAMLoginModule {
      */
     @Override
     protected String getGroupFileName() {
-        String groupFile = PASchedulerProperties.SCHEDULER_GROUP_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(groupFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            groupFile = PASchedulerProperties.getAbsolutePath(groupFile);
-        }
-
-        return groupFile;
+        return SchedulerJaasConfigUtils.getGroupFileName();
     }
 
     /**
@@ -82,14 +71,12 @@ public class SchedulerPAMLoginModule extends PAMLoginModule {
      */
     @Override
     protected String getTenantFileName() {
-        String tenantFile = PASchedulerProperties.SCHEDULER_TENANT_FILENAME.getValueAsString();
-        //test that group file path is an absolute path or not
-        if (!(new File(tenantFile).isAbsolute())) {
-            //file path is relative, so we complete the path with the prefix RM_Home constant
-            tenantFile = PASchedulerProperties.getAbsolutePath(tenantFile);
-        }
+        return SchedulerJaasConfigUtils.getTenantFileName();
+    }
 
-        return tenantFile;
+    @Override
+    protected Set<String> getConfiguredDomains() {
+        return SchedulerJaasConfigUtils.getConfiguredDomains();
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -558,6 +558,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         // setting the job properties
         job.setOwner(ident.getUsername());
         job.setTenant(ident.getTenant());
+        job.setDomain(ident.getDomain());
         // route project name inside job info
         job.setProjectName(job.getProjectName());
         if (job.getGenericInformation() != null) {
@@ -1598,6 +1599,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         userData.setUserName(userSessionInfo.getRight().getUsername());
         userData.setGroups(userSessionInfo.getRight().getGroups());
         userData.setTenant(userSessionInfo.getRight().getTenant());
+        userData.setDomain(userSessionInfo.getRight().getDomain());
         userData.setFilterByTenant(PASchedulerProperties.SCHEDULER_TENANT_FILTER.getValueAsBoolean());
         userData.setAllTenantPermission(userSessionInfo.getRight().isAllTenantPermission());
         userData.setAllJobPlannerPermission(userSessionInfo.getRight().isAllJobPlannerPermission());
@@ -1645,12 +1647,15 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
 
     IdentifiedJob toIdentifiedJob(ClientJobState clientJobState) {
         UserIdentificationImpl uIdent = new UserIdentificationImpl(clientJobState.getOwner(),
-                                                                   clientJobState.getTenant());
+                                                                   clientJobState.getTenant(),
+                                                                   clientJobState.getDomain());
         return new IdentifiedJob(clientJobState.getId(), uIdent, clientJobState.getGenericInformation());
     }
 
     IdentifiedJob toIdentifiedJob(JobInfo jobInfo) {
-        UserIdentificationImpl uIdent = new UserIdentificationImpl(jobInfo.getJobOwner(), jobInfo.getTenant());
+        UserIdentificationImpl uIdent = new UserIdentificationImpl(jobInfo.getJobOwner(),
+                                                                   jobInfo.getTenant(),
+                                                                   jobInfo.getDomain());
         return new IdentifiedJob(jobInfo.getJobId(), uIdent, jobInfo.getGenericInformation());
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -188,6 +188,8 @@ public class JobData implements Serializable {
 
     private String tenant;
 
+    private String domain;
+
     private String jobName;
 
     private long submittedTime;
@@ -271,6 +273,7 @@ public class JobData implements Serializable {
         jobInfo.setJobId(jobId);
         jobInfo.setJobOwner(getOwner());
         jobInfo.setTenant(getTenant());
+        jobInfo.setDomain(getDomain());
         jobInfo.setProjectName(getProjectName());
         jobInfo.setBucketName(getBucketName());
         jobInfo.setLabel(getLabel());
@@ -356,6 +359,7 @@ public class JobData implements Serializable {
         internalJob.setCumulatedCoreTime(getCumulatedCoreTime());
         internalJob.setOwner(getOwner());
         internalJob.setTenant(getTenant());
+        internalJob.setDomain(getDomain());
         internalJob.setDescription(getDescription());
         internalJob.setInputSpace(getInputSpace());
         internalJob.setOutputSpace(getOutputSpace());
@@ -434,6 +438,9 @@ public class JobData implements Serializable {
         jobRuntimeData.setStatusRank(job.getStatus().getRank());
         jobRuntimeData.setOwner(job.getOwner());
         jobRuntimeData.setTenant(job.getTenant());
+        if (job.getDomain() != null) {
+            jobRuntimeData.setDomain(job.getDomain().toLowerCase());
+        }
         jobRuntimeData.setCredentials(job.getCredentials());
         jobRuntimeData.setPriority(job.getPriority());
         jobRuntimeData.setNumberOfPendingTasks(job.getNumberOfPendingTasks());
@@ -845,6 +852,15 @@ public class JobData implements Serializable {
 
     public void setTenant(String tenant) {
         this.tenant = tenant;
+    }
+
+    @Column(name = "DOMAIN", nullable = true)
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
     }
 
     // NOTE: the jobData and jobContent is basically a one to one association,

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -1307,6 +1307,23 @@ public abstract class InternalJob extends JobState {
     }
 
     /**
+     * @see org.ow2.proactive.scheduler.common.job.JobState#getDomain()
+     */
+    @Override
+    public String getDomain() {
+        return jobInfo.getDomain();
+    }
+
+    /**
+     * To set the domain name of this job owner.
+     *
+     * @param domain the domain to set.
+     */
+    public void setDomain(String domain) {
+        this.jobInfo.setDomain(domain);
+    }
+
+    /**
      * Get the credentials for this job
      *
      * @return the credentials for this job

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/common/job/JobStateTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/common/job/JobStateTest.java
@@ -114,6 +114,11 @@ public class JobStateTest extends ProActiveTestClean {
             }
 
             @Override
+            public String getDomain() {
+                return null;
+            }
+
+            @Override
             public JobType getType() {
                 return null;
             }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendStateTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendStateTest.java
@@ -80,7 +80,7 @@ public class SchedulerFrontendStateTest extends ProActiveTestClean {
 
         // create a bunch of active sessions, they will be removed in 1s
         for (int i = 0; i < 100; i++) {
-            UserIdentificationImpl identification = new UserIdentificationImpl("john", (String) null);
+            UserIdentificationImpl identification = new UserIdentificationImpl("john", (String) null, (String) null);
             identification.setHostName("localhost");
             schedulerFrontendState.connect(new UniqueID("abc" + i), identification, null);
         }

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/SchedulerFrontendTest.java
@@ -111,7 +111,9 @@ public class SchedulerFrontendTest extends ProActiveTestClean {
      */
     @Test
     public void testConnection() throws KeyException, AlreadyConnectedException {
-        schedulerFrontend.connect(new UniqueID(), new UserIdentificationImpl("admin", (String) null), null);
+        schedulerFrontend.connect(new UniqueID(),
+                                  new UserIdentificationImpl("admin", (String) null, (String) null),
+                                  null);
 
         Mockito.verify(spacesSupport, times(1)).registerUserSpace("admin", null);
     }


### PR DESCRIPTION
 - Added configuration settings to control which domains can be used during a login
 - store domain information in the JaaS subject
 - when using Multi-Ldap authentication, domain == tenant
 - In windows operating system, the domain list is by default the current windows domain
 - store domain information along the JobData in the scheduler database
 - added endpoints that return the list of configured domains