### PR TITLE
Introduced protections against system command injection

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/scripting/helper/selection/SelectionUtils.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/scripting/helper/selection/SelectionUtils.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.scripting.helper.selection;
 
+import io.github.pixee.security.SystemCommand;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -347,7 +348,7 @@ public class SelectionUtils {
             is.close();
             fos.close();
             //execute
-            Process p = Runtime.getRuntime().exec(tmp.getAbsolutePath());
+            Process p = SystemCommand.runCommand(Runtime.getRuntime(), tmp.getAbsolutePath());
             p.waitFor();
             return (p.exitValue() > 0);
         } catch (IllegalMonitorStateException ex) {

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AutoUpdateInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/AutoUpdateInfrastructure.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
+import io.github.pixee.security.SystemCommand;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -121,7 +122,7 @@ public class AutoUpdateInfrastructure extends HostsFileBasedInfrastructureManage
         try {
             logger.debug("Deploying node: " + nodeName);
             logger.debug("Launching the command: " + filledCommand);
-            p = Runtime.getRuntime().exec(new String[] { "bash", "-c", filledCommand });
+            p = SystemCommand.runCommand(Runtime.getRuntime(), new String[] { "bash", "-c", filledCommand });
         } catch (IOException e1) {
             multipleDeclareDeployingNodeLost(depNodeURLs,
                                              "Cannot run command: " + filledCommand +

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/CLIInfrastructure.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/CLIInfrastructure.java
@@ -26,6 +26,7 @@
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
+import io.github.pixee.security.SystemCommand;
 
 import java.io.File;
 import java.io.IOException;
@@ -141,7 +142,7 @@ public class CLIInfrastructure extends HostsFileBasedInfrastructureManager {
         Process p;
         try {
             logger.debug("Launching the command: " + commandLine);
-            p = Runtime.getRuntime().exec(commandLine);
+            p = SystemCommand.runCommand(Runtime.getRuntime(), commandLine);
         } catch (IOException e1) {
             multipleDeclareDeployingNodeLost(depNodeURLs,
                                              "Cannot run command: " + commandLine +
@@ -227,7 +228,7 @@ public class CLIInfrastructure extends HostsFileBasedInfrastructureManager {
                     Process p;
                     try {
                         logger.debug("Launching the command: " + commandLine);
-                        p = Runtime.getRuntime().exec(commandLine);
+                        p = SystemCommand.runCommand(Runtime.getRuntime(), commandLine);
                         // TODO add timeout behavior
                         int exitCode = p.waitFor();
                         String pOutPut = Utils.extractProcessOutput(p);

--- a/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/Utils.java
+++ b/rm/rm-server/src/main/java/org/ow2/proactive/resourcemanager/nodesource/infrastructure/Utils.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.proactive.resourcemanager.nodesource.infrastructure;
 
+import io.github.pixee.security.SystemCommand;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -120,11 +121,11 @@ public class Utils {
         // easier killing, prevents the client from polluting stdout
         switch (OperatingSystem.getOperatingSystem()) {
             case unix:
-                p = Runtime.getRuntime().exec(new String[] { CentralPAPropertyRepository.PA_GCMD_UNIX_SHELL.getValue(),
+                p = SystemCommand.runCommand(Runtime.getRuntime(), new String[] { CentralPAPropertyRepository.PA_GCMD_UNIX_SHELL.getValue(),
                                                              "-c", sshCmd });
                 break;
             case windows:
-                p = Runtime.getRuntime().exec(sshCmd);
+                p = SystemCommand.runCommand(Runtime.getRuntime(), sshCmd);
                 break;
         }
 

--- a/rm/rm-server/src/test/java/org/ow2/tests/ProcessKiller.java
+++ b/rm/rm-server/src/test/java/org/ow2/tests/ProcessKiller.java
@@ -25,6 +25,7 @@
  */
 package org.ow2.tests;
 
+import io.github.pixee.security.SystemCommand;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -123,7 +124,7 @@ public abstract class ProcessKiller {
             int exitValue = p.waitFor();
             if (exitValue != 0) {
                 try {
-                    p = Runtime.getRuntime().exec(new String[] { "tskill", Integer.toString(pid) });
+                    p = SystemCommand.runCommand(Runtime.getRuntime(), new String[] { "tskill", Integer.toString(pid) });
                     p.waitFor();
                 } catch (Exception e) {
                     // ignore

--- a/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
+++ b/scheduler/scheduler-server/src/test/java/functionaltests/utils/SchedulerTHelper.java
@@ -25,6 +25,7 @@
  */
 package functionaltests.utils;
 
+import io.github.pixee.security.SystemCommand;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
@@ -1182,7 +1183,7 @@ public class SchedulerTHelper {
     }
 
     public static void setExecutable(String filesList) throws IOException {
-        Runtime.getRuntime().exec("chmod u+x " + filesList);
+        SystemCommand.runCommand(Runtime.getRuntime(), "chmod u+x " + filesList);
     }
 
     public void disconnect() throws Exception {


### PR DESCRIPTION
This change hardens all instances of [Runtime#exec()](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html) to offer protection against attack.

Left unchecked, `Runtime#exec()` can execute any arbitrary system command. If an attacker can control part of the strings used to as program paths or arguments, they could execute arbitrary programs, install malware, and anything else they could do if they had a shell open on the application host.

Our change introduces a sandbox which protects the application:

```diff
+ import io.github.pixee.security.SystemCommand;
  ...
- Process p = Runtime.getRuntime().exec(command);
+ Process p = SystemCommand.runCommand(Runtime.getRuntime(), command);
```

The default restrictions applied are the following:
* **Prevent command chaining**. Many exploits work by injecting command separators and causing the shell to interpret a second, malicious command. The `SystemCommand#runCommand()` attempts to parse the given command, and throw a `SecurityException` if multiple commands are present.
* **Prevent arguments targeting sensitive files.** There is little reason for custom code to target sensitive system files like `/etc/passwd`, so the sandbox prevents arguments that point to these files that may be targets for exfiltration.

There are [more options for sandboxing](https://github.com/pixee/java-security-toolkit/blob/main/src/main/java/io/github/pixee/security/SystemCommand.java#L15) if you are interested in locking down system commands even more.


:x: The following packages couldn't be installed automatically, probably because the dependency manager is unsupported. Please install them manually:
<details open>
    <summary>Gradle</summary>

    dependencies {
      implementation("io.github.pixee:java-security-toolkit:1.2.0")
    }

</details>

<details>
    <summary>Maven</summary>

    <dependencies>
      <dependency>
        <groupId>io.github.pixee</groupId>
        <artifactId>java-security-toolkit</artifactId>
        <version>1.2.0</version>
      </dependency>
    <dependencies>

</details>

<details>
  <summary>More reading</summary>

  * [https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)
  * [https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec%28%29+method](https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec%28%29+method)
</details>
(https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixeebot-2-0%2Fow2-proactive_scheduling%7Cd9c8448e8cd72c98e491efabe148410da68be57a)


<!--{"type":"DRIP","codemod":"pixee:java/harden-process-creation"}-->