### PR TITLE
Disable some tests on windows that use a ssh server

### DIFF
--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestNodeSourceThreadPool.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestNodeSourceThreadPool.java
@@ -26,6 +26,7 @@
 package functionaltests.nodesource;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +73,8 @@ public class TestNodeSourceThreadPool extends RMFunctionalTest {
 
     @Before
     public void setup() throws Exception {
+        // ignore test on windows, the windows command spawned from the ssh server fails (without any possibility to make it work)
+        assumeTrue(OperatingSystem.getOperatingSystem() != OperatingSystem.windows);
         TestSSHInfrastructureV2.startSSHServer();
     }
 

--- a/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesource/TestSSHInfrastructureV2RestartDownNodesPolicy.java
@@ -26,11 +26,13 @@
 package functionaltests.nodesource;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.proactive.core.node.Node;
+import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.resourcemanager.common.NodeState;
 import org.ow2.proactive.resourcemanager.common.RMState;
 import org.ow2.proactive.resourcemanager.common.event.RMEventType;
@@ -56,6 +58,8 @@ public class TestSSHInfrastructureV2RestartDownNodesPolicy extends RMFunctionalT
 
     @Before
     public void setup() throws Exception {
+        // ignore test on windows, the windows command spawned from the ssh server fails (without any possibility to make it work)
+        assumeTrue(OperatingSystem.getOperatingSystem() != OperatingSystem.windows);
         TestSSHInfrastructureV2.startSSHServer();
     }
 

--- a/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverSSHInfrastructureV2Test.java
+++ b/rm/rm-server/src/test/java/functionaltests/nodesrecovery/RecoverSSHInfrastructureV2Test.java
@@ -27,6 +27,7 @@ package functionaltests.nodesrecovery;
 
 import static com.google.common.truth.Truth.assertThat;
 import static functionaltests.nodesrecovery.RecoverInfrastructureTestHelper.NODES_RECOVERABLE;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.util.HashSet;
@@ -37,6 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+import org.objectweb.proactive.utils.OperatingSystem;
 import org.ow2.proactive.resourcemanager.common.NodeState;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeEvent;
 import org.ow2.proactive.resourcemanager.common.event.RMNodeSourceEvent;
@@ -68,6 +70,8 @@ public class RecoverSSHInfrastructureV2Test extends RMFunctionalTest {
 
     @Before
     public void setup() throws Exception {
+        // ignore test on windows, the windows command spawned from the ssh server fails (without any possibility to make it work)
+        assumeTrue(OperatingSystem.getOperatingSystem() != OperatingSystem.windows);
         TestSSHInfrastructureV2.startSSHServer();
         RMTHelper.log("SSH server started");
     }


### PR DESCRIPTION
Using a more recent JRE fail these tests (which are not essential on windows).