### PR TITLE
Add base path configuration in config/web/settings.ini

### DIFF
--- a/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
+++ b/common/common-http/src/main/java/org/ow2/proactive/web/WebProperties.java
@@ -138,6 +138,12 @@ public enum WebProperties implements PACommonProperties {
 
     WEB_CONTENT_SECURITY_POLICY_REPORT_ONLY("web.content.security.policy.report.only", PropertyType.STRING),
 
+    /**
+     * Can be used when the server is receiving http requests relative to a base path. In that case incoming requests will be rewritten
+     * e.g. /base_path/resource/ will be rewritten to /resource/
+     */
+    WEB_BASE_PATH("web.base.path", PropertyType.STRING),
+
     WEB_PCA_PROXY_REWRITE_ENABLED("web.pca.proxy.rewrite.enabled", PropertyType.BOOLEAN, "true"),
 
     WEB_PCA_PROXY_REWRITE_REFERER_CACHE_SIZE("web.pca.proxy.rewrite.referer.cache.size", PropertyType.INTEGER, "10000"),

--- a/config/web/settings.ini
+++ b/config/web/settings.ini
@@ -88,6 +88,10 @@ web.https.cyphers.excluded.add=TLS_DHE.*,TLS_EDH.*
 # web.content.security.policy=default-src 'self' example.com *.example.com
 # web.content.security.policy.report.only=default-src 'self' example.com *.example.com
 
+# Can be used when the server is receiving http requests relative to a base path. In that case incoming requests will be rewritten
+# e.g. /base/path/resource/ will be rewritten to /resource/
+# web.base.path=/base/path
+
 # Enable PCA Proxy rewriter to route requests coming from proxyfied applications
 web.pca.proxy.rewrite.enabled=true
 


### PR DESCRIPTION
This property allows to silently rewrite incoming requests /base/path/resource/ to /resource/

Also, /base/path will be redirected to /base/path/ to allow the browser to issue requests without a missing slash