### PR TITLE
Fix getNodeSourceConfiguration when used from rmapi script binding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -510,6 +510,7 @@ def exportedProjects= [
         ":rest:rest-api",
         ":rest:rest-client",
         ":rest:rest-smartproxy",
+        ":rm:rm-api",
         ":rm:rm-client",
         ":rm:rm-server"
 ]

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMRestClient.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/client/RMRestClient.java
@@ -49,8 +49,11 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContexts;
+import org.codehaus.jackson.map.AnnotationIntrospector;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
+import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
 import org.jboss.resteasy.client.jaxrs.ClientHttpEngine;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -115,6 +118,14 @@ public class RMRestClient {
         @Override
         public ObjectMapper getContext(Class<?> objectType) {
             ObjectMapper objectMapper = new ObjectMapper();
+
+            AnnotationIntrospector primary = new JacksonAnnotationIntrospector();
+            AnnotationIntrospector secondary = new JaxbAnnotationIntrospector();
+            AnnotationIntrospector pair = new AnnotationIntrospector.Pair(primary, secondary);
+
+            objectMapper.setAnnotationIntrospector(pair);
+
+            objectMapper.configure(DeserializationConfig.Feature.USE_ANNOTATIONS, true);
             objectMapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             return objectMapper;
         }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -1262,7 +1262,7 @@ public class RMRest implements RMRestInterface {
 
     private <T> T orThrowRpe(T future) throws PermissionRestException {
         try {
-            PAFuture.getFutureValue(future);
+            future = PAFuture.getFutureValue(future);
             return future;
         } catch (SecurityException e) {
             throw new PermissionRestException(e);

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/ConfigurableField.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/ConfigurableField.java
@@ -46,6 +46,9 @@ public class ConfigurableField implements Serializable {
     @XmlJavaTypeAdapter(ConfigurableAdapter.class)
     private Configurable meta;
 
+    public ConfigurableField() {
+    }
+
     public ConfigurableField(String name, String value, Configurable configurable) {
         this.name = name;
         this.value = value;

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/NodeSourceConfiguration.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/nodesource/common/NodeSourceConfiguration.java
@@ -50,6 +50,9 @@ public class NodeSourceConfiguration implements Serializable {
 
     private PluginDescriptor policyPluginDescriptor;
 
+    public NodeSourceConfiguration() {
+    }
+
     public NodeSourceConfiguration(String nodeSourceName, boolean nodesRecoverable,
             PluginDescriptor infrastructurePluginDescriptor, PluginDescriptor policyPluginDescriptor) {
         this.nodeSourceName = nodeSourceName;


### PR DESCRIPTION
 - add a JaxbAnnotationIntrospector able to read JAXB annotations (this is required for XmlJavaTypeAdapter annotations)
 - add empty constructors in NodeSourceConfiguration and ConfigurableField
 - fix PAFuture.getFutureValue usage

 Also, add rm-api project in javadoc