### PR TITLE
Improve performance of ExtendedSchedulerPolicy

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -165,8 +165,11 @@ pa.scheduler.startscripts.paths=tools/LoadPackages.groovy
 # Size of parsed workflow cache, used to optimize workflow submission time
 pa.scheduler.stax.job.cache=1000
 
-# Size of the cache used to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds)
+# Size of the cache used by the scheduling policy to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds)
 pa.scheduler.startat.cache=5000
+
+# optimization cache used used by the scheduling policy to avoid parsing the same pending jobs continuously
+pa.scheduler.startat.value.cache=30000
 
 # Expiration period in seconds of cache used to download workflows
 pa.scheduler.download.cache.expiration=60

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -149,8 +149,11 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Size of parsed workflow cache, used to optimize workflow submission time */
     SCHEDULER_STAX_JOB_CACHE("pa.scheduler.stax.job.cache", PropertyType.INTEGER, "1000"),
 
-    /** size of the cache used to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds) **/
+    /** size of the cache used by the scheduling policy to ensure that delayed jobs or tasks are scheduled at the precise date (without skipping seconds) **/
     SCHEDULER_STARTAT_CACHE("pa.scheduler.startat.cache", PropertyType.INTEGER, "5000"),
+
+    /** optimization cache used by the scheduling policy to avoid parsing the same pending jobs continuously **/
+    SCHEDULER_STARTAT_VALUE_CACHE("pa.scheduler.startat.value.cache", PropertyType.INTEGER, "30000"),
 
     /** Expiration period in seconds of cache used to download workflows */
     SCHEDULER_DOWNLOAD_CACHE_EXPIRATION("pa.scheduler.download.cache.expiration", PropertyType.INTEGER, "60"),

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingMethodImpl.java
@@ -360,6 +360,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
 
         schedulingMainLoopTimingLogger.end("loadAndInit");
 
+        currentPolicy.beforeIsTaskExecutable();
         while (!tasksRetrievedFromPolicy.isEmpty() &&
                (!PASchedulerProperties.SCHEDULER_POLCY_STRICT_FIFO.getValueAsBoolean() || !freeResources.isEmpty())) {
 
@@ -477,6 +478,7 @@ public final class SchedulingMethodImpl implements SchedulingMethod {
             schedulingMainLoopTimingLogger.end("createExecutions");
 
         }
+        currentPolicy.afterIsTaskExecutable();
 
         // number of nodes needed to start all pending tasks
         updateNeededNodes(neededNodes);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/Policy.java
@@ -106,6 +106,20 @@ public abstract class Policy implements Serializable {
     }
 
     /**
+     * Can be overridden to perform actions before multiple isTaskExecutable are called
+     */
+    public void beforeIsTaskExecutable() {
+
+    }
+
+    /**
+     * Can be overridden to perform actions after multiple isTaskExecutable are called
+     */
+    public void afterIsTaskExecutable() {
+
+    }
+
+    /**
      * Set the RM state
      *
      * @param state resource manager state

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/MultipleTimingLogger.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/MultipleTimingLogger.java
@@ -90,6 +90,10 @@ public class MultipleTimingLogger {
         }
     }
 
+    public void clear() {
+        allTimings.clear();
+    }
+
 }
 
 class TimingModel {


### PR DESCRIPTION
 - use an LRU cache for getStartAtValue (this prevents costly operations over the same job and task)
 - changed the key of delayedJobsWakeUpCache to be the startAt time instead of job id
 - added timer loggers to monitor performances when the logger is in debug