### PR TITLE
Fix updateStartAt

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -119,9 +119,11 @@ class LiveJobs {
 
     private final OnErrorPolicyInterpreter onErrorPolicyInterpreter = new OnErrorPolicyInterpreter();
 
-    private final StartAtUpdater startAtUpdater = new StartAtUpdater();
+    private final StartAtUpdater startAtUpdater;
 
     private final SynchronizationInternal synchronizationInternal;
+
+    private SchedulingService service;
 
     private static final String SIGNAL_ORIGINATOR = "scheduler";
 
@@ -129,10 +131,13 @@ class LiveJobs {
 
     private static final TaskId SIGNAL_TASK_ID = TaskIdImpl.makeTaskId(SIGNAL_TASK);
 
-    LiveJobs(SchedulerDBManager dbManager, SchedulerStateUpdate listener, SynchronizationInternal synchronizationAPI) {
+    LiveJobs(SchedulerDBManager dbManager, SchedulerStateUpdate listener, SynchronizationInternal synchronizationAPI,
+            SchedulingService service) {
         this.dbManager = dbManager;
         this.listener = listener;
         this.synchronizationInternal = synchronizationAPI;
+        this.service = service;
+        this.startAtUpdater = new StartAtUpdater(service);
     }
 
     Collection<RunningTaskData> getRunningTasks() {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -140,7 +140,7 @@ public class SchedulingService {
             SynchronizationInternal synchronizationAPI) throws Exception {
         this.infrastructure = infrastructure;
         this.listener = listener;
-        this.jobs = new LiveJobs(infrastructure.getDBManager(), listener, synchronizationAPI);
+        this.jobs = new LiveJobs(infrastructure.getDBManager(), listener, synchronizationAPI, this);
         if (recoveredState != null) {
             recover(recoveredState);
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
@@ -198,6 +198,12 @@ public class ExtendedSchedulerPolicy extends DefaultPolicy {
         return executionCycleJobs;
     }
 
+    public void updateStartAt(String key, String startAt) {
+        if (startAtCache.containsKey(key)) {
+            startAtCache.put(key, startAt);
+        }
+    }
+
     private String getStartAtValue(JobDescriptor jobDesc) {
         String key = jobDesc.getJobId().value();
         if (startAtCache.containsKey(key)) {

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/LiveJobsTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/LiveJobsTest.java
@@ -84,7 +84,7 @@ public class LiveJobsTest extends ProActiveTestClean {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
-        liveJobs = new LiveJobs(dbManager, listener, null);
+        liveJobs = new LiveJobs(dbManager, listener, null, null);
     }
 
     @Test(timeout = 60000)

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.ow2.proactive.scheduler.common.util.ISO8601DateUtil;
+import org.ow2.proactive.scheduler.core.SchedulingService;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptorImpl;
 import org.ow2.proactive.scheduler.job.InternalJob;
@@ -65,9 +66,12 @@ public class StartAtUpdaterTest {
     @Mock
     private SchedulerDBManager dbManager;
 
+    @Mock
+    private SchedulingService service;
+
     @Before
     public void init() {
-        this.startAtUpdater = new StartAtUpdater();
+        this.startAtUpdater = new StartAtUpdater(service);
         MockitoAnnotations.initMocks(this);
 
         when(internalJob.getJobDescriptor()).thenReturn(jobDescriptor);


### PR DESCRIPTION
When updating the startAt value of a pending job, the cache used by ExtendedSchedulerPolicy need to be updated.

Accordingly, the StartAtUpdater must be able to retrieve the policy instance and ask it to update the startAt value of a given job or task.