### PR TITLE
SchedulerNodeClient: when connection fails, use the scheduler rest pu…

### DIFF
--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ExceptionUtility.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/ExceptionUtility.java
@@ -26,23 +26,13 @@
 package org.ow2.proactive.scheduler.rest;
 
 import java.lang.reflect.Constructor;
+import java.security.KeyException;
 
-import org.ow2.proactive.scheduler.common.exception.JobAlreadyFinishedException;
-import org.ow2.proactive.scheduler.common.exception.JobCreationException;
-import org.ow2.proactive.scheduler.common.exception.NotConnectedException;
-import org.ow2.proactive.scheduler.common.exception.PermissionException;
-import org.ow2.proactive.scheduler.common.exception.SubmissionClosedException;
-import org.ow2.proactive.scheduler.common.exception.UnknownJobException;
-import org.ow2.proactive.scheduler.common.exception.UnknownTaskException;
+import javax.security.auth.login.LoginException;
+
+import org.ow2.proactive.scheduler.common.exception.*;
 import org.ow2.proactive.scheduler.signal.SignalApiException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobAlreadyFinishedRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.JobCreationRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.NotConnectedRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.PermissionRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SignalApiRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SubmissionClosedRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownJobRestException;
-import org.ow2.proactive_grid_cloud_portal.scheduler.exception.UnknownTaskRestException;
+import org.ow2.proactive_grid_cloud_portal.scheduler.exception.*;
 
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
@@ -59,6 +49,20 @@ public class ExceptionUtility {
         } else {
             throw new RuntimeException(e);
         }
+    }
+
+    public static RuntimeException throwNCEOrKEOrLEOrSE(Exception e)
+            throws SchedulerException, LoginException, KeyException {
+        if (e instanceof LoginException) {
+            throw (LoginException) e;
+        } else if (e instanceof KeyException) {
+            throw (KeyException) e;
+        } else if (e instanceof SchedulerRestException) {
+            throw reconstructError(e, SchedulerException.class);
+        } else {
+            throwNCE(e);
+        }
+        return new RuntimeException(e);
     }
 
     public static RuntimeException throwNCEOrPE(Exception e) throws NotConnectedException, PermissionException {

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/executors/forked/env/ForkedTaskVariablesManager.java
@@ -180,6 +180,7 @@ public class ForkedTaskVariablesManager implements Serializable {
         if (container.getDecrypter() != null && !Strings.isNullOrEmpty(container.getSchedulerRestUrl())) {
             return new SchedulerNodeClient(container.getDecrypter(),
                                            container.getSchedulerRestUrl(),
+                                           container.getInitializer().getSchedulerRestPublicUrl(),
                                            container.getTaskId().getJobId(),
                                            container.getInitializer().getGlobalVariables(),
                                            container.getInitializer().getGlobalGenericInformation());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/rmproxies/RMProxyActiveObject.java
@@ -257,9 +257,12 @@ public class RMProxyActiveObject {
             //retrieve scheduler URL to bind with schedulerapi, globalspaceapi, and userspaceapi
             String schedulerUrl = PASchedulerProperties.SCHEDULER_REST_URL.getValueAsString();
 
+            String schedulerPublicUrl = PASchedulerProperties.SCHEDULER_REST_PUBLIC_URL.getValueAsString();
+
             logger.debug("Binding schedulerapi...");
             SchedulerNodeClient client = new SchedulerNodeClient(decrypter,
                                                                  schedulerUrl,
+                                                                 schedulerPublicUrl,
                                                                  taskId.getJobId(),
                                                                  Collections.emptyMap(),
                                                                  Collections.emptyMap());


### PR DESCRIPTION
…blic url when configured

When connection to the scheduler fails (for example, when the scheduler is behind a reverse proxy), and a scheduler rest public url is configured, the scheduler client will attempt to connect using the public url.