### PR TITLE
Add startAt to JobData and Jobinfo

### DIFF
--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/SchedulerRestInterface.java
@@ -2694,6 +2694,25 @@ public interface SchedulerRestInterface {
     final String startAt) throws RestException;
 
     /**
+     * Change the START_AT generic information for multiple jobs and reset the
+     * scheduledAt at task level
+     *
+     * @param sessionId
+     *            current session
+     * @param startAt
+     *            its value should be ISO 8601 compliant
+     * @param jobIdList
+     *      a list of job ids as JSON body
+     */
+    @PUT
+    @Path("jobs/startat/{startAt}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    boolean changeStartAtMultiple(@HeaderParam("sessionid")
+    final String sessionId, @PathParam("startAt")
+    final String startAt, List<String> jobIdList) throws RestException;
+
+    /**
      * Get portal configuration properties
      */
     @GET

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/dto/JobInfoData.java
@@ -113,6 +113,8 @@ public class JobInfoData implements java.io.Serializable {
 
     private String submissionMode;
 
+    private Long startAt = null;
+
     public void setToBeRemoved() {
         toBeRemoved = true;
     }
@@ -425,6 +427,14 @@ public class JobInfoData implements java.io.Serializable {
         this.numberOfNodesInParallel = numberOfNodesInParallel;
     }
 
+    public Long getStartAt() {
+        return startAt;
+    }
+
+    public void setStartAt(Long startAt) {
+        this.startAt = startAt;
+    }
+
     @Override
     public String toString() {
         return "JobInfoData{ " + "startTime=" + startTime + ", finishedTime=" + finishedTime + ", submittedTime=" +
@@ -439,7 +449,7 @@ public class JobInfoData implements java.io.Serializable {
                ", detailedSignals=" + detailedSignals + ", attachedServices=" + attachedServices +
                ", externalEndpointUrls=" + externalEndpointUrls + ", cumulatedCoreTime=" + cumulatedCoreTime +
                ", numberOfNodes=" + numberOfNodes + ", numberOfNodesInParallel=" + numberOfNodesInParallel +
-               ", submissionMode=" + submissionMode + " }";
+               ", submissionMode=" + submissionMode + ", startAt=" + startAt + " }";
     }
 
 }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/SchedulerClient.java
@@ -1574,6 +1574,7 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         jobInfoImpl.setResultMapPresent(jobInfoData.isResultMapPresent());
         jobInfoImpl.setLabel(jobInfoData.getLabel());
         jobInfoImpl.setSubmissionMode(jobInfoData.getSubmissionMode());
+        jobInfoImpl.setStartAt(jobInfoData.getStartAt());
         return jobInfoImpl;
     }
 
@@ -1583,6 +1584,19 @@ public class SchedulerClient extends ClientBase implements ISchedulerClient {
         boolean isJobStartAtChanged = false;
         try {
             isJobStartAtChanged = restApi().changeStartAt(sid, jobId.value(), startAt);
+        } catch (Exception e) {
+            throwUJEOrNCEOrPE(e);
+        }
+        return isJobStartAtChanged;
+    }
+
+    @Override
+    public boolean changeStartAt(List<JobId> jobIdList, String startAt)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        boolean isJobStartAtChanged = false;
+        try {
+            List<String> jobIds = jobIdList.stream().map(jobId -> jobId.value()).collect(Collectors.toList());
+            isJobStartAtChanged = restApi().changeStartAtMultiple(sid, startAt, jobIds);
         } catch (Exception e) {
             throwUJEOrNCEOrPE(e);
         }

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/DataUtility.java
@@ -102,6 +102,7 @@ public class DataUtility {
         impl.setNumberOfNodes(d.getNumberOfNodes());
         impl.setSubmissionMode(d.getSubmissionMode());
         impl.setLabel(d.getLabel());
+        impl.setStartAt(d.getStartAt());
         return impl;
     }
 

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/JobInfoImpl.java
@@ -117,6 +117,8 @@ public class JobInfoImpl implements JobInfo {
 
     private Long parentId;
 
+    private Long startAt;
+
     private int childrenCount;
 
     public void setFinishedTime(long finishedTime) {
@@ -495,5 +497,14 @@ public class JobInfoImpl implements JobInfo {
 
     public void setChildrenCount(int childrenCount) {
         this.childrenCount = childrenCount;
+    }
+
+    @Override
+    public Long getStartAt() {
+        return startAt;
+    }
+
+    public void setStartAt(Long startAt) {
+        this.startAt = startAt;
     }
 }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -3526,6 +3526,20 @@ public class SchedulerStateRest implements SchedulerRestInterface {
     }
 
     @Override
+    public boolean changeStartAtMultiple(String sessionId, String startAt, List<String> jobIdList)
+            throws RestException {
+        try {
+            final Scheduler s = checkAccess(sessionId, "PUT jobs/startat");
+            List<JobId> jobIds = jobIdList.stream()
+                                          .map(jobId -> JobIdImpl.makeJobId(jobId))
+                                          .collect(Collectors.toList());
+            return s.changeStartAt(jobIds, startAt);
+        } catch (SchedulerException e) {
+            throw RestException.wrapExceptionToRest(e);
+        }
+    }
+
+    @Override
     public Map<Object, Object> getPortalConfiguration(String sessionId) throws RestException {
         try {
             final Scheduler s = checkAccess(sessionId, "GET configuration/portal");

--- a/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
+++ b/rest/rest-smartproxy/src/main/java/org/ow2/proactive_grid_cloud_portal/smartproxy/RestSmartProxyImpl.java
@@ -717,6 +717,12 @@ public class RestSmartProxyImpl extends AbstractSmartProxy<RestJobTrackerImpl>
     }
 
     @Override
+    public boolean changeStartAt(List<JobId> jobIdList, String startAt)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        return _getScheduler().changeStartAt(jobIdList, startAt);
+    }
+
+    @Override
     public String getJobContent(JobId jobId) throws SchedulerException {
         return _getScheduler().getJobContent(jobId);
     }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/JobSortParameter.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/JobSortParameter.java
@@ -45,5 +45,6 @@ public enum JobSortParameter {
     FINISHED_TASKS,
     FAILED_TASKS,
     FAULTY_TASKS,
-    IN_ERROR_TASKS
+    IN_ERROR_TASKS,
+    START_AT
 }

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/Scheduler.java
@@ -1918,6 +1918,19 @@ public interface Scheduler extends SchedulerUsage, ThirdPartyCredentials, Servic
             throws NotConnectedException, UnknownJobException, PermissionException;
 
     /**
+     * Change the START_AT generic information for multiple jobs at job level and reset the
+     * scheduledAt at task level
+     *
+     * @param jobIdList
+     *            id of the jobs that needs to be updated
+     * @param startAt
+     *            its value should be ISO 8601 compliant
+     */
+    @RoleWrite
+    boolean changeStartAt(List<JobId> jobIdList, String startAt)
+            throws NotConnectedException, UnknownJobException, PermissionException;
+
+    /**
      * @param jobId job id of existing job
      * @return copy of the xml which was submitted to the scheduler
      */

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/Job.java
@@ -154,6 +154,11 @@ public abstract class Job extends CommonAttribute {
     protected String submissionMode = "";
 
     /**
+     * Return the scheduled time of the job, defined by the generic information START_AT
+     */
+    protected Long startAt = null;
+
+    /**
      * ProActive Empty Constructor
      */
     public Job() {
@@ -457,6 +462,14 @@ public abstract class Job extends CommonAttribute {
             replacementVariables.put(variable.getName(), variable.getValue());
         }
         return replacementVariables;
+    }
+
+    public Long getStartAt() {
+        return startAt;
+    }
+
+    public void setStartAt(Long startAt) {
+        this.startAt = startAt;
     }
 
     @Override

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/JobInfo.java
@@ -363,6 +363,12 @@ public interface JobInfo extends Serializable {
     Long getParentId();
 
     /**
+     * Return the scheduled time of the job, defined by the generic information START_AT
+     * @return scheduled time of the job of the job, or null it is not defined
+     */
+    Long getStartAt();
+
+    /**
      * Return the number of children jobs
      * @return number of children jobs
      */

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/common/util/SchedulerProxyUserInterface.java
@@ -928,6 +928,13 @@ public class SchedulerProxyUserInterface implements Scheduler, Serializable, Sch
 
     @Override
     @ImmediateService
+    public boolean changeStartAt(List<JobId> jobIdList, String startAt)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        return uischeduler.changeStartAt(jobIdList, startAt);
+    }
+
+    @Override
+    @ImmediateService
     public String getJobContent(JobId jobId) throws SchedulerException {
         return uischeduler.getJobContent(jobId);
     }

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/ClientJobState.java
@@ -174,6 +174,7 @@ public class ClientJobState extends JobState {
         }
         // update job info
         this.jobInfo = new JobInfoImpl((JobInfoImpl) info);
+        this.setGenericInformation(jobInfo.getGenericInformation());
         // update skipped tasks
         if (this.jobInfo.getTasksSkipped() != null) {
             for (TaskId id : tasks.keySet()) {

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/JobInfoImpl.java
@@ -162,6 +162,8 @@ public class JobInfoImpl implements JobInfo {
 
     private Long parentId = null;
 
+    private Long startAt = null;
+
     private int childrenCount = 0;
 
     private String submissionMode = null;
@@ -222,6 +224,7 @@ public class JobInfoImpl implements JobInfo {
         this.preciousTasks = jobInfo.getPreciousTasks();
         this.parentId = jobInfo.getParentId();
         this.childrenCount = jobInfo.getChildrenCount();
+        this.startAt = jobInfo.getStartAt();
     }
 
     /**
@@ -685,6 +688,15 @@ public class JobInfoImpl implements JobInfo {
 
     public void setParentId(Long parentId) {
         this.parentId = parentId;
+    }
+
+    @Override
+    public Long getStartAt() {
+        return startAt;
+    }
+
+    public void setStartAt(Long startAt) {
+        this.startAt = startAt;
     }
 
     @Override

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.java
@@ -965,6 +965,13 @@ public class SchedulerNodeClient implements ISchedulerClient, Serializable {
     }
 
     @Override
+    public boolean changeStartAt(List<JobId> jobIdList, String startAt)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        renewSession();
+        return client.changeStartAt(jobIdList, startAt);
+    }
+
+    @Override
     public String getJobContent(JobId jobId) throws SchedulerException {
         renewSession();
         return client.getJobContent(jobId);

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/LiveJobs.java
@@ -365,7 +365,13 @@ class LiveJobs {
             return false;
         }
         try {
-            return startAtUpdater.updateStartAt(jobData.job, startAt, dbManager);
+            boolean answer = startAtUpdater.updateStartAt(jobData.job, startAt, dbManager);
+            if (answer) {
+                listener.jobStateUpdated(jobData.job.getOwner(),
+                                         new NotificationData<JobInfo>(SchedulerEvent.JOB_UPDATED,
+                                                                       new JobInfoImpl((JobInfoImpl) jobData.job.getJobInfo())));
+            }
+            return answer;
         } finally {
             jobData.unlock();
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontend.java
@@ -2496,12 +2496,40 @@ public class SchedulerFrontend implements InitActive, Scheduler, RunActive, EndA
     @RoleWrite
     public boolean changeStartAt(JobId jobId, String startAt)
             throws UnknownJobException, NotConnectedException, PermissionException {
+        String currentUser = frontendState.getCurrentUser();
         Method currentMethod = new Object() {
         }.getClass().getEnclosingMethod();
         frontendState.checkPermissionsWrite(currentMethod,
                                             frontendState.getIdentifiedJob(jobId),
                                             YOU_DO_NOT_HAVE_PERMISSION_TO_CHANGE_THE_START_AT_VALUE_OF_THIS_JOB);
+        logger.info("Request to change startAt (scheduled time) on job " + jobId + " with new value " + startAt +
+                    " received from " + currentUser);
         return schedulingService.changeStartAt(jobId, startAt);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @ImmediateService
+    @RoleWrite
+    public boolean changeStartAt(List<JobId> jobIdList, String startAt)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        String currentUser = frontendState.getCurrentUser();
+        Method currentMethod = new Object() {
+        }.getClass().getEnclosingMethod();
+        for (JobId jobId : jobIdList) {
+            frontendState.checkPermissionsWrite(currentMethod,
+                                                frontendState.getIdentifiedJob(jobId),
+                                                YOU_DO_NOT_HAVE_PERMISSION_TO_CHANGE_THE_START_AT_VALUE_OF_THIS_JOB);
+        }
+        logger.info("Request to change startAt (scheduled time) on jobs " + jobIdList + " with new value " + startAt +
+                    " received from " + currentUser);
+        boolean answer = true;
+        for (JobId jobId : jobIdList) {
+            answer = answer && schedulingService.changeStartAt(jobId, startAt);
+        }
+        return answer;
     }
 
     @Override

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/JobData.java
@@ -112,6 +112,7 @@ import com.google.common.collect.Lists;
                 @NamedQuery(name = "updateJobDataRemovedTimeInBulk", query = "update JobData set removedTime = :removedTime, lastUpdatedTime = :lastUpdatedTime where id in (:jobIdList)"),
                 @NamedQuery(name = "updateJobDataSetJobToBeRemoved", query = "update JobData set toBeRemoved = :toBeRemoved, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "updateJobDataPriority", query = "update JobData set priority = :priority, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
+                @NamedQuery(name = "updateJobDataStartAt", query = "update JobData set startAt = :startAt, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "increaseJobDataChildrenCount", query = "update JobData set childrenCount = childrenCount+1, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "increaseJobDataChildrenCountAmount", query = "update JobData set childrenCount = childrenCount + :amount, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
                 @NamedQuery(name = "decreaseJobDataChildrenCount", query = "update JobData set childrenCount = childrenCount-1, lastUpdatedTime = :lastUpdatedTime where id = :jobId"),
@@ -161,7 +162,8 @@ import com.google.common.collect.Lists;
                                       @Index(name = "JOB_DATA_JOB_NAME", columnList = "JOB_NAME"),
                                       @Index(name = "JOB_DATA_PROJECT_NAME", columnList = "PROJECT_NAME"),
                                       @Index(name = "JOB_DATA_SUBMISSION_MODE", columnList = "SUBMISSION_MODE"),
-                                      @Index(name = "JOB_DATA_LABEL", columnList = "LABEL"), })
+                                      @Index(name = "JOB_DATA_LABEL", columnList = "LABEL"),
+                                      @Index(name = "JOB_DATA_START_AT", columnList = "START_AT DESC") })
 public class JobData implements Serializable {
 
     private static final Logger logger = Logger.getLogger(JobData.class);
@@ -268,6 +270,8 @@ public class JobData implements Serializable {
 
     private String submissionMode;
 
+    private Long startAt;
+
     JobInfoImpl createJobInfo(JobId jobId) {
         JobInfoImpl jobInfo = new JobInfoImpl();
         jobInfo.setJobId(jobId);
@@ -311,6 +315,7 @@ public class JobData implements Serializable {
         List<String> pTasks = getPreciousTasks();
         jobInfo.setPreciousTasks(pTasks);
         jobInfo.setSubmissionMode(getSubmissionMode());
+        jobInfo.setStartAt(getStartAt());
         return jobInfo;
     }
 
@@ -405,6 +410,7 @@ public class JobData implements Serializable {
             }
 
         }
+        internalJob.setStartAt(getStartAt());
         return internalJob;
     }
 
@@ -462,6 +468,7 @@ public class JobData implements Serializable {
         jobRuntimeData.setExternalEndpointUrls(job.getExternalEndpointUrls());
         jobRuntimeData.setSubmissionMode(job.getSubmissionMode());
         jobRuntimeData.setLabel(job.getLabel());
+        jobRuntimeData.setStartAt(job.getStartAt());
 
         return jobRuntimeData;
     }
@@ -944,6 +951,15 @@ public class JobData implements Serializable {
 
     public void setExternalEndpointUrls(Map<String, ExternalEndpoint> externalEndpointUrls) {
         this.externalEndpointUrls = externalEndpointUrls;
+    }
+
+    @Column(name = "START_AT", nullable = true)
+    public Long getStartAt() {
+        return startAt;
+    }
+
+    public void setStartAt(Long startAt) {
+        this.startAt = startAt;
     }
 
     public void addJobContent(Job job) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -38,10 +38,7 @@ import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import javax.persistence.criteria.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Level;
@@ -350,6 +347,9 @@ public class SchedulerDBManager {
                             break;
                         case STATE:
                             sortOrder = configureSortOrder(cb, root, param, "statusRank");
+                            break;
+                        case START_AT:
+                            sortOrder = configureSortOrder(cb, root, param, "startAt");
                             break;
                         case SUBMIT_TIME:
                             sortOrder = configureSortOrder(cb, root, param, "submittedTime");
@@ -2808,6 +2808,28 @@ public class SchedulerDBManager {
                           .setParameter("jobId", jobId)
                           .setParameter("amount", increaseAmount)
                           .executeUpdate();
+        });
+    }
+
+    public void updateStartAt(Long jobId, Long startAt) {
+        executeReadWriteTransaction(session -> {
+            return session.getNamedQuery("updateJobDataStartAt")
+                          .setParameter("lastUpdatedTime", new Date().getTime())
+                          .setParameter("jobId", jobId)
+                          .setParameter("startAt", startAt)
+                          .executeUpdate();
+        });
+    }
+
+    public void updateGenericInfo(Long jobId, Map<String, String> genericInfo) {
+        executeReadWriteTransaction(session -> {
+            CriteriaBuilder cb = session.getCriteriaBuilder();
+            CriteriaUpdate<JobData> criteriaUpdate = cb.createCriteriaUpdate(JobData.class);
+            Root<JobData> root = criteriaUpdate.from(JobData.class);
+            criteriaUpdate.set("genericInformation", genericInfo);
+            criteriaUpdate.where(cb.equal(root.get("id"), jobId));
+            session.createQuery(criteriaUpdate).executeUpdate();
+            return null;
         });
     }
 

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdater.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdater.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.ow2.proactive.scheduler.common.job.JobStatus;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.util.ISO8601DateUtil;
 import org.ow2.proactive.scheduler.core.SchedulingService;
@@ -66,7 +67,10 @@ public class StartAtUpdater {
         boolean updatedTasksNotEmpty = !updatedTasks.isEmpty();
 
         if (updatedTasksNotEmpty) {
+            job.setStartAt(scheduledTime);
             dbManager.updateTaskSchedulingTime(job, scheduledTime);
+            dbManager.updateStartAt(job.getId().longValue(), scheduledTime);
+            dbManager.updateGenericInfo(job.getId().longValue(), job.getRuntimeGenericInformation());
         }
 
         return updatedTasksNotEmpty;
@@ -99,7 +103,7 @@ public class StartAtUpdater {
 
         Map<String, String> genericInformation = job.getRuntimeGenericInformation();
 
-        if (isValidStartAt(genericInformation, startAt)) {
+        if (job.getStatus() == JobStatus.PENDING && isValidStartAt(genericInformation, startAt)) {
             genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
             job.setGenericInformation(genericInformation);
             if (schedulerPolicy != null) {

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJob.java
@@ -1367,6 +1367,11 @@ public abstract class InternalJob extends JobState {
         jobInfo.setToBeRemoved();
     }
 
+    public void setStartAt(Long startAt) {
+        super.setStartAt(startAt);
+        jobInfo.setStartAt(startAt);
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/job/InternalJobFactory.java
@@ -25,14 +25,12 @@
  */
 package org.ow2.proactive.scheduler.job;
 
+import static org.ow2.proactive.scheduler.policy.ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT;
+
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import org.apache.log4j.Logger;
@@ -50,6 +48,7 @@ import org.ow2.proactive.scheduler.common.task.NativeTask;
 import org.ow2.proactive.scheduler.common.task.ScriptTask;
 import org.ow2.proactive.scheduler.common.task.Task;
 import org.ow2.proactive.scheduler.common.task.flow.FlowActionType;
+import org.ow2.proactive.scheduler.common.util.ISO8601DateUtil;
 import org.ow2.proactive.scheduler.core.OnErrorPolicyInterpreter;
 import org.ow2.proactive.scheduler.task.containers.ScriptExecutableContainer;
 import org.ow2.proactive.scheduler.task.internal.InternalForkedScriptTask;
@@ -369,6 +368,17 @@ public class InternalJobFactory {
         //special behavior
         jobToSet.setPriority(job.getPriority());
         jobToSet.setParentId(job.getParentId());
+        Map<String, String> genericInfo = jobToSet.getRuntimeGenericInformation();
+        if (genericInfo.containsKey(GENERIC_INFORMATION_KEY_START_AT)) {
+            String startAt = genericInfo.get(GENERIC_INFORMATION_KEY_START_AT);
+            try {
+                Date startAtDate = ISO8601DateUtil.toDate(startAt);
+                jobToSet.setStartAt(startAtDate.getTime());
+            } catch (Exception e) {
+                logger.error("Error when parsing START_AT=" + startAt + " for job " + jobToSet.getName());
+            }
+        }
+
     }
 
     /**

--- a/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/StandardTestSuite.java
@@ -164,6 +164,7 @@ import functionaltests.workflow.TestXMLTransformer;
 import functionaltests.workflow.javatask.ComplexTypeArgsTest;
 import functionaltests.workflow.nativetask.TestJobNativeSubmission;
 import functionaltests.workflow.nativetask.TestNativeTaskPaths;
+import functionaltests.workflow.startat.TestStartAt;
 import functionaltests.workflow.variables.TestModifyPropagatedVariables;
 import functionaltests.workflow.variables.TestNonForkedScriptTaskVariablePropagation;
 import functionaltests.workflow.variables.TestPropagatedVariables;
@@ -228,7 +229,7 @@ import functionaltests.workflow.variables.Test_SCHEDULING_2034;
                       TestWorkflowIterationAwareness.class, TestWorkingDirStaticCommand.class,
                       Test_SCHEDULING_2034.class, TestJobSubmittedParallel.class, TestTaskSynchronization.class,
                       TestMarkedAsFinished.class, RestartAllInErrorTasksTest.class, TestJobWhenSchedulerPaused.class,
-                      TestTaskForkParameter.class, TestJobLabels.class,
+                      TestTaskForkParameter.class, TestJobLabels.class, TestStartAt.class,
 
                       // Tests with scheduler restart
                       JobRecoverTest.class, TestForkedTaskWorkingDir.class, TestKillTaskWhileExecutingScripts.class,

--- a/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestJobRuntimeData.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/db/schedulerdb/TestJobRuntimeData.java
@@ -86,6 +86,7 @@ public class TestJobRuntimeData extends BaseSchedulerDBTest {
         Assert.assertEquals(1, runtimeData.getNumberOfRunningTasks());
         Assert.assertEquals(0, runtimeData.getNumberOfFinishedTasks());
         Assert.assertEquals(0, runtimeData.getNumberOfPendingTasks());
+        Assert.assertNull(runtimeData.getStartAt());
         Assert.assertTrue(runtimeData.getStartTime() > 0);
 
         internalTask = runtimeData.getITasks().get(0);

--- a/scheduler/scheduler-server/src/test/java/functionaltests/workflow/startat/TestStartAt.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/workflow/startat/TestStartAt.java
@@ -1,0 +1,90 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionaltests.workflow.startat;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.ow2.proactive.scheduler.common.Scheduler;
+import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.job.JobState;
+import org.ow2.proactive.scheduler.common.job.TaskFlowJob;
+import org.ow2.proactive.scheduler.common.task.CommonAttribute;
+import org.ow2.proactive.scheduler.common.task.JavaTask;
+import org.ow2.proactive.scheduler.examples.EmptyTask;
+
+import functionaltests.utils.SchedulerFunctionalTestNoRestart;
+import functionaltests.utils.SchedulerTHelper;
+
+
+public class TestStartAt extends SchedulerFunctionalTestNoRestart {
+
+    private final String JOB_NAME = this.getClass().getSimpleName();
+
+    private final String FUTURE_START_AT = "3000-01-01T00:00:00+00:00";
+
+    private final String OLD_START_AT = "1970-01-01T00:00:00+00:00";
+
+    @Test
+    public void testChangeStartAt() throws Throwable {
+
+        JobId jobId = schedulerHelper.submitJob(createJob());
+        SchedulerTHelper.log("Job submitted, id " + jobId.toString());
+        JobState js = schedulerHelper.waitForEventJobSubmitted(jobId);
+
+        Assert.assertThat(js.getJobInfo().getStartAt(), Matchers.greaterThan(System.currentTimeMillis()));
+
+        Scheduler scheduler = schedulerHelper.getSchedulerInterface();
+
+        scheduler.changeStartAt(jobId, OLD_START_AT);
+
+        js = scheduler.getJobState(jobId);
+
+        Assert.assertThat(js.getJobInfo().getStartAt(), Matchers.lessThan(System.currentTimeMillis()));
+        Assert.assertEquals(js.getJobInfo().getGenericInformation().get(CommonAttribute.GENERIC_INFO_START_AT_KEY),
+                            OLD_START_AT);
+        schedulerHelper.waitForEventJobFinished(jobId);
+    }
+
+    private TaskFlowJob createJob() throws Exception {
+        TaskFlowJob job = new TaskFlowJob();
+        job.setName(JOB_NAME);
+        setStartAt(job);
+
+        JavaTask javaTask = new JavaTask();
+        javaTask.setExecutableClassName(EmptyTask.class.getName());
+        String TASK_NAME = "task name";
+        javaTask.setName(TASK_NAME);
+        job.addTask(javaTask);
+
+        return job;
+    }
+
+    private void setStartAt(TaskFlowJob job) {
+        job.addGenericInformation(CommonAttribute.GENERIC_INFO_START_AT_KEY, FUTURE_START_AT);
+    }
+
+}

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/scheduler/core/helpers/StartAtUpdaterTest.java
@@ -38,11 +38,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.ow2.proactive.scheduler.common.job.JobStatus;
 import org.ow2.proactive.scheduler.common.util.ISO8601DateUtil;
 import org.ow2.proactive.scheduler.core.SchedulingService;
 import org.ow2.proactive.scheduler.core.db.SchedulerDBManager;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptorImpl;
 import org.ow2.proactive.scheduler.job.InternalJob;
+import org.ow2.proactive.scheduler.job.JobIdImpl;
 import org.ow2.proactive.scheduler.policy.ExtendedSchedulerPolicy;
 import org.ow2.proactive.scheduler.task.internal.InternalTask;
 
@@ -75,6 +77,7 @@ public class StartAtUpdaterTest {
         MockitoAnnotations.initMocks(this);
 
         when(internalJob.getJobDescriptor()).thenReturn(jobDescriptor);
+        when(internalJob.getId()).thenReturn(JobIdImpl.makeJobId("1"));
     }
 
     @Test
@@ -86,6 +89,7 @@ public class StartAtUpdaterTest {
         internalTasks.add(internalTask);
 
         when(internalJob.getITasks()).thenReturn(internalTasks);
+        when(internalJob.getStatus()).thenReturn(JobStatus.PENDING);
         Map<String, String> genericInformation = Maps.newHashMap();
 
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
@@ -105,6 +109,7 @@ public class StartAtUpdaterTest {
         internalTasks.add(internalTask);
 
         when(internalJob.getITasks()).thenReturn(internalTasks);
+        when(internalJob.getStatus()).thenReturn(JobStatus.PENDING);
         Map<String, String> genericInformation = Maps.newHashMap();
         when(internalJob.getRuntimeGenericInformation()).thenReturn(genericInformation);
 
@@ -124,6 +129,7 @@ public class StartAtUpdaterTest {
         internalTasks.add(internalTask);
 
         when(internalJob.getITasks()).thenReturn(internalTasks);
+        when(internalJob.getStatus()).thenReturn(JobStatus.PENDING);
         Map<String, String> genericInformation = Maps.newHashMap();
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
         when(internalJob.getRuntimeGenericInformation()).thenReturn(genericInformation);
@@ -143,6 +149,7 @@ public class StartAtUpdaterTest {
 
         ArrayList<InternalTask> internalTasks = Lists.newArrayList();
         when(internalJob.getITasks()).thenReturn(internalTasks);
+        when(internalJob.getStatus()).thenReturn(JobStatus.PENDING);
         Map<String, String> genericInformation = Maps.newHashMap();
         genericInformation.put(ExtendedSchedulerPolicy.GENERIC_INFORMATION_KEY_START_AT, startAt);
         when(internalJob.getRuntimeGenericInformation()).thenReturn(genericInformation);

--- a/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
+++ b/scheduler/scheduler-smartproxy/src/main/java/org/ow2/proactive/scheduler/smartproxy/SmartProxyImpl.java
@@ -882,6 +882,12 @@ public class SmartProxyImpl extends AbstractSmartProxy<JobTrackerImpl> implement
     }
 
     @Override
+    public boolean changeStartAt(List<JobId> jobIdList, String startAt)
+            throws NotConnectedException, UnknownJobException, PermissionException {
+        return schedulerProxy.changeStartAt(jobIdList, startAt);
+    }
+
+    @Override
     public String getJobContent(JobId jobId) throws SchedulerException {
         return schedulerProxy.getJobContent(jobId);
     }


### PR DESCRIPTION
startAt is stored in the database and searchable

ensure that changeStartAt request updates the value stored in JobData and the generic info

add a changeStartAt request that accepts multiple jobs