### PR TITLE
Upgrade xerces and ivy versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,7 +352,7 @@ dependencies {
     nativeBundle 'net.sf.jpam:libjpam:1.1-proactive:native'
     nativeBundle 'jsr223:jsr223-powershell:0.2.3:native'
 
-    compile 'org.codehaus.groovy:groovy-all:2.4.12'
+    compile 'org.codehaus.groovy:groovy-all:2.4.21'
     compile 'commons-io:commons-io:2.7'
 }
 

--- a/common/common-api/build.gradle
+++ b/common/common-api/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testRuntime 'org.jruby:jruby-complete:9.4.3.0'
     testRuntime 'org.python:jython-standalone:2.7.3'
-    testRuntime 'org.codehaus.groovy:groovy-all:2.4.12'
+    testRuntime 'org.codehaus.groovy:groovy-all:2.4.21'
     testRuntime 'jsr223:jsr223-nativeshell:0.6.2'
     testCompile 'junit:junit:4.12'
 }

--- a/rest/rest-client/build.gradle
+++ b/rest/rest-client/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compile project(':rest:rest-api')
     compile project(":scheduler:scheduler-api")
 
-    runtime 'xerces:xercesImpl:2.11.0'
+    runtime 'xerces:xercesImpl:2.12.2'
 
     testCompile functionalTestDependencies
     testCompile project(':rest:rest-server').sourceSets.test.output

--- a/rm/rm-node/build.gradle
+++ b/rm/rm-node/build.gradle
@@ -24,8 +24,9 @@ dependencies {
     runtime 'org.jruby:jruby-complete:9.4.3.0'
     runtime 'org.python:jython-standalone:2.7.3'
 
-    runtime 'org.apache.ivy:ivy:2.1.0'
-    runtime 'org.codehaus.groovy:groovy-all:2.4.12'
+    // ivy is used in groovy for the @Grab annotation
+    runtime 'org.apache.ivy:ivy:2.5.2'
+    runtime 'org.codehaus.groovy:groovy-all:2.4.21'
     runtime 'jsr223:jsr223-nativeshell:0.6.2'
     runtime 'jsr223:jsr223-docker-compose:0.3.6'
     runtime 'jsr223:jsr223-perl:0.1.2'

--- a/scheduler/scheduler-api/build.gradle
+++ b/scheduler/scheduler-api/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     runtime 'com.fasterxml.woodstox:woodstox-core:5.0.1'
     runtime 'msv:relaxngDatatype:20050913'
     runtime 'msv:xsdlib:20050913'
-    runtime 'xerces:xercesImpl:2.11.0'
+    runtime 'xerces:xercesImpl:2.12.2'
 
     testCompile project(':common:common-api').sourceSets.test.output
 }

--- a/scheduler/scheduler-server/build.gradle
+++ b/scheduler/scheduler-server/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 
-    testCompile 'org.codehaus.groovy:groovy-all:2.4.12'
+    testCompile 'org.codehaus.groovy:groovy-all:2.4.21'
 
     testCompile 'org.jvnet.winp:winp:1.28'
     testCompile files("${System.properties['java.home']}/../lib/tools.jar")


### PR DESCRIPTION
As the upgraded ivy version is used by groovy @Grab annotation and it now requires specific java xml parser properties to work, automate the addition of these properties in the forked JVM.