### PR TITLE
Ensure DB backward compatibility

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -891,11 +891,11 @@ public class JobData implements Serializable {
     }
 
     @Column(name = "CUMULATED_CORE_TIME")
-    public long getCumulatedCoreTime() {
+    public Long getCumulatedCoreTime() {
         return cumulatedCoreTime != null ? cumulatedCoreTime : 0L;
     }
 
-    public void setCumulatedCoreTime(long cumulatedCoreTime) {
+    public void setCumulatedCoreTime(Long cumulatedCoreTime) {
         this.cumulatedCoreTime = cumulatedCoreTime;
     }
 


### PR DESCRIPTION
Use wrapper Long object instead of primitive long to be able to retrieve null from DB for new cumulatedCoreTime field.
Also retorn a Long in getter for the sake of consistency.

Fixes:

```
org.ow2.proactive.db.DatabaseManagerException: javax.persistence.PersistenceException: org.hibernate.PropertyAccessException:
Null value was assigned to a property of primitive type setter of org.ow2.proactive.scheduler.core.db.JobData.cumulatedCoreTime
```