### PR TITLE
Perform scheduler houskeeping in seperate transactions

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -1637,7 +1637,11 @@ public class SchedulerDBManager {
     public void executeHousekeepingInDB(final List<Long> jobIdList, final boolean shouldRemoveFromDb) {
         List<List<Long>> jobIdSubSets = Lists.partition(jobIdList, MAX_ITEMS_IN_LIST);
         for (List<Long> jobIdSubList : jobIdSubSets) {
-            executeReadWriteTransaction(new HousekeepingSessionWork(jobIdSubList, shouldRemoveFromDb));
+            HousekeepingSessionWork housekeepingSessionWork = new HousekeepingSessionWork(jobIdSubList,
+                                                                                          shouldRemoveFromDb);
+            for (SessionWork<Integer> sessionWork : housekeepingSessionWork.getAllTransactions()) {
+                executeReadWriteTransaction(sessionWork);
+            }
         }
     }
 


### PR DESCRIPTION
Instead of using a single transaction for all operations, we perform a transaction for each operation.

This is a tentative fix for a deadlock issue which appeared on Oracle