### PR TITLE
Improve LicenseSchedulingPolicy performance

### DIFF
--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/ExtendedSchedulerPolicy.java
@@ -98,7 +98,7 @@ public class ExtendedSchedulerPolicy extends DefaultPolicy {
     @Override
     public LinkedList<EligibleTaskDescriptor> getOrderedTasks(List<JobDescriptor> jobDescList) {
         initialize();
-        schedulingPolicyTimingLogger.start("ESP.getOrderTasks");
+        schedulingPolicyTimingLogger.start("ESP.getOrderedTasks");
         Date now = new Date();
         LinkedList<EligibleTaskDescriptor> executionCycleTasks = new LinkedList<>();
 
@@ -147,7 +147,7 @@ public class ExtendedSchedulerPolicy extends DefaultPolicy {
                 }
             }
         }
-        schedulingPolicyTimingLogger.end("ESP.getOrderTasks");
+        schedulingPolicyTimingLogger.end("ESP.getOrderedTasks");
         if (!schedulingPolicyTimingLogger.isHierarchical()) {
             schedulingPolicyTimingLogger.printTimings(Level.DEBUG);
             schedulingPolicyTimingLogger.clear();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/license/LicenseSchedulingPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/license/LicenseSchedulingPolicy.java
@@ -93,9 +93,9 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
                 if (nbTokens > 0) {
                     licenseSynchronization.addSoftware(software, nbTokens);
                 } else {
-                    // In order to distinguish the case where there is no more token (all are used)
-                    // and the case where it is set to <= 0 in the config file
-                    licenseSynchronization.addSoftware(software, -1);
+                    logger.error("In " + LicenseConfiguration.getConfiguration().getPath() + ": software " + software +
+                                 " has incorrect value " + nbTokens);
+                    continue;
                 }
             }
             licenseSynchronization.persist();

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/license/LicenseSchedulingPolicy.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/policy/license/LicenseSchedulingPolicy.java
@@ -29,6 +29,7 @@ import java.util.*;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.map.LRUMap;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.ow2.proactive.scheduler.common.JobDescriptor;
@@ -36,6 +37,7 @@ import org.ow2.proactive.scheduler.common.job.JobId;
 import org.ow2.proactive.scheduler.common.job.JobStatus;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.task.TaskStatus;
+import org.ow2.proactive.scheduler.core.properties.PASchedulerProperties;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptor;
 import org.ow2.proactive.scheduler.descriptor.EligibleTaskDescriptorImpl;
 import org.ow2.proactive.scheduler.descriptor.JobDescriptorImpl;
@@ -66,6 +68,11 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
     // For DB persistence
     private LicenseSynchronization licenseSynchronization = null;
 
+    // cache used to store the start at value of a given job or task
+    private static final Map<String, String> requiredLicencesCache = Collections.synchronizedMap(new LRUMap<>(PASchedulerProperties.SCHEDULER_STARTAT_VALUE_CACHE.getValueAsInt()));
+
+    private volatile boolean needPersist = false;
+
     protected void initialize() {
         if (schedulingPolicyTimingLogger == null) {
             schedulingPolicyTimingLogger = new MultipleTimingLogger("LicenseSchedulingPolicyTiming", logger, true);
@@ -86,7 +93,7 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
                 try {
                     nbTokens = Integer.parseInt(properties.getProperty(software));
                 } catch (NumberFormatException e) {
-                    logger.debug("Fatal error, cannot parse token number from the license properties file");
+                    logger.error("Fatal error, cannot parse token number from the license properties file");
                     throw e;
                 }
 
@@ -105,65 +112,88 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
     private void removeFinishedJobsAndReleaseTokens(String requiredLicense) {
         schedulingPolicyTimingLogger.start("LP.removeFinishedJobsAndReleaseTokens");
 
+        schedulingPolicyTimingLogger.start("LP.getPersistedJobsLicense");
         LinkedBlockingQueue<String> eligibleJobsDescriptorsLicense = licenseSynchronization.getPersistedJobsLicense(requiredLicense);
+        schedulingPolicyTimingLogger.end("LP.getPersistedJobsLicense");
 
         Iterator<String> iter = eligibleJobsDescriptorsLicense.iterator();
         String currentJobIdAsString;
         JobId currentJobId;
         JobStatus currentJobStatus;
+        boolean anyChange = false;
+        schedulingPolicyTimingLogger.start("LP.Jobs.getRemainingTokens");
         int currentNbTokens = licenseSynchronization.getRemainingTokens(requiredLicense);
+        schedulingPolicyTimingLogger.end("LP.Jobs.getRemainingTokens");
         while (iter.hasNext()) {
-
             currentJobIdAsString = iter.next();
             currentJobId = JobIdImpl.makeJobId(currentJobIdAsString);
+            schedulingPolicyTimingLogger.start("LP.getJobStatus");
             currentJobStatus = schedulingService.getJobStatus(currentJobId);
-            logger.debug("Considering job " + currentJobIdAsString + " with status " + currentJobStatus +
+            schedulingPolicyTimingLogger.end("LP.getJobStatus");
+            logger.trace("Considering job " + currentJobIdAsString + " with status " + currentJobStatus +
                          " requiring token for license " + requiredLicense);
 
+            schedulingPolicyTimingLogger.start("LP.isJobAlive");
             if (!schedulingService.isJobAlive(currentJobId) || currentJobStatus == JobStatus.PAUSED ||
                 currentJobStatus == JobStatus.IN_ERROR) {
-                logger.debug("Releasing token");
+                logger.trace("Releasing token");
                 iter.remove();
                 currentNbTokens++;
+                anyChange = true;
             } else {
-                logger.debug("Job status does not allow to release a token");
+                logger.trace("Job status does not allow to release a token");
             }
+            schedulingPolicyTimingLogger.end("LP.isJobAlive");
         }
-        licenseSynchronization.setNbTokens(requiredLicense, currentNbTokens);
-        licenseSynchronization.markJobLicenseChange(requiredLicense);
-        licenseSynchronization.persist();
+        if (anyChange) {
+            licenseSynchronization.setNbTokens(requiredLicense, currentNbTokens);
+            licenseSynchronization.markJobLicenseChange(requiredLicense);
+            needPersist = true;
+        }
         schedulingPolicyTimingLogger.end("LP.removeFinishedJobsAndReleaseTokens");
     }
 
     private void removeFinishedTasksAndReleaseTokens(String requiredLicense) {
         schedulingPolicyTimingLogger.start("LP.removeFinishedTasksAndReleaseTokens");
 
+        schedulingPolicyTimingLogger.start("LP.getPersistedTasksLicense");
         LinkedBlockingQueue<String> eligibleTasksDescriptorsLicense = licenseSynchronization.getPersistedTasksLicense(requiredLicense);
+        schedulingPolicyTimingLogger.end("LP.getPersistedTasksLicense");
 
         Iterator<String> iter = eligibleTasksDescriptorsLicense.iterator();
         String currentTaskIdAsString;
         TaskId currentTaskId;
         TaskStatus currentTaskStatus;
+        boolean anyChange = false;
+        schedulingPolicyTimingLogger.start("LP.Tasks.getRemainingTokens");
         int currentNbTokens = licenseSynchronization.getRemainingTokens(requiredLicense);
+        schedulingPolicyTimingLogger.end("LP.Tasks.getRemainingTokens");
         while (iter.hasNext()) {
             currentTaskIdAsString = iter.next();
             currentTaskId = TaskIdImpl.makeTaskId(currentTaskIdAsString);
+            schedulingPolicyTimingLogger.start("LP.getTaskStatus");
             currentTaskStatus = schedulingService.getTaskStatus(currentTaskId);
-            logger.debug("Considering task " + currentTaskIdAsString + " with status " + currentTaskStatus +
+            schedulingPolicyTimingLogger.end("LP.getTaskStatus");
+            logger.trace("Considering task " + currentTaskIdAsString + " with status " + currentTaskStatus +
                          " requiring token for license " + requiredLicense);
 
+            schedulingPolicyTimingLogger.start("LP.isTaskAlive");
             if (!schedulingService.isTaskAlive(currentTaskId) || currentTaskStatus == TaskStatus.PAUSED ||
                 currentTaskStatus == TaskStatus.IN_ERROR) {
-                logger.debug("Releasing token");
+                logger.trace("Releasing token");
                 iter.remove();
                 currentNbTokens++;
+                anyChange = true;
             } else {
-                logger.debug("Task status does not allow to release a token");
+                logger.trace("Task status does not allow to release a token");
             }
+            schedulingPolicyTimingLogger.end("LP.isTaskAlive");
         }
-        licenseSynchronization.setNbTokens(requiredLicense, currentNbTokens);
-        licenseSynchronization.markTaskLicenseChange(requiredLicense);
-        licenseSynchronization.persist();
+        if (anyChange) {
+            licenseSynchronization.setNbTokens(requiredLicense, currentNbTokens);
+            licenseSynchronization.markTaskLicenseChange(requiredLicense);
+            needPersist = true;
+        }
         schedulingPolicyTimingLogger.end("LP.removeFinishedTasksAndReleaseTokens");
     }
 
@@ -171,18 +201,19 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
         schedulingPolicyTimingLogger.start("LP.canGetToken");
         try {
             if (licenseSynchronization.getRemainingTokens(currentRequiredLicense) == -1) {
-                logger.debug("No token specified in the config file, return false");
+                logger.trace("No token specified in the config file, return false");
                 return false;
             } else if (licenseSynchronization.getRemainingTokens(currentRequiredLicense) > 0) {
-                logger.debug("There are still remaining licenses, return true");
+                logger.trace("There are still remaining licenses, return true");
                 return true;
             } else { // == 0
-                logger.debug("Removing all terminated jobs/tasks and check again if there are remaining licenses");
+                logger.trace("Removing all terminated jobs/tasks and check again if there are remaining licenses");
+
                 removeFinishedJobsAndReleaseTokens(currentRequiredLicense);
                 removeFinishedTasksAndReleaseTokens(currentRequiredLicense);
 
                 if (licenseSynchronization.getRemainingTokens(currentRequiredLicense) > 0) {
-                    logger.debug("There are remaining licenses after releasing tokens, return true");
+                    logger.trace("There are remaining licenses after releasing tokens, return true");
                     return true;
                 }
                 return false;
@@ -197,44 +228,52 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
         try {
 
             // Retrieve required licenses names from the job generic informations
-            final String requiredLicenses = job.getInternal().getRuntimeGenericInformation().get(REQUIRED_LICENSES);
+            schedulingPolicyTimingLogger.start("LP.acquireTokensForJob.getRequiredLicenses");
+            final String requiredLicenses = getRequiredLicenses(job);
+            schedulingPolicyTimingLogger.end("LP.acquireTokensForJob.getRequiredLicenses");
             final String jobId = job.getJobId().value();
 
             // If it requires software licenses
             if (requiredLicenses != null) {
 
-                logger.debug("For job considering licenses " + requiredLicenses);
+                logger.trace("For job considering licenses " + requiredLicenses);
 
                 // Do not execute if one of the required license can not be obtained
                 final HashSet<String> requiredLicensesSet = new HashSet<String>(Arrays.asList(requiredLicenses.split("\\s*,\\s*")));
                 boolean jobHoldsToken, canGetToken;
                 for (String requiredLicense : requiredLicensesSet) {
 
+                    schedulingPolicyTimingLogger.start("LP.acquireTokensForJob.containsLicense");
                     if (!licenseSynchronization.containsLicense(requiredLicense)) {
-                        logger.debug("The required software is not specified in the license properties file, keep job pending");
+                        logger.trace("The required software is not specified in the license properties file, keep job pending");
                         return false;
                     }
+                    schedulingPolicyTimingLogger.end("LP.acquireTokensForJob.containsLicense");
 
                     jobHoldsToken = licenseSynchronization.containsJobId(requiredLicense, jobId);
+                    schedulingPolicyTimingLogger.start("LP.acquireTokensForJob.canGetToken");
                     canGetToken = canGetToken(requiredLicense);
+                    schedulingPolicyTimingLogger.end("LP.acquireTokensForJob.canGetToken");
                     if (!jobHoldsToken && !canGetToken) {
-                        logger.debug("Job does not already hold a token for " + requiredLicense +
+                        logger.trace("Job does not already hold a token for " + requiredLicense +
                                      " and cannot get a new one, keep job pending");
                         return false;
                     }
                 }
-                logger.debug("Job eligible since it can get all tokens or already hold them");
+                logger.trace("Job eligible since it can get all tokens or already hold them");
+                schedulingPolicyTimingLogger.start("LP.acquireTokensForJob.addJobToLicense");
                 for (String requiredLicense : requiredLicensesSet) {
                     if (!licenseSynchronization.containsJobId(requiredLicense, jobId)) {
                         licenseSynchronization.addJobToLicense(requiredLicense, jobId);
                         licenseSynchronization.markJobLicenseChange(requiredLicense);
+                        needPersist = true;
                     }
                 }
-                licenseSynchronization.persist();
+                schedulingPolicyTimingLogger.end("LP.acquireTokensForJob.addJobToLicense");
                 return true;
 
             } else {
-                logger.debug("Job eligible since it does not require any license");
+                logger.trace("Job eligible since it does not require any license");
                 return true;
             }
         } finally {
@@ -243,44 +282,61 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
 
     }
 
+    private String getRequiredLicenses(JobDescriptorImpl job) {
+        if (requiredLicencesCache.containsKey(job.getJobId().toString())) {
+            return requiredLicencesCache.get(job.getJobId().toString());
+        }
+        final String requiredLicenses = job.getInternal().getRuntimeGenericInformation().get(REQUIRED_LICENSES);
+        requiredLicencesCache.put(job.getJobId().toString(), requiredLicenses);
+        return requiredLicenses;
+    }
+
     private String getRequiredLicenses(EligibleTaskDescriptor task) {
         // Do not consider the runtime GIs to test if REQUIRED_LICENSES is specified at the task level
         // since these inherit from the job level ones
         // And if REQUIRED_LICENSES is specified at the task level (i.e. in the unresolved GIs)
         // Consider the runtime GIs to get the resolved REQUIRED_LICENSES
+        if (requiredLicencesCache.containsKey(task.getTaskId().toString())) {
+            return requiredLicencesCache.get(task.getTaskId().toString());
+        }
         final InternalTask internTask = ((EligibleTaskDescriptorImpl) task).getInternal();
-        if (internTask.getGenericInformation().get(REQUIRED_LICENSES) != null) {
-            // Retrieve required licenses names from the task generic informations
-            return internTask.getRuntimeGenericInformation().get(REQUIRED_LICENSES);
+        if (internTask.getGenericInformation().containsKey(REQUIRED_LICENSES)) {
+            // Retrieve required licenses names from the task generic information
+            String licenses = internTask.getRuntimeGenericInformation().get(REQUIRED_LICENSES);
+            requiredLicencesCache.put(task.getTaskId().toString(), licenses);
+            return licenses;
         } else {
-            logger.debug("Task eligible since it does not require any license");
+            logger.trace("Task eligible since it does not require any license");
+            requiredLicencesCache.put(task.getTaskId().toString(), null);
             return null;
         }
     }
 
     private boolean notRequireLicenseOrLicenseExists(EligibleTaskDescriptor task) {
 
+        schedulingPolicyTimingLogger.start("LP.notRequireLicense.getRequiredLicenses");
         String requiredLicenses = getRequiredLicenses(task);
+        schedulingPolicyTimingLogger.end("LP.notRequireLicense.getRequiredLicenses");
 
         // If it requires software licenses
         if (requiredLicenses != null) {
 
-            logger.debug("For task considering licenses " + requiredLicenses);
+            logger.trace("For task considering licenses " + requiredLicenses);
 
             // Do not execute if one of the required license can not be obtained
             final HashSet<String> requiredLicensesSet = new HashSet<String>(Arrays.asList(requiredLicenses.split("\\s*,\\s*")));
             for (String requiredLicense : requiredLicensesSet) {
 
                 if (!licenseSynchronization.containsLicense(requiredLicense)) {
-                    logger.debug("Task not eligible since no token exists for this license");
+                    logger.trace("Task not eligible since no token exists for this license");
                     return false;
                 }
             }
-            logger.debug("Task eligible since all required licenses are specified in the properties file");
+            logger.trace("Task eligible since all required licenses are specified in the properties file");
             return true;
 
         } else {
-            logger.debug("Task eligible since it does not require any license");
+            logger.trace("Task eligible since it does not require any license");
             return true;
         }
     }
@@ -299,6 +355,7 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
 
         initialize();
         schedulingPolicyTimingLogger.start("LP.getOrderedTasks");
+        needPersist = false;
 
         // Filter jobs according to the parent policy
         List<JobDescriptor> filteredJobDescList = super.filterJobs(jobDescList);
@@ -311,9 +368,17 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
         LinkedList<EligibleTaskDescriptor> orderedTasksDescFromParentPolicy = super.getOrderedTasks(filteredJobDescList);
 
         // Keep only tasks which, either does not require license, or require licenses specified in the config file (without considering tokens)
+        schedulingPolicyTimingLogger.start("LP.notRequireLicenseOrLicenseExists");
         LinkedList<EligibleTaskDescriptor> filteredOrderedTasksDescFromParentPolicy = orderedTasksDescFromParentPolicy.stream()
                                                                                                                       .filter(taskDesc -> notRequireLicenseOrLicenseExists(taskDesc))
                                                                                                                       .collect(Collectors.toCollection(LinkedList::new));
+        schedulingPolicyTimingLogger.end("LP.notRequireLicenseOrLicenseExists");
+        if (needPersist) {
+            schedulingPolicyTimingLogger.start("LP.getOrderedTasks.persist");
+            licenseSynchronization.persist();
+            schedulingPolicyTimingLogger.end("LP.getOrderedTasks.persist");
+            needPersist = false;
+        }
 
         schedulingPolicyTimingLogger.end("LP.getOrderedTasks");
         schedulingPolicyTimingLogger.printTimings(Level.DEBUG);
@@ -337,29 +402,34 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
     public boolean isTaskExecutable(NodeSet selectedNodes, EligibleTaskDescriptor task) {
 
         schedulingPolicyTimingLogger.start("LP.isTaskExecutable");
+        needPersist = false;
         try {
             // If it requires software licenses
+            schedulingPolicyTimingLogger.start("LP.isTaskExecutable.getRequiredLicenses");
             String requiredLicenses = getRequiredLicenses(task);
+            schedulingPolicyTimingLogger.end("LP.isTaskExecutable.getRequiredLicenses");
             String jobId = ((EligibleTaskDescriptorImpl) task).getInternal().getJobId().value();
             String taskId = task.getTaskId().toString();
 
             if (requiredLicenses != null) {
 
-                logger.debug("Try to get tokens for licenses " + requiredLicenses);
+                logger.trace("Try to get tokens for licenses " + requiredLicenses);
                 boolean taskHoldsToken, jobHoldsToken, canGetToken;
                 final HashSet<String> requiredLicensesSet = new HashSet<String>(Arrays.asList(requiredLicenses.split("\\s*,\\s*")));
                 for (String requiredLicense : requiredLicensesSet) {
 
                     jobHoldsToken = licenseSynchronization.containsJobId(requiredLicense, jobId);
                     taskHoldsToken = licenseSynchronization.containsTaskId(requiredLicense, taskId);
+                    schedulingPolicyTimingLogger.start("LP.isTaskExecutable.canGetToken");
                     canGetToken = canGetToken(requiredLicense);
+                    schedulingPolicyTimingLogger.end("LP.isTaskExecutable.canGetToken");
 
-                    logger.debug("For license " + requiredLicense + " task " + taskId + " holds a token? " +
+                    logger.trace("For license " + requiredLicense + " task " + taskId + " holds a token? " +
                                  taskHoldsToken + " job " + jobId + " holds a token? " + jobHoldsToken +
                                  " a new token is available? " + canGetToken);
 
                     if (!jobHoldsToken && !taskHoldsToken && !canGetToken) {
-                        logger.debug("Task and its job do not already hold a token for " + requiredLicense +
+                        logger.trace("Task and its job do not already hold a token for " + requiredLicense +
                                      " and cannot get a new one, keep task pending");
                         return false;
                     }
@@ -369,23 +439,28 @@ public class LicenseSchedulingPolicy extends ExtendedSchedulerPolicy {
                     taskHoldsToken = licenseSynchronization.containsTaskId(requiredLicense, taskId);
                     jobHoldsToken = licenseSynchronization.containsJobId(requiredLicense, jobId);
 
-                    logger.debug("For license " + requiredLicense + " taskHoldsToken? " + taskHoldsToken +
+                    logger.trace("For license " + requiredLicense + " taskHoldsToken? " + taskHoldsToken +
                                  " jobHoldsToken? " + jobHoldsToken);
 
                     if (taskHoldsToken || jobHoldsToken) {
-                        logger.debug("The license " + requiredLicense +
+                        logger.trace("The license " + requiredLicense +
                                      " is already obtained at the job level or the task level, use it without getting a new token");
                     } else {
-                        logger.debug("Task and its job do not already hold a token for " + requiredLicense +
+                        logger.trace("Task and its job do not already hold a token for " + requiredLicense +
                                      " but acquiring a new one");
                         licenseSynchronization.addTaskToLicense(requiredLicense, taskId);
                         licenseSynchronization.markTaskLicenseChange(requiredLicense);
                     }
                 }
-                licenseSynchronization.persist();
+                if (needPersist) {
+                    schedulingPolicyTimingLogger.start("LP.isTaskExecutable.persist");
+                    licenseSynchronization.persist();
+                    schedulingPolicyTimingLogger.end("LP.isTaskExecutable.persist");
+                    needPersist = false;
+                }
                 return true;
             } else {
-                logger.debug("Executable since it does not require any license");
+                logger.trace("Executable since it does not require any license");
                 return true;
             }
         } finally {


### PR DESCRIPTION
 - cache job/tasks REQUIRED_LICENCE generic info inside a LRU map
 - call persist() at the end of getOrderedTasks if a change occurred and not for each job/task