### PR TITLE
Add nodeTokens selection script binding

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/rm/RMRest.java
@@ -397,6 +397,14 @@ public class RMRest implements RMRestInterface {
                                    .collect(Collectors.toList()));
             }
         });
+        state.getNodeSource().forEach(event -> {
+            if (event.getAccessTokens() != null && !event.getAccessTokens().isEmpty()) {
+                tokens.addAll(event.getAccessTokens()
+                                   .stream()
+                                   .filter(token -> (name != null ? token.matches(name) : true))
+                                   .collect(Collectors.toList()));
+            }
+        });
         if (tokens.isEmpty()) {
             return "PA:LIST()";
         } else {

--- a/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMNodeSourceEvent.java
+++ b/rm/rm-api/src/main/java/org/ow2/proactive/resourcemanager/common/event/RMNodeSourceEvent.java
@@ -25,7 +25,10 @@
  */
 package org.ow2.proactive.resourcemanager.common.event;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 import org.objectweb.proactive.annotation.PublicAPI;
 import org.ow2.proactive.resourcemanager.common.RMConstants;
@@ -70,6 +73,8 @@ public class RMNodeSourceEvent extends RMEvent {
 
     private String policyType;
 
+    private List<String> accessTokens;
+
     /**
      * ProActive Empty constructor.
      */
@@ -82,7 +87,7 @@ public class RMNodeSourceEvent extends RMEvent {
      */
     public RMNodeSourceEvent(String nodeSourceName, String nodeSourceDescription,
             LinkedHashMap<String, String> additionalInformation, String nodeSourceAdmin, String nodeSourceStatus,
-            String infrastructureType, String policyType) {
+            String infrastructureType, String policyType, String[] accessTokens) {
         this.nodeSourceName = nodeSourceName;
         this.nodeSourceDescription = nodeSourceDescription;
         this.additionalInformation = new LinkedHashMap<>(additionalInformation);
@@ -90,6 +95,7 @@ public class RMNodeSourceEvent extends RMEvent {
         this.nodeSourceStatus = nodeSourceStatus;
         this.infrastructureType = infrastructureType;
         this.policyType = policyType;
+        this.accessTokens = accessTokens != null ? Arrays.asList(accessTokens) : Collections.emptyList();
     }
 
     /**
@@ -97,7 +103,7 @@ public class RMNodeSourceEvent extends RMEvent {
      */
     public RMNodeSourceEvent(RMEventType type, String initiator, String nodeSourceName, String nodeSourceDescription,
             LinkedHashMap<String, String> additionalInformation, String nodeSourceAdmin, String nodeSourceStatus,
-            String infrastructureType, String policyType) {
+            String infrastructureType, String policyType, String[] accessTokens) {
         super(type);
         this.initiator = initiator;
         this.nodeSourceName = nodeSourceName;
@@ -107,6 +113,7 @@ public class RMNodeSourceEvent extends RMEvent {
         this.nodeSourceStatus = nodeSourceStatus;
         this.infrastructureType = infrastructureType;
         this.policyType = policyType;
+        this.accessTokens = accessTokens != null ? Arrays.asList(accessTokens) : Collections.emptyList();
     }
 
     // for testing purpose RMinitialStateTest
@@ -210,5 +217,9 @@ public class RMNodeSourceEvent extends RMEvent {
 
     public String getPolicyType() {
         return policyType;
+    }
+
+    public List<String> getAccessTokens() {
+        return accessTokens;
     }
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/core/RMCore.java
@@ -1744,7 +1744,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                             nodeSourceToRemove.getAdministrator().getName(),
                                                             NodeSourceStatus.NODES_UNDEPLOYED.toString(),
                                                             nodeSourceToRemove.getDescriptor().getInfrastructureType(),
-                                                            nodeSourceToRemove.getDescriptor().getPolicyType()));
+                                                            nodeSourceToRemove.getDescriptor().getPolicyType(),
+                                                            nodeSourceToRemove.getNodeUserAccessType().getTokens()));
 
             // asynchronously delegate the removal process to the node source
             nodeSourceToRemove.shutdown(this.caller);
@@ -1821,7 +1822,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                               descriptor.getProvider().getName(),
                                                               nodeSource.getStatus().toString(),
                                                               descriptor.getInfrastructureType(),
-                                                              descriptor.getPolicyType()));
+                                                              descriptor.getPolicyType(),
+                                                              nodeSource.getNodeUserAccessType().getTokens()));
     }
 
     // ----------------------------------------------------------------------
@@ -2239,7 +2241,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                                        nodeSourceStatus.toString(),
                                                                        nodeSource.getDescriptor()
                                                                                  .getInfrastructureType(),
-                                                                       nodeSource.getDescriptor().getPolicyType());
+                                                                       nodeSource.getDescriptor().getPolicyType(),
+                                                                       nodeSource.getNodeUserAccessType().getTokens());
 
                 if (nodeSourceCanBeRemoved(nodeSourceName)) {
                     logger.info(NODE_SOURCE_STRING + nodeSourceName + HAS_BEEN_SUCCESSFULLY +
@@ -2573,7 +2576,9 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                                   nodeSourceToRemove.getStatus().toString(),
                                                                   nodeSourceToRemove.getDescriptor()
                                                                                     .getInfrastructureType(),
-                                                                  nodeSourceToRemove.getDescriptor().getPolicyType()));
+                                                                  nodeSourceToRemove.getDescriptor().getPolicyType(),
+                                                                  nodeSourceToRemove.getNodeUserAccessType()
+                                                                                    .getTokens()));
         }
     }
 
@@ -2597,7 +2602,8 @@ public class RMCore implements ResourceManager, InitActive, RunActive {
                                                             nodeSourceToRemove.getAdministrator().getName(),
                                                             status.toString(),
                                                             nodeSourceToRemove.getDescriptor().getInfrastructureType(),
-                                                            nodeSourceToRemove.getDescriptor().getPolicyType()));
+                                                            nodeSourceToRemove.getDescriptor().getPolicyType(),
+                                                            nodeSourceToRemove.getNodeUserAccessType().getTokens()));
 
             // asynchronously delegate the removal process to the node source
             nodeSourceToRemove.shutdown(this.caller);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/NodeSource.java
@@ -645,7 +645,8 @@ public class NodeSource implements InitActive, RunActive {
                                                                   this.administrator.getName(),
                                                                   this.getStatus().toString(),
                                                                   this.getDescriptor().getInfrastructureType(),
-                                                                  this.getDescriptor().getPolicyType()));
+                                                                  this.getDescriptor().getPolicyType(),
+                                                                  this.nodeUserAccessType.getTokens()));
         }
     }
 
@@ -1101,6 +1102,7 @@ public class NodeSource implements InitActive, RunActive {
                                      this.administrator.getName(),
                                      this.getStatus().toString(),
                                      this.descriptor.getInfrastructureType(),
-                                     this.descriptor.getPolicyType());
+                                     this.descriptor.getPolicyType(),
+                                     this.nodeUserAccessType.getTokens());
     }
 }

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNodeImpl.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/rmnode/RMNodeImpl.java
@@ -112,6 +112,8 @@ public class RMNodeImpl extends AbstractRMNode {
 
     public static final String NODE_HOST_BINDING = "nodehost";
 
+    public static final String NODE_TOKENS_BINDING = "nodeTokens";
+
     /**
      * Constructs a new instance. Initial state is set to {@link NodeState#FREE}.
      *

--- a/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
+++ b/rm/rm-server/src/test/java/org/ow2/proactive/resourcemanager/core/RMCoreTest.java
@@ -71,6 +71,7 @@ import org.ow2.proactive.resourcemanager.frontend.RMMonitoringImpl;
 import org.ow2.proactive.resourcemanager.nodesource.NodeSource;
 import org.ow2.proactive.resourcemanager.nodesource.NodeSourceDescriptor;
 import org.ow2.proactive.resourcemanager.nodesource.NodeSourceStatus;
+import org.ow2.proactive.resourcemanager.nodesource.policy.AccessType;
 import org.ow2.proactive.resourcemanager.rmnode.RMDeployingNode;
 import org.ow2.proactive.resourcemanager.rmnode.RMNode;
 import org.ow2.proactive.resourcemanager.rmnode.RMNodeHelper;
@@ -130,6 +131,9 @@ public class RMCoreTest {
     @Mock
     private NodeSourceDescriptor nodeSourceDescriptor;
 
+    @Mock
+    private AccessType mockedAccessType;
+
     private NodesLockRestorationManager nodesLockRestorationManager;
 
     private NodesRecoveryManager nodesRecoveryManager;
@@ -140,6 +144,8 @@ public class RMCoreTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         when(mockedNodeSource.getDescriptor()).thenReturn(nodeSourceDescriptor);
+        when(mockedNodeSource.getNodeUserAccessType()).thenReturn(mockedAccessType);
+        when(mockedAccessType.getTokens()).thenReturn(null);
         when(nodeSourceDescriptor.getStatus()).thenReturn(NodeSourceStatus.NODES_DEPLOYED);
         when(mockedNodeSource.getStatus()).thenReturn(NodeSourceStatus.NODES_DEPLOYED);
         when(mockedNodeSource.getAdministrator()).thenReturn(mockedAdministrator);


### PR DESCRIPTION
Allows to retrieve the tokens list from a selection script (useful when there are multiple tokens defined, and the task execution must be restrained to a specific configuration)

implemented modifications in ProbablisticSelectionManager to take into account the fact that the node tokens may vary over time.

Also, allow RMRest model/tokens endpoint to return the list of tokens defined inside a node source userAccessType (and not only present inside running nodes).