### PR TITLE
Improve SchedulerState serialization

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -400,7 +400,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
 
         return Lambda.withLock(stateReadLock,
                                () -> myJobsOnly ? schedulerState.filterOnUser(ui.getUser().getUsername())
-                                                : schedulerState);
+                                                : schedulerState.copy());
 
     }
 


### PR DESCRIPTION
implement readObject / writeObject methods to avoid serializing synchronized maps