### PR TITLE
ExtendedSchedulerPolicy: sort after filtering tasks

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulingService.java
@@ -190,6 +190,7 @@ public class SchedulingService {
         }
 
         schedulingThread = new SchedulingThread(schedulingMethod, this);
+        schedulingThread.setPriority(Thread.MAX_PRIORITY);
         schedulingThread.start();
 
         pinger = new NodePingThread(this);


### PR DESCRIPTION
Also:
 - remove redundant sort
 - set max priority to scheduling thread
 - cache startAt to date conversion