### PR TITLE
SchedulerStateRest.getDescription: fallback mechanism when scheduler …

### DIFF
--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/scheduler/SchedulerStateRest.java
@@ -2218,9 +2218,17 @@ public class SchedulerStateRest implements SchedulerRestInterface {
         try {
             String jobXml = scheduler.getJobContent(JobIdImpl.makeJobId(jobId));
             Job job;
-            try (InputStream tmpWorkflowStream = IOUtils.toInputStream(jobXml, Charset.forName(FILE_ENCODING))) {
-                job = JobFactory.getFactory().createJob(tmpWorkflowStream, null, null, scheduler, space, sessionId);
+            try {
+                try (InputStream tmpWorkflowStream = IOUtils.toInputStream(jobXml, Charset.forName(FILE_ENCODING))) {
+                    job = JobFactory.getFactory().createJob(tmpWorkflowStream, null, null, scheduler, space, sessionId);
+                }
+            } catch (Exception e) {
+                // in case of an error, create the job without scheduler or dataspace support
+                try (InputStream tmpWorkflowStream = IOUtils.toInputStream(jobXml, Charset.forName(FILE_ENCODING))) {
+                    job = JobFactory.getFactory().createJob(tmpWorkflowStream, null, null, null, null, sessionId);
+                }
             }
+
             WorkflowDescription workflowDescription = new WorkflowDescription();
             workflowDescription.setName(job.getName());
             workflowDescription.setProjectName(job.getProjectName());


### PR DESCRIPTION
…or space generate issues

In some cases, a workflow might be invalid when scheduler support is enabled (e.g. missing 3rd-party credentials). When such error occurs, we fall back by disabling scheduler or data space support.