### PR TITLE
RMNodeStarter: do not call loadSigarIfRunningWithOneJar if monitoring…

### DIFF
--- a/config/log/scriptengines.properties
+++ b/config/log/scriptengines.properties
@@ -7,6 +7,7 @@ log4j.logger.jsr223.docker.compose.utils.DockerComposePropertyLoader=INFO, CONSO
 log4j.logger.jsr223.perl.utils.PerlPropertyLoader=INFO, CONSOLE
 log4j.logger.jsr223.cpython=WARN, CONSOLE
 log4j.logger.jsr223.scala=WARN, CONSOLE
+log4j.logger.org.ow2.proactive.scripting.GroovyClassInfoHandler=OFF, CONSOLE
 
 # File appender - add logs to Node logs because nodes execute the scriptengine
 log4j.appender.SCRIPTENGINES=org.apache.log4j.RollingFileAppender

--- a/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
+++ b/rm/rm-node/src/main/java/org/ow2/proactive/resourcemanager/utils/RMNodeStarter.java
@@ -468,9 +468,12 @@ public class RMNodeStarter {
         configureSecurityManager();
         configureRMAndProActiveHomes();
         configureProActiveDefaultConfigurationFile();
-        loadSigarIfRunningWithOneJar();
 
         String nodeName = parseCommandLine(args);
+
+        if (!disabledMonitoring) {
+            loadSigarIfRunningWithOneJar();
+        }
 
         configureLogging(nodeName);
 


### PR DESCRIPTION
… is disabled

also, disable GroovyClassInfoHandler log in forked jvm output