### PR TITLE
CommonRest: change tenants endpoints semantic

### DIFF
--- a/common/common-api/build.gradle
+++ b/common/common-api/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile 'org.ow2.proactive:process-tree-killer:1.0.3'
     compile group: 'org.jasypt', name: 'jasypt', version: '1.9.3'
     compile "at.favre.lib:bcrypt:0.10.2"
+    compile 'com.google.guava:guava:32.0.1-jre'
 
     testRuntime 'org.jruby:jruby-complete:9.4.3.0'
     testRuntime 'org.python:jython-standalone:2.7.3'

--- a/common/common-api/src/main/java/org/ow2/proactive/authentication/UsersService.java
+++ b/common/common-api/src/main/java/org/ow2/proactive/authentication/UsersService.java
@@ -31,6 +31,8 @@ import java.util.Set;
 
 import javax.security.auth.login.LoginException;
 
+import com.google.common.collect.Multimap;
+
 
 public interface UsersService {
 
@@ -100,26 +102,26 @@ public interface UsersService {
     List<OutputUserInfo> deleteUser(String userName) throws LoginException;
 
     /**
-     * List the groups to tenant associations
-     * @return map of group to tenant associations
+     * List the tenant associations
+     * @return multimap of tenant to group associations
      */
-    Map<String, String> listGroupsToTenant();
+    Multimap<String, String> listTenants();
 
     /**
-     * Add a group to tenant association
-     * If the group had already a tenant associated, it will be overridden by the new tenant
-     * @param group group name
+     * Add a tenant or edit an existing tenant
+     * If the tenant already exists, its set of associated groups will be updated
      * @param tenant tenant name
-     * @return map of group to tenant associations after update
+     * @param groups set of groups associated with this tenant
+     * @return multimap of tenant to group associations after update
      */
-    Map<String, String> addGroupTenantAssociation(String group, String tenant);
+    Multimap<String, String> addOrEditTenant(String tenant, Set<String> groups);
 
     /**
-     * Remove group to tenant association
-     * @param group group name
-     * @return map of group to tenant associations after update
+     * Remove a tenant and all its group associations
+     * @param tenant tenant name
+     * @return multimap of tenant to group associations after update
      */
-    Map<String, String> removeGroupTenantAssociation(String group);
+    Multimap<String, String> removeTenant(String tenant);
 
     /**
      * Check the user's password

--- a/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRestInterface.java
+++ b/rest/rest-api/src/main/java/org/ow2/proactive_grid_cloud_portal/common/CommonRestInterface.java
@@ -29,6 +29,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import java.io.IOException;
 import java.security.KeyException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -335,7 +336,7 @@ public interface CommonRestInterface {
 
     /**
      * Create user
-     * @param sessionId id of a session (tokens will be associated with this session)
+     * @param sessionId id of a session
      * @param userInfo new account details
      * @return the list of internal users after adding the user
      */
@@ -348,7 +349,7 @@ public interface CommonRestInterface {
 
     /**
      * List users
-     * @param sessionId id of a session (tokens will be associated with this session)
+     * @param sessionId id of a session
      * @return the list of internal users
      */
     @GET
@@ -359,7 +360,7 @@ public interface CommonRestInterface {
 
     /**
      * Get user details
-     * @param sessionId id of a session (tokens will be associated with this session)
+     * @param sessionId id of a session
      * @param username username of the user
      * @return a single user details
      */
@@ -371,7 +372,7 @@ public interface CommonRestInterface {
 
     /**
      * Edit user
-     * @param sessionId id of a session (tokens will be associated with this session)
+     * @param sessionId id of a session
      * @param username username of the user
      * @param userInfo input modifications to the user
      * @return the list of internal users after editing the user
@@ -385,7 +386,7 @@ public interface CommonRestInterface {
 
     /**
      * Delete user
-     * @param sessionId id of a session (tokens will be associated with this session)
+     * @param sessionId id of a session
      * @param username username of the user
      * @return the list of internal users after deleting the user
      */
@@ -396,41 +397,42 @@ public interface CommonRestInterface {
             throws NotConnectedRestException, PermissionRestException, LoginRestException;
 
     /**
-     * List group to tenant association
-     * @param sessionId id of a session (tokens will be associated with this session)
-     * @return the group to tenant association list
+     * List tenants association
+     * @param sessionId id of a session
+     * @return the tenants to group associations
      */
     @GET
     @Path("manager/tenants")
     @Produces(MediaType.APPLICATION_JSON)
-    Map<String, String> listGroupsToTenantAssociations(@HeaderParam("sessionid") String sessionId)
+    Map<String, Collection<String>> listTenants(@HeaderParam("sessionid") String sessionId)
             throws NotConnectedRestException, PermissionRestException, LoginRestException;
 
     /**
-     * Add group to tenant association
-     * @param sessionId id of a session (tokens will be associated with this session)
-     * @param group group to associate
-     * @param tenant tenant to associate
-     * @return the group to tenant association list after modification
+     * Add or Edit a tenant
+     * @param sessionId id of a session
+     * @param tenant tenant name
+     * @param groups set of groups to associate
+     * @return the tenants to group associations after modification
      */
-    @POST
-    @Path("manager/tenants")
+    @PUT
+    @Path("manager/tenants/{tenant}")
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    Map<String, String> addGroupToTenantAssociation(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("group") String group, @QueryParam("tenant") String tenant)
+    Map<String, Collection<String>> addOrEditTenant(@HeaderParam("sessionid") String sessionId,
+            @PathParam("tenant") String tenant, Collection<String> groups)
             throws NotConnectedRestException, PermissionRestException, LoginRestException;
 
     /**
-     * Delete group to tenant association
-     * @param sessionId id of a session (tokens will be associated with this session)
-     * @param group group to associate
-     * @return the group to tenant association list after modification
+     * Delete a tenant
+     * @param sessionId id of a session
+     * @param tenant tenant name
+     * @return the tenants to group associations after modification
      */
     @DELETE
-    @Path("manager/tenants")
+    @Path("manager/tenants/{tenant}")
     @Produces(MediaType.APPLICATION_JSON)
-    Map<String, String> removeGroupToTenantAssociation(@HeaderParam("sessionid") String sessionId,
-            @QueryParam("group") String group)
+    Map<String, Collection<String>> removeTenant(@HeaderParam("sessionid") String sessionId,
+            @PathParam("tenant") String tenant)
             throws NotConnectedRestException, PermissionRestException, LoginRestException;
 
 }


### PR DESCRIPTION
The new logic allows adding or editing a tenant directly or to remove completely an existing tenant