### PR TITLE
Store script urls in database by reference

### DIFF
--- a/config/scheduler/settings.ini
+++ b/config/scheduler/settings.ini
@@ -19,6 +19,11 @@ pa.scheduler.home=.
 # Accessed inside workflows and tasks with the PA_CATALOG_REST_URL variable
 #pa.catalog.rest.url=
 
+# Store script urls in database using a reference to the catalog rest url
+# If set to true, pa.catalog.rest.url MUST be set manually and not automatically when jetty server starts
+# This setting should be used in HA Active/Passive configuration to prevent that urls stored in the database contain the wrong server name
+pa.store.catalog.ref.in.db=false
+
 # Cloud Automation rest url. If not defined, it is set automatically when starting the server.
 # Accessed inside workflows and tasks with the PA_CLOUD_AUTOMATION_REST_URL variable
 #pa.cloud-automation.rest.url

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/core/properties/PASchedulerProperties.java
@@ -424,6 +424,13 @@ public enum PASchedulerProperties implements PACommonProperties {
     CATALOG_REST_URL("pa.catalog.rest.url", PropertyType.STRING),
 
     /**
+     * Store script urls in database using a reference to the catalog rest url
+     * If set to true, pa.catalog.rest.url MUST be set manually and not automatically when jetty server starts
+     * This setting should be used in HA Active/Passive configuration to prevent that urls stored in the database contain the wrong server name
+     */
+    STORE_CATALOG_REF_IN_DB("pa.store.catalog.ref.in.db", PropertyType.BOOLEAN, "false"),
+
+    /**
      * Cloud Automation rest url
      * Accessed inside workflows and tasks with the PA_CLOUD_AUTOMATION_REST_URL variable
      */

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectionScriptData.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SelectionScriptData.java
@@ -25,9 +25,10 @@
  */
 package org.ow2.proactive.scheduler.core.db;
 
+import static org.ow2.proactive.scheduler.core.db.ScriptData.getScriptUrl;
+
 import java.io.Serializable;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 
@@ -89,7 +90,10 @@ public class SelectionScriptData {
     SelectionScript createSelectionScript() throws InvalidScriptException {
         if (script == null && url != null) {
             try {
-                return new SelectionScript(new URL(url), getScriptEngine(), parameters(), isSelectionScriptDynamic());
+                return new SelectionScript(getScriptUrl(url),
+                                           getScriptEngine(),
+                                           parameters(),
+                                           isSelectionScriptDynamic());
             } catch (MalformedURLException e) {
                 throw new InvalidScriptException(e);
             }
@@ -109,7 +113,7 @@ public class SelectionScriptData {
     protected static void initCommonAttributes(SelectionScriptData scriptData, Script<?> script) {
         scriptData.setScript(script.getScript());
         if (script.getScriptUrl() != null) {
-            scriptData.setURL(script.getScriptUrl().toExternalForm());
+            scriptData.setURL(ScriptData.getDBUrl(script.getScriptUrl()));
         }
         scriptData.setScriptEngine(script.getEngineName());
         if (script.getParameters() != null) {


### PR DESCRIPTION
When this option is enabled, script urls which contains a catalog url will be stored in the db by using $PA_CATALOG_REST_URL/path and this expression will be resolved to a local url when the job is loaded from the db.

To use this option, it is mandatory to set the catalog url manually in config/scheduler/settings.ini.

This is to prevent issues in HA active/passive of two servers using the same database