### PR TITLE
Switch default mode of HSQLDB tables to cached.

### DIFF
--- a/config/hsqldb-server.properties
+++ b/config/hsqldb-server.properties
@@ -2,7 +2,7 @@
 # ProActive Workflows and Scheduling with the default embedded
 # database, namely HSQLDB, in server mode.
 
-server.catalogs.option_line=create=true;hsqldb.tx=mvcc;hsqldb.applog=0;hsqldb.sqllog=0;hsqldb.write_delay=false;hsqldb.lob_file_scale=1;sql.nulls_order=false
+server.catalogs.option_line=create=true;hsqldb.tx=mvcc;hsqldb.default_table_type=cached;hsqldb.applog=0;hsqldb.sqllog=0;hsqldb.write_delay=false;hsqldb.lob_file_scale=1;sql.nulls_order=false
 
 # See HSQLDB configuration (table 14.1) for a description of
 # the following properties:


### PR DESCRIPTION
Using cached tables might degrade a bit the performance but should prevent OOM errors when HSQLDB is used and the database is expanding.