### PR TITLE
Add group manager read and write endpoints

### DIFF
--- a/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/authentication/UserData.java
@@ -61,6 +61,10 @@ public class UserData implements Serializable {
 
     private boolean canCreateAssociationPermission;
 
+    private boolean roleReadPermission;
+
+    private boolean roleAdminPermission;
+
     private boolean pcaAdminPermission;
 
     private boolean notificationAdminPermission;
@@ -151,6 +155,22 @@ public class UserData implements Serializable {
 
     public void setCanCreateAssociationPermission(boolean canCreateAssociationPermission) {
         this.canCreateAssociationPermission = canCreateAssociationPermission;
+    }
+
+    public boolean isRoleReadPermission() {
+        return roleReadPermission;
+    }
+
+    public void setRoleReadPermission(boolean roleReadPermission) {
+        this.roleReadPermission = roleReadPermission;
+    }
+
+    public boolean isRoleAdminPermission() {
+        return roleAdminPermission;
+    }
+
+    public void setRoleAdminPermission(boolean roleAdminPermission) {
+        this.roleAdminPermission = roleAdminPermission;
     }
 
     public boolean isPcaAdminPermission() {

--- a/common/common-client/src/main/java/org/ow2/proactive/permissions/RoleAdminPermission.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/permissions/RoleAdminPermission.java
@@ -1,0 +1,33 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.permissions;
+
+public class RoleAdminPermission extends ClientPermission {
+
+    // This serial version uid is meant to prevent issues when restoring Resource Manager database from a previous version.
+    // any addition to this class (new method, field, etc) should imply to change this uid.
+    private static final long serialVersionUID = 1L;
+}

--- a/common/common-client/src/main/java/org/ow2/proactive/permissions/RoleReaderPermission.java
+++ b/common/common-client/src/main/java/org/ow2/proactive/permissions/RoleReaderPermission.java
@@ -1,0 +1,33 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.permissions;
+
+public class RoleReaderPermission extends ClientPermission {
+
+    // This serial version uid is meant to prevent issues when restoring Resource Manager database from a previous version.
+    // any addition to this class (new method, field, etc) should imply to change this uid.
+    private static final long serialVersionUID = 1L;
+}

--- a/config/security.java.policy-server
+++ b/config/security.java.policy-server
@@ -1,27 +1,21 @@
-// SCHEDULER AND RESOURCE MANAGER CLIENTS POLICY
-//
-// USERS PERMISSIONS (EXAMPLE)
-//
-//grant principal org.ow2.proactive.authentication.principals.UserNamePrincipal "user" {
-//    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "scheduler,rm";
-//    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getAtMostNodes";
-//    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.getNodes";
-//    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNode";
-//    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.releaseNodes";
-//    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.checkNodePermission";
-//    permission org.ow2.proactive.permissions.MethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.checkNodeSourcePermission";
-//};
-
-//
-// GROUPS PERMISSIONS
-//
-// Members of "guest" group can get/free nodes and monitor the state submit jobs
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "guests" {
+    // ****** Global permissions ******
     permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "automation-dashboard,workflow-execution";
 
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    // ****** Scheduler permissions ******
+    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
 
+    // ****** Resource Manager permissions ******
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
+
+    // ****** User and Global Space permissions ******
+
+
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
@@ -31,16 +25,10 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
+
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
-
-	// --------------------------- scheduling related permission
-	//use the following line to allow a user to download full scheduler state and get events from any user
-	//"true" means that this user can get only its job in the state and listen for its events
-	//"false" means user can get full state and listen for any events.
-    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
 
     // API - access to database
     permission java.sql.SQLPermission "setLog";
@@ -49,74 +37,49 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission java.sql.SQLPermission "setNetworkTimeout";
     permission java.util.PropertyPermission "*", "read, write";
     permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
 };
 
-// Members of "user" group can get/free nodes and monitor the state, submit jobs and see jobs of other people
+
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "user" {
+    // ****** Global permissions ******
     permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    permission org.ow2.proactive.permissions.RoleReaderPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
 
-    // AuthPermission is requires for those who would like to access any mbean
-    permission javax.security.auth.AuthPermission "getSubject";
-    permission java.lang.RuntimePermission "setContextClassLoader";
-    permission javax.management.MBeanPermission "-#-[-]", "queryNames";
-    permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
-    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
-    // Granting file reading permission i.e. to read RRD database via JMX
-    permission java.io.FilePermission "<<ALL FILES>>", "read";
-
-	// --------------------------- scheduling related permission
-	// Use the following line to allow a user to manage any submitted job on the scheduler
-	//"true" means that this user can manage only his/her job
-	//"false" means that this user can manage any job
+    // ****** Scheduler permissions ******
     permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
-    // if HandleOnlyMyJobsPermission is true, it is also possible to enable read-only access to other users' jobs.
-    // Uncomment the following line to enable it
-    // permission org.ow2.proactive.scheduler.permissions.OtherUsersJobReadPermission;
-
     permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "1,2,3";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithBucketNamePermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGroupNamePermission "";
-    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
 
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
+    // ****** Resource Manager permissions ******
 
-    // API - access to database
-    permission java.sql.SQLPermission "setLog";
-    permission java.sql.SQLPermission "callAbort";
-    permission java.sql.SQLPermission "setSyncFactory";
-    permission java.sql.SQLPermission "setNetworkTimeout";
-    permission java.util.PropertyPermission "*", "read, write";
-    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
-};
-
-
-// Resource providers have the same permissions as users + an ability to add remove node
-grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "providers" {
-    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.provider";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
 
+    // ****** User and Global Space permissions ******
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
+
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
     permission javax.management.MBeanPermission "-#-[-]", "queryNames";
     permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
+    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
 
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 
@@ -127,20 +90,70 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission java.sql.SQLPermission "setNetworkTimeout";
     permission java.util.PropertyPermission "*", "read, write";
     permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
 };
 
-// Members of "nsadmins" can create/remove node sources (according to their policies)
+
+grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "providers" {
+    // ****** Global permissions ******
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
+
+    // ****** Scheduler permissions ******
+
+    // ****** Resource Manager permissions ******
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.provider";
+
+    // ****** User and Global Space permissions ******
+
+
+    // ****** JMX permissions ******
+    // AuthPermission is requires for those who would like to access any mbean
+    permission javax.security.auth.AuthPermission "getSubject";
+    permission java.lang.RuntimePermission "setContextClassLoader";
+    permission javax.management.MBeanPermission "-#-[-]", "queryNames";
+    permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
+    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
+
+    // ****** Default permissions ******
+    // Granting file reading permission i.e. to read RRD database via JMX
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+
+    // API - access to database
+    permission java.sql.SQLPermission "setLog";
+    permission java.sql.SQLPermission "callAbort";
+    permission java.sql.SQLPermission "setSyncFactory";
+    permission java.sql.SQLPermission "setNetworkTimeout";
+    permission java.util.PropertyPermission "*", "read, write";
+    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
+};
+
+
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "nsadmins" {
+    // ****** Global permissions ******
     permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
     permission org.ow2.proactive.permissions.PcaAdminPermission;
+
+    // ****** Scheduler permissions ******
+
+    // ****** Resource Manager permissions ******
     permission org.ow2.proactive.permissions.NSAdminPermission;
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.provider";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.nsadmin";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+
+    // ****** User and Global Space permissions ******
 
 
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
@@ -149,6 +162,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
 
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 
@@ -159,21 +173,26 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission java.sql.SQLPermission "setNetworkTimeout";
     permission java.util.PropertyPermission "*", "read, write";
     permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
 };
 
-// Members of "rmcoreadmins" can call any method of rmcore
-grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "rmcoreadmins" {
-    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
 
+grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "rmcoreadmins" {
+    // ****** Global permissions ******
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "rm";
     permission org.ow2.proactive.permissions.PcaAdminPermission;
+
+    // ****** Scheduler permissions ******
+
+    // ****** Resource Manager permissions ******
+    permission org.ow2.proactive.permissions.RMCoreAllPermission;
 
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.*";
 
-    permission org.ow2.proactive.permissions.RMCoreAllPermission;
+    // ****** User and Global Space permissions ******
 
-    // the following permission is disabled by default to enforce node selection restrictions for admins
-    // permission org.ow2.proactive.permissions.NodeUserAllPermission;
 
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
@@ -184,6 +203,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.ManagementMBeanImpl#*[*:*]", "*";
 
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 
@@ -194,37 +214,40 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission java.sql.SQLPermission "setNetworkTimeout";
     permission java.util.PropertyPermission "*", "read, write";
     permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
 };
 
-// Members of "scheduleradmins" can call any method of the scheduler
+
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "scheduleradmins" {
+    // ****** Global permissions ******
     permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
-
+    permission org.ow2.proactive.permissions.RoleReaderPermission;
+    permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
     permission org.ow2.proactive.permissions.PcaAdminPermission;
-    // Notification service administrator permission
     permission org.ow2.proactive.permissions.NotificationAdminPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
+    permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
 
-	// Use the following line to allow a user to manage any submitted job on the scheduler
-	//"true" means that this user can manage only his/her job
-	//"false" means that this user can manage any job
+    // ****** Scheduler permissions ******
     permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "false";
-
     permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "0,1,2,3,4,5";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
-    permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
-    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
-    permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
+    // ****** Resource Manager permissions ******
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
 
+    // ****** User and Global Space permissions ******
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
+
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
 
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
@@ -237,7 +260,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
 
-
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 
@@ -248,102 +271,40 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission java.sql.SQLPermission "setNetworkTimeout";
     permission java.util.PropertyPermission "*", "read, write";
     permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
 };
 
-// Members of "server-admins" act as administrators of both the resource manager and scheduler
+
 grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "server-admins" {
+    // ****** Global permissions ******
     permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
-
-    permission org.ow2.proactive.permissions.PcaAdminPermission;
-
-    // Notification service administrator permission
-    permission org.ow2.proactive.permissions.NotificationAdminPermission;
-
-	// Use the following line to allow a user to manage any submitted job on the scheduler
-	//"true" means that this user can manage only his/her job
-	//"false" means that this user can manage any job
-    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "false";
-    permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "0,1,2,3,4,5";
-    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
-    permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
-    permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
+    permission org.ow2.proactive.permissions.RoleAdminPermission;
     permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
+    permission org.ow2.proactive.permissions.PcaAdminPermission;
+    permission org.ow2.proactive.permissions.NotificationAdminPermission;
     permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
     permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.scheduler.permissions.CatalogAllAccessPermission;
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
-
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.*";
-
-    permission org.ow2.proactive.permissions.RMCoreAllPermission;
-
-    // the following permission is disabled by default to enforce node selection restrictions for admins
-    // permission org.ow2.proactive.permissions.NodeUserAllPermission;
-
-    // AuthPermission is requires for those who would like to access any mbean
-    permission javax.security.auth.AuthPermission "getSubject";
-    permission java.lang.RuntimePermission "setContextClassLoader";
-    permission javax.management.MBeanPermission "-#-[-]", "queryNames";
-    permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
-    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.ManagementMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]", "*";
-    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.ManagementMBeanImpl#*[*:*]", "*";
-
-    // Granting file reading permission i.e. to read RRD database via JMX
-    permission java.io.FilePermission "<<ALL FILES>>", "read";
-
-    // API - access to database
-    permission java.sql.SQLPermission "setLog";
-    permission java.sql.SQLPermission "callAbort";
-    permission java.sql.SQLPermission "setSyncFactory";
-    permission java.sql.SQLPermission "setNetworkTimeout";
-    permission java.util.PropertyPermission "*", "read, write";
-    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
-};
-
-// Members of "subadmin" behave like "server-admins" but cannot directly run scripts on nodes
-grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "subadmin" {
-    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
-
-    permission org.ow2.proactive.permissions.PcaAdminPermission;
-
-    // Notification service administrator permission
-    permission org.ow2.proactive.permissions.NotificationAdminPermission;
-
-	// Use the following line to allow a user to manage any submitted job on the scheduler
-	//"true" means that this user can manage only his/her job
-	//"false" means that this user can manage any job
+    // ****** Scheduler permissions ******
     permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "false";
     permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "0,1,2,3,4,5";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
     permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
     permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
-    permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
-    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
-    permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
+    // ****** Resource Manager permissions ******
+    permission org.ow2.proactive.permissions.RMCoreAllPermission;
 
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.*";
 
-    // disallow execute script on nodes
-    permission org.ow2.proactive.permissions.DeniedMethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.executeScript";
+    // ****** User and Global Space permissions ******
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
 
-    permission org.ow2.proactive.permissions.RMCoreAllPermission;
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
 
-    // the following permission is disabled by default to enforce node selection restrictions for admins
-    // permission org.ow2.proactive.permissions.NodeUserAllPermission;
-
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
@@ -358,6 +319,7 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.ManagementMBeanImpl#*[*:*]", "*";
 
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 
@@ -368,48 +330,42 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission java.sql.SQLPermission "setNetworkTimeout";
     permission java.util.PropertyPermission "*", "read, write";
     permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
 };
 
-// Members of "admin" group possess permissions to perform any actions
-grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "admin" {
-    permission org.ow2.proactive.permissions.AllPermission;
 
-    // API - access to database
-    permission java.sql.SQLPermission "setLog";
-    permission java.sql.SQLPermission "callAbort";
-    permission java.sql.SQLPermission "setSyncFactory";
-    permission java.sql.SQLPermission "setNetworkTimeout";
-    permission java.util.PropertyPermission "*", "read, write";
-    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
-};
-
-// Members of "watchers" group have only a read access to the scheduler and RM state
-// and the authorization to register a listener in order to receive updates of the scheduler state
-grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "watchers" {
+grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "subadmin" {
+    // ****** Global permissions ******
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "*";
+    permission org.ow2.proactive.permissions.RoleReaderPermission;
     permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    permission org.ow2.proactive.permissions.PcaAdminPermission;
+    permission org.ow2.proactive.permissions.NotificationAdminPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
+    permission org.ow2.proactive.scheduler.permissions.JobPlannerAllAccessPermission;
+
+    // ****** Scheduler permissions ******
     permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "false";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
+    permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "0,1,2,3,4,5";
+    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
+    permission org.ow2.proactive.scheduler.permissions.ConnectToResourceManagerPermission;
+    permission org.ow2.proactive.scheduler.permissions.ChangePolicyPermission;
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.*";
 
-    // API - access to database
-    permission java.sql.SQLPermission "setLog";
-    permission java.sql.SQLPermission "callAbort";
-    permission java.sql.SQLPermission "setSyncFactory";
-    permission java.sql.SQLPermission "setNetworkTimeout";
-    permission java.util.PropertyPermission "*", "read, write";
-    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
-};
+    // ****** Resource Manager permissions ******
+    permission org.ow2.proactive.permissions.RMCoreAllPermission;
 
-// Data scientist permissions
-grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "citizen-ds" {
-    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "studio,catalog-portal,workflow-execution,job-analytics";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.*";
 
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    // ****** User and Global Space permissions ******
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
 
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
+
+    // ****** Advanced permissions ******
+    permission org.ow2.proactive.permissions.DeniedMethodCallPermission "org.ow2.proactive.resourcemanager.core.RMCore.executeScript";
+
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
@@ -417,49 +373,127 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
     permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.ManagementMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.ManagementMBeanImpl#*[*:*]", "*";
+
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 
-    // --------------------------- scheduling related permission
-	// Use the following line to allow a user to manage any submitted job on the scheduler
-	//"true" means that this user can manage only his/her job
-	//"false" means that this user can manage any job
-    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
-    // if HandleOnlyMyJobsPermission is true, it is also possible to enable read-only access to other users' jobs.
-    // Uncomment the following line to enable it
-    // permission org.ow2.proactive.scheduler.permissions.OtherUsersJobReadPermission;
+    // API - access to database
+    permission java.sql.SQLPermission "setLog";
+    permission java.sql.SQLPermission "callAbort";
+    permission java.sql.SQLPermission "setSyncFactory";
+    permission java.sql.SQLPermission "setNetworkTimeout";
+    permission java.util.PropertyPermission "*", "read, write";
+    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
 
-    //required to set job priority to normal
+};
+
+
+grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "admin" {
+    // ****** Global permissions ******
+    permission org.ow2.proactive.permissions.AllPermission;
+
+    // ****** Scheduler permissions ******
+
+    // ****** Resource Manager permissions ******
+
+
+    // ****** User and Global Space permissions ******
+
+
+    // ****** JMX permissions ******
+    // AuthPermission is requires for those who would like to access any mbean
+    permission javax.security.auth.AuthPermission "getSubject";
+    permission java.lang.RuntimePermission "setContextClassLoader";
+    permission javax.management.MBeanPermission "-#-[-]", "queryNames";
+    permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
+
+    // ****** Default permissions ******
+    // Granting file reading permission i.e. to read RRD database via JMX
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+
+    // API - access to database
+    permission java.sql.SQLPermission "setLog";
+    permission java.sql.SQLPermission "callAbort";
+    permission java.sql.SQLPermission "setSyncFactory";
+    permission java.sql.SQLPermission "setNetworkTimeout";
+    permission java.util.PropertyPermission "*", "read, write";
+    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
+};
+
+
+grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "watchers" {
+    // ****** Global permissions ******
+    permission org.ow2.proactive.scheduler.permissions.TenantAllAccessPermission;
+
+    // ****** Scheduler permissions ******
+    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "false";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
+
+    // ****** Resource Manager permissions ******
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
+
+    // ****** User and Global Space permissions ******
+
+
+    // ****** JMX permissions ******
+    // AuthPermission is requires for those who would like to access any mbean
+    permission javax.security.auth.AuthPermission "getSubject";
+    permission java.lang.RuntimePermission "setContextClassLoader";
+    permission javax.management.MBeanPermission "-#-[-]", "queryNames";
+    permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
+
+    // ****** Default permissions ******
+    // Granting file reading permission i.e. to read RRD database via JMX
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+
+    // API - access to database
+    permission java.sql.SQLPermission "setLog";
+    permission java.sql.SQLPermission "callAbort";
+    permission java.sql.SQLPermission "setSyncFactory";
+    permission java.sql.SQLPermission "setNetworkTimeout";
+    permission java.util.PropertyPermission "*", "read, write";
+    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
+};
+
+
+grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "citizen-ds" {
+    // ****** Global permissions ******
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "studio,workflow-execution,catalog-portal,job-analytics";
+
+    // ****** Scheduler permissions ******
+    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
     permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "1,2,3";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithBucketNamePermission "";
     permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGroupNamePermission "";
-
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
 
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
+    // ****** Resource Manager permissions ******
 
-    // API - access to database
-    permission java.sql.SQLPermission "setLog";
-    permission java.sql.SQLPermission "callAbort";
-    permission java.sql.SQLPermission "setSyncFactory";
-    permission java.sql.SQLPermission "setNetworkTimeout";
-    permission java.util.PropertyPermission "*", "read, write";
-    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
-};
-
-grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "expert-ds" {
-    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "studio,scheduler,catalog-portal,workflow-execution,service-automation,job-analytics,job-gantt,job-planner-calendar-def,job-planner-calendar-def-workflows,job-planner-execution-planning,job-planner-gantt-chart,notification-portal";
-
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
     permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
 
+    // ****** User and Global Space permissions ******
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
+
+    // ****** JMX permissions ******
     // AuthPermission is requires for those who would like to access any mbean
     permission javax.security.auth.AuthPermission "getSubject";
     permission java.lang.RuntimePermission "setContextClassLoader";
@@ -469,30 +503,10 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
     permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
+
+    // ****** Default permissions ******
     // Granting file reading permission i.e. to read RRD database via JMX
     permission java.io.FilePermission "<<ALL FILES>>", "read";
-
-    // --------------------------- scheduling related permission
-	// Use the following line to allow a user to manage any submitted job on the scheduler
-	//"true" means that this user can manage only his/her job
-	//"false" means that this user can manage any job
-    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
-    // if HandleOnlyMyJobsPermission is true, it is also possible to enable read-only access to other users' jobs.
-    // Uncomment the following line to enable it
-    // permission org.ow2.proactive.scheduler.permissions.OtherUsersJobReadPermission;
-
-    permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "0,1,2,3,4";
-    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
-    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithBucketNamePermission "";
-    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGroupNamePermission "";
-    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
-
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.write";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
-
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
-    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
 
     // API - access to database
     permission java.sql.SQLPermission "setLog";
@@ -501,13 +515,67 @@ grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "
     permission java.sql.SQLPermission "setNetworkTimeout";
     permission java.util.PropertyPermission "*", "read, write";
     permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
 };
+
+
+grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal "expert-ds" {
+    // ****** Global permissions ******
+    permission org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission "scheduler,studio,workflow-execution,catalog-portal,job-analytics,job-gantt,job-planner-calendar-def,job-planner-calendar-def-workflows,job-planner-execution-planning,job-planner-gantt-chart,service-automation,notification-portal";
+    permission org.ow2.proactive.permissions.RoleReaderPermission;
+    permission org.ow2.proactive.scheduler.permissions.JPCanCreateAssociationPermission;
+
+    // ****** Scheduler permissions ******
+    permission org.ow2.proactive.scheduler.permissions.HandleOnlyMyJobsPermission "true";
+    permission org.ow2.proactive.scheduler.permissions.ChangePriorityPermission "0,1,2,3,4";
+    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGenericInformationPermission "";
+    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithBucketNamePermission "";
+    permission org.ow2.proactive.scheduler.permissions.HandleJobsWithGroupNamePermission "";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.basic";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.read";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.scheduler.core.SchedulerFrontend.write";
+
+    // ****** Resource Manager permissions ******
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.basic";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.read";
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive.resourcemanager.core.RMCore.write";
+
+    // ****** User and Global Space permissions ******
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.user.*";
+
+    permission org.ow2.proactive.permissions.ServiceRolePermission "org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl.global.*";
+
+    // ****** JMX permissions ******
+    // AuthPermission is requires for those who would like to access any mbean
+    permission javax.security.auth.AuthPermission "getSubject";
+    permission java.lang.RuntimePermission "setContextClassLoader";
+    permission javax.management.MBeanPermission "-#-[-]", "queryNames";
+    permission javax.management.MBeanPermission "javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]", "addNotificationListener";
+    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]", "*";
+    permission javax.management.MBeanPermission "org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]", "*";
+
+    // ****** Default permissions ******
+    // Granting file reading permission i.e. to read RRD database via JMX
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+
+    // API - access to database
+    permission java.sql.SQLPermission "setLog";
+    permission java.sql.SQLPermission "callAbort";
+    permission java.sql.SQLPermission "setSyncFactory";
+    permission java.sql.SQLPermission "setNetworkTimeout";
+    permission java.util.PropertyPermission "*", "read, write";
+    permission java.net.SocketPermission "*", "accept, connect, listen, resolve";
+
+};
+
 
 //
 // OTHER PERMISSIONS
 //
 // Allow all actions to subjects without principals above
 grant {
-	permission java.security.AllPermission;
+    permission java.security.AllPermission;
 };
-

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRestInterface.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.ow2.proactive.authentication.UserData;
+import org.ow2.proactive_grid_cloud_portal.common.dto.JAASConfiguration;
 import org.ow2.proactive_grid_cloud_portal.common.dto.LoginForm;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.RestException;
 import org.ow2.proactive_grid_cloud_portal.scheduler.exception.SchedulerRestException;
@@ -182,6 +183,40 @@ public interface CommonRestInterface {
     @Produces(MediaType.APPLICATION_JSON)
     boolean portalAccess(@HeaderParam("sessionid") String sessionId, @PathParam("portal") String portal)
             throws RestException;
+
+    /**
+     * Read existing groups roles
+     *
+     * If the user has the RoleReaderPermission, it will return the roles of the current user's groups
+     * If the user has the RoleAdminPermission, it will return all existing group roles
+     * If the user does not have either of these permissions, it will return an error
+     *
+     * @param sessionId id of a session
+     * @throws RestException if an error occurs or the session is invalid
+     * @return a structure containing the definition of group permissions
+     */
+    @GET
+    @Path("manager/groups")
+    @Produces(MediaType.APPLICATION_JSON)
+    JAASConfiguration permissionManagerGroupsRead(@HeaderParam("sessionid") String sessionId)
+            throws RestException, IOException;
+
+    /**
+     * Write groups roles
+     *
+     * If the user has the RoleAdminPermission, new roles will be written and loaded on the server
+     * If the user does not have this permission, it will return an error
+     *
+     * @param sessionId id of a session
+     * @param configuration the new role configuration
+     * @throws RestException if an error occurs or the session is invalid
+     * @return the new roles configuration
+     */
+    @PUT
+    @Path("manager/groups")
+    @Produces(MediaType.APPLICATION_JSON)
+    JAASConfiguration permissionManagerGroupsWrite(@HeaderParam("sessionid") String sessionId,
+            JAASConfiguration configuration) throws RestException, IOException;
 
     /**
      * Check if a user has admin privilege in notification service.

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASConfiguration.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common.dto;
+
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+@XmlRootElement
+public class JAASConfiguration {
+
+    private Map<String, JAASGroup> jaasGroups;
+
+    public JAASConfiguration() {
+
+    }
+
+    public Map<String, JAASGroup> getJaasGroups() {
+        return jaasGroups;
+    }
+
+    public void setJaasGroups(Map<String, JAASGroup> jaasGroups) {
+        this.jaasGroups = jaasGroups;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JAASConfiguration that = (JAASConfiguration) o;
+        return jaasGroups.equals(that.jaasGroups);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jaasGroups);
+    }
+
+    @Override
+    public String toString() {
+        return "JAASConfiguration{" + "jaasGroups=" + jaasGroups + '}';
+    }
+}

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASGroup.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASGroup.java
@@ -1,0 +1,260 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common.dto;
+
+import java.util.*;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.ImmutableMap;
+
+
+@XmlRootElement
+public class JAASGroup {
+
+    private String name;
+
+    public static Map.Entry of(String key, Boolean value) {
+        return new AbstractMap.SimpleEntry<>(key, value);
+    }
+
+    private Map<String, Boolean> portalAccess = ImmutableMap.ofEntries(of("rm", false),
+                                                                       of("scheduler", false),
+                                                                       of("studio", false),
+                                                                       of("automation-dashboard", false),
+                                                                       of("workflow-execution", false),
+                                                                       of("catalog-portal", false),
+                                                                       of("health-dashboard", false),
+                                                                       of("job-analytics", false),
+                                                                       of("job-gantt", false),
+                                                                       of("node-gantt", false),
+                                                                       of("job-planner-calendar-def", false),
+                                                                       of("job-planner-calendar-def-workflows", false),
+                                                                       of("job-planner-execution-planning", false),
+                                                                       of("job-planner-gantt-chart", false),
+                                                                       of("event-orchestration", false),
+                                                                       of("service-automation", false),
+                                                                       of("notification-portal", false));
+
+    private boolean roleAdmin = false;
+
+    private boolean roleReader = false;
+
+    private boolean pcaAdmin = false;
+
+    private boolean notificationAdmin = false;
+
+    private boolean tenantAllAccess = false;
+
+    private boolean jopPlannerCanCreateAssociation = false;
+
+    private boolean jobPlannerAdmin = false;
+
+    private boolean catalogAdmin = false;
+
+    private JAASRMRoles resourceManager = new JAASRMRoles();
+
+    private JAASSchedulerRoles scheduler = new JAASSchedulerRoles();
+
+    private Map<String, Boolean> userSpaceRoles = ImmutableMap.of("read", false, "write", false);
+
+    private Map<String, Boolean> globalSpaceRoles = ImmutableMap.of("read", false, "write", false);
+
+    private JAASGroupAdvancedRoles advanced = new JAASGroupAdvancedRoles();
+
+    public JAASGroup() {
+
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Boolean> getPortalAccess() {
+        return portalAccess;
+    }
+
+    public void setPortalAccess(Map<String, Boolean> portalAccess) {
+        this.portalAccess = portalAccess;
+    }
+
+    public boolean isRoleAdmin() {
+        return roleAdmin;
+    }
+
+    public void setRoleAdmin(boolean roleAdmin) {
+        this.roleAdmin = roleAdmin;
+    }
+
+    public boolean isRoleReader() {
+        return roleReader;
+    }
+
+    public void setRoleReader(boolean roleReader) {
+        this.roleReader = roleReader;
+    }
+
+    public boolean isPcaAdmin() {
+        return pcaAdmin;
+    }
+
+    public void setPcaAdmin(boolean pcaAdmin) {
+        this.pcaAdmin = pcaAdmin;
+    }
+
+    public boolean isNotificationAdmin() {
+        return notificationAdmin;
+    }
+
+    public void setNotificationAdmin(boolean notificationAdmin) {
+        this.notificationAdmin = notificationAdmin;
+    }
+
+    public boolean isTenantAllAccess() {
+        return tenantAllAccess;
+    }
+
+    public void setTenantAllAccess(boolean tenantAllAccess) {
+        this.tenantAllAccess = tenantAllAccess;
+    }
+
+    public boolean isJopPlannerCanCreateAssociation() {
+        return jopPlannerCanCreateAssociation;
+    }
+
+    public void setJopPlannerCanCreateAssociation(boolean jopPlannerCanCreateAssociation) {
+        this.jopPlannerCanCreateAssociation = jopPlannerCanCreateAssociation;
+    }
+
+    public boolean isJobPlannerAdmin() {
+        return jobPlannerAdmin;
+    }
+
+    public void setJobPlannerAdmin(boolean jobPlannerAdmin) {
+        this.jobPlannerAdmin = jobPlannerAdmin;
+    }
+
+    public boolean isCatalogAdmin() {
+        return catalogAdmin;
+    }
+
+    public void setCatalogAdmin(boolean catalogAdmin) {
+        this.catalogAdmin = catalogAdmin;
+    }
+
+    public JAASRMRoles getResourceManager() {
+        return resourceManager;
+    }
+
+    public void setResourceManager(JAASRMRoles resourceManager) {
+        this.resourceManager = resourceManager;
+    }
+
+    public JAASSchedulerRoles getScheduler() {
+        return scheduler;
+    }
+
+    public void setScheduler(JAASSchedulerRoles scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public Map<String, Boolean> getUserSpaceRoles() {
+        return userSpaceRoles;
+    }
+
+    public void setUserSpaceRoles(Map<String, Boolean> userSpaceRoles) {
+        this.userSpaceRoles = userSpaceRoles;
+    }
+
+    public Map<String, Boolean> getGlobalSpaceRoles() {
+        return globalSpaceRoles;
+    }
+
+    public void setGlobalSpaceRoles(Map<String, Boolean> globalSpaceRoles) {
+        this.globalSpaceRoles = globalSpaceRoles;
+    }
+
+    public JAASGroupAdvancedRoles getAdvanced() {
+        return advanced;
+    }
+
+    public void setAdvanced(JAASGroupAdvancedRoles advanced) {
+        this.advanced = advanced;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JAASGroup jaasGroup = (JAASGroup) o;
+        return roleAdmin == jaasGroup.roleAdmin && roleReader == jaasGroup.roleReader &&
+               pcaAdmin == jaasGroup.pcaAdmin && notificationAdmin == jaasGroup.notificationAdmin &&
+               tenantAllAccess == jaasGroup.tenantAllAccess &&
+               jopPlannerCanCreateAssociation == jaasGroup.jopPlannerCanCreateAssociation &&
+               jobPlannerAdmin == jaasGroup.jobPlannerAdmin && catalogAdmin == jaasGroup.catalogAdmin &&
+               name.equals(jaasGroup.name) && portalAccess.equals(jaasGroup.portalAccess) &&
+               resourceManager.equals(jaasGroup.resourceManager) && scheduler.equals(jaasGroup.scheduler) &&
+               userSpaceRoles.equals(jaasGroup.userSpaceRoles) && globalSpaceRoles.equals(jaasGroup.globalSpaceRoles) &&
+               advanced.equals(jaasGroup.advanced);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name,
+                            portalAccess,
+                            roleAdmin,
+                            roleReader,
+                            pcaAdmin,
+                            notificationAdmin,
+                            tenantAllAccess,
+                            jopPlannerCanCreateAssociation,
+                            jobPlannerAdmin,
+                            catalogAdmin,
+                            resourceManager,
+                            scheduler,
+                            userSpaceRoles,
+                            globalSpaceRoles,
+                            advanced);
+    }
+
+    @Override
+    public String toString() {
+        return "JAASGroup{" + "name='" + name + '\'' + ", portalAccess=" + portalAccess + ", roleAdmin=" + roleAdmin +
+               ", roleReader=" + roleReader + ", pcaAdmin=" + pcaAdmin + ", notificationAdmin=" + notificationAdmin +
+               ", tenantAllAccess=" + tenantAllAccess + ", jopPlannerCanCreateAssociation=" +
+               jopPlannerCanCreateAssociation + ", jobPlannerAdmin=" + jobPlannerAdmin + ", catalogAdmin=" +
+               catalogAdmin + ", resourceManager=" + resourceManager + ", scheduler=" + scheduler +
+               ", userSpaceRoles=" + userSpaceRoles + ", globalSpaceRoles=" + globalSpaceRoles + ", advanced=" +
+               advanced + '}';
+    }
+
+}

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASGroupAdvancedRoles.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASGroupAdvancedRoles.java
@@ -1,0 +1,81 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+@XmlRootElement
+public class JAASGroupAdvancedRoles {
+
+    boolean allPermissions = false;
+
+    List<String> deniedMethodCalls = new ArrayList<String>();
+
+    public JAASGroupAdvancedRoles() {
+    }
+
+    public List<String> getDeniedMethodCalls() {
+        return deniedMethodCalls;
+    }
+
+    public void setDeniedMethodCalls(List<String> deniedMethodCalls) {
+        this.deniedMethodCalls = deniedMethodCalls;
+    }
+
+    public boolean isAllPermissions() {
+        return allPermissions;
+    }
+
+    public void setAllPermissions(boolean allPermissions) {
+        this.allPermissions = allPermissions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JAASGroupAdvancedRoles that = (JAASGroupAdvancedRoles) o;
+        return allPermissions == that.allPermissions && deniedMethodCalls.equals(that.deniedMethodCalls);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(allPermissions, deniedMethodCalls);
+    }
+
+    @Override
+    public String toString() {
+        return "JAASGroupAdvancedRoles{" + "allPermissions=" + allPermissions + ", deniedMethodCalls=" +
+               deniedMethodCalls + '}';
+    }
+}

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASRMAdvancedRoles.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASRMAdvancedRoles.java
@@ -1,0 +1,89 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common.dto;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+@XmlRootElement
+public class JAASRMAdvancedRoles {
+    boolean nodeFullAccess = false;
+
+    boolean rmMyAccountReader = false;
+
+    boolean rmAllAccountsReader = false;
+
+    public JAASRMAdvancedRoles() {
+    }
+
+    public boolean isNodeFullAccess() {
+        return nodeFullAccess;
+    }
+
+    public void setNodeFullAccess(boolean nodeFullAccess) {
+        this.nodeFullAccess = nodeFullAccess;
+    }
+
+    public boolean isRmMyAccountReader() {
+        return rmMyAccountReader;
+    }
+
+    public void setRmMyAccountReader(boolean rmMyAccountReader) {
+        this.rmMyAccountReader = rmMyAccountReader;
+    }
+
+    public boolean isRmAllAccountsReader() {
+        return rmAllAccountsReader;
+    }
+
+    public void setRmAllAccountsReader(boolean rmAllAccountsReader) {
+        this.rmAllAccountsReader = rmAllAccountsReader;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JAASRMAdvancedRoles that = (JAASRMAdvancedRoles) o;
+        return nodeFullAccess == that.nodeFullAccess && rmMyAccountReader == that.rmMyAccountReader &&
+               rmAllAccountsReader == that.rmAllAccountsReader;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeFullAccess, rmMyAccountReader, rmAllAccountsReader);
+    }
+
+    @Override
+    public String toString() {
+        return "JAASRMAdvancedRoles{" + "nodeFullAccess=" + nodeFullAccess + ", rmMyAccountReader=" +
+               rmMyAccountReader + ", rmAllAccountsReader=" + rmAllAccountsReader + '}';
+    }
+}

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASRMRoles.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASRMRoles.java
@@ -1,0 +1,114 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common.dto;
+
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.ImmutableMap;
+
+
+@XmlRootElement
+public class JAASRMRoles {
+    private boolean resourceManagerGlobalAdmin = false;
+
+    private boolean nodeSourceAdmin = false;
+
+    private Map<String, Boolean> resourceManagerRoles = ImmutableMap.of("basic",
+                                                                        false,
+                                                                        "read",
+                                                                        false,
+                                                                        "write",
+                                                                        false,
+                                                                        "provider",
+                                                                        false,
+                                                                        "nsadmin",
+                                                                        false,
+                                                                        "admin",
+                                                                        false);
+
+    private JAASRMAdvancedRoles advanced = new JAASRMAdvancedRoles();
+
+    public JAASRMRoles() {
+    }
+
+    public boolean isResourceManagerGlobalAdmin() {
+        return resourceManagerGlobalAdmin;
+    }
+
+    public void setResourceManagerGlobalAdmin(boolean resourceManagerGlobalAdmin) {
+        this.resourceManagerGlobalAdmin = resourceManagerGlobalAdmin;
+    }
+
+    public boolean isNodeSourceAdmin() {
+        return nodeSourceAdmin;
+    }
+
+    public void setNodeSourceAdmin(boolean nodeSourceAdmin) {
+        this.nodeSourceAdmin = nodeSourceAdmin;
+    }
+
+    public Map<String, Boolean> getResourceManagerRoles() {
+        return resourceManagerRoles;
+    }
+
+    public void setResourceManagerRoles(Map<String, Boolean> resourceManagerRoles) {
+        this.resourceManagerRoles = resourceManagerRoles;
+    }
+
+    public JAASRMAdvancedRoles getAdvanced() {
+        return advanced;
+    }
+
+    public void setAdvanced(JAASRMAdvancedRoles advanced) {
+        this.advanced = advanced;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JAASRMRoles that = (JAASRMRoles) o;
+        return resourceManagerGlobalAdmin == that.resourceManagerGlobalAdmin &&
+               nodeSourceAdmin == that.nodeSourceAdmin && resourceManagerRoles.equals(that.resourceManagerRoles) &&
+               advanced.equals(that.advanced);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceManagerGlobalAdmin, nodeSourceAdmin, resourceManagerRoles, advanced);
+    }
+
+    @Override
+    public String toString() {
+        return "JAASRMRoles{" + "resourceManagerGlobalAdmin=" + resourceManagerGlobalAdmin + ", nodeSourceAdmin=" +
+               nodeSourceAdmin + ", resourceManagerRoles=" + resourceManagerRoles + ", advanced=" + advanced + '}';
+    }
+}

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASSchedulerAdvancedRoles.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASSchedulerAdvancedRoles.java
@@ -1,0 +1,156 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common.dto;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+@XmlRootElement
+public class JAASSchedulerAdvancedRoles {
+    boolean otherUsersJobRead = false;
+
+    String handleJobsWithGenericInformation = null;
+
+    String handleJobsWithBucketName = null;
+
+    String handleJobsWithGroupName = null;
+
+    boolean connectToResourceManager = false;
+
+    boolean changeSchedulingPolicy = false;
+
+    boolean schedulerMyAccountReader = false;
+
+    boolean schedulerAllAccountsReader = false;
+
+    public JAASSchedulerAdvancedRoles() {
+    }
+
+    public boolean isOtherUsersJobRead() {
+        return otherUsersJobRead;
+    }
+
+    public void setOtherUsersJobRead(boolean otherUsersJobRead) {
+        this.otherUsersJobRead = otherUsersJobRead;
+    }
+
+    public String getHandleJobsWithGenericInformation() {
+        return handleJobsWithGenericInformation;
+    }
+
+    public void setHandleJobsWithGenericInformation(String handleJobsWithGenericInformation) {
+        this.handleJobsWithGenericInformation = handleJobsWithGenericInformation;
+    }
+
+    public String getHandleJobsWithBucketName() {
+        return handleJobsWithBucketName;
+    }
+
+    public void setHandleJobsWithBucketName(String handleJobsWithBucketName) {
+        this.handleJobsWithBucketName = handleJobsWithBucketName;
+    }
+
+    public String getHandleJobsWithGroupName() {
+        return handleJobsWithGroupName;
+    }
+
+    public void setHandleJobsWithGroupName(String handleJobsWithGroupName) {
+        this.handleJobsWithGroupName = handleJobsWithGroupName;
+    }
+
+    public boolean isConnectToResourceManager() {
+        return connectToResourceManager;
+    }
+
+    public void setConnectToResourceManager(boolean connectToResourceManager) {
+        this.connectToResourceManager = connectToResourceManager;
+    }
+
+    public boolean isChangeSchedulingPolicy() {
+        return changeSchedulingPolicy;
+    }
+
+    public void setChangeSchedulingPolicy(boolean changeSchedulingPolicy) {
+        this.changeSchedulingPolicy = changeSchedulingPolicy;
+    }
+
+    public boolean isSchedulerMyAccountReader() {
+        return schedulerMyAccountReader;
+    }
+
+    public void setSchedulerMyAccountReader(boolean schedulerMyAccountReader) {
+        this.schedulerMyAccountReader = schedulerMyAccountReader;
+    }
+
+    public boolean isSchedulerAllAccountsReader() {
+        return schedulerAllAccountsReader;
+    }
+
+    public void setSchedulerAllAccountsReader(boolean schedulerAllAccountsReader) {
+        this.schedulerAllAccountsReader = schedulerAllAccountsReader;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JAASSchedulerAdvancedRoles that = (JAASSchedulerAdvancedRoles) o;
+        return otherUsersJobRead == that.otherUsersJobRead &&
+               connectToResourceManager == that.connectToResourceManager &&
+               changeSchedulingPolicy == that.changeSchedulingPolicy &&
+               schedulerMyAccountReader == that.schedulerMyAccountReader &&
+               schedulerAllAccountsReader == that.schedulerAllAccountsReader &&
+               Objects.equals(handleJobsWithGenericInformation, that.handleJobsWithGenericInformation) &&
+               Objects.equals(handleJobsWithBucketName, that.handleJobsWithBucketName) &&
+               Objects.equals(handleJobsWithGroupName, that.handleJobsWithGroupName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(otherUsersJobRead,
+                            handleJobsWithGenericInformation,
+                            handleJobsWithBucketName,
+                            handleJobsWithGroupName,
+                            connectToResourceManager,
+                            changeSchedulingPolicy,
+                            schedulerMyAccountReader,
+                            schedulerAllAccountsReader);
+    }
+
+    @Override
+    public String toString() {
+        return "JAASSchedulerAdvancedRoles{" + "otherUsersJobRead=" + otherUsersJobRead +
+               ", handleJobsWithGenericInformation='" + handleJobsWithGenericInformation + '\'' +
+               ", handleJobsWithBucketName='" + handleJobsWithBucketName + '\'' + ", handleJobsWithGroupName='" +
+               handleJobsWithGroupName + '\'' + ", connectToResourceManager=" + connectToResourceManager +
+               ", changeSchedulingPolicy=" + changeSchedulingPolicy + ", schedulerMyAccountReader=" +
+               schedulerMyAccountReader + ", schedulerAllAccountsReader=" + schedulerAllAccountsReader + '}';
+    }
+}

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASSchedulerRoles.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/dto/JAASSchedulerRoles.java
@@ -1,0 +1,122 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common.dto;
+
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.ImmutableMap;
+
+
+@XmlRootElement
+public class JAASSchedulerRoles {
+
+    private Boolean handleOnlyMyJobs = null;
+
+    private Map<String, Boolean> changeJobPriority = ImmutableMap.of("0",
+                                                                     false,
+                                                                     "1",
+                                                                     false,
+                                                                     "2",
+                                                                     false,
+                                                                     "3",
+                                                                     false,
+                                                                     "4",
+                                                                     false,
+                                                                     "5",
+                                                                     false);
+
+    private Map<String, Boolean> schedulerRoles = ImmutableMap.of("basic",
+                                                                  false,
+                                                                  "read",
+                                                                  false,
+                                                                  "write",
+                                                                  false,
+                                                                  "admin",
+                                                                  false);
+
+    private JAASSchedulerAdvancedRoles advanced = new JAASSchedulerAdvancedRoles();
+
+    public JAASSchedulerRoles() {
+    }
+
+    public Boolean getHandleOnlyMyJobs() {
+        return handleOnlyMyJobs;
+    }
+
+    public void setHandleOnlyMyJobs(Boolean handleOnlyMyJobs) {
+        this.handleOnlyMyJobs = handleOnlyMyJobs;
+    }
+
+    public JAASSchedulerAdvancedRoles getAdvanced() {
+        return advanced;
+    }
+
+    public void setAdvanced(JAASSchedulerAdvancedRoles advanced) {
+        this.advanced = advanced;
+    }
+
+    public Map<String, Boolean> getChangeJobPriority() {
+        return changeJobPriority;
+    }
+
+    public void setChangeJobPriority(Map<String, Boolean> changeJobPriority) {
+        this.changeJobPriority = changeJobPriority;
+    }
+
+    public Map<String, Boolean> getSchedulerRoles() {
+        return schedulerRoles;
+    }
+
+    public void setSchedulerRoles(Map<String, Boolean> schedulerRoles) {
+        this.schedulerRoles = schedulerRoles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JAASSchedulerRoles that = (JAASSchedulerRoles) o;
+        return Objects.equals(handleOnlyMyJobs, that.handleOnlyMyJobs) &&
+               changeJobPriority.equals(that.changeJobPriority) && schedulerRoles.equals(that.schedulerRoles) &&
+               advanced.equals(that.advanced);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(handleOnlyMyJobs, changeJobPriority, schedulerRoles, advanced);
+    }
+
+    @Override
+    public String toString() {
+        return "JAASSchedulerRoles{" + "handleOnlyMyJobs=" + handleOnlyMyJobs + ", changeJobPriority=" +
+               changeJobPriority + ", schedulerRoles=" + schedulerRoles + ", advanced=" + advanced + '}';
+    }
+}

--- a/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
+++ b/rest/rest-client/src/main/java/org/ow2/proactive/scheduler/rest/data/UserIdentificationImpl.java
@@ -99,6 +99,16 @@ public class UserIdentificationImpl extends UserIdentification {
     }
 
     @Override
+    public boolean isRoleReadPermission() {
+        return false;
+    }
+
+    @Override
+    public boolean isRoleAdminPermission() {
+        return false;
+    }
+
+    @Override
     public boolean isCanCreateAssociationPermission() {
         return false;
     }

--- a/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/JAASParserInterface.java
+++ b/rest/rest-server/src/main/java/org/ow2/proactive_grid_cloud_portal/common/JAASParserInterface.java
@@ -1,0 +1,38 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive_grid_cloud_portal.common;
+
+import java.io.IOException;
+
+import org.ow2.proactive_grid_cloud_portal.common.dto.JAASConfiguration;
+
+
+public interface JAASParserInterface {
+
+    JAASConfiguration readJAASConfiguration() throws IOException;
+
+    void writeJAASConfiguration(JAASConfiguration configuration) throws IOException;
+}

--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/job/UserIdentification.java
@@ -86,10 +86,19 @@ public abstract class UserIdentification implements Serializable, Comparable<Use
     public abstract Set<String> getGroups();
 
     /**
-     *
-     * @return
+     * check if the user has access to all tenants
      */
     public abstract boolean isAllTenantPermission();
+
+    /**
+     * check if the user has the rights to read his groups roles
+     */
+    public abstract boolean isRoleReadPermission();
+
+    /**
+     * check if the user has the rights to modify existing groups/roles (super admin)
+     */
+    public abstract boolean isRoleAdminPermission();
 
     /**
      * Check if the user has all job planner permission

--- a/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/UserIdentificationImpl.java
+++ b/scheduler/scheduler-client/src/main/java/org/ow2/proactive/scheduler/job/UserIdentificationImpl.java
@@ -35,10 +35,7 @@ import org.ow2.proactive.authentication.principals.DomainNamePrincipal;
 import org.ow2.proactive.authentication.principals.GroupNamePrincipal;
 import org.ow2.proactive.authentication.principals.TenantPrincipal;
 import org.ow2.proactive.authentication.principals.UserNamePrincipal;
-import org.ow2.proactive.permissions.NotificationAdminPermission;
-import org.ow2.proactive.permissions.PcaAdminPermission;
-import org.ow2.proactive.permissions.RMCoreAllPermission;
-import org.ow2.proactive.permissions.ServiceRolePermission;
+import org.ow2.proactive.permissions.*;
 import org.ow2.proactive.scheduler.common.SchedulerEvent;
 import org.ow2.proactive.scheduler.common.exception.PermissionException;
 import org.ow2.proactive.scheduler.common.job.JobPriority;
@@ -160,6 +157,24 @@ public class UserIdentificationImpl extends UserIdentification {
     public boolean isAllTenantPermission() {
         try {
             return checkPermission(new TenantAllAccessPermission(), "N/A");
+        } catch (PermissionException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isRoleReadPermission() {
+        try {
+            return checkPermission(new RoleReaderPermission(), "N/A");
+        } catch (PermissionException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isRoleAdminPermission() {
+        try {
+            return checkPermission(new RoleAdminPermission(), "N/A");
         } catch (PermissionException e) {
             return false;
         }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/SchedulerFrontendState.java
@@ -1609,6 +1609,8 @@ class SchedulerFrontendState implements SchedulerStateUpdate {
         userData.setAllTenantPermission(userSessionInfo.getRight().isAllTenantPermission());
         userData.setAllJobPlannerPermission(userSessionInfo.getRight().isAllJobPlannerPermission());
         userData.setAllCatalogPermission(userSessionInfo.getRight().isAllCatalogPermission());
+        userData.setRoleReadPermission(userSessionInfo.getRight().isRoleReadPermission());
+        userData.setRoleAdminPermission(userSessionInfo.getRight().isRoleAdminPermission());
         userData.setCanCreateAssociationPermission(userSessionInfo.getRight().isCanCreateAssociationPermission());
         userData.setSchedulerAdminPermission(userSessionInfo.getRight().isSchedulerAdminPermission());
         userData.setRmCoreAllPermission(userSessionInfo.getRight().isRMCoreAllPermission());

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/util/SchedulerStarter.java
@@ -91,13 +91,9 @@ import org.ow2.proactive.scripting.ScriptHandler;
 import org.ow2.proactive.scripting.ScriptLoader;
 import org.ow2.proactive.scripting.ScriptResult;
 import org.ow2.proactive.scripting.SimpleScript;
-import org.ow2.proactive.utils.FileToBytesConverter;
-import org.ow2.proactive.utils.JettyStarter;
-import org.ow2.proactive.utils.PAMRRouterStarter;
-import org.ow2.proactive.utils.SecurityPolicyLoader;
-import org.ow2.proactive.utils.Tools;
-import org.ow2.proactive.utils.Version;
+import org.ow2.proactive.utils.*;
 import org.ow2.proactive.web.WebProperties;
+import org.ow2.proactive_grid_cloud_portal.common.CommonRest;
 
 import com.jcraft.jsch.JSch;
 
@@ -265,6 +261,8 @@ public class SchedulerStarter {
             schedulerURL = schedulerAuthenticationInterface.getHostURL();
             schedAuthInter = schedulerAuthenticationInterface;
         }
+
+        CommonRest.setJaasParserInterface(new JAASParser());
 
         if (!commandLine.hasOption(OPTION_NO_REST)) {
             long jettyStartTime = System.nanoTime();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JAASParser.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/utils/JAASParser.java
@@ -1,0 +1,609 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import javax.management.MBeanPermission;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+import org.ow2.proactive.permissions.*;
+import org.ow2.proactive.resourcemanager.core.RMCore;
+import org.ow2.proactive.scheduler.core.SchedulerFrontend;
+import org.ow2.proactive.scheduler.core.jmx.mbean.AllAccountsMBeanImpl;
+import org.ow2.proactive.scheduler.core.jmx.mbean.MyAccountMBeanImpl;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
+import org.ow2.proactive.scheduler.permissions.*;
+import org.ow2.proactive_grid_cloud_portal.common.JAASParserInterface;
+import org.ow2.proactive_grid_cloud_portal.common.PortalAccessPermission;
+import org.ow2.proactive_grid_cloud_portal.common.dto.*;
+import org.ow2.proactive_grid_cloud_portal.dataspace.RestDataspaceImpl;
+
+
+public class JAASParser implements JAASParserInterface {
+
+    private static final Logger logger = Logger.getLogger(JAASParser.class);
+
+    private static final String I = "    ";
+
+    private static final String P = "permission ";
+
+    private static final String S = "******";
+
+    private static final String NL = "\n";
+
+    private static final String GROUP_ROLE = "grant principal org.ow2.proactive.authentication.principals.GroupNamePrincipal ";
+
+    private static final String GLOBAL_ROLE_BEGIN = "grant {";
+
+    private static final String GLOBAL_ROLE = "//\n" + "// OTHER PERMISSIONS\n" + "//\n" +
+                                              "// Allow all actions to subjects without principals above\n" +
+                                              "grant {\n" + "    permission java.security.AllPermission;\n" + "};\n";
+
+    private static final String DEFAULT_FILE_ROLE = "    // Granting file reading permission i.e. to read RRD database via JMX\n" +
+                                                    "    permission java.io.FilePermission \"<<ALL FILES>>\", \"read\";\n";
+
+    private static final String DEFAULT_MBEAN_ROLE = "    // AuthPermission is requires for those who would like to access any mbean\n" +
+                                                     "    permission javax.security.auth.AuthPermission \"getSubject\";\n" +
+                                                     "    permission java.lang.RuntimePermission \"setContextClassLoader\";\n" +
+                                                     "    permission javax.management.MBeanPermission \"-#-[-]\", \"queryNames\";\n" +
+                                                     "    permission javax.management.MBeanPermission \"javax.management.MBeanServerDelegate#-[JMImplementation:type=MBeanServerDelegate]\", \"addNotificationListener\";\n";
+
+    private static final String RM_MY_ACCOUNT_BEAN_ROLE = "    permission javax.management.MBeanPermission \"org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]\", \"*\";\n" +
+                                                          "    permission javax.management.MBeanPermission \"org.ow2.proactive.resourcemanager.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]\", \"*\";\n";
+
+    private static final String RM_ALL_ACCOUNTS_BEAN_ROLE = "    permission javax.management.MBeanPermission \"org.ow2.proactive.resourcemanager.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]\", \"*\";\n" +
+                                                            "    permission javax.management.MBeanPermission \"org.ow2.proactive.resourcemanager.core.jmx.mbean.ManagementMBeanImpl#*[*:*]\", \"*\";\n";
+
+    private static final String SCHED_MY_ACCOUNT_BEAN_ROLE = "    permission javax.management.MBeanPermission \"org.ow2.proactive.scheduler.core.jmx.mbean.MyAccountMBeanImpl#*[*:*]\", \"*\";\n" +
+                                                             "    permission javax.management.MBeanPermission \"org.ow2.proactive.scheduler.core.jmx.mbean.RuntimeDataMBeanImpl#*[*:*]\", \"*\";\n";
+
+    private static final String SCHED_ALL_ACCOUNTS_BEAN_ROLE = "    permission javax.management.MBeanPermission \"org.ow2.proactive.scheduler.core.jmx.mbean.AllAccountsMBeanImpl#*[*:*]\", \"*\";\n" +
+                                                               "    permission javax.management.MBeanPermission \"org.ow2.proactive.scheduler.core.jmx.mbean.ManagementMBeanImpl#*[*:*]\", \"*\";\n";
+
+    private static final String DEFAULT_DB_ROLE = "    // API - access to database\n" +
+                                                  "    permission java.sql.SQLPermission \"setLog\";\n" +
+                                                  "    permission java.sql.SQLPermission \"callAbort\";\n" +
+                                                  "    permission java.sql.SQLPermission \"setSyncFactory\";\n" +
+                                                  "    permission java.sql.SQLPermission \"setNetworkTimeout\";\n" +
+                                                  "    permission java.util.PropertyPermission \"*\", \"read, write\";\n" +
+                                                  "    permission java.net.SocketPermission \"*\", \"accept, connect, listen, resolve\";\n";
+
+    private static final String JAAS_FILE_PATH = "config/security.java.policy-server";
+
+    @Override
+    public JAASConfiguration readJAASConfiguration() throws IOException {
+        return readJAASConfiguration(new File(System.getProperty(PASchedulerProperties.SCHEDULER_HOME.getKey()),
+                                              JAAS_FILE_PATH));
+    }
+
+    public JAASConfiguration readJAASConfiguration(File jaasFilePath) throws IOException {
+        JAASConfiguration answer = new JAASConfiguration();
+        List<String> lines = FileUtils.readLines(jaasFilePath, PASchedulerProperties.FILE_ENCODING.getValueAsString());
+        Map<String, JAASGroup> jaasGroups = new LinkedHashMap<>();
+        int beginGroup = -1;
+        int beginGlobalRole = -1;
+        String groupName = null;
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i).trim();
+            if (line.startsWith(GLOBAL_ROLE_BEGIN)) {
+                beginGlobalRole = i + 1;
+            } else if (line.startsWith(GROUP_ROLE)) {
+                beginGroup = i + 1;
+                if (line.contains("//")) {
+                    line = line.substring(0, line.indexOf("//"));
+                }
+                groupName = line.replace(GROUP_ROLE, "").replace("{", "").replace("\"", "").trim();
+            } else if (line.startsWith("}")) {
+                if (beginGroup < 0 && beginGlobalRole < 0) {
+                    throw new IllegalStateException("Invalid end group at line " + i + " without matching begin");
+                }
+                if (beginGlobalRole >= 0) {
+                    beginGlobalRole = -1;
+                    continue;
+                }
+                jaasGroups.put(groupName, readJAASGroup(groupName, lines.subList(beginGroup, i)));
+                beginGroup = -1;
+                groupName = null;
+            }
+        }
+        answer.setJaasGroups(jaasGroups);
+        return answer;
+    }
+
+    private JAASGroup readJAASGroup(String name, List<String> lines) {
+        JAASGroup answer = new JAASGroup();
+        JAASSchedulerRoles jaasSchedulerRoles = new JAASSchedulerRoles();
+        JAASSchedulerAdvancedRoles jaasSchedulerAdvancedRoles = new JAASSchedulerAdvancedRoles();
+        jaasSchedulerRoles.setAdvanced(jaasSchedulerAdvancedRoles);
+        JAASRMRoles jaasrmRoles = new JAASRMRoles();
+        JAASRMAdvancedRoles jaasrmAdvancedRoles = new JAASRMAdvancedRoles();
+        jaasrmRoles.setAdvanced(jaasrmAdvancedRoles);
+        JAASGroupAdvancedRoles jaasGroupAdvancedRoles = new JAASGroupAdvancedRoles();
+        answer.setName(name);
+        answer.setResourceManager(jaasrmRoles);
+        answer.setScheduler(jaasSchedulerRoles);
+        answer.setAdvanced(jaasGroupAdvancedRoles);
+        List<String> deniedMethodCalls = new ArrayList<>();
+
+        boolean allSchedulerRoles = false;
+        boolean allRMRoles = false;
+        boolean allUserSpaceRoles = false;
+        boolean allGlobalSpaceRoles = false;
+        List<String> schedulerRoles = new ArrayList<>();
+        List<String> rmRoles = new ArrayList<>();
+        List<String> userSpaceRoles = new ArrayList<>();
+        List<String> globalSpaceRoles = new ArrayList<>();
+
+        for (String line : lines) {
+            String originalLine = line;
+            try {
+                line = line.trim();
+                if (line.startsWith(P)) {
+                    // remove comments
+                    if (line.contains("//")) {
+                        line = line.substring(0, line.indexOf("//"));
+                    }
+                    line = line.replace(P, "").trim();
+                    line = line.substring(0, line.length() - 1).trim(); // remove ; character
+                    String permissionName;
+                    if (line.contains(" ")) {
+                        // permission with parameter
+                        permissionName = line.substring(0, line.indexOf(" "));
+                    } else {
+                        // permission without parameter
+                        permissionName = line;
+                    }
+
+                    if (PortalAccessPermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        Map<String, Boolean> portalPermissions = new LinkedHashMap<>(answer.getPortalAccess());
+                        if ("*".equals(parameter)) {
+                            portalPermissions.replaceAll((k, v) -> true);
+                        } else {
+                            for (String portal : Arrays.asList(parameter.split("\\s*,\\s*"))) {
+                                portalPermissions.put(portal, true);
+                            }
+                        }
+                        answer.setPortalAccess(portalPermissions);
+                    } else if (RoleAdminPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setRoleAdmin(true);
+                    } else if (RoleReaderPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setRoleReader(true);
+                    } else if (PcaAdminPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setPcaAdmin(true);
+                    } else if (NotificationAdminPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setNotificationAdmin(true);
+                    } else if (CatalogAllAccessPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setCatalogAdmin(true);
+                    } else if (HandleOnlyMyJobsPermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        boolean myJobs = Boolean.parseBoolean(parameter);
+                        jaasSchedulerRoles.setHandleOnlyMyJobs(myJobs);
+                    } else if (OtherUsersJobReadPermission.class.getCanonicalName().equals(permissionName)) {
+                        jaasSchedulerAdvancedRoles.setOtherUsersJobRead(true);
+                    } else if (ChangePriorityPermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        Map<String, Boolean> priorityPermission = new LinkedHashMap<>(jaasSchedulerRoles.getChangeJobPriority());
+                        for (String priority : Arrays.asList(parameter.split("\\s*,\\s*"))) {
+                            priorityPermission.put(priority, true);
+                        }
+                        jaasSchedulerRoles.setChangeJobPriority(priorityPermission);
+                    } else if (HandleJobsWithGenericInformationPermission.class.getCanonicalName()
+                                                                               .equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        jaasSchedulerAdvancedRoles.setHandleJobsWithGenericInformation(parameter);
+                    } else if (HandleJobsWithBucketNamePermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        jaasSchedulerAdvancedRoles.setHandleJobsWithBucketName(parameter);
+                    } else if (HandleJobsWithGroupNamePermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        jaasSchedulerAdvancedRoles.setHandleJobsWithGroupName(parameter);
+                    } else if (ConnectToResourceManagerPermission.class.getCanonicalName().equals(permissionName)) {
+                        jaasSchedulerAdvancedRoles.setConnectToResourceManager(true);
+                    } else if (ChangePolicyPermission.class.getCanonicalName().equals(permissionName)) {
+                        jaasSchedulerAdvancedRoles.setChangeSchedulingPolicy(true);
+                    } else if (TenantAllAccessPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setTenantAllAccess(true);
+                    } else if (JPCanCreateAssociationPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setJopPlannerCanCreateAssociation(true);
+                    } else if (JobPlannerAllAccessPermission.class.getCanonicalName().equals(permissionName)) {
+                        answer.setJobPlannerAdmin(true);
+                    } else if (AllPermission.class.getCanonicalName().equals(permissionName)) {
+                        jaasGroupAdvancedRoles.setAllPermissions(true);
+                    } else if (ServiceRolePermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        if (parameter.startsWith(SchedulerFrontend.class.getCanonicalName())) {
+                            String subParameter = parameter.replace(SchedulerFrontend.class.getCanonicalName() + ".",
+                                                                    "")
+                                                           .trim();
+                            if ("*".equals(subParameter)) {
+                                allSchedulerRoles = true;
+                            } else {
+                                schedulerRoles.add(subParameter);
+                            }
+                        } else if (parameter.startsWith(RMCore.class.getCanonicalName())) {
+                            String subParameter = parameter.replace(RMCore.class.getCanonicalName() + ".", "").trim();
+                            if ("*".equals(subParameter)) {
+                                allRMRoles = true;
+                            } else {
+                                rmRoles.add(subParameter);
+                            }
+                        } else if (parameter.startsWith(RestDataspaceImpl.class.getCanonicalName() + ".user")) {
+                            String subParameter = parameter.replace(RestDataspaceImpl.class.getCanonicalName() +
+                                                                    ".user.", "")
+                                                           .trim();
+                            if ("*".equals(subParameter)) {
+                                allUserSpaceRoles = true;
+                            } else {
+                                userSpaceRoles.add(subParameter);
+                            }
+                        } else if (parameter.startsWith(RestDataspaceImpl.class.getCanonicalName() + ".global")) {
+                            String subParameter = parameter.replace(RestDataspaceImpl.class.getCanonicalName() +
+                                                                    ".global.", "")
+                                                           .trim();
+                            if ("*".equals(subParameter)) {
+                                allGlobalSpaceRoles = true;
+                            } else {
+                                globalSpaceRoles.add(subParameter);
+                            }
+                        }
+                    } else if (RMCoreAllPermission.class.getCanonicalName().equals(permissionName)) {
+                        jaasrmRoles.setResourceManagerGlobalAdmin(true);
+                    } else if (NSAdminPermission.class.getCanonicalName().equals(permissionName)) {
+                        jaasrmRoles.setNodeSourceAdmin(true);
+                    } else if (NodeUserAllPermission.class.getCanonicalName().equals(permissionName)) {
+                        jaasrmAdvancedRoles.setNodeFullAccess(true);
+                    } else if (MBeanPermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim();
+                        if (parameter.contains(MyAccountMBeanImpl.class.getCanonicalName())) {
+                            jaasSchedulerAdvancedRoles.setSchedulerMyAccountReader(true);
+                        } else if (parameter.contains(org.ow2.proactive.resourcemanager.core.jmx.mbean.MyAccountMBeanImpl.class.getCanonicalName())) {
+                            jaasrmAdvancedRoles.setRmMyAccountReader(true);
+                        } else if (parameter.contains(AllAccountsMBeanImpl.class.getCanonicalName())) {
+                            jaasSchedulerAdvancedRoles.setSchedulerAllAccountsReader(true);
+                        } else if (parameter.contains(org.ow2.proactive.resourcemanager.core.jmx.mbean.AllAccountsMBeanImpl.class.getCanonicalName())) {
+                            jaasrmAdvancedRoles.setRmAllAccountsReader(true);
+                        }
+                    } else if (DeniedMethodCallPermission.class.getCanonicalName().equals(permissionName)) {
+                        String parameter = line.replace(permissionName, "").trim().replace("\"", "").trim();
+                        deniedMethodCalls.add(parameter);
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("Error when reading line '" + originalLine + "': " + e.getMessage());
+            }
+        }
+
+        Map<String, Boolean> rmPermissions = new LinkedHashMap<>(jaasrmRoles.getResourceManagerRoles());
+        if (allRMRoles) {
+            rmPermissions.replaceAll((k, v) -> true);
+        } else {
+            for (String role : rmRoles) {
+                rmPermissions.put(role, true);
+            }
+        }
+        jaasrmRoles.setResourceManagerRoles(rmPermissions);
+
+        Map<String, Boolean> schedPermissions = new LinkedHashMap<>(jaasSchedulerRoles.getSchedulerRoles());
+        if (allSchedulerRoles) {
+            schedPermissions.replaceAll((k, v) -> true);
+        } else {
+            for (String role : schedulerRoles) {
+                schedPermissions.put(role, true);
+            }
+        }
+        jaasSchedulerRoles.setSchedulerRoles(schedPermissions);
+
+        Map<String, Boolean> userSpacePermissions = new LinkedHashMap<>(answer.getUserSpaceRoles());
+        if (allUserSpaceRoles) {
+            userSpacePermissions.replaceAll((k, v) -> true);
+        } else {
+            for (String role : userSpaceRoles) {
+                userSpacePermissions.put(role, true);
+            }
+        }
+        answer.setUserSpaceRoles(userSpacePermissions);
+
+        Map<String, Boolean> globalSpacePermissions = new LinkedHashMap<>(answer.getGlobalSpaceRoles());
+        if (allGlobalSpaceRoles) {
+            globalSpacePermissions.replaceAll((k, v) -> true);
+        } else {
+            for (String role : globalSpaceRoles) {
+                globalSpacePermissions.put(role, true);
+            }
+        }
+        answer.setGlobalSpaceRoles(globalSpacePermissions);
+
+        jaasGroupAdvancedRoles.setDeniedMethodCalls(deniedMethodCalls);
+
+        return answer;
+    }
+
+    @Override
+    public void writeJAASConfiguration(JAASConfiguration configuration) throws IOException {
+        writeJAASConfiguration(configuration,
+                               new File(System.getProperty(PASchedulerProperties.SCHEDULER_HOME.getKey()),
+                                        JAAS_FILE_PATH));
+    }
+
+    public void writeJAASConfiguration(JAASConfiguration configuration, File jaasFilePath) throws IOException {
+        try {
+            SecurityPolicyLoader.lock.lockInterruptibly();
+            FileUtils.write(jaasFilePath,
+                            writeJAASConfigurationToString(configuration),
+                            PASchedulerProperties.FILE_ENCODING.getValueAsString());
+            SecurityPolicyLoader.reloadPolicy();
+        } catch (InterruptedException e) {
+            logger.warn("writeJAASConfiguration interrupted", e);
+        } finally {
+            SecurityPolicyLoader.lock.unlock();
+        }
+    }
+
+    private String writeJAASConfigurationToString(JAASConfiguration configuration) {
+        StringBuilder answer = new StringBuilder();
+        for (JAASGroup group : configuration.getJaasGroups().values()) {
+            answer.append(writeJAASGroup(group));
+            answer.append(NL + NL);
+        }
+        answer.append(GLOBAL_ROLE);
+        return answer.toString();
+    }
+
+    private String writeJAASGroup(JAASGroup group) {
+        StringBuilder answer = new StringBuilder();
+        answer.append(GROUP_ROLE + "\"" + group.getName() + "\" {" + NL);
+        answer.append(I + "// ****** Global permissions ******" + NL);
+        boolean isAllPortalPermission = group.getPortalAccess().entrySet().stream().allMatch(e -> e.getValue());
+        boolean noPortalPermission = group.getPortalAccess().entrySet().stream().noneMatch(e -> e.getValue());
+        if (!noPortalPermission) {
+            String portalPermissionString = group.getPortalAccess()
+                                                 .entrySet()
+                                                 .stream()
+                                                 .filter(e -> e.getValue())
+                                                 .map(e -> e.getKey())
+                                                 .reduce("", (st, e) -> st + (!st.isEmpty() ? "," : "") + e);
+            answer.append(I + P + PortalAccessPermission.class.getCanonicalName() + " \"" +
+                          (isAllPortalPermission ? "*" : portalPermissionString) + "\";" + NL);
+        }
+
+        if (group.isRoleAdmin()) {
+            answer.append(I + P + RoleAdminPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.isRoleReader()) {
+            answer.append(I + P + RoleReaderPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.isTenantAllAccess()) {
+            answer.append(I + P + TenantAllAccessPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.isPcaAdmin()) {
+            answer.append(I + P + PcaAdminPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.isNotificationAdmin()) {
+            answer.append(I + P + NotificationAdminPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.isJopPlannerCanCreateAssociation()) {
+            answer.append(I + P + JPCanCreateAssociationPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.isJobPlannerAdmin()) {
+            answer.append(I + P + JobPlannerAllAccessPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.isCatalogAdmin()) {
+            answer.append(I + P + CatalogAllAccessPermission.class.getCanonicalName() + ";" + NL);
+        }
+        if (group.getAdvanced().isAllPermissions()) {
+            answer.append(I + P + AllPermission.class.getCanonicalName() + ";" + NL);
+        }
+        answer.append(NL);
+        answer.append(I + "// ****** Scheduler permissions ******" + NL);
+        if (group.getScheduler().getHandleOnlyMyJobs() != null) {
+            if (group.getScheduler().getHandleOnlyMyJobs()) {
+                answer.append(I + P + HandleOnlyMyJobsPermission.class.getCanonicalName() + " \"true\";" + NL);
+            } else {
+                answer.append(I + P + HandleOnlyMyJobsPermission.class.getCanonicalName() + " \"false\";" + NL);
+            }
+        }
+
+        if (group.getScheduler().getAdvanced().isOtherUsersJobRead()) {
+            answer.append(I + P + OtherUsersJobReadPermission.class.getCanonicalName() + ";" + NL);
+        }
+
+        if (group.getScheduler().getChangeJobPriority() != null &&
+            group.getScheduler().getChangeJobPriority().values().stream().anyMatch(e -> e.booleanValue())) {
+            answer.append(I + P + ChangePriorityPermission.class.getCanonicalName() + " \"" + group.getScheduler()
+                                                                                                   .getChangeJobPriority()
+                                                                                                   .entrySet()
+                                                                                                   .stream()
+                                                                                                   .filter(e -> e.getValue())
+                                                                                                   .map(e -> e.getKey())
+                                                                                                   .reduce("",
+                                                                                                           (st, e) -> st +
+                                                                                                                      (!st.isEmpty() ? ","
+                                                                                                                                     : "") +
+                                                                                                                      e) +
+                          "\";" + NL);
+        }
+
+        if (group.getScheduler().getAdvanced().getHandleJobsWithGenericInformation() != null) {
+            answer.append(I + P + HandleJobsWithGenericInformationPermission.class.getCanonicalName() + " \"" +
+                          group.getScheduler().getAdvanced().getHandleJobsWithGenericInformation() + "\";" + NL);
+        }
+
+        if (group.getScheduler().getAdvanced().getHandleJobsWithBucketName() != null) {
+            answer.append(I + P + HandleJobsWithBucketNamePermission.class.getCanonicalName() + " \"" +
+                          group.getScheduler().getAdvanced().getHandleJobsWithBucketName() + "\";" + NL);
+        }
+
+        if (group.getScheduler().getAdvanced().getHandleJobsWithGroupName() != null) {
+            answer.append(I + P + HandleJobsWithGroupNamePermission.class.getCanonicalName() + " \"" +
+                          group.getScheduler().getAdvanced().getHandleJobsWithGroupName() + "\";" + NL);
+        }
+
+        if (group.getScheduler().getAdvanced().isConnectToResourceManager()) {
+            answer.append(I + P + ConnectToResourceManagerPermission.class.getCanonicalName() + ";" + NL);
+        }
+
+        if (group.getScheduler().getAdvanced().isChangeSchedulingPolicy()) {
+            answer.append(I + P + ChangePolicyPermission.class.getCanonicalName() + ";" + NL);
+        }
+
+        if (group.getScheduler() != null &&
+            group.getScheduler().getSchedulerRoles().values().stream().anyMatch(e -> e.booleanValue())) {
+            if (group.getScheduler().getSchedulerRoles().values().stream().allMatch(e -> e.booleanValue())) {
+                answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                              SchedulerFrontend.class.getCanonicalName() + ".*\";" + NL);
+            } else {
+                group.getScheduler()
+                     .getSchedulerRoles()
+                     .entrySet()
+                     .stream()
+                     .filter(e -> e.getValue())
+                     .forEach(e -> answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                                                 SchedulerFrontend.class.getCanonicalName() + "." + e.getKey() + "\";" +
+                                                 NL));
+            }
+        }
+
+        answer.append(NL);
+        answer.append(I + "// ****** Resource Manager permissions ******" + NL);
+
+        if (group.getResourceManager().isResourceManagerGlobalAdmin()) {
+            answer.append(I + P + RMCoreAllPermission.class.getCanonicalName() + ";" + NL);
+        }
+
+        if (group.getResourceManager().isNodeSourceAdmin()) {
+            answer.append(I + P + NSAdminPermission.class.getCanonicalName() + ";" + NL);
+        }
+
+        if (group.getResourceManager().getAdvanced().isNodeFullAccess()) {
+            answer.append(I + P + NodeUserAllPermission.class.getCanonicalName() + ";" + NL);
+        }
+
+        answer.append(NL);
+
+        if (group.getResourceManager().getResourceManagerRoles() != null &&
+            group.getResourceManager().getResourceManagerRoles().values().stream().anyMatch(e -> e.booleanValue())) {
+            if (group.getResourceManager()
+                     .getResourceManagerRoles()
+                     .values()
+                     .stream()
+                     .allMatch(e -> e.booleanValue())) {
+                answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                              RMCore.class.getCanonicalName() + ".*\";" + NL);
+            } else {
+                group.getResourceManager()
+                     .getResourceManagerRoles()
+                     .entrySet()
+                     .stream()
+                     .filter(e -> e.getValue())
+                     .forEach(e -> answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                                                 RMCore.class.getCanonicalName() + "." + e.getKey() + "\";" + NL));
+            }
+        }
+
+        answer.append(NL);
+        answer.append(I + "// ****** User and Global Space permissions ******" + NL);
+
+        if (group.getUserSpaceRoles() != null &&
+            group.getUserSpaceRoles().values().stream().anyMatch(e -> e.booleanValue())) {
+            if (group.getUserSpaceRoles().values().stream().allMatch(e -> e.booleanValue())) {
+                answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                              RestDataspaceImpl.class.getCanonicalName() + ".user.*\";" + NL);
+            } else {
+                group.getUserSpaceRoles()
+                     .entrySet()
+                     .stream()
+                     .filter(e -> e.getValue())
+                     .forEach(e -> answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                                                 RestDataspaceImpl.class.getCanonicalName() + ".user." + e.getKey() +
+                                                 "\";" + NL));
+            }
+        }
+
+        answer.append(NL);
+
+        if (group.getGlobalSpaceRoles() != null &&
+            group.getGlobalSpaceRoles().values().stream().anyMatch(e -> e.booleanValue())) {
+            if (group.getGlobalSpaceRoles().values().stream().allMatch(e -> e.booleanValue())) {
+                answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                              RestDataspaceImpl.class.getCanonicalName() + ".global.*\";" + NL);
+            } else {
+                group.getGlobalSpaceRoles()
+                     .entrySet()
+                     .stream()
+                     .filter(e -> e.getValue())
+                     .forEach(e -> answer.append(I + P + ServiceRolePermission.class.getCanonicalName() + " \"" +
+                                                 RestDataspaceImpl.class.getCanonicalName() + ".global." + e.getKey() +
+                                                 "\";" + NL));
+            }
+        }
+
+        if (!group.getAdvanced().getDeniedMethodCalls().isEmpty()) {
+            answer.append(NL);
+            answer.append(I + "// ****** Advanced permissions ******" + NL);
+
+            for (String deniedMethod : group.getAdvanced().getDeniedMethodCalls()) {
+                answer.append(I + P + DeniedMethodCallPermission.class.getCanonicalName() + " \"" + deniedMethod +
+                              "\";" + NL);
+            }
+        }
+
+        answer.append(NL);
+        answer.append(I + "// ****** JMX permissions ******" + NL);
+
+        answer.append(DEFAULT_MBEAN_ROLE);
+        if (group.getScheduler().getAdvanced().isSchedulerMyAccountReader()) {
+            answer.append(SCHED_MY_ACCOUNT_BEAN_ROLE);
+        }
+        if (group.getScheduler().getAdvanced().isSchedulerAllAccountsReader()) {
+            answer.append(SCHED_ALL_ACCOUNTS_BEAN_ROLE);
+        }
+        if (group.getResourceManager().getAdvanced().isRmMyAccountReader()) {
+            answer.append(RM_MY_ACCOUNT_BEAN_ROLE);
+        }
+        if (group.getResourceManager().getAdvanced().isRmAllAccountsReader()) {
+            answer.append(RM_ALL_ACCOUNTS_BEAN_ROLE);
+        }
+
+        answer.append(NL);
+        answer.append(I + "// ****** Default permissions ******" + NL);
+
+        answer.append(DEFAULT_FILE_ROLE);
+
+        answer.append(NL);
+
+        answer.append(DEFAULT_DB_ROLE);
+
+        answer.append(NL);
+
+        answer.append("};" + NL);
+        return answer.toString();
+    }
+}

--- a/scheduler/scheduler-server/src/test/java/org/ow2/proactive/utils/JAASParserTest.java
+++ b/scheduler/scheduler-server/src/test/java/org/ow2/proactive/utils/JAASParserTest.java
@@ -1,0 +1,138 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.proactive.utils;
+
+import static org.junit.Assert.*;
+import static org.ow2.proactive_grid_cloud_portal.common.dto.JAASGroup.of;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.ow2.proactive_grid_cloud_portal.common.dto.*;
+import org.ow2.tests.ProActiveTestClean;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+
+public class JAASParserTest extends ProActiveTestClean {
+
+    File dummyPolicyFile = File.createTempFile("security", "policy");
+
+    public JAASParserTest() throws IOException {
+    }
+
+    @Test
+    public void writeThenRead() throws IOException {
+        JAASConfiguration configuration = new JAASConfiguration();
+
+        JAASGroup group = new JAASGroup();
+        JAASRMRoles jaasrmRoles = new JAASRMRoles();
+        JAASRMAdvancedRoles jaasrmAdvancedRoles = new JAASRMAdvancedRoles();
+        jaasrmRoles.setAdvanced(jaasrmAdvancedRoles);
+        JAASSchedulerRoles jaasSchedulerRoles = new JAASSchedulerRoles();
+        JAASSchedulerAdvancedRoles jaasSchedulerAdvancedRoles = new JAASSchedulerAdvancedRoles();
+        jaasSchedulerRoles.setAdvanced(jaasSchedulerAdvancedRoles);
+        JAASGroupAdvancedRoles jaasGroupAdvancedRoles = new JAASGroupAdvancedRoles();
+        group.setResourceManager(jaasrmRoles);
+        group.setScheduler(jaasSchedulerRoles);
+        group.setAdvanced(jaasGroupAdvancedRoles);
+
+        group.setName("mygroup");
+        group.setPortalAccess(ImmutableMap.ofEntries(of("rm", true),
+                                                     of("scheduler", true),
+                                                     of("studio", true),
+                                                     of("automation-dashboard", false),
+                                                     of("workflow-execution", false),
+                                                     of("catalog", false),
+                                                     of("health-dashboard", false),
+                                                     of("job-analytics", false),
+                                                     of("job-gantt", false),
+                                                     of("node-gantt", false),
+                                                     of("job-planner-calendar-def", false),
+                                                     of("job-planner-calendar-def-workflows", false),
+                                                     of("job-planner-execution-planning", false),
+                                                     of("job-planner-gantt-chart", false),
+                                                     of("event-orchestration", false),
+                                                     of("service-automation", false),
+                                                     of("notification-portal", false)));
+        group.setRoleReader(true);
+        group.setPcaAdmin(true);
+        group.setNotificationAdmin(true);
+        jaasSchedulerRoles.setHandleOnlyMyJobs(false);
+        jaasSchedulerRoles.setChangeJobPriority(ImmutableMap.of("0",
+                                                                false,
+                                                                "1",
+                                                                true,
+                                                                "2",
+                                                                true,
+                                                                "3",
+                                                                true,
+                                                                "4",
+                                                                false,
+                                                                "5",
+                                                                false));
+        jaasSchedulerAdvancedRoles.setHandleJobsWithGenericInformation("toto");
+        jaasrmRoles.setResourceManagerRoles(ImmutableMap.of("basic",
+                                                            true,
+                                                            "read",
+                                                            true,
+                                                            "write",
+                                                            true,
+                                                            "provider",
+                                                            false,
+                                                            "nsadmin",
+                                                            false,
+                                                            "admin",
+                                                            false));
+        jaasSchedulerRoles.setSchedulerRoles(ImmutableMap.of("basic",
+                                                             true,
+                                                             "read",
+                                                             true,
+                                                             "write",
+                                                             true,
+                                                             "admin",
+                                                             true));
+        group.setUserSpaceRoles(ImmutableMap.of("read", true, "write", false));
+        group.setGlobalSpaceRoles(ImmutableMap.of("read", true, "write", true));
+        jaasrmAdvancedRoles.setRmMyAccountReader(true);
+        jaasrmAdvancedRoles.setRmAllAccountsReader(true);
+        jaasSchedulerAdvancedRoles.setSchedulerMyAccountReader(true);
+        jaasSchedulerAdvancedRoles.setSchedulerAllAccountsReader(true);
+        jaasGroupAdvancedRoles.setDeniedMethodCalls(ImmutableList.of("method1", "method2"));
+        configuration.setJaasGroups(ImmutableMap.of("mygroup", group));
+        JAASParser parser = new JAASParser();
+        parser.writeJAASConfiguration(configuration, dummyPolicyFile);
+        String fileContents = FileUtils.readFileToString(dummyPolicyFile);
+        System.out.println("Policy file generated:");
+        System.out.println(fileContents);
+        JAASConfiguration configuration2 = parser.readJAASConfiguration(dummyPolicyFile);
+        assertEquals("Configuration should be the same after write+read", configuration, configuration2);
+    }
+
+}


### PR DESCRIPTION
Also:
 - added RoleAdminPermission (ability to read and write all groups) and RoleReaderPermission (ability to read its own group permissions)
 - regenerated security.java.policy-server using the api
 - in order to bypass cyclic dependencies between rest-server and scheduler-server, JAASParser is initialized inside scheduler-server and passed to CommonRest as a parameter interface
 - small unit test