### PR TITLE
SchedulerDBManager: improve loadJobs performance

### DIFF
--- a/config/scheduler/database.properties
+++ b/config/scheduler/database.properties
@@ -15,7 +15,7 @@ hibernate.connection.provider_class=org.hibernate.hikaricp.internal.HikariCPConn
 
 # JDBC connection pool configuration
 # https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby
-hibernate.hikari.connectionTimeout=120000
+hibernate.hikari.connectionTimeout=1800000
 hibernate.hikari.maximumPoolSize=40
 hibernate.hikari.transactionIsolation=TRANSACTION_READ_COMMITTED
 hibernate.hikari.poolName=scheduler

--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -515,7 +515,11 @@ pa.scheduler.db.transactions.sleep.delay=1000
 pa.scheduler.db.transactions.damping.factor=2
 
 # Batch size to load Jobs from database when scheduler is restarted
-pa.scheduler.db.recovery.load.jobs.batch_size=100
+# should be set to the same value as pa.scheduler.db.items.max.size
+pa.scheduler.db.recovery.load.jobs.batch_size=1000
+
+# maximum number of threads used to load jobs from the database, this value must not be greater than hibernate.hikari.maximumPoolSize in config/scheduler/database.properties
+pa.scheduler.core.loadjobs.nbthreads=40
 
 # maximum number of items passed as parameters to some database queries (jobid list, etc)
 pa.scheduler.db.items.max.size=1000

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -106,6 +106,9 @@ public enum PASchedulerProperties implements PACommonProperties {
     /** Number of threads used to handle scheduled operations related to housekeeping */
     SCHEDULER_HOUSEKEEPING_SCHEDULED_POOL_NBTHREAD("pa.scheduler.core.housekeeping.scheduledpoolnbthreads", PropertyType.INTEGER, "5"),
 
+    /** maximum number of threads used to load jobs from the database, this value must not be greater than hibernate.hikari.maximumPoolSize in config/scheduler/database.properties **/
+    SCHEDULER_PARALLEL_LOAD_JOBS_NBTHREAD("pa.scheduler.core.loadjobs.nbthreads", PropertyType.INTEGER, "40"),
+
     /** Maximum number of threads in the thread pool that serves to recover running tasks in parallel at scheduler start up */
     SCHEDULER_PARALLEL_SCHEDULER_STATE_RECOVER_NBTHREAD("pa.scheduler.core.parallel.scheduler.state.recover.nbthreads", PropertyType.INTEGER, "100"),
 
@@ -522,7 +525,7 @@ public enum PASchedulerProperties implements PACommonProperties {
     SCHEDULER_DB_RECOVERY_LOAD_JOBS_BATCH_SIZE(
             "pa.scheduler.db.recovery.load.jobs.batch_size",
             PropertyType.INTEGER,
-            "100"),
+            "1000"),
 
     SCHEDULER_DB_ITEMS_MAX_SIZE("pa.scheduler.db.items.max.size", PropertyType.INTEGER, "1000"),
 


### PR DESCRIPTION
 - increase default batch size to 1000
 - load jobs from the database in parallel. Number of threads is configurable by a new property pa.scheduler.core.loadjobs.nbthreads
 - increase default database connection timeout