### PR TITLE
Add JPCanCreateAssociationPermission

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
@@ -57,6 +57,8 @@ public class UserData implements Serializable {
 
     private boolean allJobPlannerPermission;
 
+    private boolean canCreateAssociationPermission;
+
     private boolean pcaAdminPermission;
 
     private boolean notificationAdminPermission;
@@ -131,6 +133,14 @@ public class UserData implements Serializable {
 
     public void setAllJobPlannerPermission(boolean allJobPlannerPermission) {
         this.allJobPlannerPermission = allJobPlannerPermission;
+    }
+
+    public boolean isCanCreateAssociationPermission() {
+        return canCreateAssociationPermission;
+    }
+
+    public void setCanCreateAssociationPermission(boolean canCreateAssociationPermission) {
+        this.canCreateAssociationPermission = canCreateAssociationPermission;
     }
 
     public boolean isPcaAdminPermission() {

--- a/config/security.java.policy-server
+++ b/config/security.java.policy-server
@@ -83,6 +83,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithBucketNamePermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGroupNamePermission "";
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.write";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
@@ -213,6 +214,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
     permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
     permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
@@ -266,6 +268,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
     permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
     permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
@@ -323,6 +326,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
     permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
     permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
@@ -480,6 +484,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithBucketNamePermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGroupNamePermission "";
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
 
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.write";

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
@@ -99,6 +99,11 @@ public class UserIdentificationImpl extends UserIdentification {
     }
 
     @Override
+    public boolean isCanCreateAssociationPermission() {
+        return false;
+    }
+
+    @Override
     public boolean isAllJobPlannerPermission() {
         return false;
     }

--- a/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
+++ b/rest/rest-server/src/test/resources/functionaltests/config/server-java.security.policy
@@ -208,6 +208,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
     permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
     permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
@@ -261,6 +262,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
     permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
     permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
@@ -97,6 +97,11 @@ public abstract class UserIdentification implements Serializable, Comparable<Use
     public abstract boolean isAllJobPlannerPermission();
 
     /**
+     * Check if the user can create a job-planner association
+     */
+    public abstract boolean isCanCreateAssociationPermission();
+
+    /**
      * Check if the user has all Service Automation permissions
      */
     public abstract boolean isPcaAdminPermission();

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/UserIdentificationImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/UserIdentificationImpl.java
@@ -187,6 +187,15 @@ public class UserIdentificationImpl extends UserIdentification {
     }
 
     @Override
+    public boolean isCanCreateAssociationPermission() {
+        try {
+            return checkPermission(new JPCanCreateAssociationPermission(), "N/A");
+        } catch (PermissionException e) {
+            return false;
+        }
+    }
+
+    @Override
     public boolean isPcaAdminPermission() {
         try {
             return checkPermission(new PcaAdminPermission(), "N/A");

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/permissions/JPCanCreateAssociationPermission.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/permissions/JPCanCreateAssociationPermission.java
@@ -1,0 +1,36 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.scheduler.permissions;
+
+import org.ow2.proactive.permissions.ClientPermission;
+
+
+/**
+ * If pa.scheduler.core.tenant.filter is enabled, this permission allows a user to fully control the job planner,
+ * regardless of which tenant the user belongs to.
+ */
+public class JPCanCreateAssociationPermission extends ClientPermission {
+}

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -1604,6 +1604,7 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         userData.setFilterByTenant(PASchedulerProperties.SCHEDULER_TENANT_FILTER.getValueAsBoolean());
         userData.setAllTenantPermission(userSessionInfo.getRight().isAllTenantPermission());
         userData.setAllJobPlannerPermission(userSessionInfo.getRight().isAllJobPlannerPermission());
+        userData.setCanCreateAssociationPermission(userSessionInfo.getRight().isCanCreateAssociationPermission());
         userData.setSchedulerAdminPermission(userSessionInfo.getRight().isSchedulerAdminPermission());
         userData.setRmCoreAllPermission(userSessionInfo.getRight().isRMCoreAllPermission());
         userData.setPcaAdminPermission(userSessionInfo.getRight().isPcaAdminPermission());


### PR DESCRIPTION
This permission is aimed to be checked by the job-planner service (and portal) to ensure that the user has the right to create an association

Accordingly, added this permission to all users that have access to the job-planner portal.
Can be disabled for read-only users (e.g. guests).